### PR TITLE
ci: require approval for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: npm-publish
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Adds the `npm-publish` GitHub environment to the publish workflow so npm releases require environment approval before publishing.