### PR TITLE
feat: show prompt cache hit rate in footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ Default config values — copy this and change any value you want:
 		"staged": "+",
 		"renamed": "»",
 		"deleted": "✘",
-		"typechanged": "T"
+		"typechanged": "T",
+		"cacheHit": "󰆼"
 	},
 	"colors": {
 		"cwd": "bold cyan",

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -38,6 +38,7 @@ export type PolishedTuiConfig = {
 		renamed: string;
 		deleted: string;
 		typechanged: string;
+		cacheHit: string;
 	};
 	colors: {
 		cwd: ColorSpec;
@@ -84,6 +85,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		renamed: "»",
 		deleted: "✘",
 		typechanged: "T",
+		cacheHit: "󰆼",
 	},
 	colors: {
 		cwd: "bold cyan",
@@ -123,6 +125,7 @@ const iconKeys = [
 	"renamed",
 	"deleted",
 	"typechanged",
+	"cacheHit",
 ] as const satisfies readonly (keyof PolishedTuiConfig["icons"])[];
 
 type ConfigRecord = Record<string, unknown>;

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -7,6 +7,9 @@ import { renderStyleForSource } from "./style";
 export type UsageTotals = {
 	input: number;
 	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	latestCacheHitRate?: number;
 	cost: number;
 };
 
@@ -35,27 +38,52 @@ export function formatProviderLabel(provider: string | undefined): string {
 	);
 }
 
+function calculateCacheHitRate(
+	input: number,
+	cacheRead: number,
+	cacheWrite: number,
+): number | undefined {
+	const promptTokens = input + cacheRead + cacheWrite;
+	return promptTokens > 0 ? (cacheRead / promptTokens) * 100 : undefined;
+}
+
 export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 	let input = 0;
 	let output = 0;
+	let cacheRead = 0;
+	let cacheWrite = 0;
+	let latestCacheHitRate: number | undefined;
 	let cost = 0;
 
 	const entries = ctx.sessionManager.getEntries?.() ?? ctx.sessionManager.getBranch();
 	for (const entry of entries) {
 		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
 		const usage = (entry.message as AssistantMessage).usage;
-		input += usage?.input ?? 0;
+		const entryInput = usage?.input ?? 0;
+		const entryCacheRead = usage?.cacheRead ?? 0;
+		const entryCacheWrite = usage?.cacheWrite ?? 0;
+
+		input += entryInput;
 		output += usage?.output ?? 0;
+		cacheRead += entryCacheRead;
+		cacheWrite += entryCacheWrite;
 		cost += usage?.cost?.total ?? 0;
+		latestCacheHitRate = calculateCacheHitRate(entryInput, entryCacheRead, entryCacheWrite);
 	}
 
-	return { input, output, cost };
+	return { input, output, cacheRead, cacheWrite, latestCacheHitRate, cost };
 }
 
-export function buildTokenLabel(totals: UsageTotals): string {
+export function buildTokenLabel(totals: UsageTotals, cacheHitIcon = "󰆼"): string {
 	const parts: string[] = [];
 	if (totals.input) parts.push(`↑${formatCount(totals.input)}`);
 	if (totals.output) parts.push(`↓${formatCount(totals.output)}`);
+
+	const hasCacheTokens = totals.cacheRead > 0 || totals.cacheWrite > 0;
+	if (hasCacheTokens && totals.latestCacheHitRate !== undefined) {
+		const cacheHitRate = `${totals.latestCacheHitRate.toFixed(1)}%`;
+		parts.push(cacheHitIcon ? `${cacheHitIcon} ${cacheHitRate}` : cacheHitRate);
+	}
 	return parts.length > 0 ? parts.join(" ") : "↑0 ↓0";
 }
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -40,6 +40,8 @@ export default function (pi: ExtensionAPI) {
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
 	const getThinkingLevel = () => pi.getThinkingLevel();
+	const syncFooterState = (ctx: ExtensionContext) =>
+		syncState(state, ctx, currentConfig.icons.cacheHit);
 
 	const refreshProjectState = async (ctx: ExtensionContext) => {
 		const [gitStatus, runtime] = await Promise.all([
@@ -69,7 +71,7 @@ export default function (pi: ExtensionAPI) {
 
 	const refreshInteractiveState = (ctx: ExtensionContext, project = false) => {
 		if (!ctx.hasUI) return;
-		syncState(state, ctx);
+		syncFooterState(ctx);
 		if (project) scheduleProjectRefresh(ctx);
 		refresh();
 	};
@@ -104,7 +106,7 @@ export default function (pi: ExtensionAPI) {
 		};
 		ensureConfigExists();
 		currentConfig = loadConfig();
-		syncState(state, ctx);
+		syncFooterState(ctx);
 		stopRefreshInterval();
 		stopRefreshInterval = () => {};
 		installFooter(ctx, state, getCurrentConfig, {

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -1,6 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
-	type UsageTotals,
 	buildContextLabel,
 	buildCostLabel,
 	buildTokenLabel,
@@ -31,11 +30,11 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 	};
 }
 
-export function syncState(state: FooterState, ctx: ExtensionContext): void {
+export function syncState(state: FooterState, ctx: ExtensionContext, cacheHitIcon: string): void {
 	const totals = getUsageTotals(ctx);
 	state.modelLabel = ctx.model?.id ?? "no-model";
 	state.providerLabel = formatProviderLabel(ctx.model?.provider);
 	state.contextLabel = buildContextLabel(ctx);
-	state.tokenLabel = buildTokenLabel(totals);
+	state.tokenLabel = buildTokenLabel(totals, cacheHitIcon);
 	state.costLabel = buildCostLabel(totals);
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -20,6 +20,7 @@ describe("mergeConfig", () => {
 	it("defaults project refresh polling to 30 seconds and Starship styles", () => {
 		const config = mergeConfig({});
 		expect(config.projectRefreshIntervalMs).toBe(30_000);
+		expect(config.icons.cacheHit).toBe("󰆼");
 		expect(config.colors.gitBranch).toBe("bold purple");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
@@ -145,6 +146,7 @@ describe("mergeConfig", () => {
 			icons: {
 				cwd: 42,
 				git: "git",
+				cacheHit: "CH",
 			},
 			colors: {
 				cwd: 123,
@@ -163,6 +165,7 @@ describe("mergeConfig", () => {
 		expect(config.projectRefreshIntervalMs).toBe(defaultConfig.projectRefreshIntervalMs);
 		expect(config.icons.cwd).toBe(defaultConfig.icons.cwd);
 		expect(config.icons.git).toBe("git");
+		expect(config.icons.cacheHit).toBe("CH");
 		expect(config.colors.cwd).toBe(defaultConfig.colors.cwd);
 		expect(config.colors.gitStatus).toBe(defaultConfig.colors.gitStatus);
 		expect(config.colors.separator).toBe("dimmed");

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -6,7 +6,15 @@ import {
 	getUsageTotals,
 } from "../extensions/zentui/format";
 
-function makeAssistantEntry(input: number, output: number, cost: number) {
+const cacheHitIcon = "󰆼";
+
+function makeAssistantEntry(
+	input: number,
+	output: number,
+	cost: number,
+	cacheRead = 0,
+	cacheWrite = 0,
+) {
 	return {
 		type: "message",
 		message: {
@@ -14,10 +22,19 @@ function makeAssistantEntry(input: number, output: number, cost: number) {
 			usage: {
 				input,
 				output,
-				cacheRead: 123,
-				cacheWrite: 456,
+				cacheRead,
+				cacheWrite,
 				cost: { total: cost },
 			},
+		},
+	};
+}
+
+function makeSessionContext(entries: unknown[], branch = entries) {
+	return {
+		sessionManager: {
+			getBranch: () => branch,
+			getEntries: () => entries,
 		},
 	};
 }
@@ -34,27 +51,73 @@ describe("usage formatting", () => {
 	it("uses all session entries for totals instead of only the active branch", () => {
 		const branchEntry = makeAssistantEntry(100, 10, 1);
 		const freshTreeEntry = makeAssistantEntry(2_000_000, 100_000, 25);
-		const ctx = {
-			sessionManager: {
-				getBranch: () => [branchEntry],
-				getEntries: () => [branchEntry, freshTreeEntry],
-			},
-		};
+		const ctx = makeSessionContext([branchEntry, freshTreeEntry], [branchEntry]);
 
 		const totals = getUsageTotals(ctx as never);
 
-		expect(totals).toEqual({ input: 2_000_100, output: 100_010, cost: 26 });
-		expect(buildTokenLabel(totals)).toBe("↑2.0M ↓100k");
+		expect(totals).toEqual({
+			input: 2_000_100,
+			output: 100_010,
+			cacheRead: 0,
+			cacheWrite: 0,
+			latestCacheHitRate: 0,
+			cost: 26,
+		});
+		expect(buildTokenLabel(totals, cacheHitIcon)).toBe("↑2.0M ↓100k");
 		expect(buildCostLabel(totals)).toBe("$26.000");
 	});
 
 	it("keeps token and cost labels compact", () => {
-		const totals = { input: 3_100_000, output: 197_000, cost: 41.957 };
-		const tokenLabel = buildTokenLabel(totals);
+		const totals = { input: 3_100_000, output: 197_000, cacheRead: 0, cacheWrite: 0, cost: 41.957 };
+		const tokenLabel = buildTokenLabel(totals, cacheHitIcon);
 
 		expect(tokenLabel).toBe("↑3.1M ↓197k");
 		expect(tokenLabel).not.toContain("R");
 		expect(tokenLabel).not.toContain("W");
 		expect(buildCostLabel(totals)).toBe("$41.957");
+	});
+
+	it("shows latest prompt cache hit rate icon without R/W totals", () => {
+		const totals = {
+			input: 100,
+			output: 10,
+			cacheRead: 800,
+			cacheWrite: 100,
+			latestCacheHitRate: 80,
+			cost: 1,
+		};
+		const tokenLabel = buildTokenLabel(totals, cacheHitIcon);
+
+		expect(tokenLabel).toBe("↑100 ↓10 󰆼 80.0%");
+		expect(tokenLabel).not.toContain("CH");
+		expect(tokenLabel).not.toContain("R");
+		expect(tokenLabel).not.toContain("W");
+	});
+
+	it("uses custom and empty cache hit icons", () => {
+		const totals = {
+			input: 100,
+			output: 10,
+			cacheRead: 800,
+			cacheWrite: 100,
+			latestCacheHitRate: 80,
+			cost: 1,
+		};
+
+		expect(buildTokenLabel(totals, "CH")).toBe("↑100 ↓10 CH 80.0%");
+		expect(buildTokenLabel(totals, "")).toBe("↑100 ↓10 80.0%");
+	});
+
+	it("uses the latest assistant message for prompt cache hit rate", () => {
+		const firstEntry = makeAssistantEntry(100, 10, 1, 900, 0);
+		const latestEntry = makeAssistantEntry(200, 20, 2, 300, 500);
+		const ctx = makeSessionContext([firstEntry, latestEntry], [firstEntry]);
+
+		const totals = getUsageTotals(ctx as never);
+
+		expect(totals.cacheRead).toBe(1200);
+		expect(totals.cacheWrite).toBe(500);
+		expect(totals.latestCacheHitRate).toBe(30);
+		expect(buildTokenLabel(totals, cacheHitIcon)).toBe("↑300 ↓30 󰆼 30.0%");
 	});
 });


### PR DESCRIPTION
Adds cache-hit visibility to the pi-zentui footer, following pi v0.79.0’s new footer feature.

The footer now shows the latest prompt cache hit rate,using the same calculation as pi’s built-in footer, displayed with a nerd font icon to better match the visual style.

Also adds tests for the new cache hit rate display.