### PR TITLE
fix: count usage across session trees

### DIFF
--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -11,9 +11,11 @@ export type UsageTotals = {
 };
 
 export function formatCount(value: number): string {
-	if (value < 1000) return `${value}`;
+	if (value < 1000) return value.toString();
 	if (value < 10_000) return `${(value / 1000).toFixed(1)}k`;
-	return `${Math.round(value / 1000)}k`;
+	if (value < 1_000_000) return `${Math.round(value / 1000)}k`;
+	if (value < 10_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+	return `${Math.round(value / 1_000_000)}M`;
 }
 
 export function formatProviderLabel(provider: string | undefined): string {
@@ -38,19 +40,23 @@ export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 	let output = 0;
 	let cost = 0;
 
-	for (const entry of ctx.sessionManager.getBranch()) {
+	const entries = ctx.sessionManager.getEntries?.() ?? ctx.sessionManager.getBranch();
+	for (const entry of entries) {
 		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
-		const message = entry.message as AssistantMessage;
-		input += message.usage?.input ?? 0;
-		output += message.usage?.output ?? 0;
-		cost += message.usage?.cost?.total ?? 0;
+		const usage = (entry.message as AssistantMessage).usage;
+		input += usage?.input ?? 0;
+		output += usage?.output ?? 0;
+		cost += usage?.cost?.total ?? 0;
 	}
 
 	return { input, output, cost };
 }
 
 export function buildTokenLabel(totals: UsageTotals): string {
-	return `↑${formatCount(totals.input)} ↓${formatCount(totals.output)}`;
+	const parts: string[] = [];
+	if (totals.input) parts.push(`↑${formatCount(totals.input)}`);
+	if (totals.output) parts.push(`↓${formatCount(totals.output)}`);
+	return parts.length > 0 ? parts.join(" ") : "↑0 ↓0";
 }
 
 export function buildCostLabel(totals: UsageTotals): string {

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -140,6 +140,13 @@ export default function (pi: ExtensionAPI) {
 		activeTheme = undefined;
 	};
 
+	const syncInteractiveState = (_event: unknown, ctx: ExtensionContext) => {
+		refreshInteractiveState(ctx);
+	};
+	const syncInteractiveAndProjectState = (_event: unknown, ctx: ExtensionContext) => {
+		refreshInteractiveState(ctx, true);
+	};
+
 	pi.on("session_start", async (_event, ctx) => {
 		installUi(ctx);
 	});
@@ -164,31 +171,12 @@ export default function (pi: ExtensionAPI) {
 		cleanupUi(ctx);
 	});
 
-	pi.on("agent_start", async (_event, ctx) => {
-		refreshInteractiveState(ctx);
-	});
-
-	pi.on("agent_end", async (_event, ctx) => {
-		refreshInteractiveState(ctx, true);
-	});
-
-	pi.on("model_select", async (_event, ctx) => {
-		refreshInteractiveState(ctx);
-	});
-
-	pi.on("thinking_level_select", async (_event, ctx) => {
-		refreshInteractiveState(ctx);
-	});
-
-	pi.on("message_end", async (_event, ctx) => {
-		refreshInteractiveState(ctx, true);
-	});
-
-	pi.on("tool_execution_end", async (_event, ctx) => {
-		refreshInteractiveState(ctx, true);
-	});
-
-	pi.on("session_compact", async (_event, ctx) => {
-		refreshInteractiveState(ctx, true);
-	});
+	pi.on("agent_start", syncInteractiveState);
+	pi.on("agent_end", syncInteractiveAndProjectState);
+	pi.on("model_select", syncInteractiveState);
+	pi.on("thinking_level_select", syncInteractiveState);
+	pi.on("message_end", syncInteractiveAndProjectState);
+	pi.on("tool_execution_end", syncInteractiveAndProjectState);
+	pi.on("session_compact", syncInteractiveAndProjectState);
+	pi.on("session_tree", syncInteractiveAndProjectState);
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildCostLabel,
+	buildTokenLabel,
+	formatCount,
+	getUsageTotals,
+} from "../extensions/zentui/format";
+
+function makeAssistantEntry(input: number, output: number, cost: number) {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			usage: {
+				input,
+				output,
+				cacheRead: 123,
+				cacheWrite: 456,
+				cost: { total: cost },
+			},
+		},
+	};
+}
+
+describe("usage formatting", () => {
+	it("formats large counts with compact M suffixes", () => {
+		expect(formatCount(999)).toBe("999");
+		expect(formatCount(1_500)).toBe("1.5k");
+		expect(formatCount(123_456)).toBe("123k");
+		expect(formatCount(3_100_000)).toBe("3.1M");
+		expect(formatCount(44_000_000)).toBe("44M");
+	});
+
+	it("uses all session entries for totals instead of only the active branch", () => {
+		const branchEntry = makeAssistantEntry(100, 10, 1);
+		const freshTreeEntry = makeAssistantEntry(2_000_000, 100_000, 25);
+		const ctx = {
+			sessionManager: {
+				getBranch: () => [branchEntry],
+				getEntries: () => [branchEntry, freshTreeEntry],
+			},
+		};
+
+		const totals = getUsageTotals(ctx as never);
+
+		expect(totals).toEqual({ input: 2_000_100, output: 100_010, cost: 26 });
+		expect(buildTokenLabel(totals)).toBe("↑2.0M ↓100k");
+		expect(buildCostLabel(totals)).toBe("$26.000");
+	});
+
+	it("keeps token and cost labels compact", () => {
+		const totals = { input: 3_100_000, output: 197_000, cost: 41.957 };
+		const tokenLabel = buildTokenLabel(totals);
+
+		expect(tokenLabel).toBe("↑3.1M ↓197k");
+		expect(tokenLabel).not.toContain("R");
+		expect(tokenLabel).not.toContain("W");
+		expect(buildCostLabel(totals)).toBe("$41.957");
+	});
+});


### PR DESCRIPTION
 Fixes the footer token and cost totals.

 Previously pi-zentui only counted usage from the active session branch. This missed usage from other session trees, so
 totals could be much lower than pi's default footer.

 This change counts usage from all session entries instead, matching the default footer behavior.

 Also:
 - updates large token formatting to use M values like 3.1M
 - refreshes the footer after session tree changes
 - adds tests for session-wide usage totals

 Tested with:
 - npm run verify
 - manual testing in pi