### PR TITLE
feat: footer segment toggles and /zentui tab split

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu is split into four sections. Use `Tab` to switch between `Coloring`, `Features`, `Built-in segments`, and `Extension segments`.
+The interactive `/zentui` menu is split into four sections. Use `Tab` and `Shift+Tab` to switch between `Coloring`, `Features`, `Built-in segments`, and `Extension segments`.
 
 Useful slash-command shortcuts:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Zentui brings two popular aesthetics to Pi:
 - `[!?↑]` — git status indicators (modified, untracked, ahead/behind, stashed, etc.)
 - `via  v5.5.0` — runtime detection with version and Starship-style Nerd Font runtime/language modules
 - Right side shows context usage, token counts, and cost
+- Built-in footer segments can be shown or hidden individually from `/zentui`
 - Third-party Pi extension statuses from `ctx.ui.setStatus()` can be shown on the left,
   middle, or right side, or hidden per status key from `/zentui`
 
@@ -124,9 +125,9 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 ## Config
 
-User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, and active third-party status placements.
+User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu is split into three sections. Use `Tab` to switch between `Coloring`, `Features`, and `Status line`.
+The interactive `/zentui` menu is split into four sections. Use `Tab` to switch between `Coloring`, `Features`, `Built-in segments`, and `Extension segments`.
 
 Useful slash-command shortcuts:
 
@@ -198,6 +199,15 @@ Default config values — copy this and change any value you want:
 		"statusLine": true,
 		"copyFriendly": false
 	},
+	"footerSegments": {
+		"cwd": true,
+		"gitBranch": true,
+		"gitStatus": true,
+		"runtime": true,
+		"context": true,
+		"tokens": true,
+		"cost": true
+	},
 	"extensionStatuses": {
 		"defaultPlacement": "right",
 		"placements": {},
@@ -211,7 +221,8 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
-- `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. `/zentui` lists only statuses that are currently active.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `runtime`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
+- `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The `Extension segments` tab in `/zentui` lists only statuses that are currently active.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
 - `editorPrompt` styles the copy-friendly editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -18,6 +18,16 @@ export type UiFeaturesConfig = {
 	copyFriendly: boolean;
 };
 
+export type FooterSegmentsConfig = {
+	cwd: boolean;
+	gitBranch: boolean;
+	gitStatus: boolean;
+	runtime: boolean;
+	context: boolean;
+	tokens: boolean;
+	cost: boolean;
+};
+
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
 export type ExtensionStatusColorMode = "zentui" | "original";
 
@@ -77,6 +87,7 @@ export type PolishedTuiConfig = {
 	};
 	colorSources: ColorSourcesConfig;
 	features: UiFeaturesConfig;
+	footerSegments: FooterSegmentsConfig;
 	extensionStatuses: ExtensionStatusesConfig;
 };
 
@@ -123,6 +134,15 @@ export const defaultConfig: PolishedTuiConfig = {
 		editor: true,
 		statusLine: true,
 		copyFriendly: false,
+	},
+	footerSegments: {
+		cwd: true,
+		gitBranch: true,
+		gitStatus: true,
+		runtime: true,
+		context: true,
+		tokens: true,
+		cost: true,
 	},
 	extensionStatuses: {
 		defaultPlacement: "right",
@@ -190,6 +210,14 @@ function booleanValue(record: Record<string, unknown>, key: keyof UiFeaturesConf
 	return typeof value === "boolean" ? value : defaultConfig.features[key];
 }
 
+function footerSegmentValue(
+	record: Record<string, unknown>,
+	key: keyof FooterSegmentsConfig,
+): boolean {
+	const value = record[key];
+	return typeof value === "boolean" ? value : defaultConfig.footerSegments[key];
+}
+
 function definedColors(
 	colors: Partial<Record<keyof PolishedTuiConfig["colors"], string | undefined>>,
 ): Partial<PolishedTuiConfig["colors"]> {
@@ -252,6 +280,18 @@ function normalizeUiFeatures(record: Record<string, unknown>): UiFeaturesConfig 
 	};
 }
 
+function normalizeFooterSegments(record: Record<string, unknown>): FooterSegmentsConfig {
+	return {
+		cwd: footerSegmentValue(record, "cwd"),
+		gitBranch: footerSegmentValue(record, "gitBranch"),
+		gitStatus: footerSegmentValue(record, "gitStatus"),
+		runtime: footerSegmentValue(record, "runtime"),
+		context: footerSegmentValue(record, "context"),
+		tokens: footerSegmentValue(record, "tokens"),
+		cost: footerSegmentValue(record, "cost"),
+	};
+}
+
 export function isExtensionStatusPlacement(value: unknown): value is ExtensionStatusPlacement {
 	return value === "off" || value === "left" || value === "middle" || value === "right";
 }
@@ -296,6 +336,18 @@ function isUiFeatureKey(value: string): value is keyof UiFeaturesConfig {
 	return value === "editor" || value === "statusLine" || value === "copyFriendly";
 }
 
+function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig {
+	return (
+		value === "cwd" ||
+		value === "gitBranch" ||
+		value === "gitStatus" ||
+		value === "runtime" ||
+		value === "context" ||
+		value === "tokens" ||
+		value === "cost"
+	);
+}
+
 function validColorSourceEntries(record: Record<string, unknown>): Partial<ColorSourcesConfig> {
 	return Object.fromEntries(
 		Object.entries(record).filter((entry): entry is [keyof ColorSourcesConfig, ColorSource] => {
@@ -312,6 +364,15 @@ function validUiFeatureEntries(record: Record<string, unknown>): Partial<UiFeatu
 			return isUiFeatureKey(key) && typeof value === "boolean";
 		}),
 	) as Partial<UiFeaturesConfig>;
+}
+
+function validFooterSegmentEntries(record: Record<string, unknown>): Partial<FooterSegmentsConfig> {
+	return Object.fromEntries(
+		Object.entries(record).filter((entry): entry is [keyof FooterSegmentsConfig, boolean] => {
+			const [key, value] = entry;
+			return isFooterSegmentKey(key) && typeof value === "boolean";
+		}),
+	) as Partial<FooterSegmentsConfig>;
 }
 
 function readConfigRecord(path = configPath): ConfigRecord {
@@ -345,6 +406,9 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const features = isRecord(config.features)
 		? normalizeUiFeatures(config.features as Record<string, unknown>)
 		: defaultConfig.features;
+	const footerSegments = isRecord(config.footerSegments)
+		? normalizeFooterSegments(config.footerSegments as Record<string, unknown>)
+		: defaultConfig.footerSegments;
 	const extensionStatuses = isRecord(config.extensionStatuses)
 		? normalizeExtensionStatuses(config.extensionStatuses as Record<string, unknown>)
 		: defaultConfig.extensionStatuses;
@@ -360,6 +424,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		},
 		colorSources: { ...colorSources },
 		features: { ...features },
+		footerSegments: { ...footerSegments },
 		extensionStatuses: {
 			defaultPlacement: extensionStatuses.defaultPlacement,
 			placements: { ...extensionStatuses.placements },
@@ -418,6 +483,22 @@ export function saveUiFeaturesPatch(
 	record.features = {
 		...existing,
 		...validUiFeatureEntries(patch),
+	};
+	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return mergeConfig(record);
+}
+
+export function saveFooterSegmentsPatch(
+	patch: Partial<FooterSegmentsConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	const record = readConfigRecord(path);
+	const existing = isRecord(record.footerSegments)
+		? { ...(record.footerSegments as Record<string, unknown>) }
+		: {};
+	record.footerSegments = {
+		...existing,
+		...validFooterSegmentEntries(patch),
 	};
 	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 	return mergeConfig(record);

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -196,24 +196,32 @@ export function installFooter(
 								: "";
 				const statusBlock =
 					allStatus || aheadBehind ? gitStatusColor(`[${allStatus}${aheadBehind}]`) : "";
-				const branchLabel = branch
-					? [...["on", gitIcon, gitColor(branch)].filter(Boolean), statusBlock]
-							.filter(Boolean)
-							.join(" ")
+				const branchParts =
+					config.footerSegments.gitBranch && branch
+						? ["on", gitIcon, gitColor(branch)].filter(Boolean)
+						: [];
+				const gitStatusParts = config.footerSegments.gitStatus && statusBlock ? [statusBlock] : [];
+				const branchLabel = [...branchParts, ...gitStatusParts].filter(Boolean).join(" ");
+				const runtimeLabel = config.footerSegments.runtime
+					? formatRuntimeSegment(theme, state.runtime, config.colors.runtimePrefix, colorSource)
 					: "";
-				const runtimeLabel = formatRuntimeSegment(
-					theme,
-					state.runtime,
-					config.colors.runtimePrefix,
-					colorSource,
-				);
 
-				const left = [cwdLabel, branchLabel, runtimeLabel].filter(Boolean).join(" ");
+				const left = [config.footerSegments.cwd ? cwdLabel : "", branchLabel, runtimeLabel]
+					.filter(Boolean)
+					.join(" ");
 				const right = [
-					renderStyleForSource(theme, colorSource, contextColor, state.contextLabel),
-					renderStyleForSource(theme, colorSource, config.colors.tokens, state.tokenLabel),
-					renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel),
-				].join(separator);
+					config.footerSegments.context
+						? renderStyleForSource(theme, colorSource, contextColor, state.contextLabel)
+						: "",
+					config.footerSegments.tokens
+						? renderStyleForSource(theme, colorSource, config.colors.tokens, state.tokenLabel)
+						: "",
+					config.footerSegments.cost
+						? renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel)
+						: "",
+				]
+					.filter(Boolean)
+					.join(separator);
 				const extensionStatuses = collectExtensionStatusSegments(
 					footerData.getExtensionStatuses(),
 					config,

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -9,6 +9,7 @@ import {
 	type ColorSourcesConfig,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
+	type FooterSegmentsConfig,
 	type PolishedTuiConfig,
 	type UiFeaturesConfig,
 	ensureConfigExists,
@@ -16,6 +17,7 @@ import {
 	saveColorSourcesPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
+	saveFooterSegmentsPatch,
 	saveUiFeaturesPatch,
 } from "./config";
 import { installFooter } from "./footer";
@@ -340,6 +342,9 @@ export default function (pi: ExtensionAPI) {
 					? "another extension is currently managing the editor; reload Pi to apply this change"
 					: undefined,
 			};
+		},
+		setFooterSegments(patch: Partial<FooterSegmentsConfig>) {
+			currentConfig = saveFooterSegmentsPatch(patch);
 		},
 		getActiveExtensionStatuses() {
 			return getActiveExtensionStatuses();

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -2,9 +2,11 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import {
 	type AutocompleteItem,
+	Key,
 	type SettingItem,
 	SettingsList,
 	type SettingsListTheme,
+	matchesKey,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
 import {
@@ -334,6 +336,14 @@ function nextSection(section: SettingsSection): SettingsSection {
 	return settingsSections[(currentIndex + 1) % settingsSections.length] ?? "coloring";
 }
 
+function previousSection(section: SettingsSection): SettingsSection {
+	const currentIndex = settingsSections.indexOf(section);
+	return (
+		settingsSections[(currentIndex - 1 + settingsSections.length) % settingsSections.length] ??
+		"coloring"
+	);
+}
+
 function formatSectionTabs(
 	activeSection: SettingsSection,
 	theme: ExtensionContext["ui"]["theme"],
@@ -352,7 +362,7 @@ function withSectionFooter(lines: string[], theme: ExtensionContext["ui"]["theme
 			next[index] = safeThemeFg(
 				theme,
 				"muted",
-				"  Enter/Space to change · Tab to switch sections · Esc to close",
+				"  Enter/Space to change · Tab/Shift+Tab to switch sections · Esc to close",
 			);
 			break;
 		}
@@ -497,8 +507,9 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 						() => done(undefined),
 					);
 				settingsList = makeSettingsList();
-				const switchSection = () => {
-					activeSection = nextSection(activeSection);
+				const switchSection = (direction: "forward" | "backward") => {
+					activeSection =
+						direction === "forward" ? nextSection(activeSection) : previousSection(activeSection);
 					settingsList = makeSettingsList();
 					tui.requestRender();
 				};
@@ -526,8 +537,12 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 						settingsList.invalidate();
 					},
 					handleInput(data: string) {
-						if (data === "\t") {
-							switchSection();
+						if (matchesKey(data, Key.tab)) {
+							switchSection("forward");
+							return;
+						}
+						if (matchesKey(data, Key.shift("tab"))) {
+							switchSection("backward");
 							return;
 						}
 						settingsList.handleInput(data);

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -12,6 +12,7 @@ import {
 	type ColorSourcesConfig,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
+	type FooterSegmentsConfig,
 	type PolishedTuiConfig,
 	type UiFeaturesConfig,
 	getExtensionStatusColorMode,
@@ -33,10 +34,11 @@ const extensionStatusColorModeValues: ExtensionStatusColorMode[] = ["zentui", "o
 type FeatureState = "enabled" | "disabled";
 
 const featureStateValues: FeatureState[] = ["enabled", "disabled"];
-const settingsSections = ["coloring", "features", "statusLine"] as const;
+const settingsSections = ["coloring", "features", "builtinSegments", "extensionSegments"] as const;
 
 type ColorSettingId = "starship" | "editorMessages";
 type FeatureSettingId = keyof UiFeaturesConfig;
+type FooterSegmentSettingId = keyof FooterSegmentsConfig;
 type SettingsSection = (typeof settingsSections)[number];
 
 type SettingsCommandDeps = {
@@ -46,6 +48,7 @@ type SettingsCommandDeps = {
 		patch: Partial<UiFeaturesConfig>,
 		ctx: ExtensionContext,
 	) => { applied: boolean; reason?: string };
+	setFooterSegments: (patch: Partial<FooterSegmentsConfig>) => void;
 	getActiveExtensionStatuses: () => ReadonlyMap<string, string>;
 	setExtensionStatusPlacement: (key: string, placement: ExtensionStatusPlacement) => void;
 	setExtensionStatusColorMode: (key: string, colorMode: ExtensionStatusColorMode) => void;
@@ -79,6 +82,26 @@ const featureSettingDescriptions: Record<FeatureSettingId, string> = {
 		"Hide editor and previous-message rail glyphs for cleaner native terminal selection.",
 };
 
+const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
+	cwd: "Current directory",
+	gitBranch: "Git branch",
+	gitStatus: "Git status",
+	runtime: "Runtime",
+	context: "Context usage",
+	tokens: "Token counts",
+	cost: "Session cost",
+};
+
+const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
+	cwd: "Show or hide the current working directory segment on the left.",
+	gitBranch: "Show or hide the git branch name on the left.",
+	gitStatus: "Show or hide git status icons and ahead/behind markers.",
+	runtime: "Show or hide the detected runtime/language segment on the left.",
+	context: "Show or hide context usage on the right.",
+	tokens: "Show or hide input/output token counts on the right.",
+	cost: "Show or hide session cost on the right.",
+};
+
 const directCommandSuggestions = [
 	"editor enable",
 	"editor disable",
@@ -94,10 +117,12 @@ const directCommandSuggestions = [
 const sectionLabels: Record<SettingsSection, string> = {
 	coloring: "Coloring",
 	features: "Features",
-	statusLine: "Status line",
+	builtinSegments: "Built-in segments",
+	extensionSegments: "Extension segments",
 };
 
 const thirdPartyStatusSettingPrefix = "thirdPartyStatus:";
+const footerSegmentSettingPrefix = "footerSegment:";
 type ThirdPartyStatusSettingKind = "placement" | "colorMode";
 
 function isColorSource(value: string): value is ColorSource {
@@ -110,6 +135,18 @@ function isColorSettingId(value: string): value is ColorSettingId {
 
 function isFeatureSettingId(value: string): value is FeatureSettingId {
 	return value === "editor" || value === "statusLine" || value === "copyFriendly";
+}
+
+function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingId {
+	return (
+		value === "cwd" ||
+		value === "gitBranch" ||
+		value === "gitStatus" ||
+		value === "runtime" ||
+		value === "context" ||
+		value === "tokens" ||
+		value === "cost"
+	);
 }
 
 function isFeatureState(value: string): value is FeatureState {
@@ -132,6 +169,23 @@ function featureValue(enabled: boolean): FeatureState {
 
 function featurePatch(id: FeatureSettingId, value: FeatureState): Partial<UiFeaturesConfig> {
 	return { [id]: value === "enabled" } as Partial<UiFeaturesConfig>;
+}
+
+function footerSegmentSettingId(key: FooterSegmentSettingId): string {
+	return `${footerSegmentSettingPrefix}${key}`;
+}
+
+function footerSegmentSettingFromId(id: string): FooterSegmentSettingId | undefined {
+	if (!id.startsWith(footerSegmentSettingPrefix)) return undefined;
+	const key = id.slice(footerSegmentSettingPrefix.length);
+	return isFooterSegmentSettingId(key) ? key : undefined;
+}
+
+function footerSegmentPatch(
+	id: FooterSegmentSettingId,
+	value: FeatureState,
+): Partial<FooterSegmentsConfig> {
+	return { [id]: value === "enabled" } as Partial<FooterSegmentsConfig>;
 }
 
 function usageText(): string {
@@ -229,6 +283,16 @@ function buildItems(
 		}));
 	}
 
+	if (section === "builtinSegments") {
+		return (Object.keys(footerSegmentSettingLabels) as FooterSegmentSettingId[]).map((key) => ({
+			id: footerSegmentSettingId(key),
+			label: footerSegmentSettingLabels[key],
+			description: footerSegmentSettingDescriptions[key],
+			currentValue: featureValue(config.footerSegments[key]),
+			values: featureStateValues,
+		}));
+	}
+
 	const statuses = Array.from(activeStatuses.entries()).sort(([a], [b]) =>
 		a < b ? -1 : a > b ? 1 : 0,
 	);
@@ -237,8 +301,7 @@ function buildItems(
 			{
 				id: "noThirdPartyStatuses",
 				label: "No active statuses",
-				description:
-					"This section only lists statuses currently published through ctx.ui.setStatus().",
+				description: "This tab only lists statuses currently published through ctx.ui.setStatus().",
 				currentValue: "—",
 			},
 		];
@@ -381,6 +444,19 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									}
 
 									applyFeatureChange(id, newValue);
+									return;
+								}
+
+								const footerSegmentSetting = footerSegmentSettingFromId(id);
+								if (footerSegmentSetting && isFeatureState(newValue)) {
+									deps.setFooterSegments(footerSegmentPatch(footerSegmentSetting, newValue));
+									settingsList.updateValue(id, newValue);
+									deps.requestRender();
+									ctx.ui.notify(
+										`${footerSegmentSettingLabels[footerSegmentSetting]}: ${newValue}`,
+										"info",
+									);
+									tui.requestRender();
 									return;
 								}
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,6 +8,7 @@ import {
 	saveColorSourcesPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
+	saveFooterSegmentsPatch,
 	saveUiFeaturesPatch,
 } from "../extensions/zentui/config";
 import {
@@ -40,6 +41,15 @@ describe("mergeConfig", () => {
 			editor: true,
 			statusLine: true,
 			copyFriendly: false,
+		});
+		expect(config.footerSegments).toEqual({
+			cwd: true,
+			gitBranch: true,
+			gitStatus: true,
+			runtime: true,
+			context: true,
+			tokens: true,
+			cost: true,
 		});
 		expect(config.extensionStatuses).toEqual({
 			defaultPlacement: "right",
@@ -233,6 +243,30 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ features: { copyFriendly: "on" } }).features.copyFriendly).toBe(false);
 	});
 
+	it("accepts valid footer segment preferences and ignores invalid values", () => {
+		expect(mergeConfig({ footerSegments: { cwd: false, tokens: false } }).footerSegments).toEqual({
+			cwd: false,
+			gitBranch: true,
+			gitStatus: true,
+			runtime: true,
+			context: true,
+			tokens: false,
+			cost: true,
+		});
+		expect(
+			mergeConfig({ footerSegments: { cost: "off", gitBranch: false, gitStatus: false } })
+				.footerSegments,
+		).toEqual({
+			cwd: true,
+			gitBranch: false,
+			gitStatus: false,
+			runtime: true,
+			context: true,
+			tokens: true,
+			cost: true,
+		});
+	});
+
 	it("saves color source patches without erasing unknown user config", () => {
 		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
 		const path = join(dir, "zentui.json");
@@ -387,6 +421,71 @@ describe("mergeConfig", () => {
 				copyFriendly: false,
 			});
 			expect(raw).toEqual({ features: { editor: false } });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("saves footer segment patches without erasing unknown user config", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(
+				path,
+				`${JSON.stringify(
+					{
+						unknown: true,
+						footerSegments: {
+							cwd: true,
+							futureKey: "future",
+						},
+					},
+					null,
+					2,
+				)}\n`,
+			);
+
+			const config = saveFooterSegmentsPatch({ tokens: false, cost: false }, path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(config.footerSegments).toEqual({
+				cwd: true,
+				gitBranch: true,
+				gitStatus: true,
+				runtime: true,
+				context: true,
+				tokens: false,
+				cost: false,
+			});
+			expect(raw.unknown).toBe(true);
+			expect(raw.footerSegments).toEqual({
+				cwd: true,
+				futureKey: "future",
+				tokens: false,
+				cost: false,
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("writes only the requested footer segment setting when creating zentui.json", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			const config = saveFooterSegmentsPatch({ runtime: false }, path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(config.footerSegments).toEqual({
+				cwd: true,
+				gitBranch: true,
+				gitStatus: true,
+				runtime: false,
+				context: true,
+				tokens: true,
+				cost: true,
+			});
+			expect(raw).toEqual({ footerSegments: { runtime: false } });
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1851,7 +1851,7 @@ describe("Pi docs compliance", () => {
 		expect(themeLines.join("\n")).toContain("Features");
 		expect(themeLines.join("\n")).toContain("Built-in segments");
 		expect(themeLines.join("\n")).toContain("Extension segments");
-		expect(themeLines.join("\n")).toContain("Tab to switch sections");
+		expect(themeLines.join("\n")).toContain("Tab/Shift+Tab to switch sections");
 		expect(themeLines.at(-1)).toContain("[borderMuted]────");
 		expect(themeLines.every((line) => visibleWidth(stripTestTags(line)) <= settingsWidth)).toBe(
 			true,
@@ -2038,6 +2038,57 @@ describe("Pi docs compliance", () => {
 		component.handleInput?.("\t");
 		component.handleInput?.("\t");
 	}
+
+	it("cycles extension segments tabs backward with shift+tab", async () => {
+		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
+		let rendered = "";
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				getConfig: () => defaultConfig,
+				setColorSources() {},
+				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
+				getActiveExtensionStatuses: () => new Map<string, string>(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				requestRender() {},
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		await command?.handler("", {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: makeTaggedTheme(),
+				notify() {},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					const component = factory({ requestRender() {} }, makeTaggedTheme(), {}, () => {}) as {
+						render?: (width: number) => string[];
+						handleInput?: (data: string) => void;
+					};
+					navigateToExtensionSegmentsSection(component);
+					component.handleInput?.("\x1b[Z");
+					rendered = component.render?.(120).join("\n") ?? "";
+				},
+			},
+		});
+
+		expect(rendered).toContain("Current directory");
+		expect(rendered).not.toContain("No active statuses");
+	});
 
 	it("renders active third-party statuses in the extension segments tab", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1518,6 +1518,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1555,6 +1556,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1595,6 +1597,7 @@ describe("Pi docs compliance", () => {
 					featureChanges.push(patch);
 					return { applied: true };
 				},
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1635,6 +1638,7 @@ describe("Pi docs compliance", () => {
 					featureChanges.push(patch);
 					return { applied: true };
 				},
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1665,6 +1669,7 @@ describe("Pi docs compliance", () => {
 					featureChanges.push(patch);
 					return { applied: true };
 				},
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1703,6 +1708,7 @@ describe("Pi docs compliance", () => {
 					reason:
 						"another extension is currently managing the editor; reload Pi to apply this change",
 				}),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1748,6 +1754,7 @@ describe("Pi docs compliance", () => {
 						doneCallsAtFeatureChange.push(doneCalls);
 						return { applied: true };
 					},
+					setFooterSegments() {},
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
 					setExtensionStatusColorMode() {},
@@ -1790,7 +1797,7 @@ describe("Pi docs compliance", () => {
 	});
 
 	it("renders Zentui settings with mode-aware top and bottom borders", async () => {
-		const settingsWidth = 80;
+		const settingsWidth = 120;
 		async function renderSettings(config: PolishedTuiConfig) {
 			let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 			let lines: string[] = [];
@@ -1805,6 +1812,7 @@ describe("Pi docs compliance", () => {
 					getConfig: () => config,
 					setColorSources() {},
 					setUiFeatures: () => ({ applied: true }),
+					setFooterSegments() {},
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
 					setExtensionStatusColorMode() {},
@@ -1841,7 +1849,8 @@ describe("Pi docs compliance", () => {
 		expect(themeLines[0]).toContain("[borderMuted]────");
 		expect(themeLines.join("\n")).toContain("Coloring");
 		expect(themeLines.join("\n")).toContain("Features");
-		expect(themeLines.join("\n")).toContain("Status line");
+		expect(themeLines.join("\n")).toContain("Built-in segments");
+		expect(themeLines.join("\n")).toContain("Extension segments");
 		expect(themeLines.join("\n")).toContain("Tab to switch sections");
 		expect(themeLines.at(-1)).toContain("[borderMuted]────");
 		expect(themeLines.every((line) => visibleWidth(stripTestTags(line)) <= settingsWidth)).toBe(
@@ -1869,6 +1878,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1920,6 +1930,7 @@ describe("Pi docs compliance", () => {
 					changes.push(patch);
 				},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1984,6 +1995,7 @@ describe("Pi docs compliance", () => {
 					changes.push(patch);
 				},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -2021,7 +2033,13 @@ describe("Pi docs compliance", () => {
 		expect(changes).toEqual([{ editor: "theme", userMessages: "theme" }]);
 	});
 
-	it("renders active third-party status line statuses in their own section", async () => {
+	function navigateToExtensionSegmentsSection(component: { handleInput?: (data: string) => void }) {
+		component.handleInput?.("\t");
+		component.handleInput?.("\t");
+		component.handleInput?.("\t");
+	}
+
+	it("renders active third-party statuses in the extension segments tab", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 		let rendered = "";
 
@@ -2035,6 +2053,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () =>
 					new Map<string, string>([
 						["alpha", "A"],
@@ -2064,20 +2083,18 @@ describe("Pi docs compliance", () => {
 						render?: (width: number) => string[];
 						handleInput?: (data: string) => void;
 					};
-					component.handleInput?.("\t");
-					component.handleInput?.("\t");
+					navigateToExtensionSegmentsSection(component);
 					rendered = component.render?.(80).join("\n") ?? "";
 				},
 			},
 		});
 
-		expect(rendered).toContain("Status line");
 		expect(rendered).toContain("alpha");
 		expect(rendered).toContain("beta");
 		expect(rendered).toContain("right");
 	});
 
-	it("shows a read-only empty third-party status line section", async () => {
+	it("shows a read-only empty extension segments tab", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 		let rendered = "";
 		const placements: Array<{ key: string; placement: ExtensionStatusPlacement }> = [];
@@ -2092,6 +2109,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
@@ -2119,8 +2137,7 @@ describe("Pi docs compliance", () => {
 						render?: (width: number) => string[];
 						handleInput?: (data: string) => void;
 					};
-					component.handleInput?.("\t");
-					component.handleInput?.("\t");
+					navigateToExtensionSegmentsSection(component);
 					rendered = component.render?.(120).join("\n") ?? "";
 					component.handleInput?.("\x1b");
 				},
@@ -2132,7 +2149,7 @@ describe("Pi docs compliance", () => {
 		expect(placements).toEqual([]);
 	});
 
-	it("cycles active third-party status placement from the status line section", async () => {
+	it("cycles active third-party status placement from the extension segments tab", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 		const placements: Array<{ key: string; placement: ExtensionStatusPlacement }> = [];
 		let dependencyRenderRequests = 0;
@@ -2148,6 +2165,7 @@ describe("Pi docs compliance", () => {
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>([["alpha", "ok"]]),
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
@@ -2183,8 +2201,7 @@ describe("Pi docs compliance", () => {
 						{},
 						() => {},
 					) as { handleInput?: (data: string) => void };
-					component.handleInput?.("\t");
-					component.handleInput?.("\t");
+					navigateToExtensionSegmentsSection(component);
 					component.handleInput?.(" ");
 				},
 			},
@@ -2192,10 +2209,10 @@ describe("Pi docs compliance", () => {
 
 		expect(placements).toEqual([{ key: "alpha", placement: "off" }]);
 		expect(dependencyRenderRequests).toBe(1);
-		expect(tuiRenderRequests).toBe(3);
+		expect(tuiRenderRequests).toBe(4);
 	});
 
-	it("does not show inactive saved placements in the status line section", async () => {
+	it("does not show inactive saved placements in the extension segments tab", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 		let rendered = "";
 
@@ -2212,6 +2229,7 @@ describe("Pi docs compliance", () => {
 					}),
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
 				getActiveExtensionStatuses: () => new Map<string, string>([["active", "ok"]]),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -2237,8 +2255,7 @@ describe("Pi docs compliance", () => {
 						render?: (width: number) => string[];
 						handleInput?: (data: string) => void;
 					};
-					component.handleInput?.("\t");
-					component.handleInput?.("\t");
+					navigateToExtensionSegmentsSection(component);
 					rendered = component.render?.(80).join("\n") ?? "";
 				},
 			},


### PR DESCRIPTION
## Summary
- Add `footerSegments` config so built-in footer pieces (cwd, git, runtime, context, tokens, cost) can be shown or hidden individually
- Split `/zentui` status settings into separate **Built-in segments** and **Extension segments** tabs
- Add Shift+Tab backward navigation between `/zentui` sections

## Test plan
- [x] `npm run verify`
- [ ] Toggle built-in segments from `/zentui` and confirm footer updates
- [ ] Confirm extension status placement still works from **Extension segments**
- [ ] Confirm Tab/Shift+Tab cycle through all four `/zentui` sections