### PR TITLE
Add copyright holder to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025
+Copyright (c) 2025-2026 Luka
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

The MIT `LICENSE` copyright line read `Copyright (c) 2025` with no holder name. This adds the holder and spans the active years.

## Changes

- `LICENSE`: `Copyright (c) 2025` → `Copyright (c) 2025-2026 Luka` (copyright holder added; license text otherwise unchanged).

No source code, config, or build changes.

## Validation

- Diff is a single-line change to the copyright notice; canonical MIT text preserved.

## Notes

All other governance files referenced for this task already exist in the repo and were intentionally left untouched (`CONTRIBUTING.md`, `SECURITY.md`, `.github/CODEOWNERS`, `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/*`). Branch protection on `main` will be configured separately after merge.