### PR TITLE
feat: add package version, git commit, and git metrics segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Default config values — copy this and change any value you want:
 		"separator": "bright-black",
 		"runtimePrefix": "",
 		"sessionDuration": "yellow",
+		"packageVersion": "208",
 		"username": "bold yellow",
 		"time": "bold yellow",
 		"os": "bold white",
@@ -293,7 +294,7 @@ Center the branch between directory and cost:
 | `$git_status`       | `$status`    | `[!?↑]` status block                             |
 | `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
 | `$runtime`          |              | runtime icon + version                           |
-| `$package`          |              | project package version (manifest-derived)       |
+| `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)            |
 | `$session_duration` | `$duration`  | session running time                             |
 | `$username`         |              | `user@host`                                      |

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ Zentui brings two popular aesthetics to Pi:
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
 - Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
+- Third-party Pi extension statuses from `ctx.ui.setStatus()` can be shown on the left,
+  middle, or right side, or hidden per status key from `/zentui`
 
 ### Editor (Opencode-inspired)
 
 - Bordered input box with configurable accent rail and border colors
-- Model name and provider displayed inside the editor frame
-- Configurable model, provider, and thinking-level indicator colors
-  test
 - Prompt-box-style user messages matching the ZentUI input chrome
 - Copy-friendly mode hides editor and previous-message rail glyphs so terminal selection copies less chrome
+
+jfiowef
 
 ### Git Status Icons
 
@@ -314,7 +315,7 @@ Center the branch between directory and cost:
 | `$git_added`        |              | added line count (`+N`)                                             |
 | `$git_deleted`      |              | deleted line count (`−N`)                                           |
 | `$runtime`          |              | runtime icon + version                                              |
-| `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived) |
+| `$package`          |              | project package version, `is <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)                               |
 | `$session_duration` | `$duration`  | session running time                                                |
 | `$username`         |              | `user@host`                                                         |

--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ Zentui brings two popular aesthetics to Pi:
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
 - Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
-- Third-party Pi extension statuses from `ctx.ui.setStatus()` can be shown on the left,
-  middle, or right side, or hidden per status key from `/zentui`
 
 ### Editor (Opencode-inspired)
 
 - Bordered input box with configurable accent rail and border colors
 - Model name and provider displayed inside the editor frame
 - Configurable model, provider, and thinking-level indicator colors
+  test
 - Prompt-box-style user messages matching the ZentUI input chrome
 - Copy-friendly mode hides editor and previous-message rail glyphs so terminal selection copies less chrome
 
@@ -303,29 +302,29 @@ Center the branch between directory and cost:
 
 ### Variables
 
-| Token               | Aliases      | Renders                                          |
-| ------------------- | ------------ | ------------------------------------------------ |
-| `$cwd`              | `$directory` | current directory                                |
-| `$git_branch`       | `$branch`    | git branch with icon                             |
-| `$git_status`       | `$status`    | `[!?↑]` status block                             |
-| `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
-| `$git_commit`       | `$commit`    | short commit hash (+ exact-match tag when present)  |
-| `$git_tag`          | `$tag`       | exact-match tag at HEAD                          |
-| `$git_metrics`      |              | aggregate line changes `+added −deleted`         |
-| `$git_added`        |              | added line count (`+N`)                          |
-| `$git_deleted`      |              | deleted line count (`−N`)                        |
-| `$runtime`          |              | runtime icon + version                           |
-| `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived)  |
-| `$package_version`  |              | raw project package version (no icon)            |
-| `$session_duration` | `$duration`  | session running time                             |
-| `$username`         |              | `user@host`                                      |
-| `$os`               |              | operating-system icon                            |
-| `$time`             |              | current time `HH:MM`                             |
-| `$context`          |              | context usage (text and/or gauge via config)     |
-| `$tokens`           |              | input/output token counts                        |
-| `$cost`             |              | session cost                                     |
-| `$sep`              | `$separator` | themed ` | ` using `colors.separator`            |
-| `$fill`             | —            | special: splits zones                            |
+| Token               | Aliases      | Renders                                                             |
+| ------------------- | ------------ | ------------------------------------------------------------------- |
+| `$cwd`              | `$directory` | current directory                                                   |
+| `$git_branch`       | `$branch`    | git branch with icon                                                |
+| `$git_status`       | `$status`    | `[!?↑]` status block                                                |
+| `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)                         |
+| `$git_commit`       | `$commit`    | short commit hash (+ exact-match tag when present)                  |
+| `$git_tag`          | `$tag`       | exact-match tag at HEAD                                             |
+| `$git_metrics`      |              | aggregate line changes `+added −deleted`                            |
+| `$git_added`        |              | added line count (`+N`)                                             |
+| `$git_deleted`      |              | deleted line count (`−N`)                                           |
+| `$runtime`          |              | runtime icon + version                                              |
+| `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived) |
+| `$package_version`  |              | raw project package version (no icon)                               |
+| `$session_duration` | `$duration`  | session running time                                                |
+| `$username`         |              | `user@host`                                                         |
+| `$os`               |              | operating-system icon                                               |
+| `$time`             |              | current time `HH:MM`                                                |
+| `$context`          |              | context usage (text and/or gauge via config)                        |
+| `$tokens`           |              | input/output token counts                                           |
+| `$cost`             |              | session cost                                                        |
+| `$sep`              | `$separator` | themed `                                                            | `using`colors.separator` |
+| `$fill`             | —            | special: splits zones                                               |
 
 ### `$fill` behavior
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Default config values — copy this and change any value you want:
 		"runtimePrefix": "",
 		"sessionDuration": "yellow",
 		"packageVersion": "208",
+		"packageVersion": "208",
+		"gitCommit": "bold green",
 		"username": "bold yellow",
 		"time": "bold yellow",
 		"os": "bold white",
@@ -236,7 +238,13 @@ Default config values — copy this and change any value you want:
 		"username": false,
 		"time": false,
 		"os": false,
-		"packageVersion": false
+		"packageVersion": false,
+		"gitCommit": false
+	},
+	"gitCommit": {
+		"hashLength": 7,
+		"onlyDetached": true,
+		"showTag": true
 	},
 	"extensionStatuses": {
 		"defaultPlacement": "right",
@@ -254,8 +262,9 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures context style, path display mode/depth, and icon mode; set or clear custom formats with `/zentui format`.
+- `gitCommit`: Starship [`git_commit`](https://starship.rs/config/#git-commit)-style options for the `gitCommit` footer segment. `hashLength` (default `7`, clamped to `4`–`40`) controls the short-hash display length. `onlyDetached` (default `true`) shows the hash mainly on detached HEAD. `showTag` (default `true`) appends an exact-match tag (`git describe --tags --exact-match HEAD`). The tag probe piggybacks on the existing git refresh — it only runs when both the segment and `showTag` are on, and misses/failures degrade silently.
 - `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The `Extension segments` tab in `/zentui` lists only statuses that are currently active.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
@@ -293,6 +302,8 @@ Center the branch between directory and cost:
 | `$git_branch`       | `$branch`    | git branch with icon                             |
 | `$git_status`       | `$status`    | `[!?↑]` status block                             |
 | `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
+| `$git_commit`       | `$commit`    | short commit hash (+ exact-match tag when present)  |
+| `$git_tag`          | `$tag`       | exact-match tag at HEAD                          |
 | `$runtime`          |              | runtime icon + version                           |
 | `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)            |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Zentui brings two popular aesthetics to Pi:
 
 ### Footer (Starship-inspired)
 
-- `󰝰 dirname` — current directory with icon (`basename` by default; optional `full` path with directory depth via `pathDisplay`)
+- `dirname` — current directory (`basename` by default; optional `full` path with directory depth via `pathDisplay`)
 - `on  branch` — git branch with icon
 - `[!?↑]` — git status indicators (modified, untracked, ahead/behind, stashed, etc.)
 - `via  v5.5.0` — runtime detection with version and Starship-style Nerd Font runtime/language modules
@@ -31,10 +31,10 @@ Zentui brings two popular aesthetics to Pi:
 ### Editor (Opencode-inspired)
 
 - Bordered input box with configurable accent rail and border colors
+- Model name and provider displayed inside the editor frame
+- Configurable model, provider, and thinking-level indicator colors
 - Prompt-box-style user messages matching the ZentUI input chrome
 - Copy-friendly mode hides editor and previous-message rail glyphs so terminal selection copies less chrome
-
-jfiowef
 
 ### Git Status Icons
 
@@ -164,7 +164,7 @@ Default config values — copy this and change any value you want:
 	},
 	"icons": {
 		"mode": "auto",
-		"cwd": "󰝰",
+		"cwd": "",
 		"git": "",
 		"ahead": "↑",
 		"behind": "↓",
@@ -324,7 +324,7 @@ Center the branch between directory and cost:
 | `$context`          |              | context usage (text and/or gauge via config)                        |
 | `$tokens`           |              | input/output token counts                                           |
 | `$cost`             |              | session cost                                                        |
-| `$sep`              | `$separator` | themed `                                                            | `using`colors.separator` |
+| `$sep`              | `$separator` | themed `\|` using `colors.separator`            |
 | `$fill`             | —            | special: splits zones                                               |
 
 ### `$fill` behavior

--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ Default config values — copy this and change any value you want:
 		"packageVersion": "208",
 		"packageVersion": "208",
 		"gitCommit": "bold green",
+		"gitMetricsAdded": "bold green",
+		"gitMetricsDeleted": "bold red",
 		"username": "bold yellow",
 		"time": "bold yellow",
 		"os": "bold white",
@@ -239,12 +241,17 @@ Default config values — copy this and change any value you want:
 		"time": false,
 		"os": false,
 		"packageVersion": false,
-		"gitCommit": false
+		"gitCommit": false,
+		"gitMetrics": false
 	},
 	"gitCommit": {
 		"hashLength": 7,
 		"onlyDetached": true,
 		"showTag": true
+	},
+	"gitMetrics": {
+		"onlyNonzero": true,
+		"ignoreSubmodules": false
 	},
 	"extensionStatuses": {
 		"defaultPlacement": "right",
@@ -262,9 +269,10 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures context style, path display mode/depth, and icon mode; set or clear custom formats with `/zentui format`.
 - `gitCommit`: Starship [`git_commit`](https://starship.rs/config/#git-commit)-style options for the `gitCommit` footer segment. `hashLength` (default `7`, clamped to `4`–`40`) controls the short-hash display length. `onlyDetached` (default `true`) shows the hash mainly on detached HEAD. `showTag` (default `true`) appends an exact-match tag (`git describe --tags --exact-match HEAD`). The tag probe piggybacks on the existing git refresh — it only runs when both the segment and `showTag` are on, and misses/failures degrade silently.
+- `gitMetrics`: Starship [`git_metrics`](https://starship.rs/config/#git-metrics)-style options for the `gitMetrics` footer segment. Uses `git diff HEAD --numstat` (staged + unstaged combined — the Starship “total dirty” view) to show aggregate `+added −deleted` line counts. `onlyNonzero` (default `true`) omits each zero component independently and hides the segment entirely at `0/0`. `ignoreSubmodules` (default `false`) adds `--ignore-submodules=all`. The numstat diff piggybacks on the existing git refresh and uses a hard 2s timeout; a metrics-only failure degrades silently without discarding fresh branch/status data. On very large monorepos the diff may lag or be omitted on timeout.
 - `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The `Extension segments` tab in `/zentui` lists only statuses that are currently active.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
@@ -304,6 +312,9 @@ Center the branch between directory and cost:
 | `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
 | `$git_commit`       | `$commit`    | short commit hash (+ exact-match tag when present)  |
 | `$git_tag`          | `$tag`       | exact-match tag at HEAD                          |
+| `$git_metrics`      |              | aggregate line changes `+added −deleted`         |
+| `$git_added`        |              | added line count (`+N`)                          |
+| `$git_deleted`      |              | deleted line count (`−N`)                        |
 | `$runtime`          |              | runtime icon + version                           |
 | `$package`          |              | project package version, `via <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)            |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Zentui brings two popular aesthetics to Pi:
 - `on  branch` — git branch with icon
 - `[!?↑]` — git status indicators (modified, untracked, ahead/behind, stashed, etc.)
 - `via  v5.5.0` — runtime detection with version and Starship-style Nerd Font runtime/language modules
-- Optional segments (off by default): `user@host`, current time, OS icon, and session duration
+- Optional segments (off by default): `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
 - Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
@@ -234,7 +234,8 @@ Default config values — copy this and change any value you want:
 		"sessionDuration": false,
 		"username": false,
 		"time": false,
-		"os": false
+		"os": false,
+		"packageVersion": false
 	},
 	"extensionStatuses": {
 		"defaultPlacement": "right",
@@ -252,7 +253,7 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `runtime`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures context style, path display mode/depth, and icon mode; set or clear custom formats with `/zentui format`.
 - `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The `Extension segments` tab in `/zentui` lists only statuses that are currently active.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
@@ -292,6 +293,8 @@ Center the branch between directory and cost:
 | `$git_status`       | `$status`    | `[!?↑]` status block                             |
 | `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)      |
 | `$runtime`          |              | runtime icon + version                           |
+| `$package`          |              | project package version (manifest-derived)       |
+| `$package_version`  |              | raw project package version (no icon)            |
 | `$session_duration` | `$duration`  | session running time                             |
 | `$username`         |              | `user@host`                                      |
 | `$os`               |              | operating-system icon                            |

--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@ Default config values — copy this and change any value you want:
 		"runtimePrefix": "",
 		"sessionDuration": "yellow",
 		"packageVersion": "208",
-		"packageVersion": "208",
 		"gitCommit": "bold green",
 		"gitMetricsAdded": "bold green",
 		"gitMetricsDeleted": "bold red",

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -48,6 +48,7 @@ export type FooterSegmentsConfig = {
 	gitBranch: boolean;
 	gitStatus: boolean;
 	gitCounts: boolean;
+	gitCommit: boolean;
 	runtime: boolean;
 	context: boolean;
 	tokens: boolean;
@@ -61,6 +62,16 @@ export type FooterSegmentsConfig = {
 
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
 export type ExtensionStatusColorMode = "zentui" | "original";
+
+/**
+ * Starship `git_commit`-style options.
+ * See https://starship.rs/config/#git-commit
+ */
+export type GitCommitConfig = {
+	hashLength: number;
+	onlyDetached: boolean;
+	showTag: boolean;
+};
 
 const DEFAULT_EXTENSION_STATUS_COLOR_MODE: ExtensionStatusColorMode = "zentui";
 
@@ -94,6 +105,7 @@ export type PolishedTuiConfig = {
 		extensionStatus: ColorSpec;
 		sessionDuration: ColorSpec;
 		packageVersion: ColorSpec;
+		gitCommit: ColorSpec;
 		username: ColorSpec;
 		time: ColorSpec;
 		os: ColorSpec;
@@ -112,6 +124,7 @@ export type PolishedTuiConfig = {
 	colorSources: ColorSourcesConfig;
 	features: UiFeaturesConfig;
 	footerSegments: FooterSegmentsConfig;
+	gitCommit: GitCommitConfig;
 	extensionStatuses: ExtensionStatusesConfig;
 };
 
@@ -134,6 +147,8 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"cost",
 	"package",
 	"package_version",
+	"git_commit",
+	"git_tag",
 	"sep",
 ] as const;
 
@@ -146,6 +161,8 @@ export const FOOTER_FORMAT_ALIASES: Record<string, string> = {
 	branch: "git_branch",
 	status: "git_status",
 	state: "git_state",
+	commit: "git_commit",
+	tag: "git_tag",
 	duration: "session_duration",
 	separator: "sep",
 };
@@ -176,6 +193,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		extensionStatus: "bright-black",
 		sessionDuration: "yellow",
 		packageVersion: "208",
+		gitCommit: "bold green",
 		username: "bold yellow",
 		time: "bold yellow",
 		os: "bold white",
@@ -204,6 +222,12 @@ export const defaultConfig: PolishedTuiConfig = {
 		time: false,
 		os: false,
 		packageVersion: false,
+		gitCommit: false,
+	},
+	gitCommit: {
+		hashLength: 7,
+		onlyDetached: true,
+		showTag: true,
 	},
 	extensionStatuses: {
 		defaultPlacement: "right",
@@ -337,6 +361,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		extensionStatus: colorValue(record, "extensionStatus"),
 		sessionDuration: colorValue(record, "sessionDuration"),
 		packageVersion: colorValue(record, "packageVersion"),
+		gitCommit: colorValue(record, "gitCommit"),
 		username: colorValue(record, "username"),
 		time: colorValue(record, "time"),
 		os: colorValue(record, "os"),
@@ -385,6 +410,26 @@ function normalizeFooterSegments(record: Record<string, unknown>): FooterSegment
 		time: footerSegmentValue(record, "time"),
 		os: footerSegmentValue(record, "os"),
 		packageVersion: footerSegmentValue(record, "packageVersion"),
+		gitCommit: footerSegmentValue(record, "gitCommit"),
+	};
+}
+
+/** Clamp hashLength to Git's valid abbreviation range [4, 40]. */
+function normalizeGitHashLength(value: unknown): number {
+	const parsed = typeof value === "number" ? value : Number(value);
+	if (!Number.isFinite(parsed)) return defaultConfig.gitCommit.hashLength;
+	const rounded = Math.round(parsed);
+	return Math.min(40, Math.max(4, rounded));
+}
+
+function normalizeGitCommitConfig(record: Record<string, unknown>): GitCommitConfig {
+	return {
+		hashLength: normalizeGitHashLength(record.hashLength),
+		onlyDetached:
+			typeof record.onlyDetached === "boolean"
+				? record.onlyDetached
+				: defaultConfig.gitCommit.onlyDetached,
+		showTag: typeof record.showTag === "boolean" ? record.showTag : defaultConfig.gitCommit.showTag,
 	};
 }
 
@@ -514,6 +559,9 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const extensionStatuses = isRecord(config.extensionStatuses)
 		? normalizeExtensionStatuses(config.extensionStatuses as Record<string, unknown>)
 		: defaultConfig.extensionStatuses;
+	const gitCommit = isRecord(config.gitCommit)
+		? normalizeGitCommitConfig(config.gitCommit as Record<string, unknown>)
+		: defaultConfig.gitCommit;
 	return {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
 		footerFormat: stringValue(config, "footerFormat") ?? "",
@@ -528,6 +576,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		colorSources: { ...colorSources },
 		features: { ...features },
 		footerSegments: { ...footerSegments },
+		gitCommit,
 		extensionStatuses: {
 			defaultPlacement: extensionStatuses.defaultPlacement,
 			placements: { ...extensionStatuses.placements },

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -93,6 +93,7 @@ export type PolishedTuiConfig = {
 		runtimePrefix: ColorSpec;
 		extensionStatus: ColorSpec;
 		sessionDuration: ColorSpec;
+		packageVersion: ColorSpec;
 		username: ColorSpec;
 		time: ColorSpec;
 		os: ColorSpec;
@@ -174,6 +175,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		runtimePrefix: "",
 		extensionStatus: "bright-black",
 		sessionDuration: "yellow",
+		packageVersion: "208",
 		username: "bold yellow",
 		time: "bold yellow",
 		os: "bold white",
@@ -334,6 +336,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		runtimePrefix: colorValue(record, "runtimePrefix"),
 		extensionStatus: colorValue(record, "extensionStatus"),
 		sessionDuration: colorValue(record, "sessionDuration"),
+		packageVersion: colorValue(record, "packageVersion"),
 		username: colorValue(record, "username"),
 		time: colorValue(record, "time"),
 		os: colorValue(record, "os"),

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -56,6 +56,7 @@ export type FooterSegmentsConfig = {
 	username: boolean;
 	time: boolean;
 	os: boolean;
+	packageVersion: boolean;
 };
 
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
@@ -130,6 +131,8 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"context",
 	"tokens",
 	"cost",
+	"package",
+	"package_version",
 	"sep",
 ] as const;
 
@@ -198,6 +201,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		username: false,
 		time: false,
 		os: false,
+		packageVersion: false,
 	},
 	extensionStatuses: {
 		defaultPlacement: "right",
@@ -377,6 +381,7 @@ function normalizeFooterSegments(record: Record<string, unknown>): FooterSegment
 		username: footerSegmentValue(record, "username"),
 		time: footerSegmentValue(record, "time"),
 		os: footerSegmentValue(record, "os"),
+		packageVersion: footerSegmentValue(record, "packageVersion"),
 	};
 }
 
@@ -437,7 +442,8 @@ function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig 
 		value === "sessionDuration" ||
 		value === "username" ||
 		value === "time" ||
-		value === "os"
+		value === "os" ||
+		value === "packageVersion"
 	);
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -530,7 +530,9 @@ function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig 
 		value === "username" ||
 		value === "time" ||
 		value === "os" ||
-		value === "packageVersion"
+		value === "packageVersion" ||
+		value === "gitCommit" ||
+		value === "gitMetrics"
 	);
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -49,6 +49,7 @@ export type FooterSegmentsConfig = {
 	gitStatus: boolean;
 	gitCounts: boolean;
 	gitCommit: boolean;
+	gitMetrics: boolean;
 	runtime: boolean;
 	context: boolean;
 	tokens: boolean;
@@ -71,6 +72,15 @@ export type GitCommitConfig = {
 	hashLength: number;
 	onlyDetached: boolean;
 	showTag: boolean;
+};
+
+/**
+ * Starship `git_metrics`-style options.
+ * See https://starship.rs/config/#git-metrics
+ */
+export type GitMetricsConfig = {
+	onlyNonzero: boolean;
+	ignoreSubmodules: boolean;
 };
 
 const DEFAULT_EXTENSION_STATUS_COLOR_MODE: ExtensionStatusColorMode = "zentui";
@@ -106,6 +116,8 @@ export type PolishedTuiConfig = {
 		sessionDuration: ColorSpec;
 		packageVersion: ColorSpec;
 		gitCommit: ColorSpec;
+		gitMetricsAdded: ColorSpec;
+		gitMetricsDeleted: ColorSpec;
 		username: ColorSpec;
 		time: ColorSpec;
 		os: ColorSpec;
@@ -125,6 +137,7 @@ export type PolishedTuiConfig = {
 	features: UiFeaturesConfig;
 	footerSegments: FooterSegmentsConfig;
 	gitCommit: GitCommitConfig;
+	gitMetrics: GitMetricsConfig;
 	extensionStatuses: ExtensionStatusesConfig;
 };
 
@@ -149,6 +162,9 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"package_version",
 	"git_commit",
 	"git_tag",
+	"git_metrics",
+	"git_added",
+	"git_deleted",
 	"sep",
 ] as const;
 
@@ -194,6 +210,8 @@ export const defaultConfig: PolishedTuiConfig = {
 		sessionDuration: "yellow",
 		packageVersion: "208",
 		gitCommit: "bold green",
+		gitMetricsAdded: "bold green",
+		gitMetricsDeleted: "bold red",
 		username: "bold yellow",
 		time: "bold yellow",
 		os: "bold white",
@@ -223,11 +241,16 @@ export const defaultConfig: PolishedTuiConfig = {
 		os: false,
 		packageVersion: false,
 		gitCommit: false,
+		gitMetrics: false,
 	},
 	gitCommit: {
 		hashLength: 7,
 		onlyDetached: true,
 		showTag: true,
+	},
+	gitMetrics: {
+		onlyNonzero: true,
+		ignoreSubmodules: false,
 	},
 	extensionStatuses: {
 		defaultPlacement: "right",
@@ -362,6 +385,8 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		sessionDuration: colorValue(record, "sessionDuration"),
 		packageVersion: colorValue(record, "packageVersion"),
 		gitCommit: colorValue(record, "gitCommit"),
+		gitMetricsAdded: colorValue(record, "gitMetricsAdded"),
+		gitMetricsDeleted: colorValue(record, "gitMetricsDeleted"),
 		username: colorValue(record, "username"),
 		time: colorValue(record, "time"),
 		os: colorValue(record, "os"),
@@ -411,6 +436,7 @@ function normalizeFooterSegments(record: Record<string, unknown>): FooterSegment
 		os: footerSegmentValue(record, "os"),
 		packageVersion: footerSegmentValue(record, "packageVersion"),
 		gitCommit: footerSegmentValue(record, "gitCommit"),
+		gitMetrics: footerSegmentValue(record, "gitMetrics"),
 	};
 }
 
@@ -430,6 +456,19 @@ function normalizeGitCommitConfig(record: Record<string, unknown>): GitCommitCon
 				? record.onlyDetached
 				: defaultConfig.gitCommit.onlyDetached,
 		showTag: typeof record.showTag === "boolean" ? record.showTag : defaultConfig.gitCommit.showTag,
+	};
+}
+
+function normalizeGitMetricsConfig(record: Record<string, unknown>): GitMetricsConfig {
+	return {
+		onlyNonzero:
+			typeof record.onlyNonzero === "boolean"
+				? record.onlyNonzero
+				: defaultConfig.gitMetrics.onlyNonzero,
+		ignoreSubmodules:
+			typeof record.ignoreSubmodules === "boolean"
+				? record.ignoreSubmodules
+				: defaultConfig.gitMetrics.ignoreSubmodules,
 	};
 }
 
@@ -562,6 +601,9 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const gitCommit = isRecord(config.gitCommit)
 		? normalizeGitCommitConfig(config.gitCommit as Record<string, unknown>)
 		: defaultConfig.gitCommit;
+	const gitMetrics = isRecord(config.gitMetrics)
+		? normalizeGitMetricsConfig(config.gitMetrics as Record<string, unknown>)
+		: defaultConfig.gitMetrics;
 	return {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
 		footerFormat: stringValue(config, "footerFormat") ?? "",
@@ -577,6 +619,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		features: { ...features },
 		footerSegments: { ...footerSegments },
 		gitCommit,
+		gitMetrics,
 		extensionStatuses: {
 			defaultPlacement: extensionStatuses.defaultPlacement,
 			placements: { ...extensionStatuses.placements },

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -364,10 +364,19 @@ export function installFooter(
 							return "";
 					}
 				};
-				const branchParts =
-					config.footerSegments.gitBranch && branch
-						? ["on", gitIcon, gitColor(branch)].filter(Boolean)
-						: [];
+				const branchParts: string[] = [];
+				if (config.footerSegments.gitBranch) {
+					if (branch) {
+						branchParts.push("on", gitIcon, gitColor(branch));
+					} else if (state.commit?.detached) {
+						// Fold the short hash into the branch display on detached HEAD.
+						const shortHash = state.commit.oid
+							? `(${state.commit.oid.slice(0, config.gitCommit.hashLength)})`
+							: "";
+						const showHash = config.footerSegments.gitCommit && shortHash;
+						branchParts.push("on", gitIcon, gitColor(showHash ? `HEAD ${shortHash}` : "HEAD"));
+					}
+				}
 				const gitStatusParts = config.footerSegments.gitStatus && statusBlock ? [statusBlock] : [];
 				const showGitState = config.footerSegments.gitBranch || config.footerSegments.gitStatus;
 				const gitStateParts = showGitState && gitStateBlock ? [gitStateBlock] : [];
@@ -393,15 +402,17 @@ export function installFooter(
 							config.colors.packageVersion,
 						)
 					: "";
-				const gitCommitLabel = config.footerSegments.gitCommit
-					? formatGitCommitSegment(
-							theme,
-							state.commit,
-							config.gitCommit,
-							colorSource,
-							config.colors.gitCommit,
-						)
-					: "";
+				const hashFoldedIntoBranch = state.commit?.detached && config.footerSegments.gitBranch;
+				const gitCommitLabel =
+					config.footerSegments.gitCommit && !hashFoldedIntoBranch
+						? formatGitCommitSegment(
+								theme,
+								state.commit,
+								config.gitCommit,
+								colorSource,
+								config.colors.gitCommit,
+							)
+						: "";
 				const gitMetricsLabel = config.footerSegments.gitMetrics
 					? formatGitMetricsSegment(
 							theme,
@@ -448,8 +459,8 @@ export function installFooter(
 					branchLabel,
 					gitCommitLabel,
 					gitMetricsLabel,
-					runtimeLabel,
 					packageVersionLabel,
+					runtimeLabel,
 					sessionDurationSegment,
 				]
 					.filter(Boolean)

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -295,10 +295,22 @@ export function installFooter(
 						case "cost":
 							return renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel);
 						case "package":
-							return formatPackageVersionSegment(theme, state.packageVersion, colorSource);
+							return formatPackageVersionSegment(
+								theme,
+								state.packageVersion,
+								colorSource,
+								iconMode,
+								config.icons.package,
+								config.colors.packageVersion,
+							);
 						case "package_version":
 							return state.packageVersion?.version
-								? renderStyleForSource(theme, colorSource, "fg:green", state.packageVersion.version)
+								? renderStyleForSource(
+										theme,
+										colorSource,
+										config.colors.packageVersion,
+										state.packageVersion.version,
+									)
 								: "";
 						case "sep":
 							return renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
@@ -326,7 +338,14 @@ export function installFooter(
 						)
 					: "";
 				const packageVersionLabel = config.footerSegments.packageVersion
-					? formatPackageVersionSegment(theme, state.packageVersion, colorSource)
+					? formatPackageVersionSegment(
+							theme,
+							state.packageVersion,
+							colorSource,
+							iconMode,
+							config.icons.package,
+							config.colors.packageVersion,
+						)
 					: "";
 
 				const sessionDurationSegment = (() => {

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -369,12 +369,15 @@ export function installFooter(
 					if (branch) {
 						branchParts.push("on", gitIcon, gitColor(branch));
 					} else if (state.commit?.detached) {
-						// Fold the short hash into the branch display on detached HEAD.
-						const shortHash = state.commit.oid
-							? `(${state.commit.oid.slice(0, config.gitCommit.hashLength)})`
-							: "";
-						const showHash = config.footerSegments.gitCommit && shortHash;
-						branchParts.push("on", gitIcon, gitColor(showHash ? `HEAD ${shortHash}` : "HEAD"));
+						// `HEAD` uses git-branch style; `(hash)` uses git-commit style
+						// (bold green) per Starship `git_commit` format.
+						branchParts.push("on", gitIcon, gitColor("HEAD"));
+						if (config.footerSegments.gitCommit && state.commit.oid) {
+							const shortHash = state.commit.oid.slice(0, config.gitCommit.hashLength);
+							branchParts.push(
+								renderStyleForSource(theme, colorSource, config.colors.gitCommit, `(${shortHash})`),
+							);
+						}
 					}
 				}
 				const gitStatusParts = config.footerSegments.gitStatus && statusBlock ? [statusBlock] : [];
@@ -402,6 +405,8 @@ export function installFooter(
 							config.colors.packageVersion,
 						)
 					: "";
+				// Skip standalone gitCommit when hash is already folded into the
+				// branch display on detached HEAD.
 				const hashFoldedIntoBranch = state.commit?.detached && config.footerSegments.gitBranch;
 				const gitCommitLabel =
 					config.footerSegments.gitCommit && !hashFoldedIntoBranch

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -10,6 +10,7 @@ import {
 	contextColorTier,
 	formatCwdLabel,
 	formatGitCommitSegment,
+	formatGitMetricsSegment,
 	formatOsLabel,
 	formatPackageVersionSegment,
 	formatRuntimeSegment,
@@ -336,6 +337,35 @@ export function installFooter(
 										state.commit.tag,
 									)
 								: "";
+						case "git_metrics":
+							return config.footerSegments.gitMetrics
+								? formatGitMetricsSegment(
+										theme,
+										state.metrics,
+										config.gitMetrics,
+										colorSource,
+										config.colors.gitMetricsAdded,
+										config.colors.gitMetricsDeleted,
+									)
+								: "";
+						case "git_added":
+							return config.footerSegments.gitMetrics && state.metrics
+								? renderStyleForSource(
+										theme,
+										colorSource,
+										config.colors.gitMetricsAdded,
+										`+${state.metrics.added}`,
+									)
+								: "";
+						case "git_deleted":
+							return config.footerSegments.gitMetrics && state.metrics
+								? renderStyleForSource(
+										theme,
+										colorSource,
+										config.colors.gitMetricsDeleted,
+										`−${state.metrics.deleted}`,
+									)
+								: "";
 						default:
 							return "";
 					}
@@ -378,6 +408,16 @@ export function installFooter(
 							config.colors.gitCommit,
 						)
 					: "";
+				const gitMetricsLabel = config.footerSegments.gitMetrics
+					? formatGitMetricsSegment(
+							theme,
+							state.metrics,
+							config.gitMetrics,
+							colorSource,
+							config.colors.gitMetricsAdded,
+							config.colors.gitMetricsDeleted,
+						)
+					: "";
 
 				const sessionDurationSegment = (() => {
 					if (!config.footerSegments.sessionDuration || !state.sessionStartEpoch) return "";
@@ -413,6 +453,7 @@ export function installFooter(
 					config.footerSegments.cwd ? cwdLabel : "",
 					branchLabel,
 					gitCommitLabel,
+					gitMetricsLabel,
 					runtimeLabel,
 					packageVersionLabel,
 					sessionDurationSegment,

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -10,6 +10,7 @@ import {
 	contextColorTier,
 	formatCwdLabel,
 	formatOsLabel,
+	formatPackageVersionSegment,
 	formatRuntimeSegment,
 	formatTimeLabel,
 	formatUsernameHostLabel,
@@ -293,6 +294,12 @@ export function installFooter(
 							);
 						case "cost":
 							return renderStyleForSource(theme, colorSource, config.colors.cost, state.costLabel);
+						case "package":
+							return formatPackageVersionSegment(theme, state.packageVersion, colorSource);
+						case "package_version":
+							return state.packageVersion?.version
+								? renderStyleForSource(theme, colorSource, "fg:green", state.packageVersion.version)
+								: "";
 						case "sep":
 							return renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
 						default:
@@ -317,6 +324,9 @@ export function installFooter(
 							colorSource,
 							iconMode,
 						)
+					: "";
+				const packageVersionLabel = config.footerSegments.packageVersion
+					? formatPackageVersionSegment(theme, state.packageVersion, colorSource)
 					: "";
 
 				const sessionDurationSegment = (() => {
@@ -353,6 +363,7 @@ export function installFooter(
 					config.footerSegments.cwd ? cwdLabel : "",
 					branchLabel,
 					runtimeLabel,
+					packageVersionLabel,
 					sessionDurationSegment,
 				]
 					.filter(Boolean)

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -9,6 +9,7 @@ import {
 	buildSessionDurationLabel,
 	contextColorTier,
 	formatCwdLabel,
+	formatGitCommitSegment,
 	formatOsLabel,
 	formatPackageVersionSegment,
 	formatRuntimeSegment,
@@ -314,6 +315,27 @@ export function installFooter(
 								: "";
 						case "sep":
 							return renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
+						case "git_commit":
+							return config.footerSegments.gitCommit
+								? formatGitCommitSegment(
+										theme,
+										state.commit,
+										config.gitCommit,
+										colorSource,
+										config.colors.gitCommit,
+									)
+								: "";
+						case "git_tag":
+							return config.footerSegments.gitCommit &&
+								config.gitCommit.showTag &&
+								state.commit?.tag
+								? renderStyleForSource(
+										theme,
+										colorSource,
+										config.colors.gitCommit,
+										state.commit.tag,
+									)
+								: "";
 						default:
 							return "";
 					}
@@ -345,6 +367,15 @@ export function installFooter(
 							iconMode,
 							config.icons.package,
 							config.colors.packageVersion,
+						)
+					: "";
+				const gitCommitLabel = config.footerSegments.gitCommit
+					? formatGitCommitSegment(
+							theme,
+							state.commit,
+							config.gitCommit,
+							colorSource,
+							config.colors.gitCommit,
 						)
 					: "";
 
@@ -381,6 +412,7 @@ export function installFooter(
 					usernameSegment,
 					config.footerSegments.cwd ? cwdLabel : "",
 					branchLabel,
+					gitCommitLabel,
 					runtimeLabel,
 					packageVersionLabel,
 					sessionDurationSegment,

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -317,19 +317,15 @@ export function installFooter(
 						case "sep":
 							return renderStyleForSource(theme, colorSource, config.colors.separator, " | ");
 						case "git_commit":
-							return config.footerSegments.gitCommit
-								? formatGitCommitSegment(
-										theme,
-										state.commit,
-										config.gitCommit,
-										colorSource,
-										config.colors.gitCommit,
-									)
-								: "";
+							return formatGitCommitSegment(
+								theme,
+								state.commit,
+								config.gitCommit,
+								colorSource,
+								config.colors.gitCommit,
+							);
 						case "git_tag":
-							return config.footerSegments.gitCommit &&
-								config.gitCommit.showTag &&
-								state.commit?.tag
+							return config.gitCommit.showTag && state.commit?.tag
 								? renderStyleForSource(
 										theme,
 										colorSource,
@@ -338,18 +334,16 @@ export function installFooter(
 									)
 								: "";
 						case "git_metrics":
-							return config.footerSegments.gitMetrics
-								? formatGitMetricsSegment(
-										theme,
-										state.metrics,
-										config.gitMetrics,
-										colorSource,
-										config.colors.gitMetricsAdded,
-										config.colors.gitMetricsDeleted,
-									)
-								: "";
+							return formatGitMetricsSegment(
+								theme,
+								state.metrics,
+								config.gitMetrics,
+								colorSource,
+								config.colors.gitMetricsAdded,
+								config.colors.gitMetricsDeleted,
+							);
 						case "git_added":
-							return config.footerSegments.gitMetrics && state.metrics
+							return state.metrics
 								? renderStyleForSource(
 										theme,
 										colorSource,
@@ -358,7 +352,7 @@ export function installFooter(
 									)
 								: "";
 						case "git_deleted":
-							return config.footerSegments.gitMetrics && state.metrics
+							return state.metrics
 								? renderStyleForSource(
 										theme,
 										colorSource,

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -374,8 +374,10 @@ export function installFooter(
 						branchParts.push("on", gitIcon, gitColor("HEAD"));
 						if (config.footerSegments.gitCommit && state.commit.oid) {
 							const shortHash = state.commit.oid.slice(0, config.gitCommit.hashLength);
+							const tag = config.gitCommit.showTag && state.commit.tag ? state.commit.tag : "";
+							const inner = [shortHash, tag].filter(Boolean).join(" ");
 							branchParts.push(
-								renderStyleForSource(theme, colorSource, config.colors.gitCommit, `(${shortHash})`),
+								renderStyleForSource(theme, colorSource, config.colors.gitCommit, `(${inner})`),
 							);
 						}
 					}

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -9,7 +9,7 @@ import type {
 	PathDisplayMode,
 } from "./config";
 import type { IconMode } from "./icons";
-import { resolveOsIcon, resolveRuntimeSymbol } from "./icons";
+import { resolveOsIcon, resolvePackageIcon, resolveRuntimeSymbol } from "./icons";
 import type { PackageVersionResult } from "./package-version";
 import type { RuntimeInfo } from "./runtime";
 import { renderStyleForSource } from "./style";
@@ -246,19 +246,27 @@ export function formatRuntimeSegment(
 }
 
 /**
- * Render the package-version segment. Distinct from the runtime segment:
- * it surfaces the project’s own version (manifest-derived) rather than
- * the installed toolchain version. By design the segment is plain text
- * (no icon) so it does not collide with the runtime segment’s symbol;
- * a glyph can be added via `footerFormat` literals if the user wants one.
+ * Render the package-version segment in Starship `via <glyph> <version>` shape.
+ *
+ * Distinct from the runtime segment: this surfaces the project's own
+ * manifest version (e.g. `package.json#version`), not the installed
+ * toolchain version. Glyph comes from the Starship Nerd Font preset
+ * (https://starship.rs/presets/nerd-font); default color `208` matches
+ * the Starship `package` module default
+ * (https://starship.rs/config/#package-version).
  */
 export function formatPackageVersionSegment(
 	theme: Pick<Theme, "fg">,
 	pkg: PackageVersionResult | undefined,
 	colorSource: ColorSource,
+	mode: IconMode = "auto",
+	configuredIcon: string = "",
+	versionStyle: ColorSpec = "208",
 ): string {
 	if (!pkg) return "";
-	return renderStyleForSource(theme, colorSource, "fg:green", pkg.version);
+	const icon = resolvePackageIcon(configuredIcon, mode);
+	const label = `${icon} ${pkg.version}`;
+	return `${renderStyleForSource(theme, colorSource, "", "via")} ${renderStyleForSource(theme, colorSource, versionStyle, label)}`;
 }
 
 export type FormatCwdOptions = {

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -10,6 +10,7 @@ import type {
 } from "./config";
 import type { IconMode } from "./icons";
 import { resolveOsIcon, resolveRuntimeSymbol } from "./icons";
+import type { PackageVersionResult } from "./package-version";
 import type { RuntimeInfo } from "./runtime";
 import { renderStyleForSource } from "./style";
 
@@ -242,6 +243,22 @@ export function formatRuntimeSegment(
 	const symbol = resolveRuntimeSymbol(runtime.name, runtime.symbol, mode);
 	const label = runtime.version ? `${symbol} ${runtime.version}` : symbol;
 	return `${renderStyleForSource(theme, colorSource, prefixStyle, "via")} ${renderStyleForSource(theme, colorSource, runtime.style, label)}`;
+}
+
+/**
+ * Render the package-version segment. Distinct from the runtime segment:
+ * it surfaces the project’s own version (manifest-derived) rather than
+ * the installed toolchain version. By design the segment is plain text
+ * (no icon) so it does not collide with the runtime segment’s symbol;
+ * a glyph can be added via `footerFormat` literals if the user wants one.
+ */
+export function formatPackageVersionSegment(
+	theme: Pick<Theme, "fg">,
+	pkg: PackageVersionResult | undefined,
+	colorSource: ColorSource,
+): string {
+	if (!pkg) return "";
+	return renderStyleForSource(theme, colorSource, "fg:green", pkg.version);
 }
 
 export type FormatCwdOptions = {

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -299,7 +299,7 @@ export function formatRuntimeSegment(
 }
 
 /**
- * Render the package-version segment in Starship `via <glyph> <version>` shape.
+ * Render the package-version segment in Starship `is <glyph> <version>` shape.
  *
  * Distinct from the runtime segment: this surfaces the project's own
  * manifest version (e.g. `package.json#version`), not the installed
@@ -319,7 +319,7 @@ export function formatPackageVersionSegment(
 	if (!pkg) return "";
 	const icon = resolvePackageIcon(configuredIcon, mode);
 	const label = `${icon} ${pkg.version}`;
-	return `${renderStyleForSource(theme, colorSource, "", "via")} ${renderStyleForSource(theme, colorSource, versionStyle, label)}`;
+	return `${renderStyleForSource(theme, colorSource, "", "is")} ${renderStyleForSource(theme, colorSource, versionStyle, label)}`;
 }
 
 export type FormatCwdOptions = {

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -8,7 +8,7 @@ import type {
 	ContextThresholds,
 	PathDisplayMode,
 } from "./config";
-import type { GitCommitInfo } from "./git";
+import type { GitCommitInfo, GitMetricsInfo } from "./git";
 import type { IconMode } from "./icons";
 import { resolveOsIcon, resolvePackageIcon, resolveRuntimeSymbol } from "./icons";
 import type { PackageVersionResult } from "./package-version";
@@ -36,6 +36,35 @@ export function formatGitCommitSegment(
 	if (!hash && !tag) return "";
 	const label = [hash, tag].filter(Boolean).join(" ");
 	return renderStyleForSource(theme, colorSource, style, label);
+}
+
+/**
+ * Starship `git_metrics` style — render `+added −deleted` line counts.
+ * See https://starship.rs/config/#git-metrics
+ *
+ * When `onlyNonzero` is true, each zero component is omitted independently
+ * and the whole segment hides at 0/0.
+ */
+export function formatGitMetricsSegment(
+	theme: Pick<Theme, "fg">,
+	metrics: GitMetricsInfo | null | undefined,
+	config: { onlyNonzero: boolean },
+	colorSource: ColorSource,
+	addedStyle: ColorSpec,
+	deletedStyle: ColorSpec,
+): string {
+	if (!metrics) return "";
+	const showAdded = !config.onlyNonzero || metrics.added > 0;
+	const showDeleted = !config.onlyNonzero || metrics.deleted > 0;
+	if (!showAdded && !showDeleted) return "";
+	const parts: string[] = [];
+	if (showAdded) {
+		parts.push(renderStyleForSource(theme, colorSource, addedStyle, `+${metrics.added}`));
+	}
+	if (showDeleted) {
+		parts.push(renderStyleForSource(theme, colorSource, deletedStyle, `−${metrics.deleted}`));
+	}
+	return parts.join(" ");
 }
 
 export type UsageTotals = {

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -30,8 +30,9 @@ export function formatGitCommitSegment(
 	style: ColorSpec,
 ): string {
 	if (!commit?.oid) return "";
-	const showHash = !config.onlyDetached || commit.detached;
-	const hash = showHash ? commit.oid.slice(0, config.hashLength) : "";
+	// Starship's only_detached hides the whole module when attached.
+	if (config.onlyDetached && !commit.detached) return "";
+	const hash = commit.oid.slice(0, config.hashLength);
 	const tag = config.showTag && commit.tag ? commit.tag : "";
 	if (!hash && !tag) return "";
 	const label = [hash, tag].filter(Boolean).join(" ");

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -8,11 +8,35 @@ import type {
 	ContextThresholds,
 	PathDisplayMode,
 } from "./config";
+import type { GitCommitInfo } from "./git";
 import type { IconMode } from "./icons";
 import { resolveOsIcon, resolvePackageIcon, resolveRuntimeSymbol } from "./icons";
 import type { PackageVersionResult } from "./package-version";
 import type { RuntimeInfo } from "./runtime";
 import { renderStyleForSource } from "./style";
+
+/**
+ * Starship `git_commit` style — render a short hash, optionally with an
+ * exact-match tag. See https://starship.rs/config/#git-commit
+ *
+ * Visibility is decided by the caller; this helper only formats the data.
+ * `hashLength` is clamped to [4, 40] upstream.
+ */
+export function formatGitCommitSegment(
+	theme: Pick<Theme, "fg">,
+	commit: GitCommitInfo | undefined,
+	config: { hashLength: number; onlyDetached: boolean; showTag: boolean },
+	colorSource: ColorSource,
+	style: ColorSpec,
+): string {
+	if (!commit?.oid) return "";
+	const showHash = !config.onlyDetached || commit.detached;
+	const hash = showHash ? commit.oid.slice(0, config.hashLength) : "";
+	const tag = config.showTag && commit.tag ? commit.tag : "";
+	if (!hash && !tag) return "";
+	const label = [hash, tag].filter(Boolean).join(" ");
+	return renderStyleForSource(theme, colorSource, style, label);
+}
 
 export type UsageTotals = {
 	input: number;

--- a/extensions/zentui/git.ts
+++ b/extensions/zentui/git.ts
@@ -88,6 +88,8 @@ export function emptyGitStatus(): GitStatusSummary {
 		typechanged: 0,
 		gitState: undefined,
 		gitStateLabel: undefined,
+		commit: undefined,
+		metrics: undefined,
 	};
 }
 

--- a/extensions/zentui/git.ts
+++ b/extensions/zentui/git.ts
@@ -28,6 +28,15 @@ export type GitCommitInfo = {
 	tag: string | null;
 };
 
+/**
+ * Starship `git_metrics`-style aggregate line-change counts.
+ * See https://starship.rs/config/#git-metrics
+ */
+export type GitMetricsInfo = {
+	added: number;
+	deleted: number;
+};
+
 export type GitStatusSummary = {
 	branch?: string;
 	dirty: boolean;
@@ -44,6 +53,7 @@ export type GitStatusSummary = {
 	gitState?: GitOperationState;
 	gitStateLabel?: string;
 	commit?: GitCommitInfo;
+	metrics?: GitMetricsInfo | null;
 };
 
 export type GitReadResult =
@@ -152,6 +162,37 @@ export function parseGitStatusPorcelain(stdoutText: string, stashCount: number):
 	return status;
 }
 
+/**
+ * Parse `git diff --numstat` output into aggregate added/deleted counts.
+ *
+ * Each line is `added\tdeleted\tpath` (or `added\tdeleted\told\tnew` for
+ * renames). Binary rows carry `-` in both numeric columns and are skipped.
+ * Malformed/unparseable lines are ignored rather than aborting the sum.
+ *
+ * See https://git-scm.com/docs/git-diff#Documentation/git-diff.txt---numstat
+ */
+export function parseGitNumstat(stdoutText: string): GitMetricsInfo {
+	let added = 0;
+	let deleted = 0;
+	for (const line of stdoutText.split(/\r?\n/)) {
+		if (!line) continue;
+		const parts = line.split("\t");
+		// `added\tdeleted\tpath...` — need at least 3 tab-delimited fields.
+		if (parts.length < 3) continue;
+		const a = parts[0];
+		const d = parts[1];
+		// Binary files report `-` for both; skip.
+		if (a === "-" || d === "-") continue;
+		const na = Number(a);
+		const nd = Number(d);
+		if (!Number.isFinite(na) || !Number.isFinite(nd)) continue;
+		if (na < 0 || nd < 0) continue;
+		added += na;
+		deleted += nd;
+	}
+	return { added, deleted };
+}
+
 function readOptionalText(path: string | undefined): string | undefined {
 	if (!path || !existsSync(path)) return undefined;
 	try {
@@ -245,6 +286,13 @@ function isNotARepoError(error: unknown): boolean {
 export type ReadGitStatusOptions = {
 	/** Run `git describe --tags --exact-match HEAD` for the git_commit segment. */
 	readExactTag?: boolean;
+	/**
+	 * Run `git diff HEAD --numstat` for the git_metrics segment. Uses the
+	 * Starship-like “total dirty” view (staged + unstaged combined).
+	 */
+	readMetrics?: boolean;
+	/** Add `--ignore-submodules=all` to the metrics diff when requested. */
+	ignoreSubmodules?: boolean;
 };
 
 export async function readGitStatus(
@@ -252,8 +300,11 @@ export async function readGitStatus(
 	options: ReadGitStatusOptions = {},
 ): Promise<GitReadResult> {
 	const readExactTag = options.readExactTag === true;
+	const readMetrics = options.readMetrics === true;
 	try {
-		const [{ stdout: statusStdout }, stashResult, tagResult] = await Promise.all([
+		const numstatArgs = ["diff", "HEAD", "--numstat"];
+		if (options.ignoreSubmodules) numstatArgs.push("--ignore-submodules=all");
+		const [{ stdout: statusStdout }, stashResult, tagResult, metricsResult] = await Promise.all([
 			execFileAsync("git", ["status", "--porcelain=2", "--branch"], {
 				cwd,
 				timeout: GIT_COMMAND_TIMEOUT_MS,
@@ -271,6 +322,15 @@ export async function readGitStatus(
 						() => ({ stdout: "" }),
 					)
 				: Promise.resolve({ stdout: "" }),
+			readMetrics
+				? execFileAsync("git", numstatArgs, {
+						cwd,
+						timeout: GIT_COMMAND_TIMEOUT_MS,
+					}).then(
+						(r) => ({ stdout: typeof r.stdout === "string" ? r.stdout : String(r.stdout) }),
+						() => ({ stdout: "", failed: true as const }),
+					)
+				: Promise.resolve({ stdout: "", failed: true as const }),
 		]);
 		const stdoutText = typeof statusStdout === "string" ? statusStdout : String(statusStdout);
 		const stashStdout =
@@ -282,6 +342,17 @@ export async function readGitStatus(
 				typeof tagResult.stdout === "string" ? tagResult.stdout : String(tagResult.stdout);
 			const tag = tagStdout.trim();
 			status.commit = { ...status.commit, tag: tag || null };
+		}
+		if (readMetrics) {
+			if ("failed" in metricsResult && metricsResult.failed) {
+				status.metrics = null;
+			} else {
+				const metricsStdout =
+					typeof metricsResult.stdout === "string"
+						? metricsResult.stdout
+						: String(metricsResult.stdout);
+				status.metrics = parseGitNumstat(metricsStdout);
+			}
 		}
 		const operation = await readGitOperationState(cwd);
 		return {

--- a/extensions/zentui/git.ts
+++ b/extensions/zentui/git.ts
@@ -13,6 +13,21 @@ export type GitOperationState =
 	| "REVERTING"
 	| "BISECTING";
 
+/**
+ * Starship `git_commit`-style info derived from the existing porcelain probe.
+ *
+ * `oid` is the full `branch.oid` from `git status --porcelain=2 --branch`
+ * (free — no extra git call). `detached` mirrors `branch.head === "(detached)"`.
+ * `tag` is populated only when the caller opts into the exact-tag probe
+ * (`readGitStatus({ readExactTag: true })`); `null` means no exact-match tag
+ * or the probe was skipped.
+ */
+export type GitCommitInfo = {
+	oid: string | null;
+	detached: boolean;
+	tag: string | null;
+};
+
 export type GitStatusSummary = {
 	branch?: string;
 	dirty: boolean;
@@ -28,6 +43,7 @@ export type GitStatusSummary = {
 	typechanged: number;
 	gitState?: GitOperationState;
 	gitStateLabel?: string;
+	commit?: GitCommitInfo;
 };
 
 export type GitReadResult =
@@ -69,11 +85,26 @@ export function parseGitStatusPorcelain(stdoutText: string, stashCount: number):
 	const status = emptyGitStatus();
 	status.stashed = stashCount;
 
+	let oid: string | null = null;
+	let sawBranchHead = false;
+	let detached = false;
+
 	for (const line of stdoutText.split(/\r?\n/)) {
 		if (!line) continue;
+		if (line.startsWith("# branch.oid ")) {
+			const value = line.slice("# branch.oid ".length).trim();
+			if (value && value !== "(initial)") oid = value;
+			continue;
+		}
 		if (line.startsWith("# branch.head ")) {
+			sawBranchHead = true;
 			const branch = line.slice("# branch.head ".length).trim();
-			status.branch = branch && branch !== "(detached)" ? branch : undefined;
+			if (branch === "(detached)") {
+				detached = true;
+				status.branch = undefined;
+			} else if (branch) {
+				status.branch = branch;
+			}
 			continue;
 		}
 		if (line.startsWith("# branch.ab ")) {
@@ -110,6 +141,12 @@ export function parseGitStatusPorcelain(stdoutText: string, stashCount: number):
 		if (y === "M") status.modified += 1;
 		else if (y === "D") status.deleted += 1;
 		else if (y === "T") status.typechanged += 1;
+	}
+
+	// Only populate commit info when we actually saw branch headers (inside
+	// a repo with commits). An unborn branch has no oid.
+	if (sawBranchHead) {
+		status.commit = { oid, detached, tag: null };
 	}
 
 	return status;
@@ -200,9 +237,23 @@ function isNotARepoError(error: unknown): boolean {
 	return /not a git repository|outside repository|not a git repo/i.test(message);
 }
 
-export async function readGitStatus(cwd: string): Promise<GitReadResult> {
+/**
+ * Options for the optional probes that piggyback on the existing git refresh.
+ * Both default to `false` so no extra git process is spawned unless a segment
+ * is enabled and needs the data.
+ */
+export type ReadGitStatusOptions = {
+	/** Run `git describe --tags --exact-match HEAD` for the git_commit segment. */
+	readExactTag?: boolean;
+};
+
+export async function readGitStatus(
+	cwd: string,
+	options: ReadGitStatusOptions = {},
+): Promise<GitReadResult> {
+	const readExactTag = options.readExactTag === true;
 	try {
-		const [{ stdout: statusStdout }, stashResult] = await Promise.all([
+		const [{ stdout: statusStdout }, stashResult, tagResult] = await Promise.all([
 			execFileAsync("git", ["status", "--porcelain=2", "--branch"], {
 				cwd,
 				timeout: GIT_COMMAND_TIMEOUT_MS,
@@ -211,12 +262,27 @@ export async function readGitStatus(cwd: string): Promise<GitReadResult> {
 				cwd,
 				timeout: GIT_COMMAND_TIMEOUT_MS,
 			}).catch(() => ({ stdout: "" })),
+			readExactTag
+				? execFileAsync("git", ["describe", "--tags", "--exact-match", "HEAD"], {
+						cwd,
+						timeout: GIT_COMMAND_TIMEOUT_MS,
+					}).then(
+						(r) => ({ stdout: typeof r.stdout === "string" ? r.stdout : String(r.stdout) }),
+						() => ({ stdout: "" }),
+					)
+				: Promise.resolve({ stdout: "" }),
 		]);
 		const stdoutText = typeof statusStdout === "string" ? statusStdout : String(statusStdout);
 		const stashStdout =
 			typeof stashResult.stdout === "string" ? stashResult.stdout : String(stashResult.stdout);
 		const stashCount = stashStdout.split(/\r?\n/).filter((line) => line.trim().length > 0).length;
 		const status = parseGitStatusPorcelain(stdoutText, stashCount);
+		if (status.commit) {
+			const tagStdout =
+				typeof tagResult.stdout === "string" ? tagResult.stdout : String(tagResult.stdout);
+			const tag = tagStdout.trim();
+			status.commit = { ...status.commit, tag: tag || null };
+		}
 		const operation = await readGitOperationState(cwd);
 		return {
 			kind: "ok",

--- a/extensions/zentui/icons.ts
+++ b/extensions/zentui/icons.ts
@@ -1,7 +1,8 @@
 /**
  * Icon mode defaults and resolvers.
  *
- * Nerd defaults must stay byte-identical to historical `defaultConfig.icons`.
+ * Nerd defaults must stay byte-identical to historical `defaultConfig.icons`,
+ * except where intentionally changed to match the Starship Nerd Font preset.
  * User string overrides always win over mode defaults.
  */
 
@@ -56,11 +57,12 @@ export const ICON_GLYPH_KEYS = [
 ] as const satisfies readonly (keyof IconGlyphs)[];
 
 /**
- * Historical Nerd Font defaults (byte-identical to prior defaultConfig.icons).
+ * Nerd Font defaults.
  *
- * New defaults (e.g. `package`) come from the Starship Nerd Font preset
- * (https://starship.rs/presets/nerd-font), which is the project's
- * authoritative glyph source per user direction.
+ * The `cwd` icon is intentionally empty — Starship's `directory` module
+ * has no default symbol. Other defaults match historical values; new
+ * additions (e.g. `package`) come from the Starship Nerd Font preset
+ * (https://starship.rs/presets/nerd-font).
  */
 export const NERD_DEFAULT_ICONS: IconGlyphs = {
 	cwd: "",

--- a/extensions/zentui/icons.ts
+++ b/extensions/zentui/icons.ts
@@ -27,6 +27,7 @@ export type IconGlyphs = {
 	username: string;
 	time: string;
 	os: string;
+	package: string;
 };
 
 export type ResolvedIcons = IconGlyphs & { mode: IconMode };
@@ -51,9 +52,16 @@ export const ICON_GLYPH_KEYS = [
 	"username",
 	"time",
 	"os",
+	"package",
 ] as const satisfies readonly (keyof IconGlyphs)[];
 
-/** Historical Nerd Font defaults (byte-identical to prior defaultConfig.icons). */
+/**
+ * Historical Nerd Font defaults (byte-identical to prior defaultConfig.icons).
+ *
+ * New defaults (e.g. `package`) come from the Starship Nerd Font preset
+ * (https://starship.rs/presets/nerd-font), which is the project's
+ * authoritative glyph source per user direction.
+ */
 export const NERD_DEFAULT_ICONS: IconGlyphs = {
 	cwd: "󰝰",
 	git: "",
@@ -74,6 +82,8 @@ export const NERD_DEFAULT_ICONS: IconGlyphs = {
 	username: "",
 	time: "",
 	os: "",
+	// Starship Nerd Font preset — `package` module glyph.
+	package: "",
 };
 
 export const ASCII_DEFAULT_ICONS: IconGlyphs = {
@@ -96,6 +106,7 @@ export const ASCII_DEFAULT_ICONS: IconGlyphs = {
 	username: "@",
 	time: "t",
 	os: "o",
+	package: "pkg",
 };
 
 export const OS_PLATFORM_ICONS_NERD: Record<string, string> = {
@@ -222,4 +233,18 @@ export function resolveRuntimeSymbol(
 ): string {
 	if (mode !== "ascii") return nerdSymbol;
 	return RUNTIME_ASCII_SYMBOLS[name] ?? (name.slice(0, 3) || "*");
+}
+
+/**
+ * Resolve the package-version segment icon for the active mode.
+ *
+ * Honors a configured `icons.package` override; otherwise falls back to the
+ * mode default (Nerd Font preset / ASCII label).
+ */
+export function resolvePackageIcon(configuredPackageIcon: string, mode: IconMode = "auto"): string {
+	const modeDefault = modeDefaultIcons(mode).package;
+	if (typeof configuredPackageIcon === "string" && configuredPackageIcon.length > 0) {
+		return configuredPackageIcon;
+	}
+	return modeDefault;
 }

--- a/extensions/zentui/icons.ts
+++ b/extensions/zentui/icons.ts
@@ -63,7 +63,7 @@ export const ICON_GLYPH_KEYS = [
  * authoritative glyph source per user direction.
  */
 export const NERD_DEFAULT_ICONS: IconGlyphs = {
-	cwd: "󰝰",
+	cwd: "",
 	git: "",
 	ahead: "↑",
 	behind: "↓",
@@ -87,7 +87,7 @@ export const NERD_DEFAULT_ICONS: IconGlyphs = {
 };
 
 export const ASCII_DEFAULT_ICONS: IconGlyphs = {
-	cwd: "~",
+	cwd: "",
 	git: "*",
 	ahead: "^",
 	behind: "v",

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -30,6 +30,7 @@ import {
 import { installFooter } from "./footer";
 import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
+import { readPackageVersionResult } from "./package-version";
 import {
 	createProjectRefreshScheduler,
 	type ScheduleProjectRefreshOptions,
@@ -104,12 +105,17 @@ export default function (pi: ExtensionAPI) {
 		syncState(state, ctx, currentConfig.icons.cacheHit);
 
 	const refreshProjectState = async (ctx: ExtensionContext) => {
-		const [git, runtime] = await Promise.all([readGitStatus(ctx.cwd), readRuntimeInfo(ctx.cwd)]);
+		const [git, runtime, packageVersion] = await Promise.all([
+			readGitStatus(ctx.cwd),
+			readRuntimeInfo(ctx.cwd),
+			readPackageVersionResult(ctx.cwd),
+		]);
 		lastProjectCwd = applyProjectRefreshToState(state, {
 			cwd: ctx.cwd,
 			previousCwd: lastProjectCwd,
 			git,
 			runtime,
+			packageVersion,
 		});
 	};
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -105,8 +105,11 @@ export default function (pi: ExtensionAPI) {
 		syncState(state, ctx, currentConfig.icons.cacheHit);
 
 	const refreshProjectState = async (ctx: ExtensionContext) => {
+		const gitCommitConfig = currentConfig.gitCommit;
+		const segments = currentConfig.footerSegments;
+		const wantExactTag = segments.gitCommit && gitCommitConfig.showTag;
 		const [git, runtime, packageVersion] = await Promise.all([
-			readGitStatus(ctx.cwd),
+			readGitStatus(ctx.cwd, { readExactTag: wantExactTag }),
 			readRuntimeInfo(ctx.cwd),
 			readPackageVersionResult(ctx.cwd),
 		]);

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -106,10 +106,16 @@ export default function (pi: ExtensionAPI) {
 
 	const refreshProjectState = async (ctx: ExtensionContext) => {
 		const gitCommitConfig = currentConfig.gitCommit;
+		const gitMetricsConfig = currentConfig.gitMetrics;
 		const segments = currentConfig.footerSegments;
 		const wantExactTag = segments.gitCommit && gitCommitConfig.showTag;
+		const wantMetrics = segments.gitMetrics;
 		const [git, runtime, packageVersion] = await Promise.all([
-			readGitStatus(ctx.cwd, { readExactTag: wantExactTag }),
+			readGitStatus(ctx.cwd, {
+				readExactTag: wantExactTag,
+				readMetrics: wantMetrics,
+				ignoreSubmodules: gitMetricsConfig.ignoreSubmodules,
+			}),
 			readRuntimeInfo(ctx.cwd),
 			readPackageVersionResult(ctx.cwd),
 		]);

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -108,8 +108,14 @@ export default function (pi: ExtensionAPI) {
 		const gitCommitConfig = currentConfig.gitCommit;
 		const gitMetricsConfig = currentConfig.gitMetrics;
 		const segments = currentConfig.footerSegments;
-		const wantExactTag = segments.gitCommit && gitCommitConfig.showTag;
-		const wantMetrics = segments.gitMetrics;
+		const fmt = currentConfig.footerFormat;
+		// Enable optional probes when the segment is on OR a custom footerFormat
+		// references the relevant variable. Mirrors the session-duration timer
+		// pattern so format-only users still get data.
+		const formatNeedsTag = /\$\{?(?:git_tag|tag)\b/.test(fmt);
+		const formatNeedsMetrics = /\$\{?(?:git_metrics|git_added|git_deleted)\b/.test(fmt);
+		const wantExactTag = (segments.gitCommit && gitCommitConfig.showTag) || formatNeedsTag;
+		const wantMetrics = segments.gitMetrics || formatNeedsMetrics;
 		const [git, runtime, packageVersion] = await Promise.all([
 			readGitStatus(ctx.cwd, {
 				readExactTag: wantExactTag,

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -113,9 +113,13 @@ export default function (pi: ExtensionAPI) {
 		// references the relevant variable. Mirrors the session-duration timer
 		// pattern so format-only users still get data.
 		const formatNeedsTag = /\$\{?(?:git_tag|tag)\b/.test(fmt);
+		const formatNeedsCommit = /\$\{?(?:git_commit|commit)\b/.test(fmt);
 		const formatNeedsMetrics = /\$\{?(?:git_metrics|git_added|git_deleted)\b/.test(fmt);
-		const wantExactTag = (segments.gitCommit && gitCommitConfig.showTag) || formatNeedsTag;
+		const formatNeedsPackage = /\$\{?(?:package|package_version)\b/.test(fmt);
+		const wantExactTag =
+			((segments.gitCommit || formatNeedsCommit) && gitCommitConfig.showTag) || formatNeedsTag;
 		const wantMetrics = segments.gitMetrics || formatNeedsMetrics;
+		const wantPackage = segments.packageVersion || formatNeedsPackage;
 		const [git, runtime, packageVersion] = await Promise.all([
 			readGitStatus(ctx.cwd, {
 				readExactTag: wantExactTag,
@@ -123,7 +127,7 @@ export default function (pi: ExtensionAPI) {
 				ignoreSubmodules: gitMetricsConfig.ignoreSubmodules,
 			}),
 			readRuntimeInfo(ctx.cwd),
-			readPackageVersionResult(ctx.cwd),
+			wantPackage ? readPackageVersionResult(ctx.cwd) : Promise.resolve(undefined),
 		]);
 		lastProjectCwd = applyProjectRefreshToState(state, {
 			cwd: ctx.cwd,

--- a/extensions/zentui/package-version.ts
+++ b/extensions/zentui/package-version.ts
@@ -1,0 +1,650 @@
+/**
+ * Project package version detection (Starship `package` module parity).
+ *
+ * Pure file parsing only — no shell-outs, no parent-directory traversal,
+ * no render-time reads. The reader operates on the current cwd and the
+ * same top-level entries the runtime detector sees, then hands back a
+ * silent null when no manifest is present or any parser fails.
+ *
+ * Supported manifest sources (intersected with runtimes Zentui detects):
+ *   bun / nodejs → package.json
+ *   deno         → deno.json / deno.jsonc
+ *   maven        → pom.xml
+ *   gradle       → gradle.properties
+ *   python       → pyproject.toml, setup.cfg
+ *   rust         → Cargo.toml (package.version or workspace-inherited)
+ *   php          → composer.json
+ *   crystal      → shard.yml
+ *   dart         → pubspec.yaml, pubspec.yml
+ *   elixir       → mix.exs
+ *   elm          → elm.json
+ *   fortran      → fpm.toml
+ *   gleam        → gleam.toml
+ *   haskell      → *.cabal
+ *   helm         → Chart.yaml
+ *   julia        → Project.toml
+ *   meson        → meson.build
+ *   nim          → *.nimble
+ *   ruby         → *.gemspec
+ *   vlang        → v.mod
+ *   xmake        → xmake.lua
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+export type PackageVersionResult = {
+	/** Starship ecosystem key — matches `runtimeMetadata[].name` where it exists. */
+	ecosystem: string;
+	/** Raw version string as authored in the manifest. */
+	version: string;
+};
+
+export type PackageVersionReadResult =
+	| { kind: "ok"; result: PackageVersionResult | null }
+	| { kind: "error" };
+
+/**
+ * A single manifest source. `kind` selects the lookup mode:
+ *   "file"        — try each of `files` exactly (cheap, no scan).
+ *   "extensions"  — pick the first entry in `cwd` whose extension matches one in `files`.
+ * `parse` receives the raw file text and either returns a cleaned version
+ * string or `undefined`. Parsers must be total (never throw); any
+ * failure means `undefined`.
+ */
+type ManifestSource = {
+	files: readonly string[];
+	parse: (raw: string) => string | undefined;
+	kind?: "file" | "extensions";
+};
+
+export const PACKAGE_VERSION_ECOSYSTEMS = [
+	"bun",
+	"nodejs",
+	"deno",
+	"maven",
+	"gradle",
+	"python",
+	"rust",
+	"php",
+	"crystal",
+	"dart",
+	"elixir",
+	"elm",
+	"fortran",
+	"gleam",
+	"haskell",
+	"helm",
+	"julia",
+	"meson",
+	"nim",
+	"ruby",
+	"vlang",
+	"xmake",
+] as const;
+
+// --- String cleaning -----------------------------------------------------
+
+/**
+ * Strip surrounding quotes / leading `v` and trim trailing metadata.
+ * Empty / whitespace-only values return `undefined`.
+ */
+function cleanVersion(value: string | undefined): string | undefined {
+	if (!value) return undefined;
+	let text = value.trim();
+	if (!text) return undefined;
+
+	if (text.length >= 2) {
+		const first = text[0];
+		const last = text[text.length - 1];
+		if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+			text = text.slice(1, -1);
+		}
+	}
+
+	while (text.startsWith("v") || text.startsWith("V")) {
+		// Only strip `v` when the next char is a digit — `v3.2.1` → `3.2.1`,
+		// but a bare word like `via` is left alone.
+		const next = text[1];
+		if (!next || next < "0" || next > "9") break;
+		text = text.slice(1);
+	}
+
+	text = text.trim();
+	if (!text) return undefined;
+
+	// Reject obvious junk (whitespace, control chars, braces).
+	if (/[\s\r\n\t]/.test(text)) return undefined;
+	if (/[{}\\<>]/.test(text)) return undefined;
+
+	return text;
+}
+
+// --- JSON helpers --------------------------------------------------------
+
+function safeJsonParse(raw: string): unknown {
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Strip `//` and `/* * /` comments so JSON-with-comments can be parsed by
+ * `JSON.parse`. Quoted strings are preserved. Only used for `.jsonc`.
+ */
+function stripJsonComments(raw: string): string {
+	let result = "";
+	let inString = false;
+	let stringQuote = "";
+	let inBlockComment = false;
+	let inLineComment = false;
+	for (let i = 0; i < raw.length; i++) {
+		const ch = raw[i];
+		const next = raw[i + 1];
+		if (inLineComment) {
+			if (ch === "\n") {
+				inLineComment = false;
+				result += "\n";
+			}
+			continue;
+		}
+		if (inBlockComment) {
+			if (ch === "*" && next === "/") {
+				inBlockComment = false;
+				i += 1;
+			}
+			continue;
+		}
+		if (inString) {
+			result += ch;
+			if (ch === "\\" && next !== undefined) {
+				result += next;
+				i += 1;
+			} else if (ch === stringQuote) {
+				inString = false;
+			}
+			continue;
+		}
+		if (ch === "/" && next === "/") {
+			inLineComment = true;
+			i += 1;
+			continue;
+		}
+		if (ch === "/" && next === "*") {
+			inBlockComment = true;
+			i += 1;
+			continue;
+		}
+		if (ch === '"' || ch === "'") {
+			inString = true;
+			stringQuote = ch;
+			result += ch;
+			continue;
+		}
+		result += ch;
+	}
+	return result;
+}
+
+function safeJsoncParse(raw: string): unknown {
+	try {
+		return JSON.parse(stripJsonComments(raw));
+	} catch {
+		return undefined;
+	}
+}
+
+function readJsonVersionField(raw: string, key: string): string | undefined {
+	const parsed = safeJsonParse(raw);
+	if (!parsed || typeof parsed !== "object") return undefined;
+	const value = (parsed as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+function readJsoncVersionField(raw: string, key: string): string | undefined {
+	const parsed = safeJsoncParse(raw);
+	if (!parsed || typeof parsed !== "object") return undefined;
+	const value = (parsed as Record<string, unknown>)[key];
+	return typeof value === "string" ? value : undefined;
+}
+
+// --- TOML helpers --------------------------------------------------------
+
+/**
+ * Parse only the static `key = "value"` (or `key = 'value'`) assignment of a
+ * simple TOML section header (e.g. `[project]`, `[tool.poetry]`, `[workspace]`).
+ * Sufficient for the manifest keys we care about; inline tables and
+ * multi-line arrays fall back to `undefined`.
+ *
+ * Sections are matched as a leading `[name]` (or `[[name]]`) header; key
+ * matches continue until the next section header or end of file.
+ */
+function readTomlSectionKeyValue(raw: string, section: string, key: string): string | undefined {
+	const lines = raw.split(/\r?\n/);
+	let inTargetSection = false;
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+
+		const headerMatch = trimmed.match(/^\[\[?([^\]]+)\]?\]\s*$/);
+		if (headerMatch) {
+			const name = (headerMatch[1] ?? "").trim();
+			inTargetSection = name === section;
+			continue;
+		}
+
+		if (!inTargetSection) continue;
+
+		const match = trimmed.match(/^([A-Za-z0-9_-]+)\s*=\s*(.*)$/);
+		if (!match) continue;
+		const candidateKey = match[1] ?? "";
+		if (candidateKey !== key) continue;
+
+		let value = (match[2] ?? "").trim();
+		const trailingComment = value.indexOf("#");
+		if (trailingComment >= 0 && !isInsideString(value, trailingComment)) {
+			value = value.slice(0, trailingComment).trim();
+		}
+		return value || undefined;
+	}
+
+	return undefined;
+}
+
+/** A key-value pair at the top of a TOML file, before any section header. */
+function readTopLevelTomlValue(raw: string, key: string): string | undefined {
+	const lines = raw.split(/\r?\n/);
+	for (const line of lines) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith("#")) continue;
+		if (trimmed.startsWith("[")) return undefined; // entered a section
+		const match = trimmed.match(/^([A-Za-z0-9_-]+)\s*=\s*(.*?)\s*$/);
+		if (!match) continue;
+		const candidateKey = match[1] ?? "";
+		if (candidateKey !== key) continue;
+		return trimQuotes((match[2] ?? "").trim());
+	}
+	return undefined;
+}
+
+function trimQuotes(value: string): string {
+	if (value.length < 2) return value;
+	const first = value[0];
+	const last = value[value.length - 1];
+	if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+		return value.slice(1, -1);
+	}
+	return value;
+}
+
+function isInsideString(value: string, index: number): boolean {
+	let inSingle = false;
+	let inDouble = false;
+	for (let i = 0; i < index; i++) {
+		const ch = value[i];
+		if (ch === "\\") {
+			i += 1;
+			continue;
+		}
+		if (!inDouble && ch === "'") inSingle = !inSingle;
+		else if (!inSingle && ch === '"') inDouble = !inDouble;
+	}
+	return inSingle || inDouble;
+}
+
+// --- YAML helper (line-oriented; supports only top-level `key:`) ---------
+
+function readYamlTopLevelValue(raw: string, key: string): string | undefined {
+	const lines = raw.split(/\r?\n/);
+	const target = `${key}:`;
+	for (const line of lines) {
+		if (line.startsWith(" ") || line.startsWith("\t")) continue;
+		if (!line.startsWith(target)) continue;
+		const value = line.slice(target.length).trim();
+		return value || undefined;
+	}
+	return undefined;
+}
+
+// --- Per-ecosystem parsers -----------------------------------------------
+
+/**
+ * Locate a `package` stanza in a `.cabal` file and extract its `version`
+ * field. Modern cabal files (>= 1.12) drop the explicit `package`
+ * keyword; the file itself IS the package stanza, with `library`,
+ * `executable`, `test-suite`, `common`, etc. stanzas delimited by
+ * column-0 openers. We accept both indented (`  version: …`) and
+ * top-level (`version: …`) `version:` lines up to the first stanza opener.
+ */
+function extractCabalPackageVersion(raw: string): string | undefined {
+	const lines = raw.split(/\r?\n/);
+	let packageStart = 0;
+	for (let i = 0; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		if (/^package\s*$/i.test(line.trim())) {
+			packageStart = i + 1;
+			break;
+		}
+	}
+
+	for (let i = packageStart; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		if (line.trim() === "") continue;
+		if (line.trim().startsWith("--")) continue;
+		// A non-indented, non-empty line closes the package stanza.
+		if (!/^\s/.test(line)) break;
+		const match = line.match(/^\s*version\s*:\s*(.+?)\s*$/i);
+		if (match) return cleanVersion(match[1]);
+	}
+
+	// Legacy form: `version:` lives at column 0 alongside `name:`, before
+	// any stanza opener (e.g. `library`).
+	for (let i = packageStart; i < lines.length; i++) {
+		const line = lines[i] ?? "";
+		const trimmed = line.trim();
+		if (trimmed === "" || trimmed.startsWith("--")) continue;
+		// First non-keyword, non-empty line ends the package section.
+		if (!/^[a-zA-Z][\w-]*\s*:/.test(trimmed)) break;
+		const match = trimmed.match(/^version\s*:\s*(.+?)\s*$/i);
+		if (match) return cleanVersion(match[1]);
+	}
+
+	return undefined;
+}
+
+const parsers: readonly ManifestSource[] = [
+	// npm / bun — package.json
+	{
+		files: ["package.json"],
+		parse: (raw) => cleanVersion(readJsonVersionField(raw, "version")),
+	},
+	// deno — deno.json / deno.jsonc
+	{
+		files: ["deno.json", "deno.jsonc"],
+		parse: (raw) => cleanVersion(readJsoncVersionField(raw, "version")),
+	},
+	// maven — pom.xml: project/version (direct child, simple case).
+	{
+		files: ["pom.xml"],
+		parse: (raw) => {
+			const match = raw.match(/<project\b[^>]*>[\s\S]*?<version>\s*([^<]+?)\s*<\/version>/i);
+			return cleanVersion(match?.[1]);
+		},
+	},
+	// gradle — gradle.properties key=value
+	{
+		files: ["gradle.properties"],
+		parse: (raw) => {
+			for (const line of raw.split(/\r?\n/)) {
+				const match = line.match(/^\s*version\s*[:=]\s*(.+?)\s*$/i);
+				if (match) return cleanVersion(match[1]);
+			}
+			return undefined;
+		},
+	},
+	// python — pyproject.toml ([project].version or [tool.poetry].version)
+	{
+		files: ["pyproject.toml"],
+		parse: (raw) => {
+			const project = cleanVersion(readTomlSectionKeyValue(raw, "project", "version"));
+			if (project) return project;
+			return cleanVersion(readTomlSectionKeyValue(raw, "tool.poetry", "version"));
+		},
+	},
+	// python — setup.cfg ([metadata].version)
+	{
+		files: ["setup.cfg"],
+		parse: (raw) => cleanVersion(readTomlSectionKeyValue(raw, "metadata", "version")),
+	},
+	// rust — Cargo.toml ([package].version, with workspace inheritance)
+	{
+		files: ["Cargo.toml"],
+		parse: (raw) => {
+			// Direct assignment wins (string literal version).
+			const direct = readTomlSectionKeyValue(raw, "package", "version");
+			const directClean = cleanVersion(direct);
+			if (directClean && !/^\s*version\s*\.\s*workspace\s*=\s*true/i.test(direct ?? "")) {
+				return directClean;
+			}
+
+			// Workspace inheritance: package declares `version.workspace = true`
+			// and the [workspace] block carries the actual version.
+			if (!/\bversion\s*\.\s*workspace\s*=\s*true/i.test(raw)) return undefined;
+			const workspaceMatch = raw.match(/\[workspace\][\s\S]*?version\s*=\s*["']([^"']+)["']/i);
+			return cleanVersion(workspaceMatch?.[1]);
+		},
+	},
+	// php — composer.json
+	{
+		files: ["composer.json"],
+		parse: (raw) => cleanVersion(readJsonVersionField(raw, "version")),
+	},
+	// crystal — shard.yml (top-level `version: …`)
+	{
+		files: ["shard.yml"],
+		parse: (raw) => cleanVersion(readYamlTopLevelValue(raw, "version")),
+	},
+	// dart — pubspec.yaml / pubspec.yml (top-level `version: …`)
+	{
+		files: ["pubspec.yaml", "pubspec.yml"],
+		parse: (raw) => cleanVersion(readYamlTopLevelValue(raw, "version")),
+	},
+	// elixir — mix.exs: `version: "…"` as a Mix.Project option (string literal form).
+	{
+		files: ["mix.exs"],
+		parse: (raw) => {
+			const match = raw.match(/(?:^|\n)\s*version\s*:\s*["']([^"']+)["']/);
+			return cleanVersion(match?.[1]);
+		},
+	},
+	// elm — elm.json: top-level `version` (only present in 0.19.0 application projects).
+	{
+		files: ["elm.json"],
+		parse: (raw) => cleanVersion(readJsonVersionField(raw, "version")),
+	},
+	// fortran — fpm.toml: [package] or [project] version.
+	{
+		files: ["fpm.toml"],
+		parse: (raw) => {
+			const fromPackage = cleanVersion(readTomlSectionKeyValue(raw, "package", "version"));
+			if (fromPackage) return fromPackage;
+			return cleanVersion(readTomlSectionKeyValue(raw, "project", "version"));
+		},
+	},
+	// gleam — gleam.toml top-level version
+	{
+		files: ["gleam.toml"],
+		parse: (raw) => cleanVersion(readTopLevelTomlValue(raw, "version")),
+	},
+	// haskell — *.cabal: `version:` inside a `package` stanza.
+	{
+		files: [".cabal"],
+		kind: "extensions",
+		parse: (raw) => extractCabalPackageVersion(raw),
+	},
+	// helm — Chart.yaml: top-level `version:` (chart version, distinct from appVersion)
+	{
+		files: ["Chart.yaml"],
+		parse: (raw) => cleanVersion(readYamlTopLevelValue(raw, "version")),
+	},
+	// julia — Project.toml: top-level `version = "…"`
+	{
+		files: ["Project.toml"],
+		parse: (raw) => cleanVersion(readTopLevelTomlValue(raw, "version")),
+	},
+	// meson — meson.build: static `project(..., version: '…')` form only.
+	{
+		files: ["meson.build"],
+		parse: (raw) => {
+			const match = raw.match(/\bproject\s*\([^)]*?\bversion\s*:\s*['"]([^'"]+)['"]/);
+			return cleanVersion(match?.[1]);
+		},
+	},
+	// nim — *.nimble: top-level `version = "…"` (ignore indented blocks).
+	{
+		files: [".nimble"],
+		kind: "extensions",
+		parse: (raw) => cleanVersion(readTopLevelTomlValue(raw, "version")),
+	},
+	// ruby — *.gemspec: `spec.version = "…"` static literal.
+	{
+		files: [".gemspec"],
+		kind: "extensions",
+		parse: (raw) => {
+			const quoted = raw.match(/\b(?:spec\.|\.)?version\s*=\s*["']([^"']+)["']/);
+			if (quoted) return cleanVersion(quoted[1]);
+			return undefined;
+		},
+	},
+	// vlang — v.mod: `version: '…'` after the module block.
+	{
+		files: ["v.mod"],
+		parse: (raw) => {
+			const match = raw.match(/\bversion\s*:\s*['"]([^'']+)['"]/);
+			if (match) return cleanVersion(match[1]);
+			const numeric = raw.match(/\bversion\s*:\s*([0-9][^\s,]+)/);
+			return cleanVersion(numeric?.[1]);
+		},
+	},
+	// xmake — xmake.lua: static `set_version("…")` form only.
+	{
+		files: ["xmake.lua"],
+		parse: (raw) => {
+			const match = raw.match(/^\s*set_version\s*\(\s*["']([^"']+)["']\s*\)/m);
+			return cleanVersion(match?.[1]);
+		},
+	},
+];
+
+// --- File lookup ---------------------------------------------------------
+
+function ecosystemFor(file: string): string {
+	const lower = file.toLowerCase();
+	if (lower === "package.json") return "nodejs";
+	if (lower === "pom.xml") return "maven";
+	if (lower === "gradle.properties") return "gradle";
+	if (lower === "deno.json" || lower === "deno.jsonc") return "deno";
+	if (lower === "pyproject.toml") return "python";
+	if (lower === "setup.cfg") return "python";
+	if (lower === "cargo.toml") return "rust";
+	if (lower === "composer.json") return "php";
+	if (lower === "shard.yml") return "crystal";
+	if (lower === "pubspec.yaml" || lower === "pubspec.yml") return "dart";
+	if (lower === "mix.exs") return "elixir";
+	if (lower === "elm.json") return "elm";
+	if (lower === "fpm.toml") return "fortran";
+	if (lower === "gleam.toml") return "gleam";
+	if (lower.endsWith(".cabal")) return "haskell";
+	if (lower === "chart.yaml") return "helm";
+	if (lower === "project.toml") return "julia";
+	if (lower === "meson.build") return "meson";
+	if (lower.endsWith(".nimble")) return "nim";
+	if (lower.endsWith(".gemspec")) return "ruby";
+	if (lower === "v.mod") return "vlang";
+	if (lower === "xmake.lua") return "xmake";
+	return "unknown";
+}
+
+function safeReadFile(path: string): string | undefined {
+	try {
+		return readFileSync(path, "utf8");
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Test if a `cwd` entry basename ends with one of the given extensions.
+ * `extensions` should include the leading dot.
+ */
+function hasAnyExtension(name: string, extensions: readonly string[]): boolean {
+	const lower = name.toLowerCase();
+	for (const ext of extensions) {
+		if (lower.endsWith(ext)) return true;
+	}
+	return false;
+}
+
+export function readPackageVersion(cwd: string): PackageVersionResult | null {
+	// File-mode readers: cheap `existsSync` checks in deterministic order.
+	for (let i = 0; i < parsers.length; i++) {
+		const source = parsers[i];
+		if (!source || source.kind === "extensions") continue;
+		for (const file of source.files) {
+			const full = join(cwd, file);
+			if (!existsSync(full)) continue;
+			const raw = safeReadFile(full);
+			if (raw === undefined) continue;
+			let version: string | undefined;
+			try {
+				version = source.parse(raw);
+			} catch {
+				continue;
+			}
+			if (version) return { ecosystem: ecosystemFor(file), version };
+		}
+	}
+
+	// Extension-mode readers: one readdir, then try each candidate against
+	// its parser. The reading order matches `parsers` declaration order so
+	// Haskell (`*.cabal`) is preferred over Ruby (`*.gemspec`) when both
+	// exist (very rare; deterministic and documented).
+	let entries: readonly string[];
+	try {
+		entries = readdirSync(cwd);
+	} catch {
+		return null;
+	}
+
+	for (let i = 0; i < parsers.length; i++) {
+		const source = parsers[i];
+		if (source?.kind !== "extensions") continue;
+		for (const entry of entries) {
+			if (!hasAnyExtension(entry, source.files)) continue;
+			const full = join(cwd, entry);
+			const raw = safeReadFile(full);
+			if (raw === undefined) continue;
+			let version: string | undefined;
+			try {
+				version = source.parse(raw);
+			} catch {
+				continue;
+			}
+			if (version) return { ecosystem: ecosystemFor(entry), version };
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Async wrapper for use from the project-refresh path. `null` results from
+ * `readPackageVersion` (no manifest present) are surfaced as `ok` with a
+ * null result so the caller can distinguish "no manifest in this cwd"
+ * (clear state) from "could not read cwd" / parse failure (error, keep
+ * last-good). The synchronous reader never throws on its own; we still
+ * wrap defensively so callers using this through a scheduler cannot be
+ * broken by future filesystem exceptions.
+ */
+export async function readPackageVersionResult(cwd: string): Promise<PackageVersionReadResult> {
+	try {
+		return { kind: "ok", result: readPackageVersion(cwd) };
+	} catch {
+		return { kind: "error" };
+	}
+}
+
+/**
+ * Exposed for testing — the parser table and the `cleanVersion` helper.
+ * Lets unit tests cover every ecosystem and edge case without writing
+ * temporary filesystem fixtures.
+ */
+export const __test__ = {
+	parsers,
+	cleanVersion,
+	ecosystemFor,
+	hasAnyExtension,
+};

--- a/extensions/zentui/project-state.ts
+++ b/extensions/zentui/project-state.ts
@@ -1,5 +1,6 @@
 import type { GitReadResult } from "./git";
 import { emptyGitStatus } from "./git";
+import type { PackageVersionReadResult } from "./package-version";
 import type { RuntimeReadResult } from "./runtime";
 import type { FooterState } from "./state";
 
@@ -16,6 +17,7 @@ export function applyProjectRefreshToState(
 		previousCwd: string | undefined;
 		git: GitReadResult;
 		runtime: RuntimeReadResult;
+		packageVersion?: PackageVersionReadResult;
 	},
 ): string {
 	const cwdChanged = args.previousCwd !== undefined && args.previousCwd !== args.cwd;
@@ -23,6 +25,7 @@ export function applyProjectRefreshToState(
 	if (cwdChanged) {
 		Object.assign(state, emptyGitStatus());
 		state.runtime = undefined;
+		state.packageVersion = undefined;
 	}
 
 	if (args.git.kind === "ok") {
@@ -39,6 +42,18 @@ export function applyProjectRefreshToState(
 		state.runtime = undefined;
 	}
 	// error + same cwd: keep previous runtime
+
+	if (args.packageVersion !== undefined) {
+		if (args.packageVersion.kind === "ok") {
+			// `null` means "no manifest in this cwd"; clear so the segment disappears
+			// even on the same cwd when the user removes their manifest.
+			state.packageVersion = args.packageVersion.result ?? undefined;
+		} else if (!cwdChanged) {
+			// error + same cwd: keep previous packageVersion (last-good semantics)
+		} else {
+			state.packageVersion = undefined;
+		}
+	}
 
 	return args.cwd;
 }

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -119,6 +119,7 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	cost: "Session cost",
 	packageVersion: "Package version",
 	gitCommit: "Git commit",
+	gitMetrics: "Git line metrics",
 };
 
 const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
@@ -139,6 +140,8 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 		"Show the project’s own manifest version (package.json, Cargo.toml, pyproject.toml, …). Distinct from the runtime segment, which shows the installed toolchain version.",
 	gitCommit:
 		"Show the current commit hash (and optional exact-match tag). On detached HEAD this provides context the branch segment can’t. Starship `git_commit`-style; default off.",
+	gitMetrics:
+		"Show aggregate added/deleted line counts (e.g. `+12 −3`) via `git diff HEAD --numstat`. Complements the git status counts. Starship `git_metrics`-style; default off.",
 };
 
 const directCommandSuggestions = [

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -117,6 +117,7 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	context: "Context usage",
 	tokens: "Token counts",
 	cost: "Session cost",
+	packageVersion: "Package version",
 };
 
 const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
@@ -133,6 +134,8 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 	context: "Show or hide context usage on the right.",
 	tokens: "Show or hide input/output token counts on the right.",
 	cost: "Show or hide session cost on the right.",
+	packageVersion:
+		"Show the project’s own manifest version (package.json, Cargo.toml, pyproject.toml, …). Distinct from the runtime segment, which shows the installed toolchain version.",
 };
 
 const directCommandSuggestions = [
@@ -187,7 +190,8 @@ function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingI
 		value === "cost" ||
 		value === "username" ||
 		value === "time" ||
-		value === "os"
+		value === "os" ||
+		value === "packageVersion"
 	);
 }
 

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -197,7 +197,9 @@ function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingI
 		value === "username" ||
 		value === "time" ||
 		value === "os" ||
-		value === "packageVersion"
+		value === "packageVersion" ||
+		value === "gitCommit" ||
+		value === "gitMetrics"
 	);
 }
 

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -118,6 +118,7 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	tokens: "Token counts",
 	cost: "Session cost",
 	packageVersion: "Package version",
+	gitCommit: "Git commit",
 };
 
 const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
@@ -136,6 +137,8 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 	cost: "Show or hide session cost on the right.",
 	packageVersion:
 		"Show the project’s own manifest version (package.json, Cargo.toml, pyproject.toml, …). Distinct from the runtime segment, which shows the installed toolchain version.",
+	gitCommit:
+		"Show the current commit hash (and optional exact-match tag). On detached HEAD this provides context the branch segment can’t. Starship `git_commit`-style; default off.",
 };
 
 const directCommandSuggestions = [

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -7,6 +7,7 @@ import {
 	getUsageTotals,
 } from "./format";
 import type { GitStatusSummary } from "./git";
+import type { PackageVersionResult } from "./package-version";
 import type { RuntimeInfo } from "./runtime";
 
 export type FooterState = GitStatusSummary & {
@@ -16,6 +17,7 @@ export type FooterState = GitStatusSummary & {
 	tokenLabel: string;
 	costLabel: string;
 	runtime?: RuntimeInfo;
+	packageVersion?: PackageVersionResult;
 	sessionStartEpoch?: number;
 };
 
@@ -27,6 +29,7 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 		tokenLabel: "↑0 ↓0",
 		costLabel: "$0.000",
 		runtime: undefined,
+		packageVersion: undefined,
 		sessionStartEpoch: Date.now(),
 		...gitDefaults,
 	};

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -30,6 +30,8 @@ describe("mergeConfig", () => {
 		expect(config.colors.gitBranch).toBe("bold purple");
 		expect(config.colors.packageVersion).toBe("208");
 		expect(config.colors.gitCommit).toBe("bold green");
+		expect(config.colors.gitMetricsAdded).toBe("bold green");
+		expect(config.colors.gitMetricsDeleted).toBe("bold red");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
 		expect(config.colors.extensionStatus).toBe("bright-black");
@@ -59,6 +61,7 @@ describe("mergeConfig", () => {
 			os: false,
 			packageVersion: false,
 			gitCommit: false,
+			gitMetrics: false,
 			tokens: true,
 			cost: true,
 		});
@@ -204,6 +207,12 @@ describe("mergeConfig", () => {
 		);
 		expect(mergeConfig({ colors: { gitCommit: "bold yellow" } }).colors.gitCommit).toBe(
 			"bold yellow",
+		);
+		expect(mergeConfig({ colors: { gitMetricsAdded: "green" } }).colors.gitMetricsAdded).toBe(
+			"green",
+		);
+		expect(mergeConfig({ colors: { gitMetricsDeleted: "red" } }).colors.gitMetricsDeleted).toBe(
+			"red",
 		);
 		expect(mergeConfig({ colors: { git: "syntaxKeyword" } }).colors.gitBranch).toBe(
 			"syntaxKeyword",
@@ -385,6 +394,7 @@ describe("mergeConfig", () => {
 			os: false,
 			packageVersion: false,
 			gitCommit: false,
+			gitMetrics: false,
 			tokens: false,
 			cost: true,
 		});
@@ -404,6 +414,7 @@ describe("mergeConfig", () => {
 			os: false,
 			packageVersion: false,
 			gitCommit: false,
+			gitMetrics: false,
 			tokens: true,
 			cost: true,
 		});
@@ -603,6 +614,7 @@ describe("mergeConfig", () => {
 				os: false,
 				packageVersion: false,
 				gitCommit: false,
+				gitMetrics: false,
 				tokens: false,
 				cost: false,
 			});
@@ -638,6 +650,7 @@ describe("mergeConfig", () => {
 				os: false,
 				packageVersion: false,
 				gitCommit: false,
+				gitMetrics: false,
 				tokens: true,
 				cost: true,
 			});
@@ -677,6 +690,14 @@ describe("mergeConfig", () => {
 			onlyDetached: true,
 			showTag: true,
 		});
+	});
+
+	it("gitMetrics config defaults", () => {
+		expect(defaultConfig.gitMetrics).toEqual({ onlyNonzero: true, ignoreSubmodules: false });
+		expect(mergeConfig({ gitMetrics: { onlyNonzero: false } }).gitMetrics.onlyNonzero).toBe(false);
+		expect(
+			mergeConfig({ gitMetrics: { ignoreSubmodules: true } }).gitMetrics.ignoreSubmodules,
+		).toBe(true);
 	});
 
 	it("writes and reads back footerFormat", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -28,6 +28,7 @@ describe("mergeConfig", () => {
 		expect(config.icons.cacheHit).toBe("󰆼");
 		expect(config.icons.editorPrompt).toBe("");
 		expect(config.colors.gitBranch).toBe("bold purple");
+		expect(config.colors.packageVersion).toBe("208");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
 		expect(config.colors.extensionStatus).toBe("bright-black");
@@ -195,6 +196,9 @@ describe("mergeConfig", () => {
 	it("accepts Starship colors and old color key aliases", () => {
 		expect(mergeConfig({ colors: { gitBranch: "bold purple" } }).colors.gitBranch).toBe(
 			"bold purple",
+		);
+		expect(mergeConfig({ colors: { packageVersion: "bold green" } }).colors.packageVersion).toBe(
+			"bold green",
 		);
 		expect(mergeConfig({ colors: { git: "syntaxKeyword" } }).colors.gitBranch).toBe(
 			"syntaxKeyword",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,6 +55,7 @@ describe("mergeConfig", () => {
 			username: false,
 			time: false,
 			os: false,
+			packageVersion: false,
 			tokens: true,
 			cost: true,
 		});
@@ -373,6 +374,7 @@ describe("mergeConfig", () => {
 			username: false,
 			time: false,
 			os: false,
+			packageVersion: false,
 			tokens: false,
 			cost: true,
 		});
@@ -390,6 +392,7 @@ describe("mergeConfig", () => {
 			username: false,
 			time: false,
 			os: false,
+			packageVersion: false,
 			tokens: true,
 			cost: true,
 		});
@@ -587,6 +590,7 @@ describe("mergeConfig", () => {
 				username: false,
 				time: false,
 				os: false,
+				packageVersion: false,
 				tokens: false,
 				cost: false,
 			});
@@ -620,10 +624,28 @@ describe("mergeConfig", () => {
 				username: false,
 				time: false,
 				os: false,
+				packageVersion: false,
 				tokens: true,
 				cost: true,
 			});
 			expect(raw).toEqual({ footerSegments: { runtime: false } });
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("toggles and persists the packageVersion footer segment", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			const config = saveFooterSegmentsPatch({ packageVersion: true }, path);
+			expect(config.footerSegments.packageVersion).toBe(true);
+
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(raw.footerSegments).toEqual({ packageVersion: true });
+
+			const reloaded = mergeConfig(raw);
+			expect(reloaded.footerSegments.packageVersion).toBe(true);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -29,6 +29,7 @@ describe("mergeConfig", () => {
 		expect(config.icons.editorPrompt).toBe("");
 		expect(config.colors.gitBranch).toBe("bold purple");
 		expect(config.colors.packageVersion).toBe("208");
+		expect(config.colors.gitCommit).toBe("bold green");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
 		expect(config.colors.extensionStatus).toBe("bright-black");
@@ -57,6 +58,7 @@ describe("mergeConfig", () => {
 			time: false,
 			os: false,
 			packageVersion: false,
+			gitCommit: false,
 			tokens: true,
 			cost: true,
 		});
@@ -199,6 +201,9 @@ describe("mergeConfig", () => {
 		);
 		expect(mergeConfig({ colors: { packageVersion: "bold green" } }).colors.packageVersion).toBe(
 			"bold green",
+		);
+		expect(mergeConfig({ colors: { gitCommit: "bold yellow" } }).colors.gitCommit).toBe(
+			"bold yellow",
 		);
 		expect(mergeConfig({ colors: { git: "syntaxKeyword" } }).colors.gitBranch).toBe(
 			"syntaxKeyword",
@@ -379,6 +384,7 @@ describe("mergeConfig", () => {
 			time: false,
 			os: false,
 			packageVersion: false,
+			gitCommit: false,
 			tokens: false,
 			cost: true,
 		});
@@ -397,6 +403,7 @@ describe("mergeConfig", () => {
 			time: false,
 			os: false,
 			packageVersion: false,
+			gitCommit: false,
 			tokens: true,
 			cost: true,
 		});
@@ -595,6 +602,7 @@ describe("mergeConfig", () => {
 				time: false,
 				os: false,
 				packageVersion: false,
+				gitCommit: false,
 				tokens: false,
 				cost: false,
 			});
@@ -629,6 +637,7 @@ describe("mergeConfig", () => {
 				time: false,
 				os: false,
 				packageVersion: false,
+				gitCommit: false,
 				tokens: true,
 				cost: true,
 			});
@@ -653,6 +662,21 @@ describe("mergeConfig", () => {
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
+	});
+
+	it("gitCommit config defaults and normalizes hashLength", () => {
+		expect(defaultConfig.gitCommit).toEqual({ hashLength: 7, onlyDetached: true, showTag: true });
+		expect(mergeConfig({ gitCommit: { hashLength: 3 } }).gitCommit.hashLength).toBe(4);
+		expect(mergeConfig({ gitCommit: { hashLength: 100 } }).gitCommit.hashLength).toBe(40);
+		expect(mergeConfig({ gitCommit: { hashLength: 10 } }).gitCommit.hashLength).toBe(10);
+		expect(mergeConfig({ gitCommit: { onlyDetached: false } }).gitCommit.onlyDetached).toBe(false);
+		expect(mergeConfig({ gitCommit: { showTag: false } }).gitCommit.showTag).toBe(false);
+		// Missing fields fall back to defaults.
+		expect(mergeConfig({ gitCommit: {} }).gitCommit).toEqual({
+			hashLength: 7,
+			onlyDetached: true,
+			showTag: true,
+		});
 	});
 
 	it("writes and reads back footerFormat", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -677,6 +677,25 @@ describe("mergeConfig", () => {
 		}
 	});
 
+	it("toggles and persists gitCommit and gitMetrics footer segments", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			const config = saveFooterSegmentsPatch({ gitCommit: true, gitMetrics: true }, path);
+			expect(config.footerSegments.gitCommit).toBe(true);
+			expect(config.footerSegments.gitMetrics).toBe(true);
+
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(raw.footerSegments).toEqual({ gitCommit: true, gitMetrics: true });
+
+			const reloaded = mergeConfig(raw);
+			expect(reloaded.footerSegments.gitCommit).toBe(true);
+			expect(reloaded.footerSegments.gitMetrics).toBe(true);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("gitCommit config defaults and normalizes hashLength", () => {
 		expect(defaultConfig.gitCommit).toEqual({ hashLength: 7, onlyDetached: true, showTag: true });
 		expect(mergeConfig({ gitCommit: { hashLength: 3 } }).gitCommit.hashLength).toBe(4);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -194,7 +194,7 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ icons: { mode: "ascii" } }).icons.mode).toBe("ascii");
 		expect(mergeConfig({ icons: { mode: "nerd" } }).icons.mode).toBe("nerd");
 		expect(mergeConfig({ icons: { mode: "emoji" } }).icons.mode).toBe("auto");
-		expect(mergeConfig({ icons: { mode: "ascii" } }).icons.cwd).toBe("~");
+		expect(mergeConfig({ icons: { mode: "ascii" } }).icons.cwd).toBe("");
 		expect(mergeConfig({ icons: { mode: "ascii", cwd: "DIR" } }).icons.cwd).toBe("DIR");
 	});
 

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1256,6 +1256,46 @@ describe("Pi docs compliance", () => {
 		// On branch with onlyDetached=false → hash appears.
 		expect(renderFor(false, false)).toContain(OID.slice(0, 7));
 	});
+
+	it("git metrics segment renders +added −deleted and hides at 0/0", () => {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const renderFor = (added: number, deleted: number) => {
+			const state = createInitialState(emptyGitStatus());
+			state.metrics = { added, deleted };
+			state.contextLabel = "1%/200k";
+			state.tokenLabel = "↑1 ↓2";
+			state.costLabel = "$0";
+			const config: PolishedTuiConfig = {
+				...defaultConfig,
+				footerSegments: { ...defaultConfig.footerSegments, gitMetrics: true },
+			};
+			installFooter(ctx as never, state, () => config, {
+				setRequestRender() {},
+				scheduleProjectRefresh() {},
+			});
+			const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			});
+			return footer?.render(200).join("\n") ?? "";
+		};
+
+		expect(renderFor(12, 3)).toContain("+12");
+		expect(renderFor(12, 3)).toContain("−3");
+		// 0/0 → hidden (onlyNonzero default).
+		expect(renderFor(0, 0)).not.toContain("+0");
+		expect(renderFor(0, 0)).not.toContain("−0");
+	});
 	it("renders editor rails with theme accent and borderMuted borders", () => {
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1173,8 +1173,8 @@ describe("Pi docs compliance", () => {
 		const withPackage = renderWithPackage(true);
 		const withoutPackage = renderWithPackage(false);
 		expect(withPackage).toContain("1.2.3");
-		// Starship `package` shape: `is <glyph> <version>`.
-		expect(withPackage).toContain("is");
+		// Starship `package` shape: `via <glyph> <version>`.
+		expect(withPackage).toContain("via");
 		expect(withPackage).toContain("\u{f487}");
 		expect(withoutPackage).not.toContain("1.2.3");
 	});
@@ -1249,7 +1249,7 @@ describe("Pi docs compliance", () => {
 			return footer?.render(200).join("\n") ?? "";
 		};
 
-		// Detached → short hash folds into branch display as `HEAD (hash)`.
+		// Detached → HEAD + green (hash) in branch display.
 		expect(renderFor(true, true)).toContain("HEAD");
 		expect(renderFor(true, true)).toContain(`(${OID.slice(0, 7)})`);
 		// On branch with onlyDetached → hidden.

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1157,7 +1157,11 @@ describe("Pi docs compliance", () => {
 			state.costLabel = "$0.001";
 			const config: PolishedTuiConfig = {
 				...defaultConfig,
-				footerSegments: { ...defaultConfig.footerSegments, packageVersion: enabled },
+				footerSegments: {
+					...defaultConfig.footerSegments,
+					packageVersion: enabled,
+					runtime: false,
+				},
 			};
 			installFooter(ctx as never, state, () => config, {
 				setRequestRender() {},
@@ -1173,8 +1177,8 @@ describe("Pi docs compliance", () => {
 		const withPackage = renderWithPackage(true);
 		const withoutPackage = renderWithPackage(false);
 		expect(withPackage).toContain("1.2.3");
-		// Starship `package` shape: `via <glyph> <version>`.
-		expect(withPackage).toContain("via");
+		// Starship `package` shape: `is <glyph> <version>`.
+		expect(withPackage).toContain("is");
 		expect(withPackage).toContain("\u{f487}");
 		expect(withoutPackage).not.toContain("1.2.3");
 	});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1173,6 +1173,9 @@ describe("Pi docs compliance", () => {
 		const withPackage = renderWithPackage(true);
 		const withoutPackage = renderWithPackage(false);
 		expect(withPackage).toContain("1.2.3");
+		// Starship `package` shape: `via <glyph> <version>`.
+		expect(withPackage).toContain("via");
+		expect(withPackage).toContain("\u{f487}");
 		expect(withoutPackage).not.toContain("1.2.3");
 	});
 

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1173,8 +1173,8 @@ describe("Pi docs compliance", () => {
 		const withPackage = renderWithPackage(true);
 		const withoutPackage = renderWithPackage(false);
 		expect(withPackage).toContain("1.2.3");
-		// Starship `package` shape: `via <glyph> <version>`.
-		expect(withPackage).toContain("via");
+		// Starship `package` shape: `is <glyph> <version>`.
+		expect(withPackage).toContain("is");
 		expect(withPackage).toContain("\u{f487}");
 		expect(withoutPackage).not.toContain("1.2.3");
 	});
@@ -1249,11 +1249,12 @@ describe("Pi docs compliance", () => {
 			return footer?.render(200).join("\n") ?? "";
 		};
 
-		// Detached → short hash appears.
-		expect(renderFor(true, true)).toContain(OID.slice(0, 7));
+		// Detached → short hash folds into branch display as `HEAD (hash)`.
+		expect(renderFor(true, true)).toContain("HEAD");
+		expect(renderFor(true, true)).toContain(`(${OID.slice(0, 7)})`);
 		// On branch with onlyDetached → hidden.
 		expect(renderFor(false, true)).not.toContain(OID.slice(0, 7));
-		// On branch with onlyDetached=false → hash appears.
+		// On branch with onlyDetached=false → hash appears standalone.
 		expect(renderFor(false, false)).toContain(OID.slice(0, 7));
 	});
 

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1130,6 +1130,85 @@ describe("Pi docs compliance", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 1)).toBe(true);
 	});
 
+	it("renders the package version segment when toggled on and hides it when off", () => {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+
+		const renderWithPackage = (enabled: boolean) => {
+			const state = createInitialState(emptyGitStatus());
+			state.runtime = {
+				name: "nodejs",
+				symbol: "",
+				style: "bold green",
+				version: "v22",
+			};
+			state.packageVersion = enabled ? { ecosystem: "nodejs", version: "1.2.3" } : undefined;
+			state.contextLabel = "1%/200k";
+			state.tokenLabel = "↑1 ↓2";
+			state.costLabel = "$0.001";
+			const config: PolishedTuiConfig = {
+				...defaultConfig,
+				footerSegments: { ...defaultConfig.footerSegments, packageVersion: enabled },
+			};
+			installFooter(ctx as never, state, () => config, {
+				setRequestRender() {},
+				scheduleProjectRefresh() {},
+			});
+			const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			});
+			return footer?.render(200).join("\n") ?? "";
+		};
+
+		const withPackage = renderWithPackage(true);
+		const withoutPackage = renderWithPackage(false);
+		expect(withPackage).toContain("1.2.3");
+		expect(withoutPackage).not.toContain("1.2.3");
+	});
+
+	it("does not rewrite a non-empty footerFormat when packageVersion is on", () => {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const state = createInitialState(emptyGitStatus());
+		state.packageVersion = { ecosystem: "nodejs", version: "1.2.3" };
+		state.contextLabel = "1%/200k";
+		state.tokenLabel = "↑1 ↓2";
+		state.costLabel = "$0.001";
+		const config: PolishedTuiConfig = {
+			...defaultConfig,
+			footerSegments: { ...defaultConfig.footerSegments, packageVersion: true },
+			footerFormat: "$cwd $fill $context",
+		};
+		installFooter(ctx as never, state, () => config, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map(),
+		});
+		const rendered = footer?.render(200).join("\n") ?? "";
+		expect(rendered).not.toContain("1.2.3");
+	});
 	it("renders editor rails with theme accent and borderMuted borders", () => {
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1212,6 +1212,50 @@ describe("Pi docs compliance", () => {
 		const rendered = footer?.render(200).join("\n") ?? "";
 		expect(rendered).not.toContain("1.2.3");
 	});
+
+	it("git commit segment shows hash on detached HEAD and hides it on a branch", () => {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const OID = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+		const renderFor = (detached: boolean, onlyDetached: boolean) => {
+			const state = createInitialState(emptyGitStatus());
+			state.branch = detached ? undefined : "main";
+			state.commit = { oid: OID, detached, tag: null };
+			state.contextLabel = "1%/200k";
+			state.tokenLabel = "↑1 ↓2";
+			state.costLabel = "$0";
+			const config: PolishedTuiConfig = {
+				...defaultConfig,
+				footerSegments: { ...defaultConfig.footerSegments, gitCommit: true },
+				gitCommit: { hashLength: 7, onlyDetached, showTag: true },
+			};
+			installFooter(ctx as never, state, () => config, {
+				setRequestRender() {},
+				scheduleProjectRefresh() {},
+			});
+			const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			});
+			return footer?.render(200).join("\n") ?? "";
+		};
+
+		// Detached → short hash appears.
+		expect(renderFor(true, true)).toContain(OID.slice(0, 7));
+		// On branch with onlyDetached → hidden.
+		expect(renderFor(false, true)).not.toContain(OID.slice(0, 7));
+		// On branch with onlyDetached=false → hash appears.
+		expect(renderFor(false, false)).toContain(OID.slice(0, 7));
+	});
 	it("renders editor rails with theme accent and borderMuted borders", () => {
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -22,6 +22,13 @@ describe("parseFooterFormat", () => {
 		]);
 	});
 
+	it("parses $git_commit, $commit, $git_tag, and $tag as git-commit vars", () => {
+		expect(parseFooterFormat("$git_commit")).toEqual([{ kind: "var", name: "git_commit" }]);
+		expect(parseFooterFormat("$commit")).toEqual([{ kind: "var", name: "commit" }]);
+		expect(parseFooterFormat("$git_tag")).toEqual([{ kind: "var", name: "git_tag" }]);
+		expect(parseFooterFormat("$tag")).toEqual([{ kind: "var", name: "tag" }]);
+	});
+
 	it("parses braced variables", () => {
 		const braced = "${" + "git_branch}";
 		expect(parseFooterFormat(braced)).toEqual([{ kind: "var", name: "git_branch" }]);

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -15,6 +15,13 @@ describe("parseFooterFormat", () => {
 		expect(parseFooterFormat("$cwd")).toEqual([{ kind: "var", name: "cwd" }]);
 	});
 
+	it("parses $package and $package_version as package-version vars", () => {
+		expect(parseFooterFormat("$package")).toEqual([{ kind: "var", name: "package" }]);
+		expect(parseFooterFormat("$package_version")).toEqual([
+			{ kind: "var", name: "package_version" },
+		]);
+	});
+
 	it("parses braced variables", () => {
 		const braced = "${" + "git_branch}";
 		expect(parseFooterFormat(braced)).toEqual([{ kind: "var", name: "git_branch" }]);

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -29,6 +29,12 @@ describe("parseFooterFormat", () => {
 		expect(parseFooterFormat("$tag")).toEqual([{ kind: "var", name: "tag" }]);
 	});
 
+	it("parses git-metrics vars", () => {
+		expect(parseFooterFormat("$git_metrics")).toEqual([{ kind: "var", name: "git_metrics" }]);
+		expect(parseFooterFormat("$git_added")).toEqual([{ kind: "var", name: "git_added" }]);
+		expect(parseFooterFormat("$git_deleted")).toEqual([{ kind: "var", name: "git_deleted" }]);
+	});
+
 	it("parses braced variables", () => {
 		const braced = "${" + "git_branch}";
 		expect(parseFooterFormat(braced)).toEqual([{ kind: "var", name: "git_branch" }]);

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -10,6 +10,7 @@ import {
 	contextColorTier,
 	formatCount,
 	formatCwdLabel,
+	formatGitCommitSegment,
 	formatOsLabel,
 	formatPackageVersionSegment,
 	getUsageTotals,
@@ -327,6 +328,90 @@ describe("getUsageTotals memoization", () => {
 		expect(fourth).toEqual(third);
 		expect(fourth).not.toBe(third);
 		expect(__usageTotalsComputeCount()).toBe(3);
+	});
+});
+
+describe("formatGitCommitSegment", () => {
+	const makeTheme = (): { fg: (color: string, text: string) => string } => ({
+		fg: (_color, text) => text,
+	});
+	const FULL = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+
+	it("returns empty when commit info or oid is missing", () => {
+		expect(
+			formatGitCommitSegment(
+				makeTheme(),
+				undefined,
+				{ hashLength: 7, onlyDetached: true, showTag: true },
+				"terminal",
+				"bold green",
+			),
+		).toBe("");
+		expect(
+			formatGitCommitSegment(
+				makeTheme(),
+				{ oid: null, detached: false, tag: null },
+				{ hashLength: 7, onlyDetached: true, showTag: true },
+				"terminal",
+				"bold green",
+			),
+		).toBe("");
+	});
+
+	it("shows short hash on detached HEAD", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: true, tag: null },
+			{ hashLength: 7, onlyDetached: true, showTag: true },
+			"terminal",
+			"bold green",
+		);
+		expect(out).toContain("a1b2c3d");
+	});
+
+	it("hides hash on a normal branch when onlyDetached is true", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: false, tag: null },
+			{ hashLength: 7, onlyDetached: true, showTag: true },
+			"terminal",
+			"bold green",
+		);
+		expect(out).toBe("");
+	});
+
+	it("shows hash on a normal branch when onlyDetached is false", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: false, tag: null },
+			{ hashLength: 7, onlyDetached: false, showTag: false },
+			"terminal",
+			"bold green",
+		);
+		expect(out).toContain("a1b2c3d");
+	});
+
+	it("appends exact-match tag when present", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: true, tag: "v1.2.3" },
+			{ hashLength: 7, onlyDetached: true, showTag: true },
+			"terminal",
+			"bold green",
+		);
+		expect(out).toContain("a1b2c3d");
+		expect(out).toContain("v1.2.3");
+	});
+
+	it("hides tag when showTag is false", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: true, tag: "v1.2.3" },
+			{ hashLength: 7, onlyDetached: true, showTag: false },
+			"terminal",
+			"bold green",
+		);
+		expect(out).not.toContain("v1.2.3");
 	});
 });
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -11,6 +11,7 @@ import {
 	formatCount,
 	formatCwdLabel,
 	formatGitCommitSegment,
+	formatGitMetricsSegment,
 	formatOsLabel,
 	formatPackageVersionSegment,
 	getUsageTotals,
@@ -328,6 +329,96 @@ describe("getUsageTotals memoization", () => {
 		expect(fourth).toEqual(third);
 		expect(fourth).not.toBe(third);
 		expect(__usageTotalsComputeCount()).toBe(3);
+	});
+});
+
+describe("formatGitMetricsSegment", () => {
+	const makeTheme = (): { fg: (color: string, text: string) => string } => ({
+		fg: (_color, text) => text,
+	});
+
+	it("returns empty when metrics are missing", () => {
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				undefined,
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).toBe("");
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				null,
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).toBe("");
+	});
+
+	it("renders both added and deleted", () => {
+		const out = formatGitMetricsSegment(
+			makeTheme(),
+			{ added: 12, deleted: 3 },
+			{ onlyNonzero: false },
+			"terminal",
+			"bold green",
+			"bold red",
+		);
+		expect(out).toContain("+12");
+		expect(out).toContain("−3");
+	});
+
+	it("omits each zero component independently when onlyNonzero", () => {
+		// 0 added → only show deleted.
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				{ added: 0, deleted: 5 },
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).not.toContain("+0");
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				{ added: 0, deleted: 5 },
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).toContain("−5");
+		// 0 deleted → only show added.
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				{ added: 7, deleted: 0 },
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).toContain("+7");
+	});
+
+	it("hides entirely at 0/0 when onlyNonzero", () => {
+		expect(
+			formatGitMetricsSegment(
+				makeTheme(),
+				{ added: 0, deleted: 0 },
+				{ onlyNonzero: true },
+				"terminal",
+				"bold green",
+				"bold red",
+			),
+		).toBe("");
 	});
 });
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -519,7 +519,7 @@ describe("formatPackageVersionSegment", () => {
 		);
 	});
 
-	it("renders the Starship `via <glyph> <version>` shape", () => {
+	it("renders the Starship `is <glyph> <version>` shape", () => {
 		const out = formatPackageVersionSegment(
 			makeTheme(),
 			{ ecosystem: "nodejs", version: "1.2.3" },
@@ -528,7 +528,7 @@ describe("formatPackageVersionSegment", () => {
 			"",
 			"208",
 		);
-		expect(out).toContain("via");
+		expect(out).toContain("is");
 		expect(out).toContain("\u{f487}");
 		expect(out).toContain("1.2.3");
 		// Starship `package` default color 208 → ANSI 256-color code 38;5;208.
@@ -544,7 +544,7 @@ describe("formatPackageVersionSegment", () => {
 			"",
 			"208",
 		);
-		expect(out).toContain("via");
+		expect(out).toContain("is");
 		expect(out).toContain("pkg");
 		expect(out).not.toContain("\u{f487}");
 	});

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -471,6 +471,18 @@ describe("formatGitCommitSegment", () => {
 		expect(out).toBe("");
 	});
 
+	it("hides the whole segment (including tag) on a branch when onlyDetached is true", () => {
+		const out = formatGitCommitSegment(
+			makeTheme(),
+			{ oid: FULL, detached: false, tag: "v1.0.0" },
+			{ hashLength: 7, onlyDetached: true, showTag: true },
+			"terminal",
+			"bold green",
+		);
+		expect(out).toBe("");
+		expect(out).not.toContain("v1.0.0");
+	});
+
 	it("shows hash on a normal branch when onlyDetached is false", () => {
 		const out = formatGitCommitSegment(
 			makeTheme(),

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -11,6 +11,7 @@ import {
 	formatCount,
 	formatCwdLabel,
 	formatOsLabel,
+	formatPackageVersionSegment,
 	getUsageTotals,
 	invalidateUsageTotalsCache,
 } from "../extensions/zentui/format";
@@ -326,5 +327,62 @@ describe("getUsageTotals memoization", () => {
 		expect(fourth).toEqual(third);
 		expect(fourth).not.toBe(third);
 		expect(__usageTotalsComputeCount()).toBe(3);
+	});
+});
+
+describe("formatPackageVersionSegment", () => {
+	const makeTheme = (): { fg: (color: string, text: string) => string } => ({
+		// Identity wrapper: prefix text with the requested color token so we can
+		// assert Starship style strings are routed correctly.
+		fg: (color, text) => `[${color}]${text}[/${color}]`,
+	});
+
+	it("returns empty when no package is present", () => {
+		expect(formatPackageVersionSegment(makeTheme(), undefined, "terminal", "nerd", "", "208")).toBe(
+			"",
+		);
+	});
+
+	it("renders the Starship `via <glyph> <version>` shape", () => {
+		const out = formatPackageVersionSegment(
+			makeTheme(),
+			{ ecosystem: "nodejs", version: "1.2.3" },
+			"terminal",
+			"nerd",
+			"",
+			"208",
+		);
+		expect(out).toContain("via");
+		expect(out).toContain("\u{f487}");
+		expect(out).toContain("1.2.3");
+		// Starship `package` default color 208 → ANSI 256-color code 38;5;208.
+		expect(out).toContain("38;5;208");
+	});
+
+	it("falls back to the ASCII package label in ASCII mode", () => {
+		const out = formatPackageVersionSegment(
+			makeTheme(),
+			{ ecosystem: "nodejs", version: "1.2.3" },
+			"terminal",
+			"ascii",
+			"",
+			"208",
+		);
+		expect(out).toContain("via");
+		expect(out).toContain("pkg");
+		expect(out).not.toContain("\u{f487}");
+	});
+
+	it("honors a configured package icon override", () => {
+		const out = formatPackageVersionSegment(
+			makeTheme(),
+			{ ecosystem: "nodejs", version: "1.2.3" },
+			"terminal",
+			"nerd",
+			"#", // custom override wins over mode default
+			"208",
+		);
+		expect(out).toContain("#");
+		expect(out).not.toContain("\u{f487}");
 	});
 });

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -14,6 +14,12 @@ describe("parseGitStatusPorcelain", () => {
 		expect(parseGitStatusPorcelain("", 0)).toEqual(emptyGitStatus());
 	});
 
+	it("emptyGitStatus clears commit and metrics", () => {
+		const empty = emptyGitStatus();
+		expect(empty.commit).toBeUndefined();
+		expect(empty.metrics).toBeUndefined();
+	});
+
 	it("parses branch, ahead/behind, and file states", () => {
 		const status = parseGitStatusPorcelain(
 			[

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -41,6 +41,41 @@ describe("parseGitStatusPorcelain", () => {
 		const status = parseGitStatusPorcelain("# branch.head (detached)", 0);
 		expect(status.branch).toBeUndefined();
 	});
+
+	it("captures branch.oid and detached flag", () => {
+		const detached = parseGitStatusPorcelain(
+			["# branch.oid a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2", "# branch.head (detached)"].join(
+				"\n",
+			),
+			0,
+		);
+		expect(detached.branch).toBeUndefined();
+		expect(detached.commit).toEqual({
+			oid: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+			detached: true,
+			tag: null,
+		});
+	});
+
+	it("captures branch.oid on a normal branch and reports detached=false", () => {
+		const onBranch = parseGitStatusPorcelain(
+			["# branch.oid deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "# branch.head main"].join("\n"),
+			0,
+		);
+		expect(onBranch.branch).toBe("main");
+		expect(onBranch.commit?.oid).toBe("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef");
+		expect(onBranch.commit?.detached).toBe(false);
+	});
+
+	it("treats unborn branch.oid (initial) as null and skips commit info without branch headers", () => {
+		const unborn = parseGitStatusPorcelain(
+			["# branch.oid (initial)", "# branch.head main (no commits)"].join("\n"),
+			0,
+		);
+		expect(unborn.commit?.oid).toBeNull();
+		// No branch headers at all → no commit info.
+		expect(parseGitStatusPorcelain("", 0).commit).toBeUndefined();
+	});
 });
 
 describe("detectGitState", () => {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -2,7 +2,12 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { detectGitState, emptyGitStatus, parseGitStatusPorcelain } from "../extensions/zentui/git";
+import {
+	detectGitState,
+	emptyGitStatus,
+	parseGitNumstat,
+	parseGitStatusPorcelain,
+} from "../extensions/zentui/git";
 
 describe("parseGitStatusPorcelain", () => {
 	it("returns empty status for empty output", () => {
@@ -139,6 +144,40 @@ describe("detectGitState", () => {
 		expect(detectGitState({ bisectLog: requirePath(paths, "BISECT_LOG") })).toEqual({
 			gitState: "BISECTING",
 			gitStateLabel: "BISECTING",
+		});
+	});
+
+	describe("parseGitNumstat", () => {
+		it("sums added/deleted across text files", () => {
+			expect(
+				parseGitNumstat(["10\t5\tsrc/a.ts", "3\t0\tsrc/b.ts", "0\t7\tsrc/c.ts"].join("\n")),
+			).toEqual({ added: 13, deleted: 12 });
+		});
+
+		it("skips binary rows (-\t-)", () => {
+			expect(parseGitNumstat("-\t-\tasset.png\n5\t2\tsrc.ts")).toEqual({ added: 5, deleted: 2 });
+		});
+
+		it("handles rename rows (old\tnew path)", () => {
+			expect(parseGitNumstat("0\t0\told.ts\tnew.ts")).toEqual({ added: 0, deleted: 0 });
+			expect(parseGitNumstat("5\t1\told.ts\tnew.ts")).toEqual({ added: 5, deleted: 1 });
+		});
+
+		it("handles CRLF line endings", () => {
+			expect(parseGitNumstat("3\t2\ta.ts\r\n1\t1\tb.ts\r\n")).toEqual({
+				added: 4,
+				deleted: 3,
+			});
+		});
+
+		it("ignores malformed lines", () => {
+			expect(
+				parseGitNumstat(["garbage", "", "abc\tdef\tnotnum", "5\t2\tok.ts"].join("\n")),
+			).toEqual({ added: 5, deleted: 2 });
+		});
+
+		it("returns zeros for empty output", () => {
+			expect(parseGitNumstat("")).toEqual({ added: 0, deleted: 0 });
 		});
 	});
 

--- a/test/package-version.test.ts
+++ b/test/package-version.test.ts
@@ -1,0 +1,301 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	__test__,
+	PACKAGE_VERSION_ECOSYSTEMS,
+	readPackageVersion,
+} from "../extensions/zentui/package-version";
+
+function makeProject(files: Record<string, string>): string {
+	const cwd = mkdtempSync(join(tmpdir(), "zentui-package-version-"));
+	for (const [name, content] of Object.entries(files)) {
+		const full = join(cwd, name);
+		if (name.includes("/")) {
+			mkdirSync(join(cwd, name.slice(0, name.indexOf("/"))), { recursive: true });
+		}
+		writeFileSync(full, content, "utf8");
+	}
+	return cwd;
+}
+
+function expectEcosystem(cwd: string, ecosystem: string, version: string) {
+	const result = readPackageVersion(cwd);
+	expect(result).not.toBeNull();
+	if (result === null) throw new Error("expected package version result");
+	expect(result.ecosystem).toBe(ecosystem);
+	expect(result.version).toBe(version);
+}
+
+describe("readPackageVersion", () => {
+	it("returns null when no manifest is present", () => {
+		const cwd = makeProject({});
+		expect(readPackageVersion(cwd)).toBeNull();
+	});
+
+	it("parses package.json for npm/bun projects (top-level `version`)", () => {
+		const cwd = makeProject({
+			"package.json": JSON.stringify({ name: "demo", version: "1.2.3" }),
+		});
+		expectEcosystem(cwd, "nodejs", "1.2.3");
+	});
+
+	it("strips surrounding quotes from package.json values", () => {
+		const cwd = makeProject({
+			"package.json": JSON.stringify({ name: "demo", version: '"2.0.0"' }, null, 2),
+		});
+		expect(readPackageVersion(cwd)?.version).toBe("2.0.0");
+	});
+
+	it("returns null for malformed package.json JSON without throwing", () => {
+		const cwd = makeProject({ "package.json": "{ this is not json" });
+		expect(readPackageVersion(cwd)).toBeNull();
+	});
+
+	it("parses deno.json and deno.jsonc", () => {
+		const denoJson = makeProject({ "deno.json": JSON.stringify({ version: "0.1.0" }) });
+		const denoJsonc = makeProject({
+			"deno.jsonc": `// leading comment\n${JSON.stringify({ version: "0.2.0" })}`,
+		});
+		expect(readPackageVersion(denoJson)?.version).toBe("0.1.0");
+		expect(readPackageVersion(denoJsonc)?.version).toBe("0.2.0");
+	});
+
+	it("parses Maven pom.xml first child <version>", () => {
+		const cwd = makeProject({
+			"pom.xml":
+				"<project><modelVersion>4.0.0</modelVersion><version>3.1.4</version><artifactId>x</artifactId></project>",
+		});
+		expectEcosystem(cwd, "maven", "3.1.4");
+	});
+
+	it("parses Gradle gradle.properties", () => {
+		const cwd = makeProject({ "gradle.properties": "version=4.5.6\ngroup=com.example\n" });
+		expectEcosystem(cwd, "gradle", "4.5.6");
+	});
+
+	it("parses Python pyproject.toml [project].version", () => {
+		const cwd = makeProject({
+			"pyproject.toml": `[project]\nname = "x"\nversion = "1.0.0"\n`,
+		});
+		expectEcosystem(cwd, "python", "1.0.0");
+	});
+
+	it("parses Python pyproject.toml poetry fallback", () => {
+		const cwd = makeProject({
+			"pyproject.toml": `[tool.poetry]\nname = "x"\nversion = "2.0.0"\n`,
+		});
+		expectEcosystem(cwd, "python", "2.0.0");
+	});
+
+	it("parses Python setup.cfg [metadata].version", () => {
+		const cwd = makeProject({
+			"setup.cfg": "[metadata]\nname = x\nversion = 3.2.1\n[options]\ninstall_requires = []\n",
+		});
+		expectEcosystem(cwd, "python", "3.2.1");
+	});
+
+	it("parses Rust Cargo.toml [package].version", () => {
+		const cwd = makeProject({
+			"Cargo.toml": `[package]\nname = "x"\nversion = "0.4.2"\nedition = "2021"\n`,
+		});
+		expectEcosystem(cwd, "rust", "0.4.2");
+	});
+
+	it("parses Rust Cargo.toml workspace-inherited version", () => {
+		const cwd = makeProject({
+			"Cargo.toml": `[package]\nname = "x"\nversion.workspace = true\n\n[workspace]\nversion = "0.9.0"\n`,
+		});
+		expectEcosystem(cwd, "rust", "0.9.0");
+	});
+
+	it("parses PHP composer.json version", () => {
+		const cwd = makeProject({
+			"composer.json": JSON.stringify({ name: "demo/demo", version: "1.4.0" }),
+		});
+		expectEcosystem(cwd, "php", "1.4.0");
+	});
+
+	it("parses Crystal shard.yml top-level version", () => {
+		const cwd = makeProject({
+			"shard.yml": `name: x\nversion: 0.3.0\n\ndependencies:\n  yaml: ~> 1.0\n`,
+		});
+		expectEcosystem(cwd, "crystal", "0.3.0");
+	});
+
+	it("parses Dart pubspec.yaml version", () => {
+		const cwd = makeProject({
+			"pubspec.yaml": `name: x\nversion: 2.5.0\nenvironment:\n  sdk: ">=3.0.0"\n`,
+		});
+		expectEcosystem(cwd, "dart", "2.5.0");
+	});
+
+	it("parses Dart pubspec.yml fallback", () => {
+		const cwd = makeProject({
+			"pubspec.yml": `name: x\nversion: 2.6.0\n`,
+		});
+		expectEcosystem(cwd, "dart", "2.6.0");
+	});
+
+	it("parses Elixir mix.exs project version literal", () => {
+		const cwd = makeProject({
+			"mix.exs":
+				'defmodule Demo.MixProject do\n  use Mix.Project\n\n  def project do\n    [\n      app: :demo,\n      version: "1.7.3",\n      elixir: "~> 1.14"\n    ]\n  end\nend\n',
+		});
+		expectEcosystem(cwd, "elixir", "1.7.3");
+	});
+
+	it("parses elm.json top-level version", () => {
+		const cwd = makeProject({
+			"elm.json": JSON.stringify({
+				type: "application",
+				"source-directories": ["src"],
+				"elm-version": "0.19.1",
+				version: "1.0.0",
+				dependencies: { direct: {}, indirect: {} },
+				"test-dependencies": { direct: {}, indirect: {} },
+			}),
+		});
+		expectEcosystem(cwd, "elm", "1.0.0");
+	});
+
+	it("parses Fortran fpm.toml version", () => {
+		const cwd = makeProject({
+			"fpm.toml": `[package]\nname = "x"\nversion = "0.2.1"\n`,
+		});
+		expectEcosystem(cwd, "fortran", "0.2.1");
+	});
+
+	it("parses Gleam gleam.toml top-level version", () => {
+		const cwd = makeProject({
+			"gleam.toml": `name = "x"\nversion = "1.0.0"\ndescription = "demo"\n`,
+		});
+		expectEcosystem(cwd, "gleam", "1.0.0");
+	});
+
+	it("parses Haskell *.cabal version in package stanza", () => {
+		const cwd = makeProject({
+			"x.cabal": `cabal-version: 2.4\nname: x\nversion: 0.6.0\n\nlibrary\n  exposed-modules: X\n  build-depends: base >= 4.14\n`,
+		});
+		expectEcosystem(cwd, "haskell", "0.6.0");
+	});
+
+	it("parses Helm Chart.yaml chart version", () => {
+		const cwd = makeProject({
+			"Chart.yaml":
+				'apiVersion: v2\nname: x\ndescription: demo\nversion: 0.1.2\nappVersion: "1.0.0"\n',
+		});
+		expectEcosystem(cwd, "helm", "0.1.2");
+	});
+
+	it("parses Julia Project.toml top-level version", () => {
+		const cwd = makeProject({
+			"Project.toml": `name = "X"\nversion = "0.5.2"\n\n[deps]\n\n[compat]\n`,
+		});
+		expectEcosystem(cwd, "julia", "0.5.2");
+	});
+
+	it("parses Meson meson.build static project() version literal", () => {
+		const cwd = makeProject({
+			"meson.build":
+				"project('x', 'c', version: '0.3.0', license: 'MIT')\n\n executable('x', 'main.c')\n",
+		});
+		expectEcosystem(cwd, "meson", "0.3.0");
+	});
+
+	it("parses Nim *.nimble top-level version", () => {
+		const cwd = makeProject({
+			"x.nimble": `# Package\nversion       = "0.2.1"\nauthor        = "x"\ndescription   = "demo"\nlicense       = "MIT"\n\nrequires "nim >= 1.6"\n`,
+		});
+		expectEcosystem(cwd, "nim", "0.2.1");
+	});
+
+	it("parses Ruby *.gemspec spec.version assignment", () => {
+		const cwd = makeProject({
+			"x.gemspec": `Gem::Specification.new do |s|\n  s.name = 'x'\n  s.version = '1.2.0'\n  s.summary = 'demo'\nend\n`,
+		});
+		expectEcosystem(cwd, "ruby", "1.2.0");
+	});
+
+	it("parses Vlang v.mod module version", () => {
+		const cwd = makeProject({
+			"v.mod": `Module {\n\tname: 'x'\n\tversion: '0.4.0'\n\tdescription: 'demo'\n\tauthor: 'x'\n}\n`,
+		});
+		expectEcosystem(cwd, "vlang", "0.4.0");
+	});
+
+	it("parses Xmake xmake.lua static set_version literal", () => {
+		const cwd = makeProject({
+			"xmake.lua": `add_rules("mode.debug", "mode.release")\nset_version("1.6.0")\n\ntarget("demo")\n`,
+		});
+		expectEcosystem(cwd, "xmake", "1.6.0");
+	});
+
+	it("returns null for manifests without a parseable version (silent fallback)", () => {
+		const cases: Array<[string, string]> = [
+			["package.json", JSON.stringify({ name: "demo" })],
+			["deno.json", JSON.stringify({ name: "demo" })],
+			["Cargo.toml", `[package]\nname = "x"\nedition = "2021"\n`],
+			["pyproject.toml", `[project]\nname = "x"\n`],
+			["meson.build", "project('x', 'c')\n"],
+			["xmake.lua", "add_rules('mode.debug')\n"],
+		];
+		for (const [file, content] of cases) {
+			const cwd = makeProject({ [file]: content });
+			expect(readPackageVersion(cwd)).toBeNull();
+		}
+	});
+
+	it("prefers package.json over Chart.yaml when both exist (deterministic priority)", () => {
+		const cwd = makeProject({
+			"package.json": JSON.stringify({ version: "1.0.0" }),
+			"Chart.yaml": "apiVersion: v2\nversion: 2.0.0\n",
+		});
+		const result = readPackageVersion(cwd);
+		expect(result).not.toBeNull();
+		expect(result?.ecosystem).toBe("nodejs");
+		expect(result?.version).toBe("1.0.0");
+	});
+
+	it("strips a single leading 'v' from semver versions", () => {
+		const cwd = makeProject({
+			"package.json": JSON.stringify({ version: "v3.2.1" }),
+		});
+		expect(readPackageVersion(cwd)?.version).toBe("3.2.1");
+	});
+
+	it("does not shell out and survives missing manifests silently", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "zentui-empty-project-"));
+		expect(readPackageVersion(cwd)).toBeNull();
+	});
+
+	it("exposes PACKAGE_VERSION_ECOSYSTEMS as a stable, sorted-ish list", () => {
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("bun");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("nodejs");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("python");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("rust");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("haskell");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("ruby");
+		expect(PACKAGE_VERSION_ECOSYSTEMS).toContain("nim");
+	});
+});
+
+describe("cleanVersion", () => {
+	const { cleanVersion } = __test__;
+
+	it.each([
+		["1.2.3", "1.2.3"],
+		['"1.2.3"', "1.2.3"],
+		["'1.2.3'", "1.2.3"],
+		["  1.2.3  ", "1.2.3"],
+		["v3.2.1", "3.2.1"],
+		["0.0.1-alpha", "0.0.1-alpha"],
+	])("cleans %j -> %j", (input, expected) => {
+		expect(cleanVersion(input)).toBe(expected);
+	});
+
+	it.each(["", "   ", "not a version", "1.2.3 with spaces", "{1.2.3}"])("rejects %j", (input) => {
+		expect(cleanVersion(input)).toBeUndefined();
+	});
+});

--- a/test/project-state.test.ts
+++ b/test/project-state.test.ts
@@ -89,4 +89,56 @@ describe("applyProjectRefreshToState", () => {
 		expect(state.gitStateLabel).toBe("REBASING 1/2");
 		expect(state.runtime?.name).toBe("bun");
 	});
+
+	it("applies ok packageVersion result and clears it when manifest disappears", () => {
+		const state = createInitialState(emptyGitStatus());
+
+		applyProjectRefreshToState(state, {
+			cwd: "/repo",
+			previousCwd: "/repo",
+			git: { kind: "ok", status: emptyGitStatus() },
+			runtime: { kind: "ok", runtime: undefined },
+			packageVersion: {
+				kind: "ok",
+				result: { ecosystem: "nodejs", version: "1.2.3" },
+			},
+		});
+		expect(state.packageVersion).toEqual({ ecosystem: "nodejs", version: "1.2.3" });
+
+		applyProjectRefreshToState(state, {
+			cwd: "/repo",
+			previousCwd: "/repo",
+			git: { kind: "ok", status: emptyGitStatus() },
+			runtime: { kind: "ok", runtime: undefined },
+			packageVersion: { kind: "ok", result: null },
+		});
+		expect(state.packageVersion).toBeUndefined();
+	});
+
+	it("keeps last-good packageVersion on transient error", () => {
+		const state = createInitialState(emptyGitStatus());
+		state.packageVersion = { ecosystem: "rust", version: "0.4.2" };
+
+		applyProjectRefreshToState(state, {
+			cwd: "/repo",
+			previousCwd: "/repo",
+			git: { kind: "ok", status: emptyGitStatus() },
+			runtime: { kind: "ok", runtime: undefined },
+			packageVersion: { kind: "error" },
+		});
+		expect(state.packageVersion).toEqual({ ecosystem: "rust", version: "0.4.2" });
+	});
+
+	it("clears packageVersion on cwd change even when no result is provided", () => {
+		const state = createInitialState(emptyGitStatus());
+		state.packageVersion = { ecosystem: "python", version: "2.0.0" };
+
+		applyProjectRefreshToState(state, {
+			cwd: "/new",
+			previousCwd: "/old",
+			git: { kind: "error" },
+			runtime: { kind: "error" },
+		});
+		expect(state.packageVersion).toBeUndefined();
+	});
 });

--- a/test/project-state.test.ts
+++ b/test/project-state.test.ts
@@ -141,4 +141,19 @@ describe("applyProjectRefreshToState", () => {
 		});
 		expect(state.packageVersion).toBeUndefined();
 	});
+
+	it("clears commit and metrics on cwd change", () => {
+		const state = createInitialState(emptyGitStatus());
+		state.commit = { oid: "abc123", detached: true, tag: "v1" };
+		state.metrics = { added: 10, deleted: 5 };
+
+		applyProjectRefreshToState(state, {
+			cwd: "/new",
+			previousCwd: "/old",
+			git: { kind: "error" },
+			runtime: { kind: "error" },
+		});
+		expect(state.commit).toBeUndefined();
+		expect(state.metrics).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Summary

Add three Starship-inspired footer segments (all default off) plus the Starship default-format connectors and layout:

- **Package version** (#32): Detects the project's manifest version from 22 ecosystems (npm, Cargo, pyproject, deno, maven, gradle, composer, crystal, dart, elixir, elm, fortran, gleam, haskell, helm, julia, meson, nim, ruby, vlang, xmake, bun). Renders as `is 󰏗 v0.6.0`. Segment toggle + `$package` / `$package_version` variables.
- **Git commit** (#33): Shows short HEAD hash on detached HEAD, folded into the branch display as `on  HEAD (abc1234)`. Optional exact-match tag. `$git_commit` / `$git_tag` variables. Reuses existing porcelain `branch.oid` — no extra git call for the hash.
- **Git line metrics** (#34): Shows `+added −deleted` via `git diff HEAD --numstat` (staged + unstaged, Starship "total dirty"). `$git_metrics` / `$git_added` / `$git_deleted` variables.

Other changes:
- Starship default-format connectors: directory (no icon), `is` for package, `via` for runtime.
- All optional git/package probes piggyback on the existing project refresh — no second scheduler.
- Glyphs from the [Starship Nerd Font preset](https://starship.rs/presets/nerd-font); colors from [Starship config docs](https://starship.rs/config).
- `onlyDetached` hides the whole git_commit segment (including tag) per Starship semantics.
- Probes gated by segment toggle OR footerFormat variable reference.

Closes #32, closes #33, closes #34

## Screenshots / recordings

N/A — segments are default off; user toggles via `/zentui` or `~/.pi/agent/zentui.json`. Manual `npm run pi:dev` testing recommended before merge.

## Testing

- [x] `npm run verify` (303 tests pass)
- [x] `npm run pack:check`
- [ ] Manual Pi test via `npm run pi:dev` (required for UI behavior changes)
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [x] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in a focused module.
- [x] Used a conventional commit-style PR title.
