### PR TITLE
chore: format release metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,15 +12,8 @@
 	"bugs": {
 		"url": "https://github.com/lmilojevicc/pi-zentui/issues"
 	},
-	"keywords": [
-		"pi-package",
-		"pi-extension",
-		"starship",
-		"tui"
-	],
-	"files": [
-		"extensions"
-	],
+	"keywords": ["pi-package", "pi-extension", "starship", "tui"],
+	"files": ["extensions"],
 	"scripts": {
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit",
@@ -37,9 +30,7 @@
 		"@mariozechner/pi-tui": "*"
 	},
 	"pi": {
-		"extensions": [
-			"./extensions"
-		],
+		"extensions": ["./extensions"],
 		"image": "https://raw.githubusercontent.com/lmilojevicc/pi-zentui/main/assets/zentui.png"
 	},
 	"publishConfig": {


### PR DESCRIPTION
Formats
 package metadata after version bump so CI passes.