### PR TITLE
feat: configure third-party status colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Default config values — copy this and change any value you want:
 	},
 	"extensionStatuses": {
 		"defaultPlacement": "right",
-		"placements": {}
+		"placements": {},
+		"colorModes": {}
 	}
 }
 ```

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -19,10 +19,14 @@ export type UiFeaturesConfig = {
 };
 
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
+export type ExtensionStatusColorMode = "zentui" | "original";
+
+const DEFAULT_EXTENSION_STATUS_COLOR_MODE: ExtensionStatusColorMode = "zentui";
 
 export type ExtensionStatusesConfig = {
 	defaultPlacement: ExtensionStatusPlacement;
 	placements: Record<string, ExtensionStatusPlacement>;
+	colorModes: Record<string, ExtensionStatusColorMode>;
 };
 
 const DEFAULT_PROJECT_REFRESH_INTERVAL_MS = 30_000;
@@ -123,6 +127,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	extensionStatuses: {
 		defaultPlacement: "right",
 		placements: {},
+		colorModes: {},
 	},
 };
 
@@ -251,6 +256,10 @@ export function isExtensionStatusPlacement(value: unknown): value is ExtensionSt
 	return value === "off" || value === "left" || value === "middle" || value === "right";
 }
 
+export function isExtensionStatusColorMode(value: unknown): value is ExtensionStatusColorMode {
+	return value === "zentui" || value === "original";
+}
+
 function normalizeExtensionStatuses(record: Record<string, unknown>): ExtensionStatusesConfig {
 	const defaultPlacement = isExtensionStatusPlacement(record.defaultPlacement)
 		? record.defaultPlacement
@@ -263,10 +272,19 @@ function normalizeExtensionStatuses(record: Record<string, unknown>): ExtensionS
 				),
 			)
 		: {};
+	const colorModes = isRecord(record.colorModes)
+		? Object.fromEntries(
+				Object.entries(record.colorModes).filter(
+					(entry): entry is [string, ExtensionStatusColorMode] =>
+						isExtensionStatusColorMode(entry[1]),
+				),
+			)
+		: {};
 
 	return {
 		defaultPlacement,
 		placements,
+		colorModes,
 	};
 }
 
@@ -345,6 +363,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		extensionStatuses: {
 			defaultPlacement: extensionStatuses.defaultPlacement,
 			placements: { ...extensionStatuses.placements },
+			colorModes: { ...extensionStatuses.colorModes },
 		},
 	};
 }
@@ -354,6 +373,13 @@ export function getExtensionStatusPlacement(
 	key: string,
 ): ExtensionStatusPlacement {
 	return config.extensionStatuses.placements[key] ?? config.extensionStatuses.defaultPlacement;
+}
+
+export function getExtensionStatusColorMode(
+	config: PolishedTuiConfig,
+	key: string,
+): ExtensionStatusColorMode {
+	return config.extensionStatuses.colorModes[key] ?? DEFAULT_EXTENSION_STATUS_COLOR_MODE;
 }
 
 export function loadConfig(): PolishedTuiConfig {
@@ -420,6 +446,34 @@ export function saveExtensionStatusPlacement(
 	record.extensionStatuses = {
 		...existingExtensionStatuses,
 		placements: existingPlacements,
+	};
+	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return mergeConfig(record);
+}
+
+export function saveExtensionStatusColorMode(
+	key: string,
+	colorMode: ExtensionStatusColorMode,
+	path = configPath,
+): PolishedTuiConfig {
+	const record = readConfigRecord(path);
+	const existingExtensionStatuses = isRecord(record.extensionStatuses)
+		? { ...(record.extensionStatuses as Record<string, unknown>) }
+		: {};
+	const existingColorModes = isRecord(existingExtensionStatuses.colorModes)
+		? { ...(existingExtensionStatuses.colorModes as Record<string, unknown>) }
+		: {};
+
+	Object.defineProperty(existingColorModes, key, {
+		value: colorMode,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
+
+	record.extensionStatuses = {
+		...existingExtensionStatuses,
+		colorModes: existingColorModes,
 	};
 	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 	return mergeConfig(record);

--- a/extensions/zentui/extension-status.ts
+++ b/extensions/zentui/extension-status.ts
@@ -1,11 +1,16 @@
 import { stripVTControlCharacters } from "node:util";
-import type { ExtensionStatusPlacement, PolishedTuiConfig } from "./config";
-import { getExtensionStatusPlacement } from "./config";
+import type {
+	ExtensionStatusColorMode,
+	ExtensionStatusPlacement,
+	PolishedTuiConfig,
+} from "./config";
+import { getExtensionStatusColorMode, getExtensionStatusPlacement } from "./config";
 
 export type ExtensionStatusSegment = {
 	key: string;
 	text: string;
 	placement: ExtensionStatusPlacement;
+	colorMode: ExtensionStatusColorMode;
 };
 
 export type ExtensionStatusSegmentsByPlacement = {
@@ -14,16 +19,42 @@ export type ExtensionStatusSegmentsByPlacement = {
 	right: ExtensionStatusSegment[];
 };
 
+const safeSgrPattern = /\x1b\[[0-9;:]*m/g;
+const sgrPlaceholderPattern = /__ZENTUI_SGR_(\d+)__/g;
+
 function compareKeys(a: ExtensionStatusSegment, b: ExtensionStatusSegment): number {
 	return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
 }
 
-export function sanitizeExtensionStatusText(value: string): string {
-	return stripVTControlCharacters(value)
+function normalizeStatusWhitespace(value: string): string {
+	return value
 		.replace(/[\r\n\t\f\v]+/g, " ")
 		.replace(/[\u0000-\u001f\u007f-\u009f]/g, "")
 		.replace(/\s+/g, " ")
 		.trim();
+}
+
+export function sanitizeExtensionStatusText(value: string): string {
+	return normalizeStatusWhitespace(stripVTControlCharacters(value));
+}
+
+function hasVisibleStatusText(value: string): boolean {
+	return sanitizeExtensionStatusText(value).length > 0;
+}
+
+export function sanitizeExtensionStatusOriginalText(value: string): string {
+	const safeSequences: string[] = [];
+	const protectedValue = value.replace(safeSgrPattern, (sequence) => {
+		const index = safeSequences.push(sequence) - 1;
+		return `__ZENTUI_SGR_${index}__`;
+	});
+	const cleaned = normalizeStatusWhitespace(stripVTControlCharacters(protectedValue));
+	const restored = cleaned.replace(sgrPlaceholderPattern, (_match, indexText: string) => {
+		const index = Number.parseInt(indexText, 10);
+		return safeSequences[index] ?? "";
+	});
+
+	return hasVisibleStatusText(restored) ? restored : "";
 }
 
 export function collectExtensionStatusSegments(
@@ -40,10 +71,14 @@ export function collectExtensionStatusSegments(
 		const placement = getExtensionStatusPlacement(config, key);
 		if (placement === "off") continue;
 
-		const text = sanitizeExtensionStatusText(value);
+		const colorMode = getExtensionStatusColorMode(config, key);
+		const text =
+			colorMode === "original"
+				? sanitizeExtensionStatusOriginalText(value)
+				: sanitizeExtensionStatusText(value);
 		if (!text) continue;
 
-		segments[placement].push({ key, text, placement });
+		segments[placement].push({ key, text, placement, colorMode });
 	}
 
 	segments.left.sort(compareKeys);

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
-import { collectExtensionStatusSegments } from "./extension-status";
+import { type ExtensionStatusSegment, collectExtensionStatusSegments } from "./extension-status";
 import { formatCwdLabel, formatRuntimeSegment } from "./format";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";
@@ -218,14 +218,16 @@ export function installFooter(
 					footerData.getExtensionStatuses(),
 					config,
 				);
-				const renderExtensionStatus = (text: string) =>
-					renderStyleForSource(theme, colorSource, config.colors.extensionStatus, text);
+				const renderExtensionStatus = (segment: ExtensionStatusSegment) =>
+					segment.colorMode === "original"
+						? segment.text
+						: renderStyleForSource(theme, colorSource, config.colors.extensionStatus, segment.text);
 				const content = composeFooterContent(
 					left,
 					right,
-					extensionStatuses.left.map((segment) => renderExtensionStatus(segment.text)),
-					extensionStatuses.middle.map((segment) => renderExtensionStatus(segment.text)),
-					extensionStatuses.right.map((segment) => renderExtensionStatus(segment.text)),
+					extensionStatuses.left.map(renderExtensionStatus),
+					extensionStatuses.middle.map(renderExtensionStatus),
+					extensionStatuses.right.map(renderExtensionStatus),
 					separator,
 					innerWidth,
 				);

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -7,12 +7,14 @@ import type {
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import {
 	type ColorSourcesConfig,
+	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type PolishedTuiConfig,
 	type UiFeaturesConfig,
 	ensureConfigExists,
 	loadConfig,
 	saveColorSourcesPatch,
+	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
 	saveUiFeaturesPatch,
 } from "./config";
@@ -344,6 +346,9 @@ export default function (pi: ExtensionAPI) {
 		},
 		setExtensionStatusPlacement(key: string, placement: ExtensionStatusPlacement) {
 			currentConfig = saveExtensionStatusPlacement(key, placement);
+		},
+		setExtensionStatusColorMode(key: string, colorMode: ExtensionStatusColorMode) {
+			currentConfig = saveExtensionStatusColorMode(key, colorMode);
 		},
 		requestRender() {
 			refresh();

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -10,10 +10,13 @@ import {
 import {
 	type ColorSource,
 	type ColorSourcesConfig,
+	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type PolishedTuiConfig,
 	type UiFeaturesConfig,
+	getExtensionStatusColorMode,
 	getExtensionStatusPlacement,
+	isExtensionStatusColorMode,
 	isExtensionStatusPlacement,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
@@ -26,6 +29,7 @@ const extensionStatusPlacementValues: ExtensionStatusPlacement[] = [
 	"middle",
 	"right",
 ];
+const extensionStatusColorModeValues: ExtensionStatusColorMode[] = ["zentui", "original"];
 type FeatureState = "enabled" | "disabled";
 
 const featureStateValues: FeatureState[] = ["enabled", "disabled"];
@@ -44,6 +48,7 @@ type SettingsCommandDeps = {
 	) => { applied: boolean; reason?: string };
 	getActiveExtensionStatuses: () => ReadonlyMap<string, string>;
 	setExtensionStatusPlacement: (key: string, placement: ExtensionStatusPlacement) => void;
+	setExtensionStatusColorMode: (key: string, colorMode: ExtensionStatusColorMode) => void;
 	requestRender: () => void;
 	settingsListTheme?: SettingsListTheme;
 };
@@ -93,6 +98,7 @@ const sectionLabels: Record<SettingsSection, string> = {
 };
 
 const thirdPartyStatusSettingPrefix = "thirdPartyStatus:";
+type ThirdPartyStatusSettingKind = "placement" | "colorMode";
 
 function isColorSource(value: string): value is ColorSource {
 	return value === "theme" || value === "terminal";
@@ -180,6 +186,24 @@ function argumentCompletions(prefix: string): AutocompleteItem[] | null {
 	return matches.length > 0 ? matches : null;
 }
 
+function thirdPartyStatusSettingId(key: string, kind: ThirdPartyStatusSettingKind): string {
+	return `${thirdPartyStatusSettingPrefix}${kind}:${key}`;
+}
+
+function thirdPartyStatusSettingFromId(
+	id: string,
+): { kind: ThirdPartyStatusSettingKind; key: string } | undefined {
+	if (!id.startsWith(thirdPartyStatusSettingPrefix)) return undefined;
+	const rest = id.slice(thirdPartyStatusSettingPrefix.length);
+	const separatorIndex = rest.indexOf(":");
+	if (separatorIndex < 0) return undefined;
+
+	const kind = rest.slice(0, separatorIndex);
+	if (kind !== "placement" && kind !== "colorMode") return undefined;
+
+	return { kind, key: rest.slice(separatorIndex + 1) };
+}
+
 function buildItems(
 	section: SettingsSection,
 	config: PolishedTuiConfig,
@@ -220,22 +244,26 @@ function buildItems(
 		];
 	}
 
-	return statuses.map(([key, value]) => {
+	return statuses.flatMap(([key, value]) => {
 		const sanitizedText = sanitizeExtensionStatusText(value);
-		return {
-			id: `${thirdPartyStatusSettingPrefix}${key}`,
-			label: key,
-			description: sanitizedText ? `Current status: ${sanitizedText}` : undefined,
-			currentValue: getExtensionStatusPlacement(config, key),
-			values: extensionStatusPlacementValues,
-		};
+		const description = sanitizedText ? `Current status: ${sanitizedText}` : undefined;
+		return [
+			{
+				id: thirdPartyStatusSettingId(key, "placement"),
+				label: `${key} placement`,
+				description,
+				currentValue: getExtensionStatusPlacement(config, key),
+				values: extensionStatusPlacementValues,
+			},
+			{
+				id: thirdPartyStatusSettingId(key, "colorMode"),
+				label: `${key} color`,
+				description,
+				currentValue: getExtensionStatusColorMode(config, key),
+				values: extensionStatusColorModeValues,
+			},
+		];
 	});
-}
-
-function thirdPartyStatusKeyFromSettingId(id: string): string | undefined {
-	return id.startsWith(thirdPartyStatusSettingPrefix)
-		? id.slice(thirdPartyStatusSettingPrefix.length)
-		: undefined;
 }
 
 function nextSection(section: SettingsSection): SettingsSection {
@@ -356,12 +384,33 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									return;
 								}
 
-								const thirdPartyStatusKey = thirdPartyStatusKeyFromSettingId(id);
-								if (thirdPartyStatusKey && isExtensionStatusPlacement(newValue)) {
-									deps.setExtensionStatusPlacement(thirdPartyStatusKey, newValue);
+								const thirdPartyStatusSetting = thirdPartyStatusSettingFromId(id);
+								if (
+									thirdPartyStatusSetting?.kind === "placement" &&
+									isExtensionStatusPlacement(newValue)
+								) {
+									deps.setExtensionStatusPlacement(thirdPartyStatusSetting.key, newValue);
 									settingsList.updateValue(id, newValue);
 									deps.requestRender();
-									ctx.ui.notify(`Third-party status ${thirdPartyStatusKey}: ${newValue}`, "info");
+									ctx.ui.notify(
+										`Third-party status ${thirdPartyStatusSetting.key} placement: ${newValue}`,
+										"info",
+									);
+									tui.requestRender();
+									return;
+								}
+
+								if (
+									thirdPartyStatusSetting?.kind === "colorMode" &&
+									isExtensionStatusColorMode(newValue)
+								) {
+									deps.setExtensionStatusColorMode(thirdPartyStatusSetting.key, newValue);
+									settingsList.updateValue(id, newValue);
+									deps.requestRender();
+									ctx.ui.notify(
+										`Third-party status ${thirdPartyStatusSetting.key} color: ${newValue}`,
+										"info",
+									);
 									tui.requestRender();
 								}
 							} catch (error) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -6,6 +6,7 @@ import {
 	defaultConfig,
 	mergeConfig,
 	saveColorSourcesPatch,
+	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
 	saveUiFeaturesPatch,
 } from "../extensions/zentui/config";
@@ -43,6 +44,7 @@ describe("mergeConfig", () => {
 		expect(config.extensionStatuses).toEqual({
 			defaultPlacement: "right",
 			placements: {},
+			colorModes: {},
 		});
 	});
 
@@ -76,7 +78,7 @@ describe("mergeConfig", () => {
 		);
 	});
 
-	it("accepts extension status placement config", () => {
+	it("accepts extension status placement and color mode config", () => {
 		const config = mergeConfig({
 			extensionStatuses: {
 				defaultPlacement: "middle",
@@ -84,6 +86,10 @@ describe("mergeConfig", () => {
 					alpha: "left",
 					beta: "off",
 					gamma: "right",
+				},
+				colorModes: {
+					alpha: "original",
+					beta: "zentui",
 				},
 			},
 		});
@@ -94,6 +100,10 @@ describe("mergeConfig", () => {
 				alpha: "left",
 				beta: "off",
 				gamma: "right",
+			},
+			colorModes: {
+				alpha: "original",
+				beta: "zentui",
 			},
 		});
 	});
@@ -108,15 +118,22 @@ describe("mergeConfig", () => {
 						beta: "center",
 						gamma: 1,
 					},
+					colorModes: {
+						alpha: "original",
+						beta: "muted",
+						gamma: 1,
+					},
 				},
 			}).extensionStatuses,
 		).toEqual({
 			defaultPlacement: "right",
 			placements: { alpha: "left" },
+			colorModes: { alpha: "original" },
 		});
 		expect(mergeConfig({ extensionStatuses: { placements: "none" } }).extensionStatuses).toEqual({
 			defaultPlacement: "right",
 			placements: {},
+			colorModes: {},
 		});
 	});
 
@@ -395,6 +412,79 @@ describe("mergeConfig", () => {
 		}
 	});
 
+	it("saves extension status color mode when creating zentui.json", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			const config = saveExtensionStatusColorMode("plugin.key", "original", path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(config.extensionStatuses.colorModes).toEqual({ "plugin.key": "original" });
+			expect(raw).toEqual({
+				extensionStatuses: {
+					colorModes: {
+						"plugin.key": "original",
+					},
+				},
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("saves extension status color mode without erasing placement config", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(
+				path,
+				`${JSON.stringify(
+					{
+						unknown: true,
+						colors: { futureKey: "future" },
+						extensionStatuses: {
+							defaultPlacement: "left",
+							futureKey: "future",
+							placements: {
+								alpha: "right",
+								invalid: "center",
+							},
+							colorModes: {
+								alpha: "zentui",
+								invalid: "muted",
+							},
+						},
+					},
+					null,
+					2,
+				)}\n`,
+			);
+
+			const config = saveExtensionStatusColorMode("beta", "original", path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(config.extensionStatuses).toEqual({
+				defaultPlacement: "left",
+				placements: { alpha: "right" },
+				colorModes: { alpha: "zentui", beta: "original" },
+			});
+			expect(raw.unknown).toBe(true);
+			expect(raw.colors.futureKey).toBe("future");
+			expect(raw.extensionStatuses.futureKey).toBe("future");
+			expect(raw.extensionStatuses.placements).toEqual({
+				alpha: "right",
+				invalid: "center",
+			});
+			expect(raw.extensionStatuses.colorModes).toEqual({
+				alpha: "zentui",
+				invalid: "muted",
+				beta: "original",
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("saves extension status placement without erasing unknown user config", () => {
 		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
 		const path = join(dir, "zentui.json");
@@ -425,6 +515,7 @@ describe("mergeConfig", () => {
 			expect(config.extensionStatuses).toEqual({
 				defaultPlacement: "left",
 				placements: { alpha: "right", beta: "off" },
+				colorModes: {},
 			});
 			expect(raw.unknown).toBe(true);
 			expect(raw.colors.futureKey).toBe("future");

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1387,6 +1387,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 			},
 		);
@@ -1423,6 +1424,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 			},
 		);
@@ -1462,6 +1464,7 @@ describe("Pi docs compliance", () => {
 				},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {
 					renderRequests += 1;
 				},
@@ -1501,6 +1504,7 @@ describe("Pi docs compliance", () => {
 				},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 			},
 		);
@@ -1530,6 +1534,7 @@ describe("Pi docs compliance", () => {
 				},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 			},
 		);
@@ -1567,6 +1572,7 @@ describe("Pi docs compliance", () => {
 				}),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 			},
 		);
@@ -1611,6 +1617,7 @@ describe("Pi docs compliance", () => {
 					},
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
+					setExtensionStatusColorMode() {},
 					requestRender() {},
 					settingsListTheme: {
 						label: (text) => text,
@@ -1667,6 +1674,7 @@ describe("Pi docs compliance", () => {
 					setUiFeatures: () => ({ applied: true }),
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
+					setExtensionStatusColorMode() {},
 					requestRender() {},
 					settingsListTheme: {
 						label: (text) => text,
@@ -1730,6 +1738,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 				settingsListTheme: {
 					label: (text) => text,
@@ -1780,6 +1789,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {
 					dependencyRenderRequests += 1;
 				},
@@ -1843,6 +1853,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 				settingsListTheme: {
 					label: (text) => text,
@@ -1897,6 +1908,7 @@ describe("Pi docs compliance", () => {
 						["beta", "B"],
 					]),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 				settingsListTheme: {
 					label: (text) => text,
@@ -1951,6 +1963,7 @@ describe("Pi docs compliance", () => {
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
 				},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 				settingsListTheme: {
 					label: (text) => text,
@@ -2006,6 +2019,7 @@ describe("Pi docs compliance", () => {
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
 				},
+				setExtensionStatusColorMode() {},
 				requestRender() {
 					dependencyRenderRequests += 1;
 				},
@@ -2067,6 +2081,7 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				getActiveExtensionStatuses: () => new Map<string, string>([["active", "ok"]]),
 				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
 				requestRender() {},
 				settingsListTheme: {
 					label: (text) => text,

--- a/test/extension-status.test.ts
+++ b/test/extension-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { type PolishedTuiConfig, defaultConfig } from "../extensions/zentui/config";
 import {
 	collectExtensionStatusSegments,
+	sanitizeExtensionStatusOriginalText,
 	sanitizeExtensionStatusText,
 } from "../extensions/zentui/extension-status";
 
@@ -17,6 +18,10 @@ function configWithExtensionStatuses(
 				...defaultConfig.extensionStatuses.placements,
 				...(extensionStatuses.placements ?? {}),
 			},
+			colorModes: {
+				...defaultConfig.extensionStatuses.colorModes,
+				...(extensionStatuses.colorModes ?? {}),
+			},
 		},
 	};
 }
@@ -30,6 +35,24 @@ describe("sanitizeExtensionStatusText", () => {
 
 	it("returns an empty string when no visible status remains", () => {
 		expect(sanitizeExtensionStatusText("\x1b[31m\x1b[0m\n\t")).toBe("");
+	});
+});
+
+describe("sanitizeExtensionStatusOriginalText", () => {
+	it("preserves SGR color while stripping unsafe control sequences", () => {
+		expect(sanitizeExtensionStatusOriginalText("\x1b[31mred\x1b[0m\nnext\tline")).toBe(
+			"\x1b[31mred\x1b[0m next line",
+		);
+		expect(sanitizeExtensionStatusOriginalText("\x1b]133;A\x07prompt\x1b]133;B\x07")).toBe(
+			"prompt",
+		);
+		expect(sanitizeExtensionStatusOriginalText("\x1b[32mok\x1b[0m\x1b[2K")).toBe(
+			"\x1b[32mok\x1b[0m",
+		);
+	});
+
+	it("returns an empty string when no visible original status remains", () => {
+		expect(sanitizeExtensionStatusOriginalText("\x1b[31m\x1b[0m\n\t")).toBe("");
 	});
 });
 
@@ -75,5 +98,26 @@ describe("collectExtensionStatusSegments", () => {
 
 		expect(segments.left.map((segment) => segment.key)).toEqual(["alpha", "zeta"]);
 		expect(segments.left.map((segment) => segment.text)).toEqual(["a", "z"]);
+	});
+
+	it("keeps original ANSI color only for statuses configured as original", () => {
+		const config = configWithExtensionStatuses({
+			colorModes: {
+				alpha: "original",
+				beta: "zentui",
+			},
+		});
+		const segments = collectExtensionStatusSegments(
+			new Map([
+				["alpha", "\x1b[31mred\x1b[0m"],
+				["beta", "\x1b[32mgreen\x1b[0m"],
+			]),
+			config,
+		);
+
+		expect(segments.right).toEqual([
+			{ key: "alpha", text: "\x1b[31mred\x1b[0m", placement: "right", colorMode: "original" },
+			{ key: "beta", text: "green", placement: "right", colorMode: "zentui" },
+		]);
 	});
 });


### PR DESCRIPTION
Adds configurable color handling for third-party footer statuses.

By default zentui keeps using its unified extensionStatus color. Users can now choose original color mode per third-party status to preserve ANSI styling provided by the extension.

Also updates the /zentui settings UI, config handling, README sample, and tests.