### PR TITLE
feat: configure git branch and status modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Default config values — copy this and change any value you want:
 ```json
 {
 	"projectRefreshIntervalMs": 30000,
+	"gitBranch": {
+		"enable": true,
+		"truncation_length": 50,
+		"truncation_symbol": "…"
+	},
+	"gitStatus": {
+		"enable": true
+	},
 	"icons": {
 		"cwd": "󰝰",
 		"git": "",
@@ -182,6 +190,8 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`).
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling.
+- `gitBranch`: controls the git branch module (`on  main`). `enable: false` hides the branch module. `truncation_length` is the branch-name display width to keep before appending `truncation_symbol`; runtime default is effectively unlimited, while the example uses `50` as a practical starting point.
+- `gitStatus`: controls the git status module (`[!?↑]`). `enable: false` hides status indicators.
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. `/zentui` lists only statuses that are currently active.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -1,6 +1,14 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	type GitBranchModuleConfig,
+	type GitStatusModuleConfig,
+	defaultGitBranchModuleConfig,
+	defaultGitStatusModuleConfig,
+	normalizeGitBranchModuleConfig,
+	normalizeGitStatusModuleConfig,
+} from "./git-module-config";
 import { isSupportedColorSpec } from "./style";
 
 export type ColorSpec = string;
@@ -24,6 +32,8 @@ const MIN_PROJECT_REFRESH_INTERVAL_MS = 5_000;
 
 export type PolishedTuiConfig = {
 	projectRefreshIntervalMs: number;
+	gitBranch: GitBranchModuleConfig;
+	gitStatus: GitStatusModuleConfig;
 	icons: {
 		cwd: string;
 		git: string;
@@ -70,6 +80,8 @@ export const configPath = join(getAgentDir(), "zentui.json");
 
 export const defaultConfig: PolishedTuiConfig = {
 	projectRefreshIntervalMs: DEFAULT_PROJECT_REFRESH_INTERVAL_MS,
+	gitBranch: defaultGitBranchModuleConfig,
+	gitStatus: defaultGitStatusModuleConfig,
 	icons: {
 		cwd: "󰝰",
 		git: "",
@@ -281,8 +293,12 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const extensionStatuses = isRecord(config.extensionStatuses)
 		? normalizeExtensionStatuses(config.extensionStatuses as Record<string, unknown>)
 		: defaultConfig.extensionStatuses;
+	const gitBranch = normalizeGitBranchModuleConfig(config.gitBranch);
+	const gitStatus = normalizeGitStatusModuleConfig(config.gitStatus);
 	return {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
+		gitBranch: { ...gitBranch },
+		gitStatus: { ...gitStatus },
 		icons: {
 			...defaultConfig.icons,
 			...icons,

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -3,6 +3,7 @@ import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
 import { collectExtensionStatusSegments } from "./extension-status";
 import { formatCwdLabel, formatRuntimeSegment } from "./format";
+import { renderGitModules } from "./git-modules";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";
 
@@ -161,7 +162,7 @@ export function installFooter(
 					config.colors.cwd,
 					formatCwdLabel(ctx.cwd, config.icons.cwd),
 				);
-				const branch = state.branch;
+				const gitLabel = renderGitModules(theme, colorSource, config, state);
 				const contextUsage = ctx.getContextUsage();
 				const contextColor =
 					contextUsage?.percent !== null && contextUsage?.percent !== undefined
@@ -171,36 +172,6 @@ export function installFooter(
 								? config.colors.contextWarning
 								: config.colors.contextNormal
 						: config.colors.contextNormal;
-				const gitColor = (text: string) =>
-					renderStyleForSource(theme, colorSource, config.colors.gitBranch, text);
-				const gitStatusColor = (text: string) =>
-					renderStyleForSource(theme, colorSource, config.colors.gitStatus, text);
-				const gitIcon = config.icons.git ? gitColor(config.icons.git) : "";
-				const allStatus = [
-					state.conflicted > 0 ? config.icons.conflicted : "",
-					state.stashed ? config.icons.stashed : "",
-					state.deleted > 0 ? config.icons.deleted : "",
-					state.renamed > 0 ? config.icons.renamed : "",
-					state.modified > 0 ? config.icons.modified : "",
-					state.typechanged > 0 ? config.icons.typechanged : "",
-					state.staged > 0 ? config.icons.staged : "",
-					state.untracked > 0 ? config.icons.untracked : "",
-				].join("");
-				const aheadBehind =
-					state.ahead > 0 && state.behind > 0
-						? config.icons.diverged
-						: state.ahead > 0
-							? config.icons.ahead
-							: state.behind > 0
-								? config.icons.behind
-								: "";
-				const statusBlock =
-					allStatus || aheadBehind ? gitStatusColor(`[${allStatus}${aheadBehind}]`) : "";
-				const branchLabel = branch
-					? [...["on", gitIcon, gitColor(branch)].filter(Boolean), statusBlock]
-							.filter(Boolean)
-							.join(" ")
-					: "";
 				const runtimeLabel = formatRuntimeSegment(
 					theme,
 					state.runtime,
@@ -208,7 +179,7 @@ export function installFooter(
 					colorSource,
 				);
 
-				const left = [cwdLabel, branchLabel, runtimeLabel].filter(Boolean).join(" ");
+				const left = [cwdLabel, gitLabel, runtimeLabel].filter(Boolean).join(" ");
 				const right = [
 					renderStyleForSource(theme, colorSource, contextColor, state.contextLabel),
 					renderStyleForSource(theme, colorSource, config.colors.tokens, state.tokenLabel),

--- a/extensions/zentui/git-module-config.ts
+++ b/extensions/zentui/git-module-config.ts
@@ -1,0 +1,70 @@
+export type GitBranchModuleConfig = {
+	enable: boolean;
+	truncation_length: number;
+	truncation_symbol: string;
+};
+
+export type GitStatusModuleConfig = {
+	enable: boolean;
+};
+
+export const DEFAULT_GIT_BRANCH_TRUNCATION_LENGTH = Number.MAX_SAFE_INTEGER;
+
+export const defaultGitBranchModuleConfig: GitBranchModuleConfig = {
+	enable: true,
+	truncation_length: DEFAULT_GIT_BRANCH_TRUNCATION_LENGTH,
+	truncation_symbol: "…",
+};
+
+export const defaultGitStatusModuleConfig: GitStatusModuleConfig = {
+	enable: true,
+};
+
+type ConfigRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is ConfigRecord {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function booleanValue(record: ConfigRecord, key: string, fallback: boolean): boolean {
+	const value = record[key];
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function stringValue(record: ConfigRecord, key: string, fallback: string): string {
+	const value = record[key];
+	return typeof value === "string" ? value : fallback;
+}
+
+function truncationLengthValue(record: ConfigRecord): number {
+	const value = record.truncation_length;
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return defaultGitBranchModuleConfig.truncation_length;
+	}
+
+	const length = Math.round(value);
+	if (length < 0) return defaultGitBranchModuleConfig.truncation_length;
+	return Math.min(length, DEFAULT_GIT_BRANCH_TRUNCATION_LENGTH);
+}
+
+export function normalizeGitBranchModuleConfig(value: unknown): GitBranchModuleConfig {
+	if (!isRecord(value)) return { ...defaultGitBranchModuleConfig };
+
+	return {
+		enable: booleanValue(value, "enable", defaultGitBranchModuleConfig.enable),
+		truncation_length: truncationLengthValue(value),
+		truncation_symbol: stringValue(
+			value,
+			"truncation_symbol",
+			defaultGitBranchModuleConfig.truncation_symbol,
+		),
+	};
+}
+
+export function normalizeGitStatusModuleConfig(value: unknown): GitStatusModuleConfig {
+	if (!isRecord(value)) return { ...defaultGitStatusModuleConfig };
+
+	return {
+		enable: booleanValue(value, "enable", defaultGitStatusModuleConfig.enable),
+	};
+}

--- a/extensions/zentui/git-modules.ts
+++ b/extensions/zentui/git-modules.ts
@@ -1,0 +1,120 @@
+import { visibleWidth } from "@earendil-works/pi-tui";
+import type { ColorSource, PolishedTuiConfig } from "./config";
+import type { GitStatusSummary } from "./git";
+import { type ThemeLike, renderStyleForSource } from "./style";
+
+type SegmenterSegment = { segment: string };
+
+type GraphemeSegmenter = {
+	segment(text: string): Iterable<SegmenterSegment>;
+};
+
+const Segmenter = (
+	Intl as unknown as {
+		Segmenter?: new (
+			locale: string | undefined,
+			options: { granularity: "grapheme" },
+		) => GraphemeSegmenter;
+	}
+).Segmenter;
+
+function splitGraphemes(text: string): string[] {
+	if (!Segmenter) return Array.from(text);
+	return Array.from(
+		new Segmenter(undefined, { granularity: "grapheme" }).segment(text),
+		(segment) => segment.segment,
+	);
+}
+
+function truncatePlainTextToWidth(text: string, maxWidth: number): string {
+	if (maxWidth <= 0) return "";
+
+	let result = "";
+	let width = 0;
+	for (const segment of splitGraphemes(text)) {
+		const segmentWidth = visibleWidth(segment);
+		if (width + segmentWidth > maxWidth) break;
+		result += segment;
+		width += segmentWidth;
+	}
+	return result;
+}
+
+export function truncateGitBranch(branch: string, config: PolishedTuiConfig["gitBranch"]): string {
+	const maxBranchWidth = config.truncation_length;
+	if (visibleWidth(branch) <= maxBranchWidth) return branch;
+
+	const kept = truncatePlainTextToWidth(branch, maxBranchWidth);
+	return `${kept}${config.truncation_symbol}`;
+}
+
+export function renderGitBranchModule(
+	theme: ThemeLike,
+	colorSource: ColorSource,
+	config: PolishedTuiConfig,
+	branch: string | undefined,
+): string {
+	if (!config.gitBranch.enable || !branch) return "";
+
+	const branchText = truncateGitBranch(branch, config.gitBranch);
+	if (!branchText) return "";
+
+	const gitColor = (text: string) =>
+		renderStyleForSource(theme, colorSource, config.colors.gitBranch, text);
+	const gitIcon = config.icons.git ? gitColor(config.icons.git) : "";
+	return ["on", gitIcon, gitColor(branchText)].filter(Boolean).join(" ");
+}
+
+export function formatGitStatusText(
+	state: GitStatusSummary,
+	icons: PolishedTuiConfig["icons"],
+): string {
+	const allStatus = [
+		state.conflicted > 0 ? icons.conflicted : "",
+		state.stashed ? icons.stashed : "",
+		state.deleted > 0 ? icons.deleted : "",
+		state.renamed > 0 ? icons.renamed : "",
+		state.modified > 0 ? icons.modified : "",
+		state.typechanged > 0 ? icons.typechanged : "",
+		state.staged > 0 ? icons.staged : "",
+		state.untracked > 0 ? icons.untracked : "",
+	].join("");
+	const aheadBehind =
+		state.ahead > 0 && state.behind > 0
+			? icons.diverged
+			: state.ahead > 0
+				? icons.ahead
+				: state.behind > 0
+					? icons.behind
+					: "";
+
+	return `${allStatus}${aheadBehind}`;
+}
+
+export function renderGitStatusModule(
+	theme: ThemeLike,
+	colorSource: ColorSource,
+	config: PolishedTuiConfig,
+	state: GitStatusSummary,
+): string {
+	if (!config.gitStatus.enable) return "";
+
+	const statusText = formatGitStatusText(state, config.icons);
+	return statusText
+		? renderStyleForSource(theme, colorSource, config.colors.gitStatus, `[${statusText}]`)
+		: "";
+}
+
+export function renderGitModules(
+	theme: ThemeLike,
+	colorSource: ColorSource,
+	config: PolishedTuiConfig,
+	state: GitStatusSummary,
+): string {
+	return [
+		renderGitBranchModule(theme, colorSource, config, state.branch),
+		renderGitStatusModule(theme, colorSource, config, state),
+	]
+		.filter(Boolean)
+		.join(" ");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.1.12",
+			"version": "0.1.13",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.1.12",
+	"version": "0.1.13",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",
@@ -12,8 +12,16 @@
 	"bugs": {
 		"url": "https://github.com/lmilojevicc/pi-zentui/issues"
 	},
-	"keywords": ["pi-package", "pi-extension", "pi-theme", "starship", "tui"],
-	"files": ["extensions"],
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-theme",
+		"starship",
+		"tui"
+	],
+	"files": [
+		"extensions"
+	],
 	"scripts": {
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit",
@@ -32,7 +40,9 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"pi": {
-		"extensions": ["./extensions"],
+		"extensions": [
+			"./extensions"
+		],
 		"image": "https://raw.githubusercontent.com/lmilojevicc/pi-zentui/main/assets/zentui.png"
 	},
 	"publishConfig": {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,6 +20,12 @@ describe("mergeConfig", () => {
 	it("defaults project refresh polling to 30 seconds and Starship styles", () => {
 		const config = mergeConfig({});
 		expect(config.projectRefreshIntervalMs).toBe(30_000);
+		expect(config.gitBranch).toEqual({
+			enable: true,
+			truncation_length: Number.MAX_SAFE_INTEGER,
+			truncation_symbol: "…",
+		});
+		expect(config.gitStatus).toEqual({ enable: true });
 		expect(config.colors.gitBranch).toBe("bold purple");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
@@ -40,6 +46,52 @@ describe("mergeConfig", () => {
 	it("accepts custom project refresh intervals and 0 to disable polling", () => {
 		expect(mergeConfig({ projectRefreshIntervalMs: 60_000 }).projectRefreshIntervalMs).toBe(60_000);
 		expect(mergeConfig({ projectRefreshIntervalMs: 0 }).projectRefreshIntervalMs).toBe(0);
+	});
+
+	it("accepts git branch and git status module config", () => {
+		const config = mergeConfig({
+			gitBranch: {
+				enable: false,
+				truncation_length: 50,
+				truncation_symbol: "...",
+			},
+			gitStatus: { enable: false },
+		});
+
+		expect(config.gitBranch).toEqual({
+			enable: false,
+			truncation_length: 50,
+			truncation_symbol: "...",
+		});
+		expect(config.gitStatus).toEqual({ enable: false });
+	});
+
+	it("normalizes invalid git module config", () => {
+		expect(
+			mergeConfig({
+				gitBranch: {
+					enable: "false",
+					truncation_length: -1,
+					truncation_symbol: 42,
+				},
+				gitStatus: { enable: "no" },
+			}).gitBranch,
+		).toEqual({
+			enable: true,
+			truncation_length: Number.MAX_SAFE_INTEGER,
+			truncation_symbol: "…",
+		});
+		expect(mergeConfig({ gitStatus: { enable: "no" } }).gitStatus).toEqual({ enable: true });
+		expect(mergeConfig({ gitBranch: { truncation_length: 1.6 } }).gitBranch.truncation_length).toBe(
+			2,
+		);
+		expect(
+			mergeConfig({ gitBranch: { truncation_length: Number.MAX_SAFE_INTEGER * 2 } }).gitBranch
+				.truncation_length,
+		).toBe(Number.MAX_SAFE_INTEGER);
+		expect(mergeConfig({ gitBranch: { truncation_length: 0 } }).gitBranch.truncation_length).toBe(
+			0,
+		);
 	});
 
 	it("ignores invalid project refresh intervals", () => {

--- a/test/git-modules.test.ts
+++ b/test/git-modules.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type { PolishedTuiConfig } from "../extensions/zentui/config";
+import { defaultConfig } from "../extensions/zentui/config";
+import { emptyGitStatus } from "../extensions/zentui/git";
+import { renderGitModules, truncateGitBranch } from "../extensions/zentui/git-modules";
+import type { ThemeLike } from "../extensions/zentui/style";
+
+const theme: ThemeLike = {
+	fg(_color: string, text: string) {
+		return text;
+	},
+	bold(text: string) {
+		return text;
+	},
+};
+
+function configWithGitModules(
+	gitBranch: Partial<PolishedTuiConfig["gitBranch"]> = {},
+	gitStatus: Partial<PolishedTuiConfig["gitStatus"]> = {},
+): PolishedTuiConfig {
+	return {
+		...defaultConfig,
+		gitBranch: {
+			...defaultConfig.gitBranch,
+			...gitBranch,
+		},
+		gitStatus: {
+			...defaultConfig.gitStatus,
+			...gitStatus,
+		},
+	};
+}
+
+describe("git module rendering", () => {
+	it("leaves branch names untruncated by default", () => {
+		expect(truncateGitBranch("feature/very-long-branch", defaultConfig.gitBranch)).toBe(
+			"feature/very-long-branch",
+		);
+	});
+
+	it("truncates branch names by display width and appends the full truncation symbol", () => {
+		const config = configWithGitModules({ truncation_length: 4, truncation_symbol: "..." });
+
+		expect(truncateGitBranch("feature/foo", config.gitBranch)).toBe("feat...");
+	});
+
+	it("renders only the truncation symbol when truncation length is zero", () => {
+		const config = configWithGitModules({ truncation_length: 0 });
+
+		expect(truncateGitBranch("feature/foo", config.gitBranch)).toBe("…");
+	});
+
+	it("preserves the existing combined git output when both modules are enabled", () => {
+		const state = emptyGitStatus();
+		state.branch = "main";
+		state.modified = 1;
+
+		expect(renderGitModules(theme, "theme", defaultConfig, state)).toBe("on  main [!]");
+	});
+
+	it("renders git status independently when the branch module is disabled", () => {
+		const state = emptyGitStatus();
+		state.branch = "main";
+		state.modified = 1;
+		const config = configWithGitModules({ enable: false });
+
+		expect(renderGitModules(theme, "theme", config, state)).toBe("[!]");
+	});
+
+	it("renders the branch independently when the status module is disabled", () => {
+		const state = emptyGitStatus();
+		state.branch = "main";
+		state.modified = 1;
+		const config = configWithGitModules({}, { enable: false });
+
+		expect(renderGitModules(theme, "theme", config, state)).toBe("on  main");
+	});
+
+	it("suppresses an empty branch module when truncation leaves no branch text or marker", () => {
+		const state = emptyGitStatus();
+		state.branch = "main";
+		state.modified = 1;
+		const config = configWithGitModules({ truncation_length: 0, truncation_symbol: "" });
+
+		expect(renderGitModules(theme, "theme", config, state)).toBe("[!]");
+	});
+});


### PR DESCRIPTION
 # Summary

 Adds separate `gitBranch` and `gitStatus` footer modules.

 `gitBranch` now supports Starship-style branch truncation config:

 ```json
   {
     "gitBranch": {
       "enable": true,
       "truncation_length": 50,
       "truncation_symbol": "…"
     }
   }
 ```

 `gitStatus` can be toggled on its own:

 ```json
   {
     "gitStatus": {
       "enable": true
     }
   }
 ```

 The footer preserves the existing default output when both modules are enabled:

 ```text
   on  main [!]
 ```

 Users can now hide either module independently, shorten long branch names, and customize the truncation marker.

 # Changes

 - Added focused git module config normalization in `git-module-config.ts`.
 - Moved git branch and status rendering out of `footer.ts` into `git-modules.ts`.
 - Added display-width branch truncation with configurable marker support.
 - Added independent enable flags for branch and status modules.
 - Documented the new config shape in README.md.
 - Added tests for config parsing, truncation behavior, and independent module rendering.
 - Bumped package version to `0.1.13`.

 # Validation

 Ran:

 ```bash
   npm run fmt
   npm run verify
   npm run pack:check
 ```

Tested locally: 
<img width="450" height="421" alt="image" src="https://github.com/user-attachments/assets/724d673b-9252-4b7c-88ee-fb91239f5ef3" />

