### PR TITLE
feat: add configurable rail glyph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ npm-debug.log*
 .pi/goals/
 .pi/subagent-schedules/
 .pi/tasks/
+.pi-subagents/
 bun.lock
 bun.lockb
 *.tgz

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ Default config values — copy this and change any value you want:
 		"deleted": "✘",
 		"typechanged": "T",
 		"cacheHit": "󰆼",
-		"editorPrompt": ""
+		"editorPrompt": "",
+		"rail": "│"
 	},
 	"colors": {
 		"cwd": "bold cyan",
@@ -218,7 +219,7 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`).
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling.
-- `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
+- `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
 - `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `runtime`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,13 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
 	"files": {
-		"includes": ["**", "!**/node_modules", "!**/assets/**/*.png", "!**/.agents"]
+		"includes": [
+			"**",
+			"!**/node_modules",
+			"!**/assets/**/*.png",
+			"!**/.agents",
+			"!**/.pi-subagents"
+		]
 	},
 	"formatter": {
 		"enabled": true,

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -60,6 +60,7 @@ export type PolishedTuiConfig = {
 		typechanged: string;
 		cacheHit: string;
 		editorPrompt: string;
+		rail: string;
 	};
 	colors: {
 		cwd: ColorSpec;
@@ -111,6 +112,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		typechanged: "T",
 		cacheHit: "󰆼",
 		editorPrompt: "",
+		rail: "│",
 	},
 	colors: {
 		cwd: "bold cyan",
@@ -185,6 +187,10 @@ function parseProjectRefreshIntervalMs(value: unknown): number {
 	return interval >= MIN_PROJECT_REFRESH_INTERVAL_MS
 		? interval
 		: defaultConfig.projectRefreshIntervalMs;
+}
+
+function railValue(value: unknown): string {
+	return typeof value === "string" && value.trim().length > 0 ? value : defaultConfig.icons.rail;
 }
 
 function stringValue(record: Record<string, unknown>, key: string): string | undefined {
@@ -394,9 +400,8 @@ export function ensureConfigExists(): void {
 
 export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const config = isRecord(parsed) ? parsed : {};
-	const icons = isRecord(config.icons)
-		? normalizeIcons(config.icons as Record<string, unknown>)
-		: {};
+	const iconsRecord = isRecord(config.icons) ? (config.icons as Record<string, unknown>) : {};
+	const icons = normalizeIcons(iconsRecord);
 	const colors = isRecord(config.colors)
 		? normalizeColors(config.colors as Record<string, unknown>)
 		: {};
@@ -417,6 +422,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		icons: {
 			...defaultConfig.icons,
 			...icons,
+			rail: railValue(iconsRecord.rail),
 		},
 		colors: {
 			...defaultConfig.colors,

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -111,7 +111,7 @@ function getEditorChromeWidths(config: PolishedTuiConfig, uiTheme: Theme, reset:
 				config.colorSources.editor,
 				config.colors.editorAccent,
 				EDITOR_ACCENT_FALLBACK,
-				"│",
+				config.icons.rail,
 			)}${reset} `;
 	return {
 		prompt,

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -87,6 +87,7 @@ function getUserMessageConfigKey(config: PolishedTuiConfig): string {
 		config.colorSources.userMessages,
 		config.colors.editorAccent ?? "",
 		config.colors.editorBorder ?? "",
+		config.icons.rail,
 	].join("\0");
 }
 
@@ -126,6 +127,7 @@ function fillLine(content: string, width: number): string {
 
 function renderPromptBoxRail(theme: Theme | undefined, config: PolishedTuiConfig): string {
 	if (config.features.copyFriendly) return "";
+	const railGlyph = config.icons.rail;
 
 	return `${
 		theme
@@ -134,9 +136,9 @@ function renderPromptBoxRail(theme: Theme | undefined, config: PolishedTuiConfig
 					config.colorSources.userMessages,
 					config.colors.editorAccent,
 					EDITOR_ACCENT_FALLBACK,
-					"│",
+					railGlyph,
 				)
-			: "│"
+			: railGlyph
 	} `;
 }
 

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -605,6 +605,22 @@ describe("Pi docs compliance", () => {
 		expect(stripTestTags(lines.at(-1) ?? "")).toMatch(/^─+$/);
 	});
 
+	it("renders the configured rail glyph on user messages", () => {
+		const config: PolishedTuiConfig = {
+			...defaultConfig,
+			icons: { ...defaultConfig.icons, rail: "┃" },
+		};
+		installUserMessageStyle(
+			() => makeTaggedTheme(),
+			() => config,
+		);
+
+		const raw = new UserMessageComponent("hello").render(80).join("\n");
+
+		expect(raw).toContain("[accent]┃");
+		expect(raw).not.toContain("│");
+	});
+
 	it("caches rendered user messages across repeated renders", () => {
 		const getChildren = vi.fn(() => [{ text: "hello ".repeat(2000) }]);
 		const fg = vi.fn((color: string, text: string) => `[${color}]${text}`);


### PR DESCRIPTION
## What

Adds a configurable vertical-bar rail glyph. The rail is now driven by `icons.rail` (default `│`, byte-identical to before) instead of a hard-coded literal.

## Why

The accent rail is the most visible piece of Zentui chrome, but its glyph was baked in. Users wanting the opencode look (`┃`), a double line (`║`), or a thin block (`▎`/`▏`) had no way to change it. This exposes it as config, consistent with the existing `icons` section.

## Changes

- **`config.ts`** — new `icons.rail` field (type + default `"│"`), with a coercion helper that falls back to `"│"` on non-string / empty / whitespace values; wired into `mergeConfig`.
- **`user-message.ts`** — `renderPromptBoxRail()` reads `config.icons.rail` (themed + no-theme fallback); `getUserMessageConfigKey()` includes it so config changes re-render.
- **`ui.ts`** — editor-frame rail (`getEditorChromeWidths`) uses the same `config.icons.rail`.
- **`test/extension-compliance.test.ts`** — new test asserting `icons.rail: "┃"` renders `┃` and not `│`.
- **`README.md`** — `rail` added to the default `icons` JSON example and the `icons` config bullet (one-liner); default `│`.

Default appearance is unchanged: with default config, `icons.rail === "│"` and rendered output is byte-identical (the existing `renders user messages like the ZentUI prompt box` test passes unmodified).

Also includes a small chore: ignore the `.pi-subagents/` artifact directory (`.gitignore` + `biome.json` `files.includes`) so local subagent runs no longer break `npm run verify`.

## Verification

- `npm run fmt`
- `npm run verify` — biome clean, tsc clean, **142/142 tests**
- `npm run pack:check`