### PR TITLE
chore(deps-dev): migrate biome config to v2 schema

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
-	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"files": {
-		"ignore": ["node_modules", "assets/*.png", ".agents/**"]
+		"includes": ["**", "!**/node_modules", "!**/assets/**/*.png", "!**/.agents"]
 	},
 	"formatter": {
 		"enabled": true,
@@ -11,7 +11,7 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true,
+			"preset": "recommended",
 			"suspicious": {
 				"noControlCharactersInRegex": "off"
 			}

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
-import { type ExtensionStatusSegment, collectExtensionStatusSegments } from "./extension-status";
+import { collectExtensionStatusSegments, type ExtensionStatusSegment } from "./extension-status";
 import { formatCwdLabel, formatRuntimeSegment } from "./format";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -9,29 +9,29 @@ import {
 	type ColorSourcesConfig,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
-	type FooterSegmentsConfig,
-	type PolishedTuiConfig,
-	type UiFeaturesConfig,
 	ensureConfigExists,
+	type FooterSegmentsConfig,
 	loadConfig,
+	type PolishedTuiConfig,
 	saveColorSourcesPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
 	saveFooterSegmentsPatch,
 	saveUiFeaturesPatch,
+	type UiFeaturesConfig,
 } from "./config";
 import { installFooter } from "./footer";
 import { emptyGitStatus, readGitStatus } from "./git";
 import {
+	createProjectRefreshScheduler,
 	type ScheduleProjectRefreshOptions,
 	type StopProjectRefreshInterval,
-	createProjectRefreshScheduler,
 	startProjectRefreshInterval,
 } from "./project-refresh";
 import { readRuntimeInfo } from "./runtime";
 import { installSelectorBorderStyle } from "./selector-border";
 import { registerZentuiSettingsCommand } from "./settings-command";
-import { type FooterState, createInitialState, syncState } from "./state";
+import { createInitialState, type FooterState, syncState } from "./state";
 import { PolishedEditor, WrappedPolishedEditor } from "./ui";
 import { installUserMessageStyle } from "./user-message";
 

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -3,10 +3,10 @@ import { getSettingsListTheme } from "@earendil-works/pi-coding-agent";
 import {
 	type AutocompleteItem,
 	Key,
+	matchesKey,
 	type SettingItem,
 	SettingsList,
 	type SettingsListTheme,
-	matchesKey,
 	truncateToWidth,
 } from "@earendil-works/pi-tui";
 import {
@@ -15,12 +15,12 @@ import {
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FooterSegmentsConfig,
-	type PolishedTuiConfig,
-	type UiFeaturesConfig,
 	getExtensionStatusColorMode,
 	getExtensionStatusPlacement,
 	isExtensionStatusColorMode,
 	isExtensionStatusPlacement,
+	type PolishedTuiConfig,
+	type UiFeaturesConfig,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, safeThemeFg } from "./style";

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
 			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
-				"@biomejs/biome": "^1.9.4",
+				"@biomejs/biome": "^2.5.0",
 				"@earendil-works/pi-ai": "^0.79.3",
 				"@earendil-works/pi-coding-agent": "^0.79.3",
 				"@earendil-works/pi-tui": "^0.79.3",
-				"@types/node": "^25.5.2",
+				"@types/node": "^26.0.0",
 				"typescript": "^6.0.2",
 				"vitest": "^4.1.8"
 			},
@@ -532,11 +532,10 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.0.tgz",
+			"integrity": "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
 				"biome": "bin/biome"
@@ -549,20 +548,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "1.9.4",
-				"@biomejs/cli-darwin-x64": "1.9.4",
-				"@biomejs/cli-linux-arm64": "1.9.4",
-				"@biomejs/cli-linux-arm64-musl": "1.9.4",
-				"@biomejs/cli-linux-x64": "1.9.4",
-				"@biomejs/cli-linux-x64-musl": "1.9.4",
-				"@biomejs/cli-win32-arm64": "1.9.4",
-				"@biomejs/cli-win32-x64": "1.9.4"
+				"@biomejs/cli-darwin-arm64": "2.5.0",
+				"@biomejs/cli-darwin-x64": "2.5.0",
+				"@biomejs/cli-linux-arm64": "2.5.0",
+				"@biomejs/cli-linux-arm64-musl": "2.5.0",
+				"@biomejs/cli-linux-x64": "2.5.0",
+				"@biomejs/cli-linux-x64-musl": "2.5.0",
+				"@biomejs/cli-win32-arm64": "2.5.0",
+				"@biomejs/cli-win32-x64": "2.5.0"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.0.tgz",
+			"integrity": "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -577,9 +576,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.0.tgz",
+			"integrity": "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ==",
 			"cpu": [
 				"x64"
 			],
@@ -594,13 +593,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.0.tgz",
+			"integrity": "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -611,13 +613,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.0.tgz",
+			"integrity": "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -628,13 +633,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.0.tgz",
+			"integrity": "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -645,13 +653,16 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.0.tgz",
+			"integrity": "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -662,9 +673,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.0.tgz",
+			"integrity": "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==",
 			"cpu": [
 				"arm64"
 			],
@@ -679,9 +690,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "1.9.4",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.0.tgz",
+			"integrity": "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw==",
 			"cpu": [
 				"x64"
 			],
@@ -3279,13 +3290,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "25.9.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
-			"integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+			"version": "26.0.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+			"integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": ">=7.24.0 <7.24.7"
+				"undici-types": "~8.3.0"
 			}
 		},
 		"node_modules/@types/retry": {
@@ -4524,9 +4535,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.24.6",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-			"integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
 			"dev": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1385,6 +1385,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1402,6 +1405,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1419,6 +1425,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1436,6 +1445,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1453,6 +1465,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -12,8 +12,16 @@
 	"bugs": {
 		"url": "https://github.com/lmilojevicc/pi-zentui/issues"
 	},
-	"keywords": ["pi-package", "pi-extension", "pi-theme", "starship", "tui"],
-	"files": ["extensions"],
+	"keywords": [
+		"pi-package",
+		"pi-extension",
+		"pi-theme",
+		"starship",
+		"tui"
+	],
+	"files": [
+		"extensions"
+	],
 	"scripts": {
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit",
@@ -32,7 +40,9 @@
 		"@earendil-works/pi-tui": "*"
 	},
 	"pi": {
-		"extensions": ["./extensions"],
+		"extensions": [
+			"./extensions"
+		],
 		"image": "https://raw.githubusercontent.com/lmilojevicc/pi-zentui/main/assets/zentui.png"
 	},
 	"publishConfig": {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^1.9.4",
+		"@biomejs/biome": "^2.5.0",
 		"@earendil-works/pi-ai": "^0.79.3",
 		"@earendil-works/pi-coding-agent": "^0.79.3",
 		"@earendil-works/pi-tui": "^0.79.3",
-		"@types/node": "^25.5.2",
+		"@types/node": "^26.0.0",
 		"typescript": "^6.0.2",
 		"vitest": "^4.1.8"
 	}

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -9,9 +9,9 @@ import {
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+	defaultConfig,
 	type ExtensionStatusPlacement,
 	type PolishedTuiConfig,
-	defaultConfig,
 } from "../extensions/zentui/config";
 import { installFooter } from "../extensions/zentui/footer";
 import { emptyGitStatus } from "../extensions/zentui/git";

--- a/test/extension-status.test.ts
+++ b/test/extension-status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type PolishedTuiConfig, defaultConfig } from "../extensions/zentui/config";
+import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
 import {
 	collectExtensionStatusSegments,
 	sanitizeExtensionStatusOriginalText,


### PR DESCRIPTION
Companion to dependabot PR #16. Bumps `@biomejs/biome` to 2.5.0 and migrates `biome.json` to the v2 schema (dependabot only touches `package.json`/`package-lock.json`, not the config file).

Changes:
- `biome.json` `$schema` URL bumped to 2.5.0
- `files.ignore` → `files.includes` (negation patterns), as required by v2
- `rules.recommended` → `rules.preset: "recommended"`
- biome 2's stricter import sorter reorders type-only imports ahead of value imports in 4 files: `footer.ts`, `index.ts`, `settings-command.ts`, `test/extension-compliance.test.ts`, `test/extension-status.test.ts`. Pure reordering, no semantic change.
- Picks up the `@types/node` 25 → 26 bump from PR #16 (no source changes needed).

`npm run verify` and `npm run pack:check` pass locally (lint, typecheck, 141/141 tests).
