### PR TITLE
fix(editor): remove redundant blank line above input text

### DIFF
--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -329,11 +329,10 @@ function renderPolishedFrame({
 		EDITOR_BORDER_FALLBACK,
 		"─".repeat(width),
 	);
-	const lines = ["", ...editorLines, "", railedMeta];
+	const lines = [...editorLines, "", railedMeta];
 	const renderedLines = config.features.copyFriendly
 		? [
 				top,
-				"",
 				...editorLines.map(
 					(line, index) =>
 						`${index === 0 ? prompt : copyFriendlyContinuation}${fillLine(line, innerWidth)}`,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1325,7 +1325,7 @@ describe("Pi docs compliance", () => {
 		expect(rendered.match(/claude-sonnet/g)).toHaveLength(1);
 		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
 		expect(rendered.match(/medium/g)).toHaveLength(1);
-		expect(lines).toHaveLength(5);
+		expect(lines).toHaveLength(4);
 	});
 
 	it("drops the stale leading spacer when wrapping an already-polished editor with text", () => {
@@ -1355,10 +1355,9 @@ describe("Pi docs compliance", () => {
 		const lines = editor.render(120);
 		const textIndex = lines.findIndex((line) => line.includes("typed text"));
 
-		expect(textIndex).toBe(2);
-		expect(lines).toHaveLength(6);
-		expect(stripTestTags(lines[textIndex - 2] ?? "").trim()).toMatch(/^─+$/);
-		expect(stripTestTags(lines[textIndex - 1] ?? "").trim()).toBe("│");
+		expect(textIndex).toBe(1);
+		expect(lines).toHaveLength(5);
+		expect(stripTestTags(lines[textIndex - 1] ?? "").trim()).toMatch(/^─+$/);
 	});
 
 	it("preserves a user blank line after removing stale polished editor spacing", () => {
@@ -1389,10 +1388,9 @@ describe("Pi docs compliance", () => {
 		const lines = editor.render(120);
 		const textIndex = lines.findIndex((line) => line.includes("typed text"));
 
-		expect(textIndex).toBe(3);
-		expect(lines).toHaveLength(7);
-		expect(stripTestTags(lines[textIndex - 3] ?? "").trim()).toMatch(/^─+$/);
-		expect(stripTestTags(lines[textIndex - 2] ?? "").trim()).toBe("│");
+		expect(textIndex).toBe(2);
+		expect(lines).toHaveLength(6);
+		expect(stripTestTags(lines[textIndex - 2] ?? "").trim()).toMatch(/^─+$/);
 		expect(stripTestTags(lines[textIndex - 1] ?? "").trim()).toBe("│");
 	});
 
@@ -1430,7 +1428,7 @@ describe("Pi docs compliance", () => {
 		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
 		expect(rendered.match(/xhigh/g)).toHaveLength(1);
 		expect(rendered.match(/INSERT/g)).toHaveLength(1);
-		expect(lines).toHaveLength(5);
+		expect(lines).toHaveLength(4);
 	});
 
 	it("replaces nested model lines with the current model and vim status line", () => {


### PR DESCRIPTION
## Summary

The editor frame rendered a leading blank line between the top border and the first text line. With the blue accent rail on the left, this showed up as a second ("double") blue line at the start of the input box. Dropped the extra padding line so input text sits directly under the border.

Changes:
- `extensions/zentui/ui.ts` — removed the leading `""` from the `lines` array in `renderPolishedFrame` (normal and copy-friendly paths)
- `test/extension-compliance.test.ts` — updated the 4 frame-collapse tests to match the new layout

## Screenshots / recordings

N/A for now — will drop a terminal recording in the comments if you want one. (It's a one-line removal; before/after is just "blank line gone".)

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev`
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no strings or characters replaced).
- [x] Updated `README.md` or config docs if user-facing behavior changed — N/A, cosmetic spacing fix, no config/behavior change.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in a focused module.
- [x] Used a conventional commit-style PR title (e.g. `feat: add ...`, `fix: handle ...`).
