### PR TITLE
feat: add opt-in session duration and numeric git counts footer segments

### DIFF
--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -22,10 +22,12 @@ export type FooterSegmentsConfig = {
 	cwd: boolean;
 	gitBranch: boolean;
 	gitStatus: boolean;
+	gitCounts: boolean;
 	runtime: boolean;
 	context: boolean;
 	tokens: boolean;
 	cost: boolean;
+	sessionDuration: boolean;
 };
 
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
@@ -74,6 +76,7 @@ export type PolishedTuiConfig = {
 		separator: ColorSpec;
 		runtimePrefix: ColorSpec;
 		extensionStatus: ColorSpec;
+		sessionDuration: ColorSpec;
 		editorAccent?: ColorSpec;
 		editorPrompt?: ColorSpec;
 		editorBorder?: ColorSpec;
@@ -126,6 +129,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		separator: "bright-black",
 		runtimePrefix: "",
 		extensionStatus: "bright-black",
+		sessionDuration: "yellow",
 	},
 	colorSources: {
 		starship: "theme",
@@ -141,10 +145,12 @@ export const defaultConfig: PolishedTuiConfig = {
 		cwd: true,
 		gitBranch: true,
 		gitStatus: true,
+		gitCounts: false,
 		runtime: true,
 		context: true,
 		tokens: true,
 		cost: true,
+		sessionDuration: false,
 	},
 	extensionStatuses: {
 		defaultPlacement: "right",
@@ -256,6 +262,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		separator: colorValue(record, "separator"),
 		runtimePrefix: colorValue(record, "runtimePrefix"),
 		extensionStatus: colorValue(record, "extensionStatus"),
+		sessionDuration: colorValue(record, "sessionDuration"),
 		editorAccent: colorValue(record, "editorAccent"),
 		editorPrompt: colorValue(record, "editorPrompt"),
 		editorBorder: colorValue(record, "editorBorder"),
@@ -291,10 +298,12 @@ function normalizeFooterSegments(record: Record<string, unknown>): FooterSegment
 		cwd: footerSegmentValue(record, "cwd"),
 		gitBranch: footerSegmentValue(record, "gitBranch"),
 		gitStatus: footerSegmentValue(record, "gitStatus"),
+		gitCounts: footerSegmentValue(record, "gitCounts"),
 		runtime: footerSegmentValue(record, "runtime"),
 		context: footerSegmentValue(record, "context"),
 		tokens: footerSegmentValue(record, "tokens"),
 		cost: footerSegmentValue(record, "cost"),
+		sessionDuration: footerSegmentValue(record, "sessionDuration"),
 	};
 }
 
@@ -347,10 +356,12 @@ function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig 
 		value === "cwd" ||
 		value === "gitBranch" ||
 		value === "gitStatus" ||
+		value === "gitCounts" ||
 		value === "runtime" ||
 		value === "context" ||
 		value === "tokens" ||
-		value === "cost"
+		value === "cost" ||
+		value === "sessionDuration"
 	);
 }
 

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -2,7 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
 import { collectExtensionStatusSegments, type ExtensionStatusSegment } from "./extension-status";
-import { formatCwdLabel, formatRuntimeSegment } from "./format";
+import { buildSessionDurationLabel, formatCwdLabel, formatRuntimeSegment } from "./format";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";
 
@@ -176,9 +176,16 @@ export function installFooter(
 				const gitStatusColor = (text: string) =>
 					renderStyleForSource(theme, colorSource, config.colors.gitStatus, text);
 				const gitIcon = config.icons.git ? gitColor(config.icons.git) : "";
+				const gitCounts = config.footerSegments.gitCounts;
+				const stashLabel =
+					state.stashed > 0
+						? gitCounts
+							? `${config.icons.stashed}${state.stashed}`
+							: config.icons.stashed
+						: "";
 				const allStatus = [
 					state.conflicted > 0 ? config.icons.conflicted : "",
-					state.stashed ? config.icons.stashed : "",
+					stashLabel,
 					state.deleted > 0 ? config.icons.deleted : "",
 					state.renamed > 0 ? config.icons.renamed : "",
 					state.modified > 0 ? config.icons.modified : "",
@@ -186,14 +193,18 @@ export function installFooter(
 					state.staged > 0 ? config.icons.staged : "",
 					state.untracked > 0 ? config.icons.untracked : "",
 				].join("");
-				const aheadBehind =
-					state.ahead > 0 && state.behind > 0
-						? config.icons.diverged
-						: state.ahead > 0
-							? config.icons.ahead
-							: state.behind > 0
-								? config.icons.behind
-								: "";
+				const aheadBehind = (() => {
+					if (state.ahead > 0 && state.behind > 0) {
+						return gitCounts
+							? `${config.icons.ahead}${state.ahead}${config.icons.behind}${state.behind}`
+							: config.icons.diverged;
+					}
+					if (state.ahead > 0)
+						return gitCounts ? `${config.icons.ahead}${state.ahead}` : config.icons.ahead;
+					if (state.behind > 0)
+						return gitCounts ? `${config.icons.behind}${state.behind}` : config.icons.behind;
+					return "";
+				})();
 				const statusBlock =
 					allStatus || aheadBehind ? gitStatusColor(`[${allStatus}${aheadBehind}]`) : "";
 				const branchParts =
@@ -206,9 +217,27 @@ export function installFooter(
 					? formatRuntimeSegment(theme, state.runtime, config.colors.runtimePrefix, colorSource)
 					: "";
 
-				const left = [config.footerSegments.cwd ? cwdLabel : "", branchLabel, runtimeLabel]
+				const sessionDurationSegment = (() => {
+					if (!config.footerSegments.sessionDuration || !state.sessionStartEpoch) return "";
+					const timeLabel = buildSessionDurationLabel(state.sessionStartEpoch);
+					const prefix = renderStyleForSource(theme, colorSource, "", "up for");
+					const time = renderStyleForSource(
+						theme,
+						colorSource,
+						config.colors.sessionDuration,
+						timeLabel,
+					);
+					return `${prefix} ${time}`;
+				})();
+				const left = [
+					config.footerSegments.cwd ? cwdLabel : "",
+					branchLabel,
+					runtimeLabel,
+					sessionDurationSegment,
+				]
 					.filter(Boolean)
 					.join(" ");
+
 				const right = [
 					config.footerSegments.context
 						? renderStyleForSource(theme, colorSource, contextColor, state.contextLabel)
@@ -222,6 +251,7 @@ export function installFooter(
 				]
 					.filter(Boolean)
 					.join(separator);
+
 				const extensionStatuses = collectExtensionStatusSegments(
 					footerData.getExtensionStatuses(),
 					config,

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -91,6 +91,16 @@ export function buildCostLabel(totals: UsageTotals): string {
 	return `$${totals.cost.toFixed(3)}`;
 }
 
+export function buildSessionDurationLabel(startEpoch: number): string {
+	const totalSeconds = Math.max(0, Math.floor((Date.now() - startEpoch) / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
 export function buildContextLabel(ctx: ExtensionContext): string {
 	const usage = ctx.getContextUsage();
 	const contextWindow = ctx.model?.contextWindow ?? usage?.contextWindow;

--- a/extensions/zentui/git.ts
+++ b/extensions/zentui/git.ts
@@ -11,7 +11,7 @@ export type GitStatusSummary = {
 	behind: number;
 	conflicted: number;
 	untracked: number;
-	stashed: boolean;
+	stashed: number;
 	modified: number;
 	staged: number;
 	renamed: number;
@@ -27,7 +27,7 @@ export function emptyGitStatus(): GitStatusSummary {
 		behind: 0,
 		conflicted: 0,
 		untracked: 0,
-		stashed: false,
+		stashed: 0,
 		modified: 0,
 		staged: 0,
 		renamed: 0,
@@ -36,9 +36,9 @@ export function emptyGitStatus(): GitStatusSummary {
 	};
 }
 
-export function parseGitStatusPorcelain(stdoutText: string, hasStash: boolean): GitStatusSummary {
+export function parseGitStatusPorcelain(stdoutText: string, stashCount: number): GitStatusSummary {
 	const status = emptyGitStatus();
-	status.stashed = hasStash;
+	status.stashed = stashCount;
 
 	for (const line of stdoutText.split(/\r?\n/)) {
 		if (!line) continue;
@@ -93,7 +93,7 @@ export async function readGitStatus(cwd: string): Promise<GitStatusSummary> {
 				cwd,
 				timeout: GIT_COMMAND_TIMEOUT_MS,
 			}),
-			execFileAsync("git", ["rev-parse", "--verify", "--quiet", "refs/stash"], {
+			execFileAsync("git", ["stash", "list"], {
 				cwd,
 				timeout: GIT_COMMAND_TIMEOUT_MS,
 			}).catch(() => ({ stdout: "" })),
@@ -101,7 +101,8 @@ export async function readGitStatus(cwd: string): Promise<GitStatusSummary> {
 		const stdoutText = typeof statusStdout === "string" ? statusStdout : String(statusStdout);
 		const stashStdout =
 			typeof stashResult.stdout === "string" ? stashResult.stdout : String(stashResult.stdout);
-		return parseGitStatusPorcelain(stdoutText, stashStdout.trim().length > 0);
+		const stashCount = stashStdout.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
+		return parseGitStatusPorcelain(stdoutText, stashCount);
 	} catch {
 		return emptyGitStatus();
 	}

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -21,6 +21,7 @@ import {
 	type UiFeaturesConfig,
 } from "./config";
 import { installFooter } from "./footer";
+import { buildSessionDurationLabel } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
 import {
 	createProjectRefreshScheduler,
@@ -83,6 +84,8 @@ export default function (pi: ExtensionAPI) {
 	let installedEditorFactory: EditorFactory | undefined;
 	let wrappedEditorFactory: EditorFactory | undefined;
 	let prototypePatchesInstalled = false;
+	let stopSessionTimer: () => void = () => {};
+	let lastDurationLabel = "";
 
 	const refresh = () => requestFooterRender?.();
 	const getActiveTheme = () => activeTheme;
@@ -115,6 +118,25 @@ export default function (pi: ExtensionAPI) {
 		stopRefreshInterval();
 		stopRefreshInterval = () => {};
 		projectRefreshScheduler.stop();
+	};
+
+	const startSessionTimer = () => {
+		stopSessionTimer();
+		lastDurationLabel = "";
+		const timer = setInterval(() => {
+			if (!(currentConfig.features.statusLine && currentConfig.footerSegments.sessionDuration))
+				return;
+			const label = state.sessionStartEpoch
+				? buildSessionDurationLabel(state.sessionStartEpoch)
+				: "";
+			if (label === lastDurationLabel) return;
+			lastDurationLabel = label;
+			refresh();
+		}, 1000);
+		stopSessionTimer = () => {
+			clearInterval(timer);
+			stopSessionTimer = () => {};
+		};
 	};
 
 	const installPrototypePatches = () => {
@@ -239,9 +261,11 @@ export default function (pi: ExtensionAPI) {
 		);
 		scheduleProjectRefresh(ctx, { force: true });
 		refresh();
+		startSessionTimer();
 	};
 
 	const uninstallStatusLine = (ctx: ExtensionContext) => {
+		stopSessionTimer();
 		stopProjectRefresh();
 		ctx.ui.setFooter(undefined);
 		footerInstalled = false;
@@ -297,6 +321,7 @@ export default function (pi: ExtensionAPI) {
 
 	const cleanupUi = (ctx?: ExtensionContext) => {
 		uninstallPrototypePatches();
+		stopSessionTimer();
 		stopProjectRefresh();
 		requestFooterRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
@@ -328,6 +353,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
+		state.sessionStartEpoch = Date.now();
 		installUi(ctx);
 		scheduleEditorReconciliation(ctx);
 	});

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -100,7 +100,8 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 	cwd: "Show or hide the current working directory segment on the left.",
 	gitBranch: "Show or hide the git branch name on the left.",
 	gitStatus: "Show or hide git status icons and ahead/behind markers.",
-	gitCounts: "Show numeric ahead/behind and stash counts alongside git status icons.",
+	gitCounts:
+		"Show numeric ahead/behind and stash counts (requires the Git status segment to be enabled).",
 	sessionDuration: "Show session running time on the left, after the runtime.",
 	runtime: "Show or hide the detected runtime/language segment on the left.",
 	context: "Show or hide context usage on the right.",

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -88,6 +88,8 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	cwd: "Current directory",
 	gitBranch: "Git branch",
 	gitStatus: "Git status",
+	gitCounts: "Git counts",
+	sessionDuration: "Session duration",
 	runtime: "Runtime",
 	context: "Context usage",
 	tokens: "Token counts",
@@ -98,6 +100,8 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 	cwd: "Show or hide the current working directory segment on the left.",
 	gitBranch: "Show or hide the git branch name on the left.",
 	gitStatus: "Show or hide git status icons and ahead/behind markers.",
+	gitCounts: "Show numeric ahead/behind and stash counts alongside git status icons.",
+	sessionDuration: "Show session running time on the left, after the runtime.",
 	runtime: "Show or hide the detected runtime/language segment on the left.",
 	context: "Show or hide context usage on the right.",
 	tokens: "Show or hide input/output token counts on the right.",
@@ -144,6 +148,8 @@ function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingI
 		value === "cwd" ||
 		value === "gitBranch" ||
 		value === "gitStatus" ||
+		value === "gitCounts" ||
+		value === "sessionDuration" ||
 		value === "runtime" ||
 		value === "context" ||
 		value === "tokens" ||

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -16,6 +16,7 @@ export type FooterState = GitStatusSummary & {
 	tokenLabel: string;
 	costLabel: string;
 	runtime?: RuntimeInfo;
+	sessionStartEpoch?: number;
 };
 
 export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
@@ -26,6 +27,7 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 		tokenLabel: "↑0 ↓0",
 		costLabel: "$0.000",
 		runtime: undefined,
+		sessionStartEpoch: Date.now(),
 		...gitDefaults,
 	};
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -48,6 +48,8 @@ describe("mergeConfig", () => {
 			gitStatus: true,
 			runtime: true,
 			context: true,
+			gitCounts: false,
+			sessionDuration: false,
 			tokens: true,
 			cost: true,
 		});
@@ -250,6 +252,8 @@ describe("mergeConfig", () => {
 			gitStatus: true,
 			runtime: true,
 			context: true,
+			gitCounts: false,
+			sessionDuration: false,
 			tokens: false,
 			cost: true,
 		});
@@ -262,6 +266,8 @@ describe("mergeConfig", () => {
 			gitStatus: false,
 			runtime: true,
 			context: true,
+			gitCounts: false,
+			sessionDuration: false,
 			tokens: true,
 			cost: true,
 		});
@@ -454,6 +460,8 @@ describe("mergeConfig", () => {
 				gitStatus: true,
 				runtime: true,
 				context: true,
+				gitCounts: false,
+				sessionDuration: false,
 				tokens: false,
 				cost: false,
 			});
@@ -482,6 +490,8 @@ describe("mergeConfig", () => {
 				gitStatus: true,
 				runtime: false,
 				context: true,
+				gitCounts: false,
+				sessionDuration: false,
 				tokens: true,
 				cost: true,
 			});

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	buildCostLabel,
+	buildSessionDurationLabel,
 	buildTokenLabel,
 	formatCount,
 	getUsageTotals,
@@ -119,5 +120,33 @@ describe("usage formatting", () => {
 		expect(totals.cacheWrite).toBe(500);
 		expect(totals.latestCacheHitRate).toBe(30);
 		expect(buildTokenLabel(totals, cacheHitIcon)).toBe("↑300 ↓30 󰆼 30.0%");
+	});
+});
+
+describe("buildSessionDurationLabel", () => {
+	const FIXED_NOW = 1_700_000_000_000;
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(FIXED_NOW);
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("formats seconds only", () => {
+		expect(buildSessionDurationLabel(FIXED_NOW - 45_000)).toBe("45s");
+	});
+
+	it("formats minutes and seconds", () => {
+		expect(buildSessionDurationLabel(FIXED_NOW - (2 * 60 + 13) * 1000)).toBe("2m 13s");
+	});
+
+	it("formats hours and minutes", () => {
+		expect(buildSessionDurationLabel(FIXED_NOW - (1 * 3600 + 5 * 60) * 1000)).toBe("1h 5m");
+	});
+
+	it("clamps zero and negative elapsed to 0s", () => {
+		expect(buildSessionDurationLabel(FIXED_NOW)).toBe("0s");
+		expect(buildSessionDurationLabel(FIXED_NOW + 10_000)).toBe("0s");
 	});
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -3,7 +3,7 @@ import { emptyGitStatus, parseGitStatusPorcelain } from "../extensions/zentui/gi
 
 describe("parseGitStatusPorcelain", () => {
 	it("returns empty status for empty output", () => {
-		expect(parseGitStatusPorcelain("", false)).toEqual(emptyGitStatus());
+		expect(parseGitStatusPorcelain("", 0)).toEqual(emptyGitStatus());
 	});
 
 	it("parses branch, ahead/behind, and file states", () => {
@@ -17,7 +17,7 @@ describe("parseGitStatusPorcelain", () => {
 				"? untracked.ts",
 				"u UU N... 100644 100644 100644 100644 abc abc conflict.ts",
 			].join("\n"),
-			true,
+			1,
 		);
 
 		expect(status).toMatchObject({
@@ -30,12 +30,12 @@ describe("parseGitStatusPorcelain", () => {
 			renamed: 1,
 			untracked: 1,
 			conflicted: 1,
-			stashed: true,
+			stashed: 1,
 		});
 	});
 
 	it("hides detached head as no branch", () => {
-		const status = parseGitStatusPorcelain("# branch.head (detached)", false);
+		const status = parseGitStatusPorcelain("# branch.head (detached)", 0);
 		expect(status.branch).toBeUndefined();
 	});
 });


### PR DESCRIPTION
## Summary
Two new **opt-in** footer segments for Zentui, both defaulting off (backward compatible):

- **Session duration** (`sessionDuration`): shows how long the current session has been live, e.g. `up for 2m 13s`, on the left after the runtime. Driven by a 1s timer that only re-renders when the displayed label actually changes. Only the time is colored (yellow); the `up for` prefix stays neutral.
- **Numeric git counts** (`gitCounts`): renders numeric ahead/behind and stash counts (`↑2 ↓1`, `$2`) alongside the git status icons (requires the Git status segment to be enabled).

## Details
- `config.ts`: new `footerSegments` keys `gitCounts`/`sessionDuration` (default `false`) and a `colors.sessionDuration` (default `yellow`); plumbed through normalization/validation.
- `format.ts`: `buildSessionDurationLabel()` formats elapsed time (`45s` / `2m 13s` / `1h 5m`), clamps negatives to `0s`.
- `state.ts`: `sessionStartEpoch` seeded at `session_start` and defaulted in `createInitialState`.
- `git.ts`: `stashed` changed from boolean to a count (via `git stash list`); `parseGitStatusPorcelain` now takes a numeric stash count.
- `footer.ts`: git-count rendering + the left-side `up for {time}` segment.
- `index.ts`: epoch reset on `session_start`; `startSessionTimer()` lifecycle wired into the footer install/uninstall/cleanup.
- `settings-command.ts`: both toggles exposed in `/zentui` → Built-in Segments.
- Tests: `buildSessionDurationLabel` unit tests added; `config.test.ts`/`git.test.ts` updated for the new keys and stash count.

## Validation
`npm run fmt`, `npm run verify` (lint + typecheck + 146 tests), and `npm run pack:check` all pass.

## Test plan
1. `/zentui` → Built-in Segments → enable **Git counts** (with Git status on) → footer shows `↑N`/`↓N`/`$N`.
2. Enable **Session duration** → footer shows `up for {time}` ticking live, time in yellow.
3. Defaults unchanged when both are off.