### PR TITLE
feat: status bar forwards messages from other plugins

### DIFF
--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -85,9 +85,13 @@ export function installFooter(
 					config.colors.runtimePrefix,
 					colorSource,
 				);
+				const extensionStatuses = Array.from(footerData.getExtensionStatuses().entries())
+					.map(([, text]) => renderStyleForSource(theme, colorSource, config.colors.contextNormal, text))
+					.filter(Boolean);
 
 				const left = [cwdLabel, branchLabel, runtimeLabel].filter(Boolean).join(" ");
 				const right = [
+					...extensionStatuses,
 					renderStyleForSource(theme, colorSource, contextColor, state.contextLabel),
 					renderStyleForSource(theme, colorSource, config.colors.tokens, state.tokenLabel),
 					renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel),


### PR DESCRIPTION
Hi, Luka:

Currently, status bar information added by other plugins is discarded by zentui.

This PR fixes that issue. zentui can now forward status bar information from other plugins.

- Status bar information from other plugins is displayed at the leftmost position of the right-side status bar area.
- If no color is specified, contextNormal ASCII color is used by default.
- Empty values are filtered out.

Preview:

<img width="1003" height="98" alt="image" src="https://github.com/user-attachments/assets/537610b6-4bca-4a59-ad4b-0da9a372a986" />
