### PR TITLE
feat: polish statusline reliability, gauges, groups, and git state

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu is split into four sections. Use `Tab` and `Shift+Tab` to switch between `Coloring`, `Features`, `Built-in segments`, and `Extension segments`.
+The interactive `/zentui` menu is split into five sections. Use `Tab` and `Shift+Tab` to switch between `Coloring`, `Features`, `Layout`, `Built-in segments`, and `Extension segments`.
 
 Useful slash-command shortcuts:
 
@@ -153,7 +153,13 @@ Default config values — copy this and change any value you want:
 {
 	"projectRefreshIntervalMs": 30000,
 	"footerFormat": "",
+	"contextStyle": "text",
+	"contextThresholds": {
+		"warning": 70,
+		"error": 90
+	},
 	"icons": {
+		"mode": "auto",
 		"cwd": "󰝰",
 		"git": "",
 		"ahead": "↑",
@@ -234,13 +240,15 @@ Default config values — copy this and change any value you want:
 }
 ```
 
-- Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`).
-- `projectRefreshIntervalMs`: project status polling interval; `0` disables polling.
-- `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
+- Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
+- `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
+- `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment.
+- `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
+- `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
 - `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `runtime`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
-- `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below.
+- `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures context style and icon mode; set or clear custom formats with `/zentui format`.
 - `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The `Extension segments` tab in `/zentui` lists only statuses that are currently active.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
@@ -252,13 +260,13 @@ Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.
 
 ## Footer Format Template
 
-For full control, set a Starship-style `footerFormat` template string. It supports `$variable` and `${variable}` tokens plus a special `$fill` token that splits the line into left and right zones. When set, it overrides the built-in `footerSegments` layout; when empty or omitted, the segment layout above is used.
+For full control, set a Starship-style `footerFormat` template string. It supports `$variable` and `${variable}` tokens, a special `$fill` token that splits the line into left and right zones, and conditional groups `( ... )` that drop entirely when every nested variable is empty. When set, it overrides the built-in `footerSegments` layout; when empty or omitted, the segment layout above is used.
 
 A second `$fill` creates a **centered middle zone** — content between the two fills is true-centered (`floor((gap - middle) / 2)`), just like third-party statuses placed `middle`.
 
 ```json
 {
-	"footerFormat": "$os $username $cwd on branch $git_branch$git_status using $runtime $fill $context | $tokens | $cost $time"
+	"footerFormat": "$os $username $cwd( on $git_branch)( $git_status)( via $runtime)$fill($context)($sep$tokens)($sep$cost)($sep$time)"
 }
 ```
 
@@ -272,20 +280,22 @@ Center the branch between directory and cost:
 
 ### Variables
 
-| Token               | Aliases      | Renders                   |
-| ------------------- | ------------ | ------------------------- |
-| `$cwd`              | `$directory` | current directory         |
-| `$git_branch`       | `$branch`    | git branch with icon      |
-| `$git_status`       | `$status`    | `[!?↑]` status block      |
-| `$runtime`          |              | runtime icon + version    |
-| `$session_duration` | `$duration`  | session running time      |
-| `$username`         |              | `user@host`               |
-| `$os`               |              | operating-system icon     |
-| `$time`             |              | current time `HH:MM`      |
-| `$context`          |              | context usage             |
-| `$tokens`           |              | input/output token counts |
-| `$cost`             |              | session cost              |
-| `$fill`             | —            | special: splits zones     |
+| Token               | Aliases      | Renders                                          |
+| ------------------- | ------------ | ------------------------------------------------ |
+| `$cwd`              | `$directory` | current directory                                |
+| `$git_branch`       | `$branch`    | git branch with icon                             |
+| `$git_status`       | `$status`    | `[!?↑]` status block                             |
+| `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
+| `$runtime`          |              | runtime icon + version                           |
+| `$session_duration` | `$duration`  | session running time                             |
+| `$username`         |              | `user@host`                                      |
+| `$os`               |              | operating-system icon                            |
+| `$time`             |              | current time `HH:MM`                             |
+| `$context`          |              | context usage (text and/or gauge via config)     |
+| `$tokens`           |              | input/output token counts                        |
+| `$cost`             |              | session cost                                     |
+| `$sep`              | `$separator` | themed ` | ` using `colors.separator`            |
+| `$fill`             | —            | special: splits zones                            |
 
 ### `$fill` behavior
 
@@ -298,13 +308,14 @@ Center the branch between directory and cost:
 
 - Literal text (`on branch`, `using`, `\|`, spaces) is rendered verbatim — you control all spacing.
 - Each variable renders its core value only (no `on`/`via` prefixes); add those words as literal text.
+- Conditional groups: wrap optional pieces in parentheses, e.g. `$cwd( on $git_branch)($git_status)$fill($context)`. If every `$var` inside a group is empty, the whole group (including its literals) is dropped.
 - Unknown `$variables` render empty.
 - Set or clear at runtime: `/zentui format "<template>"` and `/zentui format clear`.
 
 ## Requirements
 
 - [Pi](https://pi.dev) coding agent 0.79 or newer
-- A [Nerd Font](https://www.nerdfonts.com/) for icons
+- A [Nerd Font](https://www.nerdfonts.com/) for icons (or set `icons.mode` to `"ascii"`)
 
 ## Development
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -1,10 +1,27 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import {
+	ICON_GLYPH_KEYS,
+	type IconGlyphs,
+	type IconMode,
+	NERD_DEFAULT_ICONS,
+	normalizeIconMode,
+	type ResolvedIcons,
+	resolveConfiguredIcons,
+} from "./icons";
 import { isSupportedColorSpec } from "./style";
 
 export type ColorSpec = string;
 export type ColorSource = "theme" | "terminal";
+export type { IconMode } from "./icons";
+
+export type ContextStyle = "text" | "gauge" | "text+gauge";
+
+export type ContextThresholds = {
+	warning: number;
+	error: number;
+};
 
 export type ColorSourcesConfig = {
 	starship: ColorSource;
@@ -50,27 +67,9 @@ const MIN_PROJECT_REFRESH_INTERVAL_MS = 5_000;
 export type PolishedTuiConfig = {
 	projectRefreshIntervalMs: number;
 	footerFormat: string;
-	icons: {
-		cwd: string;
-		git: string;
-		ahead: string;
-		behind: string;
-		diverged: string;
-		conflicted: string;
-		untracked: string;
-		stashed: string;
-		modified: string;
-		staged: string;
-		renamed: string;
-		deleted: string;
-		typechanged: string;
-		cacheHit: string;
-		editorPrompt: string;
-		rail: string;
-		username: string;
-		time: string;
-		os: string;
-	};
+	contextStyle: ContextStyle;
+	contextThresholds: ContextThresholds;
+	icons: ResolvedIcons;
 	colors: {
 		cwd: ColorSpec;
 		gitBranch: ColorSpec;
@@ -113,6 +112,7 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"cwd",
 	"git_branch",
 	"git_status",
+	"git_state",
 	"runtime",
 	"session_duration",
 	"username",
@@ -121,6 +121,7 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"context",
 	"tokens",
 	"cost",
+	"sep",
 ] as const;
 
 /**
@@ -131,7 +132,9 @@ export const FOOTER_FORMAT_ALIASES: Record<string, string> = {
 	directory: "cwd",
 	branch: "git_branch",
 	status: "git_status",
+	state: "git_state",
 	duration: "session_duration",
+	separator: "sep",
 };
 
 export const configPath = join(getAgentDir(), "zentui.json");
@@ -139,26 +142,11 @@ export const configPath = join(getAgentDir(), "zentui.json");
 export const defaultConfig: PolishedTuiConfig = {
 	projectRefreshIntervalMs: DEFAULT_PROJECT_REFRESH_INTERVAL_MS,
 	footerFormat: "",
+	contextStyle: "text",
+	contextThresholds: { warning: 70, error: 90 },
 	icons: {
-		cwd: "󰝰",
-		git: "",
-		ahead: "↑",
-		behind: "↓",
-		diverged: "⇕",
-		conflicted: "=",
-		untracked: "?",
-		stashed: "$",
-		modified: "!",
-		staged: "+",
-		renamed: "»",
-		deleted: "✘",
-		typechanged: "T",
-		cacheHit: "󰆼",
-		editorPrompt: "",
-		rail: "│",
-		username: "",
-		time: "",
-		os: "",
+		mode: "auto",
+		...NERD_DEFAULT_ICONS,
 	},
 	colors: {
 		cwd: "bold cyan",
@@ -208,27 +196,6 @@ export const defaultConfig: PolishedTuiConfig = {
 	},
 };
 
-const iconKeys = [
-	"cwd",
-	"git",
-	"ahead",
-	"behind",
-	"diverged",
-	"conflicted",
-	"untracked",
-	"stashed",
-	"modified",
-	"staged",
-	"renamed",
-	"deleted",
-	"typechanged",
-	"cacheHit",
-	"editorPrompt",
-	"username",
-	"time",
-	"os",
-] as const satisfies readonly (keyof PolishedTuiConfig["icons"])[];
-
 type ConfigRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is ConfigRecord {
@@ -238,17 +205,43 @@ function isRecord(value: unknown): value is ConfigRecord {
 function parseProjectRefreshIntervalMs(value: unknown): number {
 	if (value === 0) return 0;
 	if (typeof value !== "number" || !Number.isFinite(value)) {
-		return defaultConfig.projectRefreshIntervalMs;
+		return DEFAULT_PROJECT_REFRESH_INTERVAL_MS;
 	}
 
 	const interval = Math.round(value);
-	return interval >= MIN_PROJECT_REFRESH_INTERVAL_MS
-		? interval
-		: defaultConfig.projectRefreshIntervalMs;
+	if (interval <= 0) return 0;
+	return Math.max(MIN_PROJECT_REFRESH_INTERVAL_MS, interval);
 }
 
-function railValue(value: unknown): string {
-	return typeof value === "string" && value.trim().length > 0 ? value : defaultConfig.icons.rail;
+function clampPercent(value: number): number {
+	return Math.max(0, Math.min(100, value));
+}
+
+function parseContextStyle(value: unknown): ContextStyle {
+	if (value === "text" || value === "gauge" || value === "text+gauge") return value;
+	return defaultConfig.contextStyle;
+}
+
+function parseContextThresholds(value: unknown): ContextThresholds {
+	const defaults = defaultConfig.contextThresholds;
+	if (!isRecord(value)) return { ...defaults };
+
+	const warningRaw = value.warning;
+	const errorRaw = value.error;
+	let warning =
+		typeof warningRaw === "number" && Number.isFinite(warningRaw)
+			? clampPercent(Math.round(warningRaw))
+			: defaults.warning;
+	let error =
+		typeof errorRaw === "number" && Number.isFinite(errorRaw)
+			? clampPercent(Math.round(errorRaw))
+			: defaults.error;
+	if (error < warning) {
+		const swapped = warning;
+		warning = error;
+		error = swapped;
+	}
+	return { warning, error };
 }
 
 function stringValue(record: Record<string, unknown>, key: string): string | undefined {
@@ -292,13 +285,13 @@ function definedColors(
 	) as Partial<PolishedTuiConfig["colors"]>;
 }
 
-function normalizeIcons(record: Record<string, unknown>): Partial<PolishedTuiConfig["icons"]> {
+function normalizeIconOverrides(record: Record<string, unknown>): Partial<IconGlyphs> {
 	return Object.fromEntries(
-		iconKeys.flatMap((key) => {
+		ICON_GLYPH_KEYS.flatMap((key) => {
 			const value = stringValue(record, key);
 			return value === undefined ? [] : [[key, value]];
 		}),
-	) as Partial<PolishedTuiConfig["icons"]>;
+	) as Partial<IconGlyphs>;
 }
 
 function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiConfig["colors"]> {
@@ -473,7 +466,8 @@ export function ensureConfigExists(): void {
 export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const config = isRecord(parsed) ? parsed : {};
 	const iconsRecord = isRecord(config.icons) ? (config.icons as Record<string, unknown>) : {};
-	const icons = normalizeIcons(iconsRecord);
+	const iconMode = normalizeIconMode(iconsRecord.mode);
+	const iconOverrides = normalizeIconOverrides(iconsRecord);
 	const colors = isRecord(config.colors)
 		? normalizeColors(config.colors as Record<string, unknown>)
 		: {};
@@ -492,11 +486,9 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	return {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
 		footerFormat: stringValue(config, "footerFormat") ?? "",
-		icons: {
-			...defaultConfig.icons,
-			...icons,
-			rail: railValue(iconsRecord.rail),
-		},
+		contextStyle: parseContextStyle(config.contextStyle),
+		contextThresholds: parseContextThresholds(config.contextThresholds),
+		icons: resolveConfiguredIcons(iconMode, iconOverrides),
 		colors: {
 			...defaultConfig.colors,
 			...colors,
@@ -586,6 +578,40 @@ export function saveFooterSegmentsPatch(
 export function saveFooterFormatPatch(value: string, path = configPath): PolishedTuiConfig {
 	const record = readConfigRecord(path);
 	record.footerFormat = typeof value === "string" ? value : "";
+	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return mergeConfig(record);
+}
+
+export function saveIconsModePatch(mode: IconMode, path = configPath): PolishedTuiConfig {
+	const record = readConfigRecord(path);
+	const existing = isRecord(record.icons) ? { ...(record.icons as Record<string, unknown>) } : {};
+	record.icons = {
+		...existing,
+		mode: normalizeIconMode(mode),
+	};
+	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return mergeConfig(record);
+}
+
+export function saveContextStylePatch(style: ContextStyle, path = configPath): PolishedTuiConfig {
+	const record = readConfigRecord(path);
+	record.contextStyle = parseContextStyle(style);
+	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+	return mergeConfig(record);
+}
+
+export function saveContextThresholdsPatch(
+	thresholds: Partial<ContextThresholds>,
+	path = configPath,
+): PolishedTuiConfig {
+	const record = readConfigRecord(path);
+	const existing = isRecord(record.contextThresholds)
+		? { ...(record.contextThresholds as Record<string, unknown>) }
+		: {};
+	record.contextThresholds = {
+		...existing,
+		...thresholds,
+	};
 	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 	return mergeConfig(record);
 }

--- a/extensions/zentui/footer-format.ts
+++ b/extensions/zentui/footer-format.ts
@@ -2,46 +2,98 @@
  * Starship-style footer format string parser and renderer.
  *
  * Pure module (no TUI/config imports) so it is fully unit-testable.
+ *
+ * Supports conditional groups: `( ... )` is dropped when every nested
+ * variable (and nested group) renders empty.
  */
 
 export type FormatToken =
 	| { kind: "text"; value: string }
 	| { kind: "var"; name: string }
-	| { kind: "fill" };
+	| { kind: "fill" }
+	| { kind: "group"; tokens: FormatToken[] };
 
 const TOKEN_REGEX = /\$\{([a-zA-Z_][a-zA-Z0-9_]*)\}|\$([a-zA-Z_][a-zA-Z0-9_]*)/g;
 
 /**
- * Tokenize a format string into text/var/fill tokens.
+ * Tokenize a format string into text/var/fill/group tokens.
  *
  * `$name` and `${name}` both produce a variable token. A variable named
- * `fill` becomes a fill token instead. Text between/around variables is
- * preserved exactly (including spaces). Empty input produces an empty array.
+ * `fill` becomes a fill token instead. Parentheses form conditional groups
+ * that drop entirely when all nested vars are empty.
  */
 export function parseFooterFormat(format: string): FormatToken[] {
 	if (!format) return [];
+	return parseTokenSlice(format, 0, format.length, true).tokens;
+}
 
+function parseTokenSlice(
+	format: string,
+	start: number,
+	end: number,
+	topLevel = false,
+): { tokens: FormatToken[]; nextIndex: number } {
 	const tokens: FormatToken[] = [];
-	let lastIndex = 0;
+	let index = start;
+	let textStart = start;
 
-	for (const match of format.matchAll(TOKEN_REGEX)) {
-		if (match.index !== undefined && match.index > lastIndex) {
-			tokens.push({ kind: "text", value: format.slice(lastIndex, match.index) });
+	const flushText = (until: number) => {
+		if (until > textStart) {
+			tokens.push({ kind: "text", value: format.slice(textStart, until) });
 		}
-		const name = match[1] ?? match[2];
-		if (name === "fill") {
-			tokens.push({ kind: "fill" });
-		} else {
-			tokens.push({ kind: "var", name });
+	};
+
+	while (index < end) {
+		const ch = format[index];
+
+		if (ch === "(") {
+			flushText(index);
+			const nested = parseTokenSlice(format, index + 1, end, false);
+			tokens.push({ kind: "group", tokens: nested.tokens });
+			index = nested.nextIndex;
+			textStart = index;
+			continue;
 		}
-		lastIndex = (match.index ?? 0) + match[0].length;
+
+		if (ch === ")") {
+			// Nested groups close on `)`. Unmatched top-level `)` is literal text so
+			// trailing tokens like `$cwd) $tokens` are not discarded.
+			if (topLevel) {
+				index += 1;
+				continue;
+			}
+			flushText(index);
+			return { tokens, nextIndex: index + 1 };
+		}
+
+		if (ch === "$") {
+			TOKEN_REGEX.lastIndex = index;
+			const match = TOKEN_REGEX.exec(format);
+			if (match && match.index === index && match.index < end) {
+				const full = match[0];
+				const matchEnd = match.index + full.length;
+				if (matchEnd > end) {
+					index += 1;
+					continue;
+				}
+				flushText(index);
+				const name = match[1] ?? match[2] ?? "";
+				if (name === "fill") {
+					tokens.push({ kind: "fill" });
+				} else {
+					tokens.push({ kind: "var", name });
+				}
+				index = matchEnd;
+				textStart = index;
+				continue;
+			}
+		}
+
+		index += 1;
 	}
 
-	if (lastIndex < format.length) {
-		tokens.push({ kind: "text", value: format.slice(lastIndex) });
-	}
-
-	return tokens;
+	flushText(end);
+	return { tokens, nextIndex: end };
 }
 
 /**
@@ -53,6 +105,7 @@ export function parseFooterFormat(format: string): FormatToken[] {
  *   (centered by the caller via the existing middle-zone logic), after the
  *   second → `right`.
  * - Additional fills beyond the first two are ignored.
+ * - `$fill` inside a group is ignored (renders empty).
  *
  * Text tokens contribute their `value` verbatim (unstyled/plain); var tokens
  * contribute `renderVariable(name)` (already styled by caller). No automatic
@@ -62,10 +115,7 @@ export function renderFormatSplit(
 	tokens: FormatToken[],
 	renderVariable: (name: string) => string,
 ): { left: string; middle: string; right: string } {
-	const fillIndices: number[] = [];
-	for (let index = 0; index < tokens.length; index++) {
-		if (tokens[index]?.kind === "fill") fillIndices.push(index);
-	}
+	const fillIndices = findTopLevelFillIndices(tokens);
 
 	if (fillIndices.length === 0) {
 		return {
@@ -101,6 +151,14 @@ export function renderFormatSplit(
 	};
 }
 
+function findTopLevelFillIndices(tokens: FormatToken[]): number[] {
+	const fillIndices: number[] = [];
+	for (let index = 0; index < tokens.length; index++) {
+		if (tokens[index]?.kind === "fill") fillIndices.push(index);
+	}
+	return fillIndices;
+}
+
 function renderTokenSlice(
 	tokens: FormatToken[],
 	start: number,
@@ -111,11 +169,111 @@ function renderTokenSlice(
 	for (let i = start; i < end; i++) {
 		const token = tokens[i];
 		if (!token) continue;
-		if (token.kind === "text") {
-			result += token.value;
-		} else if (token.kind === "var") {
-			result += renderVariable(token.name);
+		result += renderToken(token, renderVariable);
+	}
+	return result;
+}
+
+function renderToken(token: FormatToken, renderVariable: (name: string) => string): string {
+	if (token.kind === "text") return token.value;
+	if (token.kind === "var") return renderVariable(token.name);
+	if (token.kind === "fill") return "";
+	// group
+	const rendered = token.tokens.map((child) => renderToken(child, renderVariable)).join("");
+	if (isGroupEmpty(token, renderVariable)) return "";
+	return rendered;
+}
+
+/**
+ * Separator vars only style gaps between content; they must not keep a group
+ * alive when every real content var is empty (e.g. `($sep$tokens)` drops if
+ * tokens is empty).
+ */
+const NON_CONTENT_VARS = new Set(["sep", "separator"]);
+
+/**
+ * A group is empty iff every content var leaf is empty and every nested group
+ * is empty. Text-only groups (no vars) always show. `$sep` / `$separator` are
+ * ignored for emptiness so orphan themed pipes do not force a group to render.
+ */
+function isGroupEmpty(
+	group: FormatToken & { kind: "group" },
+	renderVariable: (name: string) => string,
+): boolean {
+	let sawContentVarOrGroup = false;
+	for (const child of group.tokens) {
+		if (child.kind === "var") {
+			if (NON_CONTENT_VARS.has(child.name)) continue;
+			sawContentVarOrGroup = true;
+			if (renderVariable(child.name) !== "") return false;
+		} else if (child.kind === "group") {
+			sawContentVarOrGroup = true;
+			if (!isGroupEmpty(child, renderVariable)) return false;
 		}
 	}
+	// Text-only groups (or groups with only $sep) are shown only when no content vars.
+	// Groups that only contain $sep still count as empty so they drop.
+	return sawContentVarOrGroup || groupOnlyNonContentVars(group);
+}
+
+function groupOnlyNonContentVars(group: FormatToken & { kind: "group" }): boolean {
+	let sawSep = false;
+	for (const child of group.tokens) {
+		if (child.kind === "text") {
+			if (child.value.trim() !== "") return false;
+			continue;
+		}
+		if (child.kind === "var") {
+			if (!NON_CONTENT_VARS.has(child.name)) return false;
+			sawSep = true;
+			continue;
+		}
+		if (child.kind === "group") return false;
+		if (child.kind === "fill") continue;
+	}
+	return sawSep;
+}
+
+/** One optional SGR sequence (`\x1b[…m`). */
+const ANSI_ONE_SRC = "\u001b\\[[0-9;]*m";
+
+/**
+ * One ` | ` separator unit, plain or with a single ANSI wrapper on either side
+ * of the spaces/pipe (matches `renderStyle(..., " | ")` output).
+ */
+const SEP_UNIT_SRC = `(?:${ANSI_ONE_SRC})?\\s+\\|\\s+(?:${ANSI_ONE_SRC})?`;
+
+/**
+ * Join non-empty parts with a separator (segment-mode style).
+ * Useful when building right-side metrics without orphan pipes.
+ */
+export function joinNonEmpty(parts: string[], separator: string): string {
+	return parts.filter(Boolean).join(separator);
+}
+
+/**
+ * Tidy a rendered format left/middle/right slice:
+ * - collapse repeated pipe separators (plain or simple ANSI-wrapped) into one
+ * - strip leading/trailing pipe separators
+ * - strip leading/trailing whitespace
+ * - drop slices that are only ANSI / whitespace after cleanup
+ */
+export function stripOrphanSeparators(rendered: string): string {
+	if (!rendered) return rendered;
+
+	// Collapse consecutive separator units, keeping the first (preserves themed color).
+	const consecutive = new RegExp(`(${SEP_UNIT_SRC})(?:${SEP_UNIT_SRC})+`, "g");
+	let result = rendered.replace(consecutive, "$1");
+
+	// Strip leading / trailing separator units.
+	result = result.replace(new RegExp(`^(?:${SEP_UNIT_SRC})+`), "");
+	result = result.replace(new RegExp(`(?:${SEP_UNIT_SRC})+$`), "");
+
+	// Strip leading / trailing plain whitespace left by empty groups.
+	result = result.replace(/^\s+/, "").replace(/\s+$/, "");
+
+	// Pure ANSI (or empty) leftovers are not useful content.
+	if (result.replace(new RegExp(ANSI_ONE_SRC, "g"), "").trim() === "") return "";
+
 	return result;
 }

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -3,15 +3,18 @@ import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
 import { FOOTER_FORMAT_ALIASES } from "./config";
 import { collectExtensionStatusSegments, type ExtensionStatusSegment } from "./extension-status";
-import { parseFooterFormat, renderFormatSplit } from "./footer-format";
+import { parseFooterFormat, renderFormatSplit, stripOrphanSeparators } from "./footer-format";
 import {
+	buildContextDisplayLabel,
 	buildSessionDurationLabel,
+	contextColorTier,
 	formatCwdLabel,
 	formatOsLabel,
 	formatRuntimeSegment,
 	formatTimeLabel,
 	formatUsernameHostLabel,
 } from "./format";
+import { resolveRuntimeSymbol } from "./icons";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";
 
@@ -162,6 +165,7 @@ export function installFooter(
 				if (width <= 0) return [""];
 				const config = getConfig();
 				const colorSource = config.colorSources.starship;
+				const iconMode = config.icons.mode;
 				const separator = renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
 				const innerWidth = Math.max(1, width - 2);
 				const cwdLabel = renderStyleForSource(
@@ -172,14 +176,20 @@ export function installFooter(
 				);
 				const branch = state.branch;
 				const contextUsage = ctx.getContextUsage();
+				const contextWindow = ctx.model?.contextWindow ?? contextUsage?.contextWindow;
+				const contextLabel = buildContextDisplayLabel({
+					percent: contextUsage?.percent,
+					contextWindow,
+					style: config.contextStyle,
+					asciiGauge: iconMode === "ascii",
+				});
+				const tier = contextColorTier(contextUsage?.percent, config.contextThresholds);
 				const contextColor =
-					contextUsage?.percent !== null && contextUsage?.percent !== undefined
-						? contextUsage.percent >= 90
-							? config.colors.contextError
-							: contextUsage.percent >= 70
-								? config.colors.contextWarning
-								: config.colors.contextNormal
-						: config.colors.contextNormal;
+					tier === "error"
+						? config.colors.contextError
+						: tier === "warning"
+							? config.colors.contextWarning
+							: config.colors.contextNormal;
 				const gitColor = (text: string) =>
 					renderStyleForSource(theme, colorSource, config.colors.gitBranch, text);
 				const gitStatusColor = (text: string) =>
@@ -216,6 +226,8 @@ export function installFooter(
 				})();
 				const statusBlock =
 					allStatus || aheadBehind ? gitStatusColor(`[${allStatus}${aheadBehind}]`) : "";
+				const gitStateLabel = state.gitStateLabel ?? "";
+				const gitStateBlock = gitStateLabel ? gitStatusColor(gitStateLabel) : "";
 				const renderVariable = (name: string): string => {
 					const canonical = FOOTER_FORMAT_ALIASES[name] ?? name;
 					switch (canonical) {
@@ -225,11 +237,16 @@ export function installFooter(
 							return branch ? (gitIcon ? `${gitIcon} ${gitColor(branch)}` : gitColor(branch)) : "";
 						case "git_status":
 							return statusBlock;
+						case "git_state":
+							return gitStateBlock;
 						case "runtime": {
 							if (!state.runtime) return "";
-							const label = state.runtime.version
-								? `${state.runtime.symbol} ${state.runtime.version}`
-								: state.runtime.symbol;
+							const symbol = resolveRuntimeSymbol(
+								state.runtime.name,
+								state.runtime.symbol,
+								iconMode,
+							);
+							const label = state.runtime.version ? `${symbol} ${state.runtime.version}` : symbol;
 							return renderStyleForSource(theme, colorSource, state.runtime.style, label);
 						}
 						case "session_duration":
@@ -253,7 +270,7 @@ export function installFooter(
 								theme,
 								colorSource,
 								config.colors.os,
-								formatOsLabel(config.icons.os),
+								formatOsLabel(config.icons.os, iconMode),
 							);
 						case "time":
 							return renderStyleForSource(
@@ -263,7 +280,7 @@ export function installFooter(
 								formatTimeLabel(config.icons.time),
 							);
 						case "context":
-							return renderStyleForSource(theme, colorSource, contextColor, state.contextLabel);
+							return renderStyleForSource(theme, colorSource, contextColor, contextLabel);
 						case "tokens":
 							return renderStyleForSource(
 								theme,
@@ -273,6 +290,8 @@ export function installFooter(
 							);
 						case "cost":
 							return renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel);
+						case "sep":
+							return renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
 						default:
 							return "";
 					}
@@ -282,9 +301,19 @@ export function installFooter(
 						? ["on", gitIcon, gitColor(branch)].filter(Boolean)
 						: [];
 				const gitStatusParts = config.footerSegments.gitStatus && statusBlock ? [statusBlock] : [];
-				const branchLabel = [...branchParts, ...gitStatusParts].filter(Boolean).join(" ");
+				const showGitState = config.footerSegments.gitBranch || config.footerSegments.gitStatus;
+				const gitStateParts = showGitState && gitStateBlock ? [gitStateBlock] : [];
+				const branchLabel = [...branchParts, ...gitStatusParts, ...gitStateParts]
+					.filter(Boolean)
+					.join(" ");
 				const runtimeLabel = config.footerSegments.runtime
-					? formatRuntimeSegment(theme, state.runtime, config.colors.runtimePrefix, colorSource)
+					? formatRuntimeSegment(
+							theme,
+							state.runtime,
+							config.colors.runtimePrefix,
+							colorSource,
+							iconMode,
+						)
 					: "";
 
 				const sessionDurationSegment = (() => {
@@ -312,7 +341,7 @@ export function installFooter(
 							theme,
 							colorSource,
 							config.colors.os,
-							formatOsLabel(config.icons.os),
+							formatOsLabel(config.icons.os, iconMode),
 						)
 					: "";
 				const left = [
@@ -336,7 +365,7 @@ export function installFooter(
 					: "";
 				const right = [
 					config.footerSegments.context
-						? renderStyleForSource(theme, colorSource, contextColor, state.contextLabel)
+						? renderStyleForSource(theme, colorSource, contextColor, contextLabel)
 						: "",
 					config.footerSegments.tokens
 						? renderStyleForSource(theme, colorSource, config.colors.tokens, state.tokenLabel)
@@ -358,9 +387,9 @@ export function installFooter(
 						middle: fmtMiddle,
 						right: fmtRight,
 					} = renderFormatSplit(parseFooterFormat(config.footerFormat), renderVariable);
-					contentLeft = fmtLeft;
-					contentMiddle = fmtMiddle;
-					contentRight = fmtRight;
+					contentLeft = stripOrphanSeparators(fmtLeft);
+					contentMiddle = stripOrphanSeparators(fmtMiddle);
+					contentRight = stripOrphanSeparators(fmtRight);
 				}
 
 				const extensionStatuses = collectExtensionStatusSegments(

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -1,7 +1,9 @@
 import { hostname, userInfo } from "node:os";
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
-import type { ColorSource, ColorSpec } from "./config";
+import type { ColorSource, ColorSpec, ContextStyle, ContextThresholds } from "./config";
+import type { IconMode } from "./icons";
+import { resolveOsIcon, resolveRuntimeSymbol } from "./icons";
 import type { RuntimeInfo } from "./runtime";
 import { renderStyleForSource } from "./style";
 
@@ -13,6 +15,26 @@ export type UsageTotals = {
 	latestCacheHitRate?: number;
 	cost: number;
 };
+
+export type ContextColorTier = "normal" | "warning" | "error";
+
+type SessionEntry = {
+	type?: string;
+	id?: string | number;
+	timestamp?: string | number;
+	message?: {
+		role?: string;
+		usage?: AssistantMessage["usage"];
+	};
+};
+
+type UsageCacheEntry = {
+	key: string;
+	totals: UsageTotals;
+};
+
+let usageTotalsCache: UsageCacheEntry | undefined;
+let usageTotalsComputeCount = 0;
 
 export function formatCount(value: number): string {
 	if (value < 1000) return value.toString();
@@ -48,7 +70,23 @@ function calculateCacheHitRate(
 	return promptTokens > 0 ? (cacheRead / promptTokens) * 100 : undefined;
 }
 
-export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
+function entryIdentity(entry: SessionEntry | undefined): string {
+	if (!entry) return "";
+	const usage = entry.message?.usage;
+	const usageKey = usage
+		? `${usage.input ?? 0}:${usage.output ?? 0}:${usage.cacheRead ?? 0}:${usage.cacheWrite ?? 0}:${usage.cost?.total ?? 0}`
+		: "";
+	return `${entry.id ?? ""}|${entry.timestamp ?? ""}|${entry.type ?? ""}|${entry.message?.role ?? ""}|${usageKey}`;
+}
+
+function buildUsageFingerprint(entries: readonly SessionEntry[]): string {
+	const first = entries[0];
+	const last = entries[entries.length - 1];
+	return `${entries.length}\0${entryIdentity(first)}\0${entryIdentity(last)}`;
+}
+
+function computeUsageTotals(entries: readonly SessionEntry[]): UsageTotals {
+	usageTotalsComputeCount += 1;
 	let input = 0;
 	let output = 0;
 	let cacheRead = 0;
@@ -56,10 +94,9 @@ export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 	let latestCacheHitRate: number | undefined;
 	let cost = 0;
 
-	const entries = ctx.sessionManager.getEntries?.() ?? ctx.sessionManager.getBranch();
 	for (const entry of entries) {
-		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
-		const usage = (entry.message as AssistantMessage).usage;
+		if (entry.type !== "message" || entry.message?.role !== "assistant") continue;
+		const usage = entry.message.usage;
 		const entryInput = usage?.input ?? 0;
 		const entryCacheRead = usage?.cacheRead ?? 0;
 		const entryCacheWrite = usage?.cacheWrite ?? 0;
@@ -72,7 +109,36 @@ export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 		latestCacheHitRate = calculateCacheHitRate(entryInput, entryCacheRead, entryCacheWrite);
 	}
 
-	return { input, output, cacheRead, cacheWrite, latestCacheHitRate, cost };
+	return Object.freeze({ input, output, cacheRead, cacheWrite, latestCacheHitRate, cost });
+}
+
+export function invalidateUsageTotalsCache(): void {
+	usageTotalsCache = undefined;
+}
+
+/** Test helper: number of full usage scans performed since process start / last reset. */
+export function __usageTotalsComputeCount(): number {
+	return usageTotalsComputeCount;
+}
+
+/** Test helper: reset memoization counters/cache. */
+export function __resetUsageTotalsCacheForTests(): void {
+	usageTotalsCache = undefined;
+	usageTotalsComputeCount = 0;
+}
+
+export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
+	const sessionManager = ctx.sessionManager as {
+		getEntries?: () => SessionEntry[];
+		getBranch: () => SessionEntry[];
+	};
+	const entries = sessionManager.getEntries?.() ?? sessionManager.getBranch();
+	const key = buildUsageFingerprint(entries);
+	if (usageTotalsCache?.key === key) return usageTotalsCache.totals;
+
+	const totals = computeUsageTotals(entries);
+	usageTotalsCache = { key, totals };
+	return totals;
 }
 
 export function buildTokenLabel(totals: UsageTotals, cacheHitIcon = "󰆼"): string {
@@ -102,15 +168,61 @@ export function buildSessionDurationLabel(startEpoch: number): string {
 	return `${seconds}s`;
 }
 
+export function contextColorTier(
+	percent: number | null | undefined,
+	thresholds: ContextThresholds = { warning: 70, error: 90 },
+): ContextColorTier {
+	if (percent === null || percent === undefined || !Number.isFinite(percent)) return "normal";
+	if (percent >= thresholds.error) return "error";
+	if (percent >= thresholds.warning) return "warning";
+	return "normal";
+}
+
+export function buildContextGauge(percent: number, width = 10, ascii = false): string {
+	const clamped = Math.max(0, Math.min(100, percent));
+	const filled = Math.round((clamped / 100) * width);
+	const on = ascii ? "#" : "█";
+	const off = ascii ? "-" : "░";
+	return `${on.repeat(filled)}${off.repeat(Math.max(0, width - filled))}`;
+}
+
+export function formatContextPercentLabel(
+	percent: number | null | undefined,
+	contextWindow: number | undefined,
+): string {
+	if (!contextWindow || contextWindow <= 0) return "--";
+	const percentLabel =
+		percent === null || percent === undefined
+			? "?"
+			: `${Math.max(0, Math.min(999, Math.round(percent)))}%`;
+	return `${percentLabel}/${formatCount(contextWindow)}`;
+}
+
+export function buildContextDisplayLabel(options: {
+	percent: number | null | undefined;
+	contextWindow: number | undefined;
+	style?: ContextStyle;
+	asciiGauge?: boolean;
+}): string {
+	const { percent, contextWindow, style = "text", asciiGauge = false } = options;
+	if (!contextWindow || contextWindow <= 0) return "--";
+
+	const text = formatContextPercentLabel(percent, contextWindow);
+	const numericPercent =
+		percent === null || percent === undefined || !Number.isFinite(percent)
+			? 0
+			: Math.max(0, Math.min(100, percent));
+	const gauge = buildContextGauge(numericPercent, 10, asciiGauge);
+
+	if (style === "gauge") return `[${gauge}]`;
+	if (style === "text+gauge") return `[${gauge}] ${text}`;
+	return text;
+}
+
 export function buildContextLabel(ctx: ExtensionContext): string {
 	const usage = ctx.getContextUsage();
 	const contextWindow = ctx.model?.contextWindow ?? usage?.contextWindow;
-
-	if (!usage || !contextWindow || contextWindow <= 0) return "--";
-
-	const percent =
-		usage.percent === null ? "?" : `${Math.max(0, Math.min(999, Math.round(usage.percent)))}%`;
-	return `${percent}/${formatCount(contextWindow)}`;
+	return formatContextPercentLabel(usage?.percent, contextWindow);
 }
 
 export function formatRuntimeSegment(
@@ -118,9 +230,11 @@ export function formatRuntimeSegment(
 	runtime: RuntimeInfo | undefined,
 	prefixStyle: ColorSpec,
 	colorSource: ColorSource,
+	mode: IconMode = "auto",
 ): string {
 	if (!runtime) return "";
-	const label = runtime.version ? `${runtime.symbol} ${runtime.version}` : runtime.symbol;
+	const symbol = resolveRuntimeSymbol(runtime.name, runtime.symbol, mode);
+	const label = runtime.version ? `${symbol} ${runtime.version}` : symbol;
 	return `${renderStyleForSource(theme, colorSource, prefixStyle, "via")} ${renderStyleForSource(theme, colorSource, runtime.style, label)}`;
 }
 
@@ -151,12 +265,10 @@ export function formatTimeLabel(icon: string): string {
 	return icon ? `${icon} ${label}` : label;
 }
 
-const osIconMap: Record<string, string> = {
-	darwin: "\uf179",
-	linux: "\uf17c",
-	win32: "\uf17a",
-};
-
-export function formatOsLabel(defaultIcon: string): string {
-	return osIconMap[process.platform] ?? defaultIcon;
+export function formatOsLabel(
+	configuredIcon: string,
+	mode: IconMode = "auto",
+	platform: string = process.platform,
+): string {
+	return resolveOsIcon(configuredIcon, mode, platform);
 }

--- a/extensions/zentui/git.ts
+++ b/extensions/zentui/git.ts
@@ -1,8 +1,17 @@
 import { execFile } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
 const GIT_COMMAND_TIMEOUT_MS = 2_000;
+
+export type GitOperationState =
+	| "REBASING"
+	| "MERGING"
+	| "CHERRY-PICKING"
+	| "REVERTING"
+	| "BISECTING";
 
 export type GitStatusSummary = {
 	branch?: string;
@@ -17,6 +26,24 @@ export type GitStatusSummary = {
 	renamed: number;
 	deleted: number;
 	typechanged: number;
+	gitState?: GitOperationState;
+	gitStateLabel?: string;
+};
+
+export type GitReadResult =
+	| { kind: "ok"; status: GitStatusSummary }
+	| { kind: "not_a_repo" }
+	| { kind: "error" };
+
+export type GitStatePaths = {
+	rebaseMerge?: string;
+	rebaseApply?: string;
+	mergeHead?: string;
+	cherryPickHead?: string;
+	revertHead?: string;
+	bisectLog?: string;
+	rebaseMsgnum?: string;
+	rebaseEnd?: string;
 };
 
 export function emptyGitStatus(): GitStatusSummary {
@@ -33,6 +60,8 @@ export function emptyGitStatus(): GitStatusSummary {
 		renamed: 0,
 		deleted: 0,
 		typechanged: 0,
+		gitState: undefined,
+		gitStateLabel: undefined,
 	};
 }
 
@@ -86,7 +115,92 @@ export function parseGitStatusPorcelain(stdoutText: string, stashCount: number):
 	return status;
 }
 
-export async function readGitStatus(cwd: string): Promise<GitStatusSummary> {
+function readOptionalText(path: string | undefined): string | undefined {
+	if (!path || !existsSync(path)) return undefined;
+	try {
+		return readFileSync(path, "utf8").trim();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Pure git operation-state detector. Paths that exist (truthy strings that
+ * callers verified with `existsSync`) select the active state in Starship order.
+ */
+export function detectGitState(paths: GitStatePaths): {
+	gitState?: GitOperationState;
+	gitStateLabel?: string;
+} {
+	if (paths.rebaseMerge || paths.rebaseApply) {
+		const msgnum = readOptionalText(paths.rebaseMsgnum);
+		const end = readOptionalText(paths.rebaseEnd);
+		if (msgnum && end) {
+			return { gitState: "REBASING", gitStateLabel: `REBASING ${msgnum}/${end}` };
+		}
+		return { gitState: "REBASING", gitStateLabel: "REBASING" };
+	}
+	if (paths.mergeHead) return { gitState: "MERGING", gitStateLabel: "MERGING" };
+	if (paths.cherryPickHead) {
+		return { gitState: "CHERRY-PICKING", gitStateLabel: "CHERRY-PICKING" };
+	}
+	if (paths.revertHead) return { gitState: "REVERTING", gitStateLabel: "REVERTING" };
+	if (paths.bisectLog) return { gitState: "BISECTING", gitStateLabel: "BISECTING" };
+	return {};
+}
+
+async function resolveGitPath(cwd: string, pathSpec: string): Promise<string | undefined> {
+	try {
+		const { stdout } = await execFileAsync("git", ["rev-parse", "--git-path", pathSpec], {
+			cwd,
+			timeout: GIT_COMMAND_TIMEOUT_MS,
+		});
+		const resolved = (typeof stdout === "string" ? stdout : String(stdout)).trim();
+		if (!resolved) return undefined;
+		return resolved.startsWith("/") ? resolved : join(cwd, resolved);
+	} catch {
+		return undefined;
+	}
+}
+
+async function readGitOperationState(cwd: string): Promise<{
+	gitState?: GitOperationState;
+	gitStateLabel?: string;
+}> {
+	const [rebaseMerge, rebaseApply, mergeHead, cherryPickHead, revertHead, bisectLog] =
+		await Promise.all([
+			resolveGitPath(cwd, "rebase-merge"),
+			resolveGitPath(cwd, "rebase-apply"),
+			resolveGitPath(cwd, "MERGE_HEAD"),
+			resolveGitPath(cwd, "CHERRY_PICK_HEAD"),
+			resolveGitPath(cwd, "REVERT_HEAD"),
+			resolveGitPath(cwd, "BISECT_LOG"),
+		]);
+
+	const existing = (path: string | undefined) => (path && existsSync(path) ? path : undefined);
+	const rebaseDir = existing(rebaseMerge) ?? existing(rebaseApply);
+
+	return detectGitState({
+		rebaseMerge: existing(rebaseMerge),
+		rebaseApply: existing(rebaseApply),
+		mergeHead: existing(mergeHead),
+		cherryPickHead: existing(cherryPickHead),
+		revertHead: existing(revertHead),
+		bisectLog: existing(bisectLog),
+		rebaseMsgnum: rebaseDir ? join(rebaseDir, "msgnum") : undefined,
+		rebaseEnd: rebaseDir ? join(rebaseDir, "end") : undefined,
+	});
+}
+
+function isNotARepoError(error: unknown): boolean {
+	const message =
+		error instanceof Error
+			? `${error.message}\n${"stderr" in error ? String((error as { stderr?: unknown }).stderr ?? "") : ""}`
+			: String(error);
+	return /not a git repository|outside repository|not a git repo/i.test(message);
+}
+
+export async function readGitStatus(cwd: string): Promise<GitReadResult> {
 	try {
 		const [{ stdout: statusStdout }, stashResult] = await Promise.all([
 			execFileAsync("git", ["status", "--porcelain=2", "--branch"], {
@@ -102,8 +216,30 @@ export async function readGitStatus(cwd: string): Promise<GitStatusSummary> {
 		const stashStdout =
 			typeof stashResult.stdout === "string" ? stashResult.stdout : String(stashResult.stdout);
 		const stashCount = stashStdout.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
-		return parseGitStatusPorcelain(stdoutText, stashCount);
-	} catch {
-		return emptyGitStatus();
+		const status = parseGitStatusPorcelain(stdoutText, stashCount);
+		const operation = await readGitOperationState(cwd);
+		return {
+			kind: "ok",
+			status: {
+				...status,
+				...operation,
+			},
+		};
+	} catch (error) {
+		if (isNotARepoError(error)) return { kind: "not_a_repo" };
+
+		// Distinguish not-a-repo vs transient with a cheap rev-parse on the error path.
+		try {
+			const { stdout } = await execFileAsync("git", ["rev-parse", "--is-inside-work-tree"], {
+				cwd,
+				timeout: GIT_COMMAND_TIMEOUT_MS,
+			});
+			const inside = (typeof stdout === "string" ? stdout : String(stdout)).trim();
+			if (inside !== "true") return { kind: "not_a_repo" };
+			return { kind: "error" };
+		} catch (inner) {
+			if (isNotARepoError(inner)) return { kind: "not_a_repo" };
+			return { kind: "error" };
+		}
 	}
 }

--- a/extensions/zentui/icons.ts
+++ b/extensions/zentui/icons.ts
@@ -1,0 +1,225 @@
+/**
+ * Icon mode defaults and resolvers.
+ *
+ * Nerd defaults must stay byte-identical to historical `defaultConfig.icons`.
+ * User string overrides always win over mode defaults.
+ */
+
+export type IconMode = "auto" | "nerd" | "ascii";
+
+export type IconGlyphs = {
+	cwd: string;
+	git: string;
+	ahead: string;
+	behind: string;
+	diverged: string;
+	conflicted: string;
+	untracked: string;
+	stashed: string;
+	modified: string;
+	staged: string;
+	renamed: string;
+	deleted: string;
+	typechanged: string;
+	cacheHit: string;
+	editorPrompt: string;
+	rail: string;
+	username: string;
+	time: string;
+	os: string;
+};
+
+export type ResolvedIcons = IconGlyphs & { mode: IconMode };
+
+export const ICON_GLYPH_KEYS = [
+	"cwd",
+	"git",
+	"ahead",
+	"behind",
+	"diverged",
+	"conflicted",
+	"untracked",
+	"stashed",
+	"modified",
+	"staged",
+	"renamed",
+	"deleted",
+	"typechanged",
+	"cacheHit",
+	"editorPrompt",
+	"rail",
+	"username",
+	"time",
+	"os",
+] as const satisfies readonly (keyof IconGlyphs)[];
+
+/** Historical Nerd Font defaults (byte-identical to prior defaultConfig.icons). */
+export const NERD_DEFAULT_ICONS: IconGlyphs = {
+	cwd: "󰝰",
+	git: "",
+	ahead: "↑",
+	behind: "↓",
+	diverged: "⇕",
+	conflicted: "=",
+	untracked: "?",
+	stashed: "$",
+	modified: "!",
+	staged: "+",
+	renamed: "»",
+	deleted: "✘",
+	typechanged: "T",
+	cacheHit: "󰆼",
+	editorPrompt: "",
+	rail: "│",
+	username: "",
+	time: "",
+	os: "",
+};
+
+export const ASCII_DEFAULT_ICONS: IconGlyphs = {
+	cwd: "~",
+	git: "*",
+	ahead: "^",
+	behind: "v",
+	diverged: "^v",
+	conflicted: "=",
+	untracked: "?",
+	stashed: "$",
+	modified: "!",
+	staged: "+",
+	renamed: ">",
+	deleted: "x",
+	typechanged: "T",
+	cacheHit: "c",
+	editorPrompt: "",
+	rail: "|",
+	username: "@",
+	time: "t",
+	os: "o",
+};
+
+export const OS_PLATFORM_ICONS_NERD: Record<string, string> = {
+	darwin: "\uf179",
+	linux: "\uf17c",
+	win32: "\uf17a",
+};
+
+export const OS_PLATFORM_ICONS_ASCII: Record<string, string> = {
+	darwin: "mac",
+	linux: "linux",
+	win32: "win",
+};
+
+/** Short ASCII labels keyed by runtime `name`. */
+export const RUNTIME_ASCII_SYMBOLS: Record<string, string> = {
+	xmake: "xm",
+	maven: "mvn",
+	gradle: "grd",
+	bun: "bun",
+	deno: "deno",
+	lua: "lua",
+	nodejs: "node",
+	python: "py",
+	golang: "go",
+	rust: "rs",
+	java: "java",
+	ruby: "rb",
+	php: "php",
+	buf: "buf",
+	cmake: "cmake",
+	cpp: "c++",
+	c: "c",
+	cobol: "cob",
+	conda: "conda",
+	crystal: "cr",
+	dart: "dart",
+	dotnet: ".net",
+	elixir: "ex",
+	elm: "elm",
+	erlang: "erl",
+	fennel: "fnl",
+	fortran: "f90",
+	gleam: "glm",
+	guix_shell: "guix",
+	haskell: "hs",
+	haxe: "hx",
+	helm: "helm",
+	julia: "jl",
+	kotlin: "kt",
+	meson: "meson",
+	mojo: "mojo",
+	nim: "nim",
+	nix_shell: "nix",
+	ocaml: "ml",
+	odin: "odin",
+	opa: "opa",
+	perl: "pl",
+	pixi: "pixi",
+	pulumi: "pul",
+	purescript: "purs",
+	raku: "raku",
+	red: "red",
+	rlang: "R",
+	scala: "scala",
+	solidity: "sol",
+	spack: "spack",
+	swift: "swift",
+	terraform: "tf",
+	typst: "typ",
+	vagrant: "vag",
+	vlang: "v",
+	zig: "zig",
+};
+
+export function isIconMode(value: unknown): value is IconMode {
+	return value === "auto" || value === "nerd" || value === "ascii";
+}
+
+export function normalizeIconMode(value: unknown): IconMode {
+	return isIconMode(value) ? value : "auto";
+}
+
+export function modeDefaultIcons(mode: IconMode): IconGlyphs {
+	return mode === "ascii" ? { ...ASCII_DEFAULT_ICONS } : { ...NERD_DEFAULT_ICONS };
+}
+
+export function resolveConfiguredIcons(
+	mode: IconMode,
+	overrides: Partial<IconGlyphs> = {},
+): ResolvedIcons {
+	const base = modeDefaultIcons(mode);
+	const rail =
+		typeof overrides.rail === "string" && overrides.rail.trim().length > 0
+			? overrides.rail
+			: base.rail;
+	return {
+		mode,
+		...base,
+		...overrides,
+		rail,
+	};
+}
+
+/**
+ * Honor a custom `icons.os` when it differs from the mode default.
+ * Otherwise map by platform for the active mode.
+ */
+export function resolveOsIcon(
+	configuredOsIcon: string,
+	mode: IconMode = "auto",
+	platform: string = process.platform,
+): string {
+	const modeDefault = modeDefaultIcons(mode).os;
+	if (configuredOsIcon !== modeDefault) return configuredOsIcon;
+	const platformMap = mode === "ascii" ? OS_PLATFORM_ICONS_ASCII : OS_PLATFORM_ICONS_NERD;
+	return platformMap[platform] ?? configuredOsIcon;
+}
+
+export function resolveRuntimeSymbol(
+	name: string,
+	nerdSymbol: string,
+	mode: IconMode = "auto",
+): string {
+	if (mode !== "ascii") return nerdSymbol;
+	return RUNTIME_ASCII_SYMBOLS[name] ?? (name.slice(0, 3) || "*");
+}

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -7,22 +7,26 @@ import type {
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import {
 	type ColorSourcesConfig,
+	type ContextStyle,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	ensureConfigExists,
 	type FooterSegmentsConfig,
+	type IconMode,
 	loadConfig,
 	type PolishedTuiConfig,
 	saveColorSourcesPatch,
+	saveContextStylePatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
 	saveFooterFormatPatch,
 	saveFooterSegmentsPatch,
+	saveIconsModePatch,
 	saveUiFeaturesPatch,
 	type UiFeaturesConfig,
 } from "./config";
 import { installFooter } from "./footer";
-import { buildSessionDurationLabel } from "./format";
+import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
 import {
 	createProjectRefreshScheduler,
@@ -30,6 +34,7 @@ import {
 	type StopProjectRefreshInterval,
 	startProjectRefreshInterval,
 } from "./project-refresh";
+import { applyProjectRefreshToState } from "./project-state";
 import { readRuntimeInfo } from "./runtime";
 import { installSelectorBorderStyle } from "./selector-border";
 import { registerZentuiSettingsCommand } from "./settings-command";
@@ -87,6 +92,7 @@ export default function (pi: ExtensionAPI) {
 	let prototypePatchesInstalled = false;
 	let stopSessionTimer: () => void = () => {};
 	let lastDurationLabel = "";
+	let lastProjectCwd: string | undefined;
 
 	const refresh = () => requestFooterRender?.();
 	const getActiveTheme = () => activeTheme;
@@ -96,12 +102,13 @@ export default function (pi: ExtensionAPI) {
 		syncState(state, ctx, currentConfig.icons.cacheHit);
 
 	const refreshProjectState = async (ctx: ExtensionContext) => {
-		const [gitStatus, runtime] = await Promise.all([
-			readGitStatus(ctx.cwd),
-			readRuntimeInfo(ctx.cwd),
-		]);
-		Object.assign(state, gitStatus);
-		state.runtime = runtime;
+		const [git, runtime] = await Promise.all([readGitStatus(ctx.cwd), readRuntimeInfo(ctx.cwd)]);
+		lastProjectCwd = applyProjectRefreshToState(state, {
+			cwd: ctx.cwd,
+			previousCwd: lastProjectCwd,
+			git,
+			runtime,
+		});
 	};
 
 	const projectRefreshScheduler = createProjectRefreshScheduler(refreshProjectState, refresh);
@@ -368,6 +375,8 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		state.sessionStartEpoch = Date.now();
+		invalidateUsageTotalsCache();
+		lastProjectCwd = undefined;
 		installUi(ctx);
 		scheduleEditorReconciliation(ctx);
 	});
@@ -393,6 +402,12 @@ export default function (pi: ExtensionAPI) {
 		setFooterFormat(value: string) {
 			currentConfig = saveFooterFormatPatch(value);
 		},
+		setIconMode(mode: IconMode) {
+			currentConfig = saveIconsModePatch(mode);
+		},
+		setContextStyle(style: ContextStyle) {
+			currentConfig = saveContextStylePatch(style);
+		},
 		getActiveExtensionStatuses() {
 			return getActiveExtensionStatuses();
 		},
@@ -411,12 +426,17 @@ export default function (pi: ExtensionAPI) {
 		cleanupUi(ctx);
 	});
 
+	const syncInteractiveAndProjectStateWithUsage = (_event: unknown, ctx: ExtensionContext) => {
+		invalidateUsageTotalsCache();
+		refreshInteractiveState(ctx, true);
+	};
+
 	pi.on("agent_start", syncInteractiveState);
 	pi.on("agent_end", syncInteractiveAndProjectState);
 	pi.on("model_select", syncInteractiveState);
 	pi.on("thinking_level_select", syncInteractiveState);
-	pi.on("message_end", syncInteractiveAndProjectState);
+	pi.on("message_end", syncInteractiveAndProjectStateWithUsage);
 	pi.on("tool_execution_end", syncInteractiveAndProjectState);
-	pi.on("session_compact", syncInteractiveAndProjectState);
-	pi.on("session_tree", syncInteractiveAndProjectState);
+	pi.on("session_compact", syncInteractiveAndProjectStateWithUsage);
+	pi.on("session_tree", syncInteractiveAndProjectStateWithUsage);
 }

--- a/extensions/zentui/project-state.ts
+++ b/extensions/zentui/project-state.ts
@@ -1,0 +1,44 @@
+import type { GitReadResult } from "./git";
+import { emptyGitStatus } from "./git";
+import type { RuntimeReadResult } from "./runtime";
+import type { FooterState } from "./state";
+
+/**
+ * Apply a project refresh (git + runtime) onto footer state, preserving
+ * last-good values on transient errors and clearing on cwd change / not-a-repo.
+ *
+ * Returns the cwd to store as `previousCwd` for the next refresh.
+ */
+export function applyProjectRefreshToState(
+	state: FooterState,
+	args: {
+		cwd: string;
+		previousCwd: string | undefined;
+		git: GitReadResult;
+		runtime: RuntimeReadResult;
+	},
+): string {
+	const cwdChanged = args.previousCwd !== undefined && args.previousCwd !== args.cwd;
+
+	if (cwdChanged) {
+		Object.assign(state, emptyGitStatus());
+		state.runtime = undefined;
+	}
+
+	if (args.git.kind === "ok") {
+		Object.assign(state, args.git.status);
+	} else if (args.git.kind === "not_a_repo") {
+		Object.assign(state, emptyGitStatus());
+	}
+	// kind === "error": keep previous git fields (unless cwdChanged already cleared)
+
+	if (args.runtime.kind === "ok") {
+		state.runtime = args.runtime.runtime;
+	} else if (cwdChanged && args.runtime.kind === "error") {
+		// Already cleared above; keep undefined.
+		state.runtime = undefined;
+	}
+	// error + same cwd: keep previous runtime
+
+	return args.cwd;
+}

--- a/extensions/zentui/runtime.ts
+++ b/extensions/zentui/runtime.ts
@@ -16,6 +16,42 @@ export type RuntimeInfo = Pick<RuntimeMetadata, "name" | "symbol" | "style"> & {
 	version?: string;
 };
 
+export type RuntimeReadResult = { kind: "ok"; runtime?: RuntimeInfo } | { kind: "error" };
+
+type RuntimeCacheEntry = {
+	fingerprint: string;
+	runtime: RuntimeInfo | undefined;
+};
+
+const RUNTIME_CACHE_MAX = 32;
+const runtimeInfoCache = new Map<string, RuntimeCacheEntry>();
+
+export function clearRuntimeInfoCache(): void {
+	runtimeInfoCache.clear();
+}
+
+function topLevelFingerprint(entries: readonly string[]): string {
+	return entries.slice().sort().join("\0");
+}
+
+function cacheRuntimeInfo(
+	cwd: string,
+	fingerprint: string,
+	runtime: RuntimeInfo | undefined,
+): void {
+	// Drop prior fingerprints for the same cwd so stale marker sets do not linger.
+	for (const key of runtimeInfoCache.keys()) {
+		if (key === cwd || key.startsWith(`${cwd}\0`)) runtimeInfoCache.delete(key);
+	}
+	const key = `${cwd}\0${fingerprint}`;
+	runtimeInfoCache.set(key, { fingerprint, runtime });
+	while (runtimeInfoCache.size > RUNTIME_CACHE_MAX) {
+		const oldest = runtimeInfoCache.keys().next().value;
+		if (oldest === undefined) break;
+		runtimeInfoCache.delete(oldest);
+	}
+}
+
 type RuntimeEnvironment = Record<string, string | undefined>;
 
 type DetectionSpec = {
@@ -769,20 +805,37 @@ export function detectRuntime(
 	return undefined;
 }
 
-export async function readRuntimeInfo(cwd: string): Promise<RuntimeInfo | undefined> {
-	let entries: string[] = [];
+export async function readRuntimeInfo(cwd: string): Promise<RuntimeReadResult> {
+	let entries: string[];
 	try {
 		entries = readdirSync(cwd);
 	} catch {
-		entries = [];
+		// readdir failure is treated as a transient error so last-good can be kept.
+		return { kind: "error" };
 	}
 
-	const runtime = detectRuntime(cwd, entries);
-	if (!runtime) return undefined;
-	return {
-		name: runtime.name,
-		symbol: runtime.symbol,
-		style: runtime.style,
-		version: await runtime.version(cwd),
-	};
+	const fingerprint = topLevelFingerprint(entries);
+	const cacheKey = `${cwd}\0${fingerprint}`;
+	const cached = runtimeInfoCache.get(cacheKey);
+	if (cached && cached.fingerprint === fingerprint) {
+		return { kind: "ok", runtime: cached.runtime };
+	}
+
+	try {
+		const runtime = detectRuntime(cwd, entries);
+		if (!runtime) {
+			cacheRuntimeInfo(cwd, fingerprint, undefined);
+			return { kind: "ok", runtime: undefined };
+		}
+		const info: RuntimeInfo = {
+			name: runtime.name,
+			symbol: runtime.symbol,
+			style: runtime.style,
+			version: await runtime.version(cwd),
+		};
+		cacheRuntimeInfo(cwd, fingerprint, info);
+		return { kind: "ok", runtime: info };
+	} catch {
+		return { kind: "error" };
+	}
 }

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -12,17 +12,20 @@ import {
 import {
 	type ColorSource,
 	type ColorSourcesConfig,
+	type ContextStyle,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FooterSegmentsConfig,
 	getExtensionStatusColorMode,
 	getExtensionStatusPlacement,
+	type IconMode,
 	isExtensionStatusColorMode,
 	isExtensionStatusPlacement,
 	type PolishedTuiConfig,
 	type UiFeaturesConfig,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
+import { isIconMode } from "./icons";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, safeThemeFg } from "./style";
 
 const colorSourceValues: ColorSource[] = ["theme", "terminal"];
@@ -33,15 +36,24 @@ const extensionStatusPlacementValues: ExtensionStatusPlacement[] = [
 	"right",
 ];
 const extensionStatusColorModeValues: ExtensionStatusColorMode[] = ["zentui", "original"];
+const contextStyleValues: ContextStyle[] = ["text", "gauge", "text+gauge"];
+const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 type FeatureState = "enabled" | "disabled";
 
 const featureStateValues: FeatureState[] = ["enabled", "disabled"];
-const settingsSections = ["coloring", "features", "builtinSegments", "extensionSegments"] as const;
+const settingsSections = [
+	"coloring",
+	"features",
+	"layout",
+	"builtinSegments",
+	"extensionSegments",
+] as const;
 
 type ColorSettingId = "starship" | "editorMessages";
 type FeatureSettingId = keyof UiFeaturesConfig;
 type FooterSegmentSettingId = keyof FooterSegmentsConfig;
 type SettingsSection = (typeof settingsSections)[number];
+type LayoutSettingId = "contextStyle" | "iconMode";
 
 type SettingsCommandDeps = {
 	getConfig: () => PolishedTuiConfig;
@@ -52,6 +64,8 @@ type SettingsCommandDeps = {
 	) => { applied: boolean; reason?: string };
 	setFooterSegments: (patch: Partial<FooterSegmentsConfig>) => void;
 	setFooterFormat: (value: string) => void;
+	setIconMode: (mode: IconMode) => void;
+	setContextStyle: (style: ContextStyle) => void;
 	getActiveExtensionStatuses: () => ReadonlyMap<string, string>;
 	setExtensionStatusPlacement: (key: string, placement: ExtensionStatusPlacement) => void;
 	setExtensionStatusColorMode: (key: string, colorMode: ExtensionStatusColorMode) => void;
@@ -128,11 +142,13 @@ const directCommandSuggestions = [
 	"copy-friendly toggle",
 	"format clear",
 	"format $cwd on $git_branch $fill $context",
+	"format $cwd( on $git_branch)($git_status)$fill($context)( | $cost)",
 ];
 
 const sectionLabels: Record<SettingsSection, string> = {
 	coloring: "Coloring",
 	features: "Features",
+	layout: "Layout",
 	builtinSegments: "Built-in segments",
 	extensionSegments: "Extension segments",
 };
@@ -172,6 +188,14 @@ function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingI
 
 function isFeatureState(value: string): value is FeatureState {
 	return value === "enabled" || value === "disabled";
+}
+
+function isContextStyle(value: string): value is ContextStyle {
+	return value === "text" || value === "gauge" || value === "text+gauge";
+}
+
+function isLayoutSettingId(value: string): value is LayoutSettingId {
+	return value === "contextStyle" || value === "iconMode";
 }
 
 function editorMessageValue(config: PolishedTuiConfig): ColorSource | "mixed" {
@@ -314,6 +338,25 @@ function buildItems(
 			currentValue: featureValue(config.features[key]),
 			values: featureStateValues,
 		}));
+	}
+
+	if (section === "layout") {
+		return [
+			{
+				id: "contextStyle",
+				label: "Context style",
+				description: "Render context as text, a gauge bar, or both.",
+				currentValue: config.contextStyle,
+				values: contextStyleValues,
+			},
+			{
+				id: "iconMode",
+				label: "Icon mode",
+				description: "auto/nerd use Nerd Font glyphs; ascii uses plain fallbacks.",
+				currentValue: config.icons.mode,
+				values: iconModeValues,
+			},
+		];
 	}
 
 	if (section === "builtinSegments") {
@@ -505,6 +548,26 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									}
 
 									applyFeatureChange(id, newValue);
+									return;
+								}
+
+								if (isLayoutSettingId(id)) {
+									if (id === "contextStyle" && isContextStyle(newValue)) {
+										deps.setContextStyle(newValue);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Context style: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
+									if (id === "iconMode" && isIconMode(newValue)) {
+										deps.setIconMode(newValue);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Icon mode: ${newValue}`, "info");
+										tui.requestRender();
+									}
 									return;
 								}
 

--- a/extensions/zentui/style.ts
+++ b/extensions/zentui/style.ts
@@ -29,11 +29,22 @@ export const EDITOR_BORDER_FALLBACK: SourceStyleFallback = {
 };
 
 function isHexColor(value: string): boolean {
-	return /^#(?:[0-9a-fA-F]{6})$/.test(value);
+	return /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/.test(value);
+}
+
+function expandHexColor(hex: string): string {
+	const body = hex.slice(1);
+	if (body.length === 3) {
+		return body
+			.split("")
+			.map((ch) => ch + ch)
+			.join("");
+	}
+	return body;
 }
 
 function hexToAnsi(hex: string, isBackground = false): string {
-	const normalized = hex.slice(1);
+	const normalized = expandHexColor(hex);
 	const r = Number.parseInt(normalized.slice(0, 2), 16);
 	const g = Number.parseInt(normalized.slice(2, 4), 16);
 	const b = Number.parseInt(normalized.slice(4, 6), 16);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -86,14 +86,42 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ projectRefreshIntervalMs: 0 }).projectRefreshIntervalMs).toBe(0);
 	});
 
+	it("clamps short project refresh intervals up to 5 seconds", () => {
+		expect(mergeConfig({ projectRefreshIntervalMs: 100 }).projectRefreshIntervalMs).toBe(5_000);
+		expect(mergeConfig({ projectRefreshIntervalMs: 4_999 }).projectRefreshIntervalMs).toBe(5_000);
+		expect(mergeConfig({ projectRefreshIntervalMs: 5_000 }).projectRefreshIntervalMs).toBe(5_000);
+	});
+
 	it("ignores invalid project refresh intervals", () => {
 		expect(mergeConfig({ projectRefreshIntervalMs: "30000" }).projectRefreshIntervalMs).toBe(
 			30_000,
 		);
-		expect(mergeConfig({ projectRefreshIntervalMs: 100 }).projectRefreshIntervalMs).toBe(30_000);
 		expect(
 			mergeConfig({ projectRefreshIntervalMs: Number.POSITIVE_INFINITY }).projectRefreshIntervalMs,
 		).toBe(30_000);
+	});
+
+	it("defaults context style/thresholds and accepts valid overrides", () => {
+		expect(mergeConfig({}).contextStyle).toBe("text");
+		expect(mergeConfig({}).contextThresholds).toEqual({ warning: 70, error: 90 });
+		expect(mergeConfig({ contextStyle: "gauge" }).contextStyle).toBe("gauge");
+		expect(mergeConfig({ contextStyle: "text+gauge" }).contextStyle).toBe("text+gauge");
+		expect(mergeConfig({ contextStyle: "bars" }).contextStyle).toBe("text");
+		expect(
+			mergeConfig({ contextThresholds: { warning: 50, error: 80 } }).contextThresholds,
+		).toEqual({ warning: 50, error: 80 });
+		expect(
+			mergeConfig({ contextThresholds: { warning: 90, error: 70 } }).contextThresholds,
+		).toEqual({ warning: 70, error: 90 });
+	});
+
+	it("defaults icon mode to auto and accepts nerd/ascii", () => {
+		expect(mergeConfig({}).icons.mode).toBe("auto");
+		expect(mergeConfig({ icons: { mode: "ascii" } }).icons.mode).toBe("ascii");
+		expect(mergeConfig({ icons: { mode: "nerd" } }).icons.mode).toBe("nerd");
+		expect(mergeConfig({ icons: { mode: "emoji" } }).icons.mode).toBe("auto");
+		expect(mergeConfig({ icons: { mode: "ascii" } }).icons.cwd).toBe("~");
+		expect(mergeConfig({ icons: { mode: "ascii", cwd: "DIR" } }).icons.cwd).toBe("DIR");
 	});
 
 	it("accepts Starship colors and old color key aliases", () => {
@@ -762,6 +790,11 @@ describe("style rendering", () => {
 
 	it("supports hex colors", () => {
 		expect(colorize(theme, "#89b4fa", "hello")).toBe("\u001b[38;2;137;180;250mhello\u001b[39m");
+	});
+
+	it("supports short #rgb hex colors by expanding to rrggbb", () => {
+		expect(colorize(theme, "#89b", "hello")).toBe("\u001b[38;2;136;153;187mhello\u001b[39m");
+		expect(renderTerminalStyle("bold #89b", "x")).toBe("\u001b[1;38;2;136;153;187mx\u001b[0m");
 	});
 
 	it("renders Starship styles before falling back to theme tokens", () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1536,6 +1536,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1575,6 +1577,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1617,6 +1621,8 @@ describe("Pi docs compliance", () => {
 				},
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1659,6 +1665,8 @@ describe("Pi docs compliance", () => {
 				},
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1691,6 +1699,8 @@ describe("Pi docs compliance", () => {
 				},
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1731,6 +1741,8 @@ describe("Pi docs compliance", () => {
 				}),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1778,6 +1790,8 @@ describe("Pi docs compliance", () => {
 					},
 					setFooterSegments() {},
 					setFooterFormat() {},
+					setIconMode() {},
+					setContextStyle() {},
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
 					setExtensionStatusColorMode() {},
@@ -1820,7 +1834,7 @@ describe("Pi docs compliance", () => {
 	});
 
 	it("renders Zentui settings with mode-aware top and bottom borders", async () => {
-		const settingsWidth = 120;
+		const settingsWidth = 160;
 		async function renderSettings(config: PolishedTuiConfig) {
 			let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 			let lines: string[] = [];
@@ -1837,6 +1851,8 @@ describe("Pi docs compliance", () => {
 					setUiFeatures: () => ({ applied: true }),
 					setFooterSegments() {},
 					setFooterFormat() {},
+					setIconMode() {},
+					setContextStyle() {},
 					getActiveExtensionStatuses: () => new Map<string, string>(),
 					setExtensionStatusPlacement() {},
 					setExtensionStatusColorMode() {},
@@ -1873,6 +1889,7 @@ describe("Pi docs compliance", () => {
 		expect(themeLines[0]).toContain("[borderMuted]────");
 		expect(themeLines.join("\n")).toContain("Coloring");
 		expect(themeLines.join("\n")).toContain("Features");
+		expect(themeLines.join("\n")).toContain("Layout");
 		expect(themeLines.join("\n")).toContain("Built-in segments");
 		expect(themeLines.join("\n")).toContain("Extension segments");
 		expect(themeLines.join("\n")).toContain("Tab/Shift+Tab to switch sections");
@@ -1904,6 +1921,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -1957,6 +1976,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -2023,6 +2044,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -2061,6 +2084,8 @@ describe("Pi docs compliance", () => {
 	});
 
 	function navigateToExtensionSegmentsSection(component: { handleInput?: (data: string) => void }) {
+		// Coloring → Features → Layout → Built-in segments → Extension segments
+		component.handleInput?.("\t");
 		component.handleInput?.("\t");
 		component.handleInput?.("\t");
 		component.handleInput?.("\t");
@@ -2082,6 +2107,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},
@@ -2134,6 +2161,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () =>
 					new Map<string, string>([
 						["alpha", "A"],
@@ -2191,6 +2220,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>(),
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
@@ -2248,6 +2279,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>([["alpha", "ok"]]),
 				setExtensionStatusPlacement(key, placement) {
 					placements.push({ key, placement });
@@ -2291,7 +2324,7 @@ describe("Pi docs compliance", () => {
 
 		expect(placements).toEqual([{ key: "alpha", placement: "off" }]);
 		expect(dependencyRenderRequests).toBe(1);
-		expect(tuiRenderRequests).toBe(4);
+		expect(tuiRenderRequests).toBe(5);
 	});
 
 	it("does not show inactive saved placements in the extension segments tab", async () => {
@@ -2313,6 +2346,8 @@ describe("Pi docs compliance", () => {
 				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
 				getActiveExtensionStatuses: () => new Map<string, string>([["active", "ok"]]),
 				setExtensionStatusPlacement() {},
 				setExtensionStatusColorMode() {},

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseFooterFormat, renderFormatSplit } from "../extensions/zentui/footer-format";
+import {
+	joinNonEmpty,
+	parseFooterFormat,
+	renderFormatSplit,
+	stripOrphanSeparators,
+} from "../extensions/zentui/footer-format";
 
 describe("parseFooterFormat", () => {
 	it("returns empty array for empty string", () => {
@@ -141,5 +146,150 @@ describe("renderFormatSplit", () => {
 		expect(left).toBe("DIR");
 		expect(middle).toBe("");
 		expect(right).toBe("");
+	});
+});
+
+describe("conditional groups", () => {
+	const renderVar = (name: string): string => {
+		const map: Record<string, string> = {
+			cwd: "DIR",
+			git_branch: "",
+			git_status: "[!]",
+			cost: "$0",
+			runtime: "",
+		};
+		return map[name] ?? "";
+	};
+
+	it("parses group tokens", () => {
+		expect(parseFooterFormat("($git_branch)")).toEqual([
+			{ kind: "group", tokens: [{ kind: "var", name: "git_branch" }] },
+		]);
+	});
+
+	it("drops a group when all vars are empty", () => {
+		const tokens = parseFooterFormat("($git_branch)");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("");
+	});
+
+	it("drops surrounding literals inside an empty group", () => {
+		const tokens = parseFooterFormat("($git_branch on )$cwd");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("DIR");
+	});
+
+	it("keeps a group when any var is non-empty", () => {
+		const tokens = parseFooterFormat("($git_status)");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("[!]");
+	});
+
+	it("supports nested groups", () => {
+		const tokens = parseFooterFormat("(($git_branch) via $runtime)$cwd");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("DIR");
+	});
+
+	it("still splits on fill outside groups", () => {
+		const tokens = parseFooterFormat("$cwd$fill($cost)");
+		const { left, right } = renderFormatSplit(tokens, renderVar);
+		expect(left).toBe("DIR");
+		expect(right).toBe("$0");
+	});
+
+	it("shows text-only groups", () => {
+		const tokens = parseFooterFormat("(literal)$cwd");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("literalDIR");
+	});
+
+	it("treats unmatched top-level ) as literal and keeps trailing tokens", () => {
+		const tokens = parseFooterFormat("$cwd) $cost");
+		expect(tokens).toEqual([
+			{ kind: "var", name: "cwd" },
+			{ kind: "text", value: ") " },
+			{ kind: "var", name: "cost" },
+		]);
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("DIR) $0");
+	});
+
+	it("keeps nested groups working when trailing tokens follow a closed group", () => {
+		const tokens = parseFooterFormat("($git_status)$cwd");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("[!]DIR");
+	});
+});
+
+describe("joinNonEmpty", () => {
+	it("joins only non-empty parts", () => {
+		expect(joinNonEmpty(["a", "", "b", ""], " | ")).toBe("a | b");
+		expect(joinNonEmpty(["", ""], " | ")).toBe("");
+		expect(joinNonEmpty(["only"], " | ")).toBe("only");
+	});
+});
+
+describe("stripOrphanSeparators", () => {
+	it("strips leading and trailing plain pipe separators", () => {
+		expect(stripOrphanSeparators(" | tokens")).toBe("tokens");
+		expect(stripOrphanSeparators("tokens | ")).toBe("tokens");
+		expect(stripOrphanSeparators(" | tokens | ")).toBe("tokens");
+	});
+
+	it("collapses repeated plain pipe separators", () => {
+		// Two themed/plain seps in a row produce " |  | " (space on both sides of each |).
+		expect(stripOrphanSeparators("ctx |  | tokens")).toBe("ctx | tokens");
+		expect(stripOrphanSeparators(" |  | $0")).toBe("$0");
+	});
+
+	it("strips leading/trailing whitespace after empty groups drop", () => {
+		expect(stripOrphanSeparators("  DIR")).toBe("DIR");
+		expect(stripOrphanSeparators("DIR  ")).toBe("DIR");
+		expect(stripOrphanSeparators("   ")).toBe("");
+	});
+
+	it("handles ANSI-wrapped themed separators", () => {
+		const sep = "\x1b[90m | \x1b[0m";
+		expect(stripOrphanSeparators(`${sep}tokens`)).toBe("tokens");
+		expect(stripOrphanSeparators(`ctx${sep}${sep}tokens`)).toBe(`ctx${sep}tokens`);
+		expect(stripOrphanSeparators(`ctx${sep}tokens${sep}`)).toBe(`ctx${sep}tokens`);
+		expect(stripOrphanSeparators(`${sep}tokens${sep}cost`)).toBe(`tokens${sep}cost`);
+	});
+
+	it("does not destroy intentional pipes without surrounding spaces", () => {
+		expect(stripOrphanSeparators("branch|feature")).toBe("branch|feature");
+	});
+
+	it("tidies right-side groups with empty middle metrics", () => {
+		const renderVar = (name: string): string => {
+			const map: Record<string, string> = {
+				context: "",
+				tokens: "",
+				cost: "$0",
+				sep: " | ",
+			};
+			return map[name] ?? "";
+		};
+		// Empty content vars drop their groups even when $sep is present.
+		const tokens = parseFooterFormat("($context)($sep$tokens)($sep$cost)");
+		const raw = renderFormatSplit(tokens, renderVar).left;
+		expect(raw).toBe(" | $0");
+		expect(stripOrphanSeparators(raw)).toBe("$0");
+	});
+
+	it("drops groups whose only non-empty var is $sep", () => {
+		const renderVar = (name: string): string => (name === "sep" ? " | " : "");
+		const tokens = parseFooterFormat("($sep$tokens)cwd");
+		expect(renderFormatSplit(tokens, renderVar).left).toBe("cwd");
+	});
+
+	it("preserves themed separators between non-empty parts", () => {
+		const sep = "\x1b[90m | \x1b[0m";
+		const renderVar = (name: string): string => {
+			const map: Record<string, string> = {
+				context: "72%",
+				tokens: "↑1",
+				cost: "$0",
+				sep,
+			};
+			return map[name] ?? "";
+		};
+		const tokens = parseFooterFormat("($context)($sep$tokens)($sep$cost)");
+		const raw = renderFormatSplit(tokens, renderVar).left;
+		expect(stripOrphanSeparators(raw)).toBe(`72%${sep}↑1${sep}$0`);
 	});
 });

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,11 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	__resetUsageTotalsCacheForTests,
+	__usageTotalsComputeCount,
+	buildContextDisplayLabel,
+	buildContextGauge,
 	buildCostLabel,
 	buildSessionDurationLabel,
 	buildTokenLabel,
+	contextColorTier,
 	formatCount,
+	formatOsLabel,
 	getUsageTotals,
+	invalidateUsageTotalsCache,
 } from "../extensions/zentui/format";
+import {
+	ASCII_DEFAULT_ICONS,
+	NERD_DEFAULT_ICONS,
+	OS_PLATFORM_ICONS_ASCII,
+	OS_PLATFORM_ICONS_NERD,
+} from "../extensions/zentui/icons";
 
 const cacheHitIcon = "󰆼";
 
@@ -148,5 +161,75 @@ describe("buildSessionDurationLabel", () => {
 	it("clamps zero and negative elapsed to 0s", () => {
 		expect(buildSessionDurationLabel(FIXED_NOW)).toBe("0s");
 		expect(buildSessionDurationLabel(FIXED_NOW + 10_000)).toBe("0s");
+	});
+});
+
+describe("formatOsLabel", () => {
+	it("honors a custom icons.os over platform defaults", () => {
+		expect(formatOsLabel("X", "auto", "darwin")).toBe("X");
+		expect(formatOsLabel("X", "ascii", "linux")).toBe("X");
+	});
+
+	it("maps platform icons when using the mode default os glyph", () => {
+		expect(formatOsLabel(NERD_DEFAULT_ICONS.os, "auto", "linux")).toBe(
+			OS_PLATFORM_ICONS_NERD.linux,
+		);
+		expect(formatOsLabel(ASCII_DEFAULT_ICONS.os, "ascii", "darwin")).toBe(
+			OS_PLATFORM_ICONS_ASCII.darwin,
+		);
+	});
+});
+
+describe("context helpers", () => {
+	it("classifies context color tiers from thresholds", () => {
+		expect(contextColorTier(10, { warning: 50, error: 80 })).toBe("normal");
+		expect(contextColorTier(50, { warning: 50, error: 80 })).toBe("warning");
+		expect(contextColorTier(80, { warning: 50, error: 80 })).toBe("error");
+		expect(contextColorTier(null)).toBe("normal");
+	});
+
+	it("builds stable-width gauges and style labels", () => {
+		expect(buildContextGauge(0, 10)).toHaveLength(10);
+		expect(buildContextGauge(100, 10)).toHaveLength(10);
+		expect(buildContextGauge(50, 10, true)).toBe("#####-----");
+		expect(buildContextDisplayLabel({ percent: 42, contextWindow: 128_000, style: "text" })).toBe(
+			"42%/128k",
+		);
+		expect(
+			buildContextDisplayLabel({ percent: 42, contextWindow: 128_000, style: "gauge" }),
+		).toMatch(/^\[.{10}\]$/);
+		expect(
+			buildContextDisplayLabel({
+				percent: 42,
+				contextWindow: 128_000,
+				style: "text+gauge",
+			}),
+		).toMatch(/^\[.{10}\] 42%\/128k$/);
+		expect(buildContextDisplayLabel({ percent: null, contextWindow: undefined })).toBe("--");
+	});
+});
+
+describe("getUsageTotals memoization", () => {
+	it("reuses totals for unchanged entries and recomputes after invalidate", () => {
+		__resetUsageTotalsCacheForTests();
+
+		const entries = [makeAssistantEntry(10, 1, 0.1)];
+		const ctx = makeSessionContext(entries) as never;
+
+		const first = getUsageTotals(ctx);
+		const second = getUsageTotals(ctx);
+		expect(second).toBe(first);
+		expect(__usageTotalsComputeCount()).toBe(1);
+
+		entries.push(makeAssistantEntry(20, 2, 0.2));
+		const third = getUsageTotals(ctx);
+		expect(third.input).toBe(30);
+		expect(__usageTotalsComputeCount()).toBe(2);
+
+		invalidateUsageTotalsCache();
+		const fourth = getUsageTotals(ctx);
+		expect(fourth).toEqual(third);
+		expect(fourth).not.toBe(third);
+		expect(__usageTotalsComputeCount()).toBe(3);
 	});
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,5 +1,8 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { emptyGitStatus, parseGitStatusPorcelain } from "../extensions/zentui/git";
+import { detectGitState, emptyGitStatus, parseGitStatusPorcelain } from "../extensions/zentui/git";
 
 describe("parseGitStatusPorcelain", () => {
 	it("returns empty status for empty output", () => {
@@ -37,5 +40,93 @@ describe("parseGitStatusPorcelain", () => {
 	it("hides detached head as no branch", () => {
 		const status = parseGitStatusPorcelain("# branch.head (detached)", 0);
 		expect(status.branch).toBeUndefined();
+	});
+});
+
+describe("detectGitState", () => {
+	function fixture(files: Record<string, string>) {
+		const root = mkdtempSync(join(tmpdir(), "zentui-git-state-"));
+		const paths: Record<string, string> = {};
+		for (const [name, content] of Object.entries(files)) {
+			const full = join(root, name);
+			const slash = name.indexOf("/");
+			if (slash > 0) {
+				mkdirSync(join(root, name.slice(0, slash)), { recursive: true });
+			}
+			writeFileSync(full, content, "utf8");
+			paths[name] = full;
+		}
+		return { root, paths };
+	}
+
+	function requirePath(paths: Record<string, string>, key: string): string {
+		const value = paths[key];
+		if (!value) throw new Error(`missing fixture path ${key}`);
+		return value;
+	}
+
+	it("detects REBASING with step counts from rebase-merge", () => {
+		const { paths } = fixture({
+			"rebase-merge/msgnum": "3\n",
+			"rebase-merge/end": "10\n",
+		});
+		const msgnum = requirePath(paths, "rebase-merge/msgnum");
+		const end = requirePath(paths, "rebase-merge/end");
+		const rebaseMerge = join(msgnum, "..");
+		expect(
+			detectGitState({
+				rebaseMerge,
+				rebaseMsgnum: msgnum,
+				rebaseEnd: end,
+			}),
+		).toEqual({ gitState: "REBASING", gitStateLabel: "REBASING 3/10" });
+	});
+
+	it("detects MERGING / CHERRY-PICKING / REVERTING / BISECTING", () => {
+		const { paths } = fixture({
+			MERGE_HEAD: "abc",
+			CHERRY_PICK_HEAD: "def",
+			REVERT_HEAD: "ghi",
+			BISECT_LOG: "log",
+		});
+		expect(detectGitState({ mergeHead: requirePath(paths, "MERGE_HEAD") })).toEqual({
+			gitState: "MERGING",
+			gitStateLabel: "MERGING",
+		});
+		expect(detectGitState({ cherryPickHead: requirePath(paths, "CHERRY_PICK_HEAD") })).toEqual({
+			gitState: "CHERRY-PICKING",
+			gitStateLabel: "CHERRY-PICKING",
+		});
+		expect(detectGitState({ revertHead: requirePath(paths, "REVERT_HEAD") })).toEqual({
+			gitState: "REVERTING",
+			gitStateLabel: "REVERTING",
+		});
+		expect(detectGitState({ bisectLog: requirePath(paths, "BISECT_LOG") })).toEqual({
+			gitState: "BISECTING",
+			gitStateLabel: "BISECTING",
+		});
+	});
+
+	it("prefers rebase over merge", () => {
+		const { paths } = fixture({
+			"rebase-apply/msgnum": "1\n",
+			"rebase-apply/end": "2\n",
+			MERGE_HEAD: "abc",
+		});
+		const msgnum = requirePath(paths, "rebase-apply/msgnum");
+		const end = requirePath(paths, "rebase-apply/end");
+		const rebaseApply = join(msgnum, "..");
+		expect(
+			detectGitState({
+				rebaseApply,
+				mergeHead: requirePath(paths, "MERGE_HEAD"),
+				rebaseMsgnum: msgnum,
+				rebaseEnd: end,
+			}).gitState,
+		).toBe("REBASING");
+	});
+
+	it("returns empty when no state files exist", () => {
+		expect(detectGitState({})).toEqual({});
 	});
 });

--- a/test/icons.test.ts
+++ b/test/icons.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { defaultConfig } from "../extensions/zentui/config";
+import {
+	ASCII_DEFAULT_ICONS,
+	ICON_GLYPH_KEYS,
+	NERD_DEFAULT_ICONS,
+	RUNTIME_ASCII_SYMBOLS,
+	resolveConfiguredIcons,
+	resolveOsIcon,
+	resolveRuntimeSymbol,
+} from "../extensions/zentui/icons";
+import { runtimeMetadata } from "../extensions/zentui/runtime";
+
+describe("icon tables", () => {
+	it("keeps nerd defaults byte-identical to historical defaultConfig icons", () => {
+		for (const key of ICON_GLYPH_KEYS) {
+			expect(NERD_DEFAULT_ICONS[key]).toBe(defaultConfig.icons[key]);
+		}
+	});
+
+	it("provides ascii defaults for every nerd icon key", () => {
+		for (const key of ICON_GLYPH_KEYS) {
+			expect(typeof ASCII_DEFAULT_ICONS[key]).toBe("string");
+		}
+	});
+
+	it("covers runtime metadata names with ascii symbols", () => {
+		for (const runtime of runtimeMetadata) {
+			expect(RUNTIME_ASCII_SYMBOLS[runtime.name]).toBeTruthy();
+		}
+	});
+});
+
+describe("resolveConfiguredIcons", () => {
+	it("starts from nerd for auto/nerd and ascii for ascii mode", () => {
+		expect(resolveConfiguredIcons("auto").cwd).toBe(NERD_DEFAULT_ICONS.cwd);
+		expect(resolveConfiguredIcons("nerd").git).toBe(NERD_DEFAULT_ICONS.git);
+		expect(resolveConfiguredIcons("ascii").cwd).toBe(ASCII_DEFAULT_ICONS.cwd);
+	});
+
+	it("lets user overrides win over mode defaults", () => {
+		expect(resolveConfiguredIcons("ascii", { cwd: "DIR", os: "X" })).toMatchObject({
+			mode: "ascii",
+			cwd: "DIR",
+			os: "X",
+			git: ASCII_DEFAULT_ICONS.git,
+		});
+	});
+});
+
+describe("resolveOsIcon", () => {
+	it("always honors a custom os icon", () => {
+		expect(resolveOsIcon("X", "auto", "darwin")).toBe("X");
+		expect(resolveOsIcon("X", "ascii", "linux")).toBe("X");
+		expect(resolveOsIcon("X", "nerd", "win32")).toBe("X");
+	});
+
+	it("maps platforms when os is still the mode default", () => {
+		expect(resolveOsIcon(NERD_DEFAULT_ICONS.os, "auto", "linux")).toBe("\uf17c");
+		expect(resolveOsIcon(ASCII_DEFAULT_ICONS.os, "ascii", "darwin")).toBe("mac");
+	});
+});
+
+describe("resolveRuntimeSymbol", () => {
+	it("returns nerd symbol unless ascii mode is active", () => {
+		expect(resolveRuntimeSymbol("nodejs", "", "auto")).toBe("");
+		expect(resolveRuntimeSymbol("nodejs", "", "ascii")).toBe("node");
+	});
+});

--- a/test/project-state.test.ts
+++ b/test/project-state.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { emptyGitStatus } from "../extensions/zentui/git";
+import { applyProjectRefreshToState } from "../extensions/zentui/project-state";
+import { createInitialState } from "../extensions/zentui/state";
+
+describe("applyProjectRefreshToState", () => {
+	it("keeps last-good git and runtime on transient errors", () => {
+		const state = createInitialState({
+			...emptyGitStatus(),
+			branch: "main",
+			modified: 2,
+		});
+		state.runtime = { name: "nodejs", symbol: "n", style: "bold green", version: "v22" };
+
+		applyProjectRefreshToState(state, {
+			cwd: "/repo",
+			previousCwd: "/repo",
+			git: { kind: "error" },
+			runtime: { kind: "error" },
+		});
+
+		expect(state.branch).toBe("main");
+		expect(state.modified).toBe(2);
+		expect(state.runtime?.name).toBe("nodejs");
+	});
+
+	it("clears git when not a repo", () => {
+		const state = createInitialState({
+			...emptyGitStatus(),
+			branch: "main",
+			dirty: true,
+			modified: 1,
+		});
+
+		applyProjectRefreshToState(state, {
+			cwd: "/tmp",
+			previousCwd: "/tmp",
+			git: { kind: "not_a_repo" },
+			runtime: { kind: "ok", runtime: undefined },
+		});
+
+		expect(state.branch).toBeUndefined();
+		expect(state.modified).toBe(0);
+		expect(state.dirty).toBe(false);
+	});
+
+	it("clears previous project state on cwd change before applying results", () => {
+		const state = createInitialState({
+			...emptyGitStatus(),
+			branch: "old-branch",
+			modified: 3,
+		});
+		state.runtime = { name: "python", symbol: "p", style: "yellow bold", version: "v3" };
+
+		applyProjectRefreshToState(state, {
+			cwd: "/new",
+			previousCwd: "/old",
+			git: { kind: "error" },
+			runtime: { kind: "error" },
+		});
+
+		expect(state.branch).toBeUndefined();
+		expect(state.modified).toBe(0);
+		expect(state.runtime).toBeUndefined();
+	});
+
+	it("applies ok git/runtime results", () => {
+		const state = createInitialState(emptyGitStatus());
+		const nextCwd = applyProjectRefreshToState(state, {
+			cwd: "/repo",
+			previousCwd: undefined,
+			git: {
+				kind: "ok",
+				status: {
+					...emptyGitStatus(),
+					branch: "feat",
+					gitState: "REBASING",
+					gitStateLabel: "REBASING 1/2",
+				},
+			},
+			runtime: {
+				kind: "ok",
+				runtime: { name: "bun", symbol: "b", style: "bold red", version: "v1" },
+			},
+		});
+
+		expect(nextCwd).toBe("/repo");
+		expect(state.branch).toBe("feat");
+		expect(state.gitStateLabel).toBe("REBASING 1/2");
+		expect(state.runtime?.name).toBe("bun");
+	});
+});

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { detectRuntime, runtimeMetadata } from "../extensions/zentui/runtime";
+import {
+	clearRuntimeInfoCache,
+	detectRuntime,
+	readRuntimeInfo,
+	runtimeMetadata,
+} from "../extensions/zentui/runtime";
 
 function starshipRuntimeModules(): string[] {
 	const toml = readFileSync("test/fixtures/starship-nerd-font-symbols.toml", "utf8");
@@ -146,5 +151,33 @@ describe("detectRuntime", () => {
 		if (!runtime) throw new Error("expected runtime");
 		expect(runtime.name).toBe(name);
 		expect(runtime.style).toBe(style);
+	});
+});
+
+describe("readRuntimeInfo cache", () => {
+	it("caches version probes for the same cwd + marker fingerprint", async () => {
+		clearRuntimeInfoCache();
+		const project = makeProject([{ path: "package.json" }]);
+
+		const first = await readRuntimeInfo(project.cwd);
+		const second = await readRuntimeInfo(project.cwd);
+		expect(first).toEqual(second);
+		expect(first.kind).toBe("ok");
+		if (first.kind === "ok") {
+			expect(first.runtime?.name).toBe("nodejs");
+		}
+
+		// Marker change busts cache and re-detects.
+		writeFileSync(join(project.cwd, "bun.lock"), "", "utf8");
+		const third = await readRuntimeInfo(project.cwd);
+		expect(third.kind).toBe("ok");
+		if (third.kind === "ok") {
+			expect(third.runtime?.name).toBe("bun");
+		}
+	});
+
+	it("returns error when cwd cannot be read", async () => {
+		const result = await readRuntimeInfo(join(tmpdir(), "zentui-missing-runtime-dir-xyz"));
+		expect(result).toEqual({ kind: "error" });
 	});
 });


### PR DESCRIPTION
## Summary

Statusline reliability and layout polish for Zentui:

- **Reliability:** honor `icons.os`, keep last-good git/runtime on transient failures, clamp short refresh intervals up to 5s, accept `#rgb` hex, memoize usage totals, cache runtime probes
- **Icons:** `icons.mode` (`auto` / `nerd` / `ascii`) with ASCII fallback map
- **Context:** `contextStyle` (`text` / `gauge` / `text+gauge`) and configurable warn/error thresholds
- **Format:** conditional `footerFormat` groups `(...)`, themed `$sep` / `$separator`
- **Git:** operation badges (REBASING / MERGING / CHERRY-PICKING / …) via `$git_state`
- **Settings:** `/zentui` Layout tab for context style + icon mode; layout still via segments or user `footerFormat` JSON (no built-in format presets)

## Screenshots / recordings

N/A in this PR body — recommend a quick local `npm run pi:dev` smoke of footer segments, `footerFormat` groups, and `/zentui` Layout after merge.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [ ] Manual Pi test via `npm run pi:dev` (required for UI behavior changes)
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [x] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in a focused module.
- [x] Used a conventional commit-style PR title (e.g. `feat: add ...`, `fix: handle ...`).