### PR TITLE
fix: handle stale ctx in isTuiContext

### DIFF
--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -60,8 +60,12 @@ function getZentuiEditorBaseFactory(factory: EditorFactory | undefined): EditorF
 }
 
 function isTuiContext(ctx: ExtensionContext): boolean {
-	const mode = (ctx as ExtensionContext & { mode?: string }).mode;
-	return ctx.hasUI && (mode === undefined || mode === "tui");
+	try {
+		const mode = (ctx as ExtensionContext & { mode?: string }).mode;
+		return ctx.hasUI && (mode === undefined || mode === "tui");
+	} catch {
+		return false;
+	}
 }
 
 export default function (pi: ExtensionAPI) {


### PR DESCRIPTION
## Summary

Found while running `pi --print --mode json` with no prompt — the process crashed with `Error: This extension ctx is
stale…`. On `session_start`, zentui schedules a deferred `setTimeout` (`scheduleEditorReconciliation`) that captures
the ctx. With no prompt, print mode `dispose()`s the session almost immediately, which invalidates that ctx; when the
deferred timer fires afterward, `isTuiContext(ctx)` reads the asserting `ctx.mode` getter and throws — an uncaught
error in a timer callback that kills Node. A prompt-bearing run doesn't crash because the model call keeps the ctx
active long enough for the 0ms timer to fire first.

Fix: wrap the `ctx.mode`/`ctx.hasUI` reads in `isTuiContext` with `try / catch { return false; }`. A stale ctx isn't
a TUI context, so the deferred reconciliation bails out silently. This matches the extension's existing
silent-fallback pattern (config.ts, git.ts, runtime.ts, style.ts, user-message.ts).

## Screenshots / recordings

N/A — internal lifecycle/crash fix, no rendering change.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev` (required for UI behavior changes)
- [ ] Added or updated tests where practical

Reproduced 3/3 crashes with the old code and 3/3 clean exits with the fix, using the no-prompt print command loaded
via `pi --no-extensions -e ./extensions/zentui/index.ts` (same flags as `pi:dev`).

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [ ] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in a focused module.
- [x] Used a conventional commit-style PR title (e.g. `feat: add ...`, `fix: handle ...`).
