### PR TITLE
fix: harden pi integration lifecycle

### DIFF
--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -2,10 +2,14 @@ import { randomUUID } from "node:crypto";
 import {
 	closeSync,
 	existsSync,
+	fchmodSync,
 	fsyncSync,
+	lstatSync,
 	openSync,
 	readFileSync,
+	realpathSync,
 	renameSync,
+	statSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -634,8 +638,8 @@ function validFooterSegmentEntries(record: Record<string, unknown>): Partial<Foo
 }
 
 type ConfigFileState =
-	| { kind: "missing"; record: ConfigRecord }
-	| { kind: "valid"; record: ConfigRecord }
+	| { kind: "missing"; record: ConfigRecord; writePath: string }
+	| { kind: "valid"; record: ConfigRecord; writePath: string; mode: number }
 	| { kind: "corrupt"; error: unknown };
 
 function errorCode(error: unknown): string | undefined {
@@ -645,23 +649,34 @@ function errorCode(error: unknown): string | undefined {
 }
 
 function readConfigFileState(path: string): ConfigFileState {
+	let writePath = path;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf8"));
+		const pathStat = lstatSync(path);
+		if (pathStat.isSymbolicLink()) writePath = realpathSync(path);
+		const targetStat = statSync(writePath);
+		const parsed = JSON.parse(readFileSync(writePath, "utf8"));
 		return isRecord(parsed)
-			? { kind: "valid", record: parsed }
+			? { kind: "valid", record: parsed, writePath, mode: targetStat.mode & 0o7777 }
 			: { kind: "corrupt", error: new Error("top-level value must be a JSON object") };
 	} catch (error) {
-		return errorCode(error) === "ENOENT"
-			? { kind: "missing", record: {} }
-			: { kind: "corrupt", error };
+		if (errorCode(error) === "ENOENT") {
+			try {
+				lstatSync(path);
+			} catch (pathError) {
+				if (errorCode(pathError) === "ENOENT")
+					return { kind: "missing", record: {}, writePath: path };
+			}
+		}
+		return { kind: "corrupt", error };
 	}
 }
 
-function writeConfigAtomically(path: string, record: ConfigRecord): void {
+function writeConfigAtomically(path: string, record: ConfigRecord, mode?: number): void {
 	const tempPath = join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
 	let file: number | undefined;
 	try {
-		file = openSync(tempPath, "wx");
+		file = openSync(tempPath, "wx", mode ?? 0o666);
+		if (mode !== undefined) fchmodSync(file, mode);
 		writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, "utf8");
 		fsyncSync(file);
 		closeSync(file);
@@ -693,7 +708,11 @@ function mutateConfig(path: string, mutate: (record: ConfigRecord) => void): Pol
 		);
 	}
 	mutate(state.record);
-	writeConfigAtomically(path, state.record);
+	writeConfigAtomically(
+		state.writePath,
+		state.record,
+		state.kind === "valid" ? state.mode : undefined,
+	);
 	return mergeConfig(state.record);
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -1,5 +1,15 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+	closeSync,
+	existsSync,
+	fsyncSync,
+	openSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import {
 	ICON_GLYPH_KEYS,
@@ -623,14 +633,68 @@ function validFooterSegmentEntries(record: Record<string, unknown>): Partial<Foo
 	) as Partial<FooterSegmentsConfig>;
 }
 
-function readConfigRecord(path = configPath): ConfigRecord {
+type ConfigFileState =
+	| { kind: "missing"; record: ConfigRecord }
+	| { kind: "valid"; record: ConfigRecord }
+	| { kind: "corrupt"; error: unknown };
+
+function errorCode(error: unknown): string | undefined {
+	return typeof error === "object" && error !== null && "code" in error
+		? String(error.code)
+		: undefined;
+}
+
+function readConfigFileState(path: string): ConfigFileState {
 	try {
-		if (!existsSync(path)) return {};
 		const parsed = JSON.parse(readFileSync(path, "utf8"));
-		return isRecord(parsed) ? parsed : {};
-	} catch {
-		return {};
+		return isRecord(parsed)
+			? { kind: "valid", record: parsed }
+			: { kind: "corrupt", error: new Error("top-level value must be a JSON object") };
+	} catch (error) {
+		return errorCode(error) === "ENOENT"
+			? { kind: "missing", record: {} }
+			: { kind: "corrupt", error };
 	}
+}
+
+function writeConfigAtomically(path: string, record: ConfigRecord): void {
+	const tempPath = join(dirname(path), `.${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+	let file: number | undefined;
+	try {
+		file = openSync(tempPath, "wx");
+		writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, "utf8");
+		fsyncSync(file);
+		closeSync(file);
+		file = undefined;
+		renameSync(tempPath, path);
+	} catch (error) {
+		if (file !== undefined) {
+			try {
+				closeSync(file);
+			} catch {}
+		}
+		try {
+			unlinkSync(tempPath);
+		} catch (cleanupError) {
+			if (errorCode(cleanupError) !== "ENOENT") {
+				// Preserve the persistence failure; the best-effort cleanup error is secondary.
+			}
+		}
+		throw error;
+	}
+}
+
+function mutateConfig(path: string, mutate: (record: ConfigRecord) => void): PolishedTuiConfig {
+	const state = readConfigFileState(path);
+	if (state.kind === "corrupt") {
+		const detail = state.error instanceof Error ? ` (${state.error.message})` : "";
+		throw new Error(
+			`Refusing to save Zentui config because ${path} is corrupt or unreadable; fix or remove it first.${detail}`,
+		);
+	}
+	mutate(state.record);
+	writeConfigAtomically(path, state.record);
+	return mergeConfig(state.record);
 }
 
 export function ensureConfigExists(): void {
@@ -724,129 +788,119 @@ export function saveColorSourcesPatch(
 	patch: Partial<ColorSourcesConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.colorSources)
-		? { ...(record.colorSources as Record<string, unknown>) }
-		: {};
-	record.colorSources = {
-		...existing,
-		...validColorSourceEntries(patch),
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.colorSources)
+			? { ...(record.colorSources as Record<string, unknown>) }
+			: {};
+		record.colorSources = {
+			...existing,
+			...validColorSourceEntries(patch),
+		};
+	});
 }
 
 export function saveUiFeaturesPatch(
 	patch: Partial<UiFeaturesConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.features)
-		? { ...(record.features as Record<string, unknown>) }
-		: {};
-	record.features = {
-		...existing,
-		...validUiFeatureEntries(patch),
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.features)
+			? { ...(record.features as Record<string, unknown>) }
+			: {};
+		record.features = {
+			...existing,
+			...validUiFeatureEntries(patch),
+		};
+	});
 }
 
 export function saveFooterSegmentsPatch(
 	patch: Partial<FooterSegmentsConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.footerSegments)
-		? { ...(record.footerSegments as Record<string, unknown>) }
-		: {};
-	record.footerSegments = {
-		...existing,
-		...validFooterSegmentEntries(patch),
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.footerSegments)
+			? { ...(record.footerSegments as Record<string, unknown>) }
+			: {};
+		record.footerSegments = {
+			...existing,
+			...validFooterSegmentEntries(patch),
+		};
+	});
 }
 
 export function saveFooterFormatPatch(value: string, path = configPath): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	record.footerFormat = typeof value === "string" ? value : "";
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		record.footerFormat = typeof value === "string" ? value : "";
+	});
 }
 
 export function saveIconsModePatch(mode: IconMode, path = configPath): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.icons) ? { ...(record.icons as Record<string, unknown>) } : {};
-	record.icons = {
-		...existing,
-		mode: normalizeIconMode(mode),
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.icons) ? { ...(record.icons as Record<string, unknown>) } : {};
+		record.icons = {
+			...existing,
+			mode: normalizeIconMode(mode),
+		};
+	});
 }
 
 export function saveContextStylePatch(style: ContextStyle, path = configPath): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	record.contextStyle = parseContextStyle(style);
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		record.contextStyle = parseContextStyle(style);
+	});
 }
 
 export function saveSeparatorPatch(
 	separator: SeparatorStyle,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	record.separator = parseSeparatorStyle(separator);
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		record.separator = parseSeparatorStyle(separator);
+	});
 }
 
 export function saveContextThresholdsPatch(
 	thresholds: Partial<ContextThresholds>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.contextThresholds)
-		? { ...(record.contextThresholds as Record<string, unknown>) }
-		: {};
-	record.contextThresholds = {
-		...existing,
-		...thresholds,
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.contextThresholds)
+			? { ...(record.contextThresholds as Record<string, unknown>) }
+			: {};
+		record.contextThresholds = {
+			...existing,
+			...thresholds,
+		};
+	});
 }
 
 export function savePathDisplayPatch(
 	patch: Partial<PathDisplayConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.pathDisplay)
-		? { ...(record.pathDisplay as Record<string, unknown>) }
-		: {};
-	if (patch.mode !== undefined) existing.mode = patch.mode;
-	if (patch.depth !== undefined) existing.depth = patch.depth;
-	record.pathDisplay = existing;
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.pathDisplay)
+			? { ...(record.pathDisplay as Record<string, unknown>) }
+			: {};
+		if (patch.mode !== undefined) existing.mode = patch.mode;
+		if (patch.depth !== undefined) existing.depth = patch.depth;
+		record.pathDisplay = existing;
+	});
 }
 
 export function saveGitBranchPatch(
 	patch: Partial<GitBranchConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.gitBranch)
-		? { ...(record.gitBranch as Record<string, unknown>) }
-		: {};
-	if (patch.maxLength !== undefined)
-		existing.maxLength = normalizeGitBranchMaxLength(patch.maxLength);
-	record.gitBranch = existing;
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.gitBranch)
+			? { ...(record.gitBranch as Record<string, unknown>) }
+			: {};
+		if (patch.maxLength !== undefined)
+			existing.maxLength = normalizeGitBranchMaxLength(patch.maxLength);
+		record.gitBranch = existing;
+	});
 }
 
 export function saveExtensionStatusPlacement(
@@ -854,27 +908,26 @@ export function saveExtensionStatusPlacement(
 	placement: ExtensionStatusPlacement,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existingExtensionStatuses = isRecord(record.extensionStatuses)
-		? { ...(record.extensionStatuses as Record<string, unknown>) }
-		: {};
-	const existingPlacements = isRecord(existingExtensionStatuses.placements)
-		? { ...(existingExtensionStatuses.placements as Record<string, unknown>) }
-		: {};
+	return mutateConfig(path, (record) => {
+		const existingExtensionStatuses = isRecord(record.extensionStatuses)
+			? { ...(record.extensionStatuses as Record<string, unknown>) }
+			: {};
+		const existingPlacements = isRecord(existingExtensionStatuses.placements)
+			? { ...(existingExtensionStatuses.placements as Record<string, unknown>) }
+			: {};
 
-	Object.defineProperty(existingPlacements, key, {
-		value: placement,
-		enumerable: true,
-		configurable: true,
-		writable: true,
+		Object.defineProperty(existingPlacements, key, {
+			value: placement,
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+
+		record.extensionStatuses = {
+			...existingExtensionStatuses,
+			placements: existingPlacements,
+		};
 	});
-
-	record.extensionStatuses = {
-		...existingExtensionStatuses,
-		placements: existingPlacements,
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
 }
 
 export function saveExtensionStatusColorMode(
@@ -882,43 +935,41 @@ export function saveExtensionStatusColorMode(
 	colorMode: ExtensionStatusColorMode,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existingExtensionStatuses = isRecord(record.extensionStatuses)
-		? { ...(record.extensionStatuses as Record<string, unknown>) }
-		: {};
-	const existingColorModes = isRecord(existingExtensionStatuses.colorModes)
-		? { ...(existingExtensionStatuses.colorModes as Record<string, unknown>) }
-		: {};
+	return mutateConfig(path, (record) => {
+		const existingExtensionStatuses = isRecord(record.extensionStatuses)
+			? { ...(record.extensionStatuses as Record<string, unknown>) }
+			: {};
+		const existingColorModes = isRecord(existingExtensionStatuses.colorModes)
+			? { ...(existingExtensionStatuses.colorModes as Record<string, unknown>) }
+			: {};
 
-	Object.defineProperty(existingColorModes, key, {
-		value: colorMode,
-		enumerable: true,
-		configurable: true,
-		writable: true,
+		Object.defineProperty(existingColorModes, key, {
+			value: colorMode,
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+
+		record.extensionStatuses = {
+			...existingExtensionStatuses,
+			colorModes: existingColorModes,
+		};
 	});
-
-	record.extensionStatuses = {
-		...existingExtensionStatuses,
-		colorModes: existingColorModes,
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
 }
 
 export function saveFixedEditorPatch(
 	patch: Partial<FixedEditorConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	const record = readConfigRecord(path);
-	const existing = isRecord(record.fixedEditor)
-		? { ...(record.fixedEditor as Record<string, unknown>) }
-		: {};
-	record.fixedEditor = {
-		...existing,
-		...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
-		...(patch.mouseScroll !== undefined ? { mouseScroll: patch.mouseScroll } : {}),
-		...(patch.copyNotice !== undefined ? { copyNotice: patch.copyNotice } : {}),
-	};
-	writeFileSync(path, `${JSON.stringify(record, null, 2)}\n`, "utf8");
-	return mergeConfig(record);
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.fixedEditor)
+			? { ...(record.fixedEditor as Record<string, unknown>) }
+			: {};
+		record.fixedEditor = {
+			...existing,
+			...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
+			...(patch.mouseScroll !== undefined ? { mouseScroll: patch.mouseScroll } : {}),
+			...(patch.copyNotice !== undefined ? { copyNotice: patch.copyNotice } : {}),
+		};
+	});
 }

--- a/extensions/zentui/fixed-editor/cluster.ts
+++ b/extensions/zentui/fixed-editor/cluster.ts
@@ -1,118 +1,22 @@
 /**
- * Cluster discovery and rendering for the fixed editor.
+ * Cluster rendering for the fixed editor.
  *
- * The "cluster" is the set of Pi TUI children around the editor that should be
- * pinned at the bottom: status container, above-editor widget, editor,
- * below-editor widget, and footer.
+ * Pi-specific cluster discovery and validation live in pi-compat.ts. This module
+ * only renders the already-verified pinned components.
  *
  * @internal
  */
 
 import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
+import type { PiFixedCluster, PiRenderableCapability } from "./pi-compat";
 import type { ClusterRender } from "./types";
 
-/** Minimal Component shape needed for rendering. */
-type Renderable = {
-	render(width: number): string[];
-	/** Saved original render when the compositor has patched render → [] */
-	__zentuiOriginalRender?: (width: number) => string[];
-};
+export type FixedCluster = PiFixedCluster;
 
-/** Minimal Container shape for child scanning. */
-type ContainerLike = Renderable & {
-	children: unknown[];
-};
-
-/** Check if a value is a container-like object (has children + render). */
-function isContainerLike(value: unknown): value is ContainerLike {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		Array.isArray(Reflect.get(value, "children")) &&
-		typeof Reflect.get(value, "render") === "function"
-	);
-}
-
-/** Check if a value looks like an editor component (duck-typed). */
-function isEditorLike(value: unknown): boolean {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		typeof Reflect.get(value, "getText") === "function" &&
-		typeof Reflect.get(value, "setText") === "function" &&
-		typeof Reflect.get(value, "handleInput") === "function"
-	);
-}
-
-/**
- * Find the index in `children` of the container holding the editor.
- * Prefers the focused component's parent; falls back to scanning for
- * an editor-like grandchild.
- */
-export function findEditorContainerIndex(
-	children: unknown[],
-	focusedComponent?: unknown,
-): number | undefined {
-	// Try focused component first.
-	if (focusedComponent && typeof focusedComponent === "object") {
-		const idx = children.findIndex(
-			(c) => isContainerLike(c) && c.children.includes(focusedComponent),
-		);
-		if (idx !== -1) return idx;
-	}
-
-	// Scan for a container with an editor-like child.
-	const idx = children.findIndex(
-		(c) => isContainerLike(c) && c.children.some((gc) => isEditorLike(gc)),
-	);
-	return idx === -1 ? undefined : idx;
-}
-
-/** The 5-component cluster pinned at the bottom. */
-export type FixedCluster = {
-	status: Renderable | null;
-	aboveWidget: Renderable | null;
-	editor: Renderable;
-	belowWidget: Renderable | null;
-	footer: Renderable | null;
-};
-
-/**
- * Patch a cluster component's render to return [] (hide from transcript).
- * Saves the original render for cluster painting.
- */
-export function hideRenderable(component: Renderable | null): void {
-	if (!component || component.__zentuiOriginalRender) return;
-	component.__zentuiOriginalRender = component.render.bind(component);
-	component.render = () => [];
-}
-
-/** Restore a cluster component's original render. */
-export function restoreRenderable(component: Renderable | null): void {
-	if (!component?.__zentuiOriginalRender) return;
-	component.render = component.__zentuiOriginalRender;
-	delete component.__zentuiOriginalRender;
-}
-
-/** Build the cluster from children around the editor index. */
-export function buildCluster(children: unknown[], editorIdx: number): FixedCluster | null {
-	const editor = children[editorIdx];
-	if (!editor || typeof (editor as Renderable).render !== "function") return null;
-	return {
-		status: (children[editorIdx - 2] as Renderable | undefined) ?? null,
-		aboveWidget: (children[editorIdx - 1] as Renderable | undefined) ?? null,
-		editor: editor as Renderable,
-		belowWidget: (children[editorIdx + 1] as Renderable | undefined) ?? null,
-		footer: (children[editorIdx + 2] as Renderable | undefined) ?? null,
-	};
-}
-
-/** Render a component at `width`, using the saved original render if hidden. */
-function renderComponent(component: Renderable | null, width: number): string[] {
+function renderComponent(component: PiRenderableCapability | null, width: number): string[] {
 	if (!component) return [];
-	const renderFn = component.__zentuiOriginalRender ?? component.render;
-	const lines = renderFn.call(component, width);
+	const lines = component.render.call(component.target, width);
 	// Strip only trailing blank lines — internal blank lines (e.g. editor
 	// padding in copy-friendly mode) must be preserved.
 	let end = lines.length;

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -14,15 +14,13 @@
 import { copyToClipboard } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 
-import {
-	buildCluster,
-	type FixedCluster,
-	findEditorContainerIndex,
-	hideRenderable,
-	renderCluster,
-	restoreRenderable,
-} from "./cluster";
+import { renderCluster } from "./cluster";
 import { clampScrollOffset, parseKeyboardScroll, parseMouseEvent } from "./input";
+import type {
+	PiFixedEditorCapabilities,
+	PiMethodCapability,
+	PiRenderableCapability,
+} from "./pi-compat";
 import { highlightSelection, SelectionState } from "./selection";
 import {
 	CLEAR_LINE,
@@ -43,32 +41,42 @@ import {
 	SYNC_END,
 	setScrollRegion,
 } from "./terminal-modes";
-import type { ClusterRender, CompositorConfig, TerminalLike, TuiLike } from "./types";
+import type { ClusterRender, CompositorConfig } from "./types";
 
-/** Property descriptor for the original `terminal.rows` getter. */
-type RowsDescriptor = PropertyDescriptor | undefined;
-
-function descriptorForRows(terminal: TerminalLike): RowsDescriptor {
-	let target: object | null = terminal;
-	while (target) {
-		const descriptor = Object.getOwnPropertyDescriptor(target, "rows");
-		if (descriptor) return descriptor;
-		target = Object.getPrototypeOf(target);
-	}
-	return undefined;
+function replaceMethod(
+	capability: PiMethodCapability,
+	method: (...args: unknown[]) => unknown,
+): void {
+	const descriptor = capability.ownDescriptor;
+	Object.defineProperty(capability.target, capability.key, {
+		...(descriptor ?? { configurable: true, enumerable: false, writable: true }),
+		value: method,
+	});
 }
 
-function readRawRows(terminal: TerminalLike, descriptor: RowsDescriptor): number {
-	if (descriptor?.get) {
-		const value = descriptor.get.call(terminal);
-		return typeof value === "number" && Number.isFinite(value) ? value : 24;
+function restoreMethod(capability: PiMethodCapability): void {
+	if (capability.ownDescriptor) {
+		Object.defineProperty(capability.target, capability.key, capability.ownDescriptor);
+	} else {
+		Reflect.deleteProperty(capability.target, capability.key);
 	}
-	if (descriptor && "value" in descriptor) {
-		const value = descriptor.value;
-		return typeof value === "number" && Number.isFinite(value) ? value : 24;
+}
+
+function hideRenderable(capability: PiRenderableCapability | null): void {
+	if (!capability) return;
+	Object.defineProperty(capability.target, "render", {
+		...(capability.ownDescriptor ?? { configurable: true, enumerable: false, writable: true }),
+		value: () => [],
+	});
+}
+
+function restoreRenderable(capability: PiRenderableCapability | null): void {
+	if (!capability) return;
+	if (capability.ownDescriptor) {
+		Object.defineProperty(capability.target, "render", capability.ownDescriptor);
+	} else {
+		Reflect.deleteProperty(capability.target, "render");
 	}
-	const value = Reflect.get(terminal, "rows");
-	return typeof value === "number" && Number.isFinite(value) ? value : 24;
 }
 
 function sanitizeLine(line: string, width: number): string {
@@ -76,20 +84,14 @@ function sanitizeLine(line: string, width: number): string {
 }
 
 export class TerminalSplitCompositor {
-	private readonly tui: TuiLike;
-	private readonly terminal: TerminalLike;
+	private readonly capabilities: PiFixedEditorCapabilities;
 	private readonly getConfig: () => CompositorConfig;
-	private cluster: FixedCluster | null = null;
-
-	private readonly rowsDescriptor: RowsDescriptor;
-	private readonly originalWrite: (data: string) => void;
-	private readonly originalDoRender: (() => void) | null;
-	private readonly originalRender: ((width: number) => string[]) | null;
 	private removeInputListener: (() => void) | null = null;
 	private emergencyCleanup: (() => void) | null = null;
 
 	private installed = false;
 	private disposed = false;
+	private terminalModesEntered = false;
 	private writing = false;
 	private renderingCluster = false;
 	private checkingOverlay = false;
@@ -117,146 +119,160 @@ export class TerminalSplitCompositor {
 	private cachedClusterRender: { width: number; rows: number; render: ClusterRender } | null = null;
 
 	constructor(
-		tui: TuiLike,
-		terminal: TerminalLike,
+		capabilities: PiFixedEditorCapabilities,
 		getConfig: () => CompositorConfig,
 		onCopy?: () => void,
 		onDismissNotice?: () => void,
 	) {
-		this.tui = tui;
-		this.terminal = terminal;
+		this.capabilities = capabilities;
 		this.getConfig = getConfig;
 		this.onCopy = onCopy ?? null;
 		this.onDismissNotice = onDismissNotice ?? null;
-		this.rowsDescriptor = descriptorForRows(terminal);
-		this.originalWrite = terminal.write.bind(terminal);
-		this.originalDoRender = typeof tui.doRender === "function" ? tui.doRender.bind(tui) : null;
-		this.originalRender = typeof tui.render === "function" ? tui.render.bind(tui) : null;
 	}
 
-	/** Install all patches. Returns true on success, false if capabilities missing. */
 	install(): boolean {
 		if (this.installed) return true;
-		if (typeof this.terminal.write !== "function") return false;
-		if (typeof this.tui.addInputListener !== "function") return false;
-		if (!this.originalDoRender || !this.originalRender) return false;
-
-		const children = this.tui.children;
-		if (!Array.isArray(children) || children.length < 3) return false;
-
-		const editorIdx = findEditorContainerIndex(children, this.tui.focusedComponent);
-		if (editorIdx === undefined) return false;
-
-		const cluster = buildCluster(children, editorIdx);
-		if (!cluster) return false;
-		this.cluster = cluster;
-
-		// Hide cluster components from Pi's normal render so they don't appear
-		// in the scrollable transcript. Their original render output is captured
-		// via __zentuiOriginalRender and painted separately by paintCluster.
-		for (const component of [
-			cluster.status,
-			cluster.aboveWidget,
-			cluster.editor,
-			cluster.belowWidget,
-			cluster.footer,
-		]) {
-			hideRenderable(component);
-		}
-
-		// Enter terminal modes.
-		this.originalWrite(
-			SYNC_BEGIN +
-				ENTER_ALT_SCREEN +
-				DISABLE_ALT_SCROLL +
-				(this.getConfig().mouseScroll ? ENABLE_MOUSE_SGR : DISABLE_MOUSE) +
-				SYNC_END,
-		);
-
-		// Emergency cleanup on crash.
-		this.emergencyCleanup = () => {
-			if (!this.disposed) this.restoreForExit();
-		};
-		process.once("exit", this.emergencyCleanup);
-
-		// Redefine terminal.rows so Pi renders only the scrollable region.
-		Object.defineProperty(this.terminal, "rows", {
-			configurable: true,
-			get: () => this.getScrollableRows(),
-		});
-
-		// Patch tui.render to apply scroll offset.
-		this.tui.render = (width: number) => this.renderScrollableRoot(width);
-
-		// Patch tui.doRender to paint cluster after original render.
-		this.tui.doRender = () => {
-			this.cachedClusterRender = null; // Invalidate cluster cache per render pass.
-			try {
-				this.originalDoRender?.();
-				this.requestRepaint();
-			} catch {
-				// If doRender throws, the original write already happened.
+		if (this.disposed) return false;
+		const cluster = this.capabilities.cluster;
+		try {
+			for (const component of [
+				cluster.status,
+				cluster.aboveWidget,
+				cluster.editor,
+				cluster.belowWidget,
+				cluster.footer,
+			]) {
+				hideRenderable(component);
 			}
-		};
+			Object.defineProperty(this.capabilities.terminal, "rows", {
+				configurable: true,
+				get: () => this.getScrollableRows(),
+			});
+			replaceMethod(this.capabilities.renderMethod, (width) =>
+				this.renderScrollableRoot(Number(width)),
+			);
+			replaceMethod(this.capabilities.doRenderMethod, () => {
+				this.cachedClusterRender = null;
+				try {
+					this.callOriginalDoRender();
+					this.requestRepaint();
+				} catch {
+					// If doRender throws, the original write already happened.
+				}
+			});
+			replaceMethod(this.capabilities.writeMethod, (data) => this.write(String(data)));
 
-		// Patch terminal.write to wrap in scroll region.
-		this.terminal.write = (data: string) => this.write(data);
+			const removeInputListener = this.capabilities.addInputListener((data) =>
+				this.handleInput(data),
+			);
+			if (typeof removeInputListener !== "function") throw new TypeError("Invalid input listener");
+			this.removeInputListener = removeInputListener as () => void;
+			this.emergencyCleanup = () => {
+				if (!this.disposed) this.restoreForExit();
+			};
+			process.once("exit", this.emergencyCleanup);
 
-		// Register input listener for scroll.
-		this.removeInputListener = this.tui.addInputListener((data: string) => this.handleInput(data));
-
-		this.installed = true;
-		this.tui.requestRender?.(true);
+			this.terminalModesEntered = true;
+			this.callOriginalWrite(
+				SYNC_BEGIN +
+					ENTER_ALT_SCREEN +
+					DISABLE_ALT_SCROLL +
+					(this.getConfig().mouseScroll ? ENABLE_MOUSE_SGR : DISABLE_MOUSE) +
+					SYNC_END,
+			);
+			this.installed = true;
+		} catch {
+			this.rollbackInstallation();
+			return false;
+		}
+		try {
+			this.capabilities.requestRender?.(true);
+		} catch {}
 		return true;
 	}
 
-	/** Full teardown — restore all patches, reset terminal modes. */
 	dispose(): void {
 		if (this.disposed) return;
 		this.disposed = true;
-
-		this.removeInputListener?.();
+		if (!this.installed) return;
+		const removeInputListener = this.removeInputListener;
 		this.removeInputListener = null;
-
+		try {
+			removeInputListener?.();
+		} catch {}
 		if (this.mouseResumeTimer) {
 			clearTimeout(this.mouseResumeTimer);
 			this.mouseResumeTimer = null;
 		}
-
 		if (this.emergencyCleanup) {
 			process.removeListener("exit", this.emergencyCleanup);
 			this.emergencyCleanup = null;
 		}
+		this.restorePatchedCapabilities();
+		this.restoreForExit();
+		this.terminalModesEntered = false;
+		this.installed = false;
+		try {
+			this.capabilities.requestRender?.(true);
+		} catch {}
+	}
 
-		this.terminal.write = this.originalWrite;
-		if (this.originalDoRender) this.tui.doRender = this.originalDoRender;
-		if (this.originalRender) this.tui.render = this.originalRender;
-
-		// Restore cluster components' original render methods.
-		if (this.cluster) {
-			for (const component of [
-				this.cluster.status,
-				this.cluster.aboveWidget,
-				this.cluster.editor,
-				this.cluster.belowWidget,
-				this.cluster.footer,
-			]) {
-				restoreRenderable(component);
-			}
+	private rollbackInstallation(): void {
+		const removeInputListener = this.removeInputListener;
+		this.removeInputListener = null;
+		try {
+			removeInputListener?.();
+		} catch {}
+		if (this.emergencyCleanup) {
+			process.removeListener("exit", this.emergencyCleanup);
+			this.emergencyCleanup = null;
 		}
+		this.restorePatchedCapabilities();
+		if (this.terminalModesEntered) this.restoreForExit();
+		this.terminalModesEntered = false;
+		this.installed = false;
+	}
 
-		if (this.rowsDescriptor) {
-			Object.defineProperty(this.terminal, "rows", this.rowsDescriptor);
+	private restorePatchedCapabilities(): void {
+		restoreMethod(this.capabilities.writeMethod);
+		restoreMethod(this.capabilities.doRenderMethod);
+		restoreMethod(this.capabilities.renderMethod);
+		for (const component of [
+			this.capabilities.cluster.status,
+			this.capabilities.cluster.aboveWidget,
+			this.capabilities.cluster.editor,
+			this.capabilities.cluster.belowWidget,
+			this.capabilities.cluster.footer,
+		]) {
+			restoreRenderable(component);
+		}
+		if (this.capabilities.rowsOwnDescriptor) {
+			Object.defineProperty(
+				this.capabilities.terminal,
+				"rows",
+				this.capabilities.rowsOwnDescriptor,
+			);
 		} else {
-			Reflect.deleteProperty(this.terminal, "rows");
+			Reflect.deleteProperty(this.capabilities.terminal, "rows");
 		}
+	}
 
-		this.restoreTerminalState();
-		this.tui.requestRender?.(true);
+	private callOriginalWrite(data: string): void {
+		Reflect.apply(this.capabilities.writeMethod.method, this.capabilities.terminal, [data]);
+	}
+
+	private callOriginalDoRender(): void {
+		Reflect.apply(this.capabilities.doRenderMethod.method, this.capabilities.tui, []);
+	}
+
+	private callOriginalRender(width: number): string[] {
+		return Reflect.apply(this.capabilities.renderMethod.method, this.capabilities.tui, [
+			width,
+		]) as string[];
 	}
 
 	private getRawRows(): number {
-		return Math.max(2, readRawRows(this.terminal, this.rowsDescriptor));
+		return Math.max(2, this.capabilities.readRawRows());
 	}
 
 	private getClusterRender(width: number, rawRows: number): ClusterRender {
@@ -266,9 +282,7 @@ export class TerminalSplitCompositor {
 		const wasRendering = this.renderingCluster;
 		this.renderingCluster = true;
 		try {
-			const render = this.cluster
-				? renderCluster(this.cluster, width, rawRows)
-				: { lines: [], cursor: null };
+			const render = renderCluster(this.capabilities.cluster, width, rawRows);
 			this.cachedClusterRender = { width, rows: rawRows, render };
 			return render;
 		} finally {
@@ -287,7 +301,7 @@ export class TerminalSplitCompositor {
 			return this.getRawRows();
 		}
 		const rawRows = this.getRawRows();
-		const width = Math.max(1, this.terminal.columns || 80);
+		const width = Math.max(1, this.capabilities.getColumns() || 80);
 		const cluster = this.getClusterRender(width, rawRows);
 		return Math.max(1, rawRows - cluster.lines.length);
 	}
@@ -296,27 +310,22 @@ export class TerminalSplitCompositor {
 		if (this.checkingOverlay) return false;
 		this.checkingOverlay = true;
 		try {
-			if (typeof this.tui.hasOverlay === "function" && this.tui.hasOverlay()) return true;
-			const stack = this.tui.overlayStack;
-			if (!Array.isArray(stack)) return false;
-			return stack.some((entry) => entry && entry.hidden !== true);
+			return this.capabilities.hasVisibleOverlay();
 		} finally {
 			this.checkingOverlay = false;
 		}
 	}
 
 	private renderScrollableRoot(width: number): string[] {
-		if (!this.originalRender || this.disposed) return this.originalRender?.(width) ?? [];
+		if (this.disposed) return this.callOriginalRender(width);
 
-		if (this.hasVisibleOverlay()) {
-			return this.originalRender(width);
-		}
+		if (this.hasVisibleOverlay()) return this.callOriginalRender(width);
 
 		const rawRows = this.getRawRows();
 		const cluster = this.getClusterRender(Math.max(1, width), rawRows);
 		const scrollableRows = Math.max(1, rawRows - cluster.lines.length);
 
-		const lines = this.originalRender(Math.max(1, width));
+		const lines = this.callOriginalRender(Math.max(1, width));
 
 		// Adjust scroll offset when new content arrives while scrolled up.
 		if (
@@ -362,14 +371,14 @@ export class TerminalSplitCompositor {
 		if (keyboard.action === "jumpBottom") {
 			this.scrollOffset = 0;
 			this.selection.clear();
-			this.tui.requestRender?.();
+			this.capabilities.requestRender?.();
 			return undefined; // Let Enter propagate to the editor.
 		}
 
 		const rawRows = this.getRawRows();
 		const scrollableRows = Math.max(
 			1,
-			rawRows - this.getClusterRender(this.terminal.columns || 80, rawRows).lines.length,
+			rawRows - this.getClusterRender(this.capabilities.getColumns() || 80, rawRows).lines.length,
 		);
 
 		if (keyboard.action === "pageUp") {
@@ -411,7 +420,7 @@ export class TerminalSplitCompositor {
 			}
 			this.selection.clear();
 			this.pauseMouseReporting();
-			this.tui.requestRender?.();
+			this.capabilities.requestRender?.();
 			return;
 		}
 
@@ -427,12 +436,12 @@ export class TerminalSplitCompositor {
 
 		if (ev.action === "press") {
 			this.selection.start(lineIndex, col);
-			this.tui.requestRender?.();
+			this.capabilities.requestRender?.();
 			return;
 		}
 		if (ev.action === "drag" && this.selection.isDragging) {
 			this.selection.extend(lineIndex, col + 1);
-			this.tui.requestRender?.();
+			this.capabilities.requestRender?.();
 			return;
 		}
 		if (ev.action === "release" && this.selection.isDragging) {
@@ -440,7 +449,7 @@ export class TerminalSplitCompositor {
 			this.selection.setDragging(false);
 			const text = this.selection.getSelectedText(this.rootLines);
 			this.selection.clear();
-			this.tui.requestRender?.();
+			this.capabilities.requestRender?.();
 			if (text) {
 				void copyToClipboard(text);
 				if (this.getConfig().copyNotice) this.onCopy?.();
@@ -452,11 +461,11 @@ export class TerminalSplitCompositor {
 	/** Temporarily disable mouse reporting so the terminal's native context menu works. */
 	private pauseMouseReporting(): void {
 		if (this.mouseResumeTimer) clearTimeout(this.mouseResumeTimer);
-		this.originalWrite(SYNC_BEGIN + DISABLE_MOUSE + SYNC_END);
+		this.callOriginalWrite(SYNC_BEGIN + DISABLE_MOUSE + SYNC_END);
 		this.mouseResumeTimer = setTimeout(() => {
 			this.mouseResumeTimer = null;
 			if (!this.disposed) {
-				this.originalWrite(SYNC_BEGIN + ENABLE_MOUSE_SGR + SYNC_END);
+				this.callOriginalWrite(SYNC_BEGIN + ENABLE_MOUSE_SGR + SYNC_END);
 			}
 		}, 1200);
 		if (typeof this.mouseResumeTimer === "object" && "unref" in this.mouseResumeTimer) {
@@ -468,7 +477,7 @@ export class TerminalSplitCompositor {
 		const next = clampScrollOffset(this.scrollOffset + delta, this.maxScrollOffset);
 		if (next === this.scrollOffset) return;
 		this.scrollOffset = next;
-		this.tui.requestRender?.();
+		this.capabilities.requestRender?.();
 	}
 
 	private paintCluster(cluster: ClusterRender, rawRows: number, width: number): string {
@@ -502,11 +511,8 @@ export class TerminalSplitCompositor {
 	 * instead of the tracked row.
 	 */
 	private syncTuiCursor(scrollBottom: number): string {
-		const hardwareCursorRow = this.tui.hardwareCursorRow;
-		const viewportTop = this.tui.previousViewportTop;
-		if (typeof hardwareCursorRow !== "number" || typeof viewportTop !== "number") {
-			return "";
-		}
+		const { hardwareCursorRow, previousViewportTop: viewportTop } =
+			this.capabilities.getCursorBookkeeping();
 		const row = Math.max(1, Math.min(scrollBottom, hardwareCursorRow - viewportTop + 1));
 		return cursorTo(row, 1);
 	}
@@ -514,10 +520,10 @@ export class TerminalSplitCompositor {
 	private requestRepaint(): void {
 		if (this.disposed || this.hasVisibleOverlay()) return;
 		const rawRows = this.getRawRows();
-		const width = Math.max(1, this.terminal.columns || 80);
+		const width = Math.max(1, this.capabilities.getColumns() || 80);
 		const cluster = this.getClusterRender(width, rawRows);
 		if (cluster.lines.length === 0) return;
-		this.originalWrite(
+		this.callOriginalWrite(
 			SYNC_BEGIN +
 				DISABLE_AUTOWRAP +
 				this.paintCluster(cluster, rawRows, width) +
@@ -529,21 +535,21 @@ export class TerminalSplitCompositor {
 
 	private write(data: string): void {
 		if (this.disposed || this.writing || this.hasVisibleOverlay()) {
-			this.originalWrite(data);
+			this.callOriginalWrite(data);
 			return;
 		}
 		this.writing = true;
 		try {
 			const rawRows = this.getRawRows();
-			const width = Math.max(1, this.terminal.columns || 80);
+			const width = Math.max(1, this.capabilities.getColumns() || 80);
 			const cluster = this.getClusterRender(width, rawRows);
 			const reservedRows = cluster.lines.length;
 			if (reservedRows === 0 || rawRows <= 2) {
-				this.originalWrite(data);
+				this.callOriginalWrite(data);
 				return;
 			}
 			const scrollBottom = Math.max(1, rawRows - reservedRows);
-			this.originalWrite(
+			this.callOriginalWrite(
 				SYNC_BEGIN +
 					DISABLE_AUTOWRAP +
 					setScrollRegion(1, scrollBottom) +
@@ -560,7 +566,7 @@ export class TerminalSplitCompositor {
 	}
 
 	private restoreTerminalState(): void {
-		this.originalWrite(
+		this.callOriginalWrite(
 			SYNC_BEGIN +
 				RESET_SCROLL_REGION +
 				DISABLE_MOUSE +

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -86,7 +86,10 @@ function sanitizeLine(line: string, width: number): string {
 export class TerminalSplitCompositor {
 	private readonly capabilities: PiFixedEditorCapabilities;
 	private readonly getConfig: () => CompositorConfig;
-	private removeInputListener: (() => void) | null = null;
+	private inputListener:
+		| ((data: string) => { consume?: boolean; data?: string } | undefined)
+		| null = null;
+	private inputListenerDisposer: (() => void) | null = null;
 	private emergencyCleanup: (() => void) | null = null;
 
 	private installed = false;
@@ -162,11 +165,12 @@ export class TerminalSplitCompositor {
 			});
 			replaceMethod(this.capabilities.writeMethod, (data) => this.write(String(data)));
 
-			const removeInputListener = this.capabilities.addInputListener((data) =>
-				this.handleInput(data),
-			);
-			if (typeof removeInputListener !== "function") throw new TypeError("Invalid input listener");
-			this.removeInputListener = removeInputListener as () => void;
+			this.inputListener = (data) => this.handleInput(data);
+			const inputListenerDisposer = this.capabilities.addInputListener(this.inputListener);
+			if (typeof inputListenerDisposer !== "function") {
+				throw new TypeError("Invalid input listener disposer");
+			}
+			this.inputListenerDisposer = inputListenerDisposer as () => void;
 			this.emergencyCleanup = () => {
 				if (!this.disposed) this.restoreForExit();
 			};
@@ -195,11 +199,7 @@ export class TerminalSplitCompositor {
 		if (this.disposed) return;
 		this.disposed = true;
 		if (!this.installed) return;
-		const removeInputListener = this.removeInputListener;
-		this.removeInputListener = null;
-		try {
-			removeInputListener?.();
-		} catch {}
+		this.clearInputListener();
 		if (this.mouseResumeTimer) {
 			clearTimeout(this.mouseResumeTimer);
 			this.mouseResumeTimer = null;
@@ -218,11 +218,7 @@ export class TerminalSplitCompositor {
 	}
 
 	private rollbackInstallation(): void {
-		const removeInputListener = this.removeInputListener;
-		this.removeInputListener = null;
-		try {
-			removeInputListener?.();
-		} catch {}
+		this.clearInputListener();
 		if (this.emergencyCleanup) {
 			process.removeListener("exit", this.emergencyCleanup);
 			this.emergencyCleanup = null;
@@ -231,6 +227,25 @@ export class TerminalSplitCompositor {
 		if (this.terminalModesEntered) this.restoreForExit();
 		this.terminalModesEntered = false;
 		this.installed = false;
+	}
+
+	private clearInputListener(): void {
+		const listener = this.inputListener;
+		const disposer = this.inputListenerDisposer;
+		this.inputListener = null;
+		this.inputListenerDisposer = null;
+		let disposed = false;
+		if (disposer) {
+			try {
+				disposer();
+				disposed = true;
+			} catch {}
+		}
+		if (!disposed && listener) {
+			try {
+				this.capabilities.removeInputListener(listener);
+			} catch {}
+		}
 	}
 
 	private restorePatchedCapabilities(): void {

--- a/extensions/zentui/fixed-editor/index.ts
+++ b/extensions/zentui/fixed-editor/index.ts
@@ -127,32 +127,36 @@ function installFromProbe(
 	getConfig: () => PolishedTuiConfig,
 ): void {
 	if (compositor) return;
-	const config = getConfig();
-	if (!config.fixedEditor?.enabled) return;
+	try {
+		const config = getConfig();
+		if (!config.fixedEditor?.enabled) return;
 
-	const capabilities = inspectPiTui(tui);
-	if (!capabilities) {
+		const capabilities = inspectPiTui(tui);
+		if (!capabilities) {
+			warnUnsupported(ctx);
+			return;
+		}
+
+		const next = new TerminalSplitCompositor(
+			capabilities,
+			() => ({
+				enabled: getConfig().fixedEditor?.enabled ?? false,
+				mouseScroll: getConfig().fixedEditor?.mouseScroll ?? false,
+				copyNotice: getConfig().fixedEditor?.copyNotice ?? true,
+			}),
+			ctx.hasUI ? () => showCopyNotice(ctx, getConfig) : undefined,
+			ctx.hasUI ? () => clearCopyNotice(ctx) : undefined,
+		);
+
+		if (!next.install()) {
+			warnUnsupported(ctx);
+			return;
+		}
+
+		compositor = next;
+	} catch {
 		warnUnsupported(ctx);
-		return;
 	}
-
-	const next = new TerminalSplitCompositor(
-		capabilities,
-		() => ({
-			enabled: getConfig().fixedEditor?.enabled ?? false,
-			mouseScroll: getConfig().fixedEditor?.mouseScroll ?? false,
-			copyNotice: getConfig().fixedEditor?.copyNotice ?? true,
-		}),
-		ctx.hasUI ? () => showCopyNotice(ctx, getConfig) : undefined,
-		ctx.hasUI ? () => clearCopyNotice(ctx) : undefined,
-	);
-
-	if (!next.install()) {
-		warnUnsupported(ctx);
-		return;
-	}
-
-	compositor = next;
 }
 
 const WIDGET_KEY = "zentui-fixed-editor-probe";
@@ -193,7 +197,7 @@ export function installFixedEditorProbe(
  * Dispose the compositor if active.
  * Call from session_shutdown and cleanupUi.
  */
-export function disposeFixedEditor(): void {
+export function disposeFixedEditor(ctx?: ExtensionContext): void {
 	cancelProbeInstall?.();
 	cancelProbeInstall = null;
 	compositor?.dispose();
@@ -202,11 +206,8 @@ export function disposeFixedEditor(): void {
 		clearTimeout(copyNoticeTimer);
 		copyNoticeTimer = null;
 	}
-	if (storedCtx) {
-		const ctx = storedCtx;
-		storedCtx = null;
-		clearCopyNotice(ctx);
-	}
+	storedCtx = null;
+	if (ctx) clearCopyNotice(ctx);
 }
 
 /**

--- a/extensions/zentui/fixed-editor/index.ts
+++ b/extensions/zentui/fixed-editor/index.ts
@@ -15,13 +15,13 @@ import type { PolishedTuiConfig } from "../config";
 import type { SessionLifecycle } from "../session-lifecycle";
 import { renderStyleForSourceOrFallback } from "../style";
 import { TerminalSplitCompositor } from "./compositor";
-import type { TuiLike } from "./types";
+import { inspectPiTui } from "./pi-compat";
 
 let compositor: TerminalSplitCompositor | null = null;
 let didWarnUnsupported = false;
 let copyNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 let storedCtx: ExtensionContext | null = null;
-let probeGeneration = 0;
+let cancelProbeInstall: (() => void) | null = null;
 const COPY_NOTICE_KEY = "zentui-copy-notice";
 const COPY_NOTICE_MS = 2500;
 
@@ -81,10 +81,9 @@ function showCopyNotice(ctx: ExtensionContext, getConfig: () => PolishedTuiConfi
 		return new CopyNoticeComponent(text, border);
 	});
 	if (copyNoticeTimer) clearTimeout(copyNoticeTimer);
-	const generation = probeGeneration;
 	copyNoticeTimer = setTimeout(() => {
 		copyNoticeTimer = null;
-		if (generation !== probeGeneration || storedCtx !== ctx) return;
+		if (storedCtx !== ctx) return;
 		if (!ctx.hasUI || typeof ctx.ui.setWidget !== "function") return;
 		ctx.ui.setWidget(COPY_NOTICE_KEY, undefined);
 	}, COPY_NOTICE_MS);
@@ -94,19 +93,17 @@ function showCopyNotice(ctx: ExtensionContext, getConfig: () => PolishedTuiConfi
  * Minimal component that triggers a callback on first render, then returns [].
  */
 class ProbeComponent implements Component {
-	private readonly lifecycle: SessionLifecycle;
 	private readonly onInstall: () => void;
 	private hasQueuedInstall = false;
 
-	constructor(lifecycle: SessionLifecycle, onInstall: () => void) {
-		this.lifecycle = lifecycle;
+	constructor(onInstall: () => void) {
 		this.onInstall = onInstall;
 	}
 
 	render(): string[] {
 		if (!this.hasQueuedInstall) {
 			this.hasQueuedInstall = true;
-			this.lifecycle.queueMicrotask(this.onInstall);
+			this.onInstall();
 		}
 		return [];
 	}
@@ -133,16 +130,14 @@ function installFromProbe(
 	const config = getConfig();
 	if (!config.fixedEditor?.enabled) return;
 
-	const tuiLike = tui as unknown as TuiLike;
-	const terminal = tuiLike.terminal;
-	if (!terminal || typeof terminal.write !== "function") {
+	const capabilities = inspectPiTui(tui);
+	if (!capabilities) {
 		warnUnsupported(ctx);
 		return;
 	}
 
 	const next = new TerminalSplitCompositor(
-		tuiLike,
-		terminal,
+		capabilities,
 		() => ({
 			enabled: getConfig().fixedEditor?.enabled ?? false,
 			mouseScroll: getConfig().fixedEditor?.mouseScroll ?? false,
@@ -176,16 +171,18 @@ export function installFixedEditorProbe(
 	if (typeof ctx.ui.setWidget !== "function") return;
 	didWarnUnsupported = false;
 	storedCtx = ctx;
-	probeGeneration += 1;
-	const generation = probeGeneration;
+	cancelProbeInstall?.();
+	cancelProbeInstall = null;
 
 	ctx.ui.setWidget(
 		WIDGET_KEY,
 		(tui: TUI) =>
-			new ProbeComponent(lifecycle, () => {
-				lifecycle.queueMicrotask(() => {
-					if (generation !== probeGeneration) return;
-					installFromProbe(ctx, tui, getConfig);
+			new ProbeComponent(() => {
+				cancelProbeInstall = lifecycle.queueMicrotask(() => {
+					cancelProbeInstall = lifecycle.queueMicrotask(() => {
+						cancelProbeInstall = null;
+						installFromProbe(ctx, tui, getConfig);
+					});
 				});
 			}),
 		{ placement: "aboveEditor" },
@@ -197,7 +194,8 @@ export function installFixedEditorProbe(
  * Call from session_shutdown and cleanupUi.
  */
 export function disposeFixedEditor(): void {
-	probeGeneration += 1;
+	cancelProbeInstall?.();
+	cancelProbeInstall = null;
 	compositor?.dispose();
 	compositor = null;
 	if (copyNoticeTimer) {
@@ -216,7 +214,8 @@ export function disposeFixedEditor(): void {
  * Useful for full UI cleanup.
  */
 export function removeFixedEditorProbe(ctx: ExtensionContext): void {
-	probeGeneration += 1;
+	cancelProbeInstall?.();
+	cancelProbeInstall = null;
 	if (!ctx.hasUI) return;
 	if (typeof ctx.ui.setWidget !== "function") return;
 	ctx.ui.setWidget(WIDGET_KEY, undefined);

--- a/extensions/zentui/fixed-editor/index.ts
+++ b/extensions/zentui/fixed-editor/index.ts
@@ -12,6 +12,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 
 import type { PolishedTuiConfig } from "../config";
+import type { SessionLifecycle } from "../session-lifecycle";
 import { renderStyleForSourceOrFallback } from "../style";
 import { TerminalSplitCompositor } from "./compositor";
 import type { TuiLike } from "./types";
@@ -20,15 +21,16 @@ let compositor: TerminalSplitCompositor | null = null;
 let didWarnUnsupported = false;
 let copyNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 let storedCtx: ExtensionContext | null = null;
+let probeGeneration = 0;
 const COPY_NOTICE_KEY = "zentui-copy-notice";
 const COPY_NOTICE_MS = 2500;
 
 function clearCopyNotice(ctx: ExtensionContext): void {
-	if (!ctx.hasUI || typeof ctx.ui.setWidget !== "function") return;
 	if (copyNoticeTimer) {
 		clearTimeout(copyNoticeTimer);
 		copyNoticeTimer = null;
 	}
+	if (!ctx.hasUI || typeof ctx.ui.setWidget !== "function") return;
 	ctx.ui.setWidget(COPY_NOTICE_KEY, undefined);
 }
 
@@ -79,9 +81,12 @@ function showCopyNotice(ctx: ExtensionContext, getConfig: () => PolishedTuiConfi
 		return new CopyNoticeComponent(text, border);
 	});
 	if (copyNoticeTimer) clearTimeout(copyNoticeTimer);
+	const generation = probeGeneration;
 	copyNoticeTimer = setTimeout(() => {
-		ctx.ui.setWidget(COPY_NOTICE_KEY, undefined);
 		copyNoticeTimer = null;
+		if (generation !== probeGeneration || storedCtx !== ctx) return;
+		if (!ctx.hasUI || typeof ctx.ui.setWidget !== "function") return;
+		ctx.ui.setWidget(COPY_NOTICE_KEY, undefined);
 	}, COPY_NOTICE_MS);
 }
 
@@ -89,17 +94,19 @@ function showCopyNotice(ctx: ExtensionContext, getConfig: () => PolishedTuiConfi
  * Minimal component that triggers a callback on first render, then returns [].
  */
 class ProbeComponent implements Component {
+	private readonly lifecycle: SessionLifecycle;
 	private readonly onInstall: () => void;
 	private hasQueuedInstall = false;
 
-	constructor(onInstall: () => void) {
+	constructor(lifecycle: SessionLifecycle, onInstall: () => void) {
+		this.lifecycle = lifecycle;
 		this.onInstall = onInstall;
 	}
 
 	render(): string[] {
 		if (!this.hasQueuedInstall) {
 			this.hasQueuedInstall = true;
-			queueMicrotask(this.onInstall);
+			this.lifecycle.queueMicrotask(this.onInstall);
 		}
 		return [];
 	}
@@ -163,17 +170,23 @@ const WIDGET_KEY = "zentui-fixed-editor-probe";
 export function installFixedEditorProbe(
 	ctx: ExtensionContext,
 	getConfig: () => PolishedTuiConfig,
+	lifecycle: SessionLifecycle,
 ): void {
-	if (!ctx.hasUI) return;
+	if (!lifecycle.isCurrent() || !ctx.hasUI) return;
 	if (typeof ctx.ui.setWidget !== "function") return;
 	didWarnUnsupported = false;
 	storedCtx = ctx;
+	probeGeneration += 1;
+	const generation = probeGeneration;
 
 	ctx.ui.setWidget(
 		WIDGET_KEY,
 		(tui: TUI) =>
-			new ProbeComponent(() => {
-				queueMicrotask(() => installFromProbe(ctx, tui, getConfig));
+			new ProbeComponent(lifecycle, () => {
+				lifecycle.queueMicrotask(() => {
+					if (generation !== probeGeneration) return;
+					installFromProbe(ctx, tui, getConfig);
+				});
 			}),
 		{ placement: "aboveEditor" },
 	);
@@ -184,6 +197,7 @@ export function installFixedEditorProbe(
  * Call from session_shutdown and cleanupUi.
  */
 export function disposeFixedEditor(): void {
+	probeGeneration += 1;
 	compositor?.dispose();
 	compositor = null;
 	if (copyNoticeTimer) {
@@ -191,7 +205,9 @@ export function disposeFixedEditor(): void {
 		copyNoticeTimer = null;
 	}
 	if (storedCtx) {
-		clearCopyNotice(storedCtx);
+		const ctx = storedCtx;
+		storedCtx = null;
+		clearCopyNotice(ctx);
 	}
 }
 
@@ -200,6 +216,7 @@ export function disposeFixedEditor(): void {
  * Useful for full UI cleanup.
  */
 export function removeFixedEditorProbe(ctx: ExtensionContext): void {
+	probeGeneration += 1;
 	if (!ctx.hasUI) return;
 	if (typeof ctx.ui.setWidget !== "function") return;
 	ctx.ui.setWidget(WIDGET_KEY, undefined);

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -1,0 +1,259 @@
+/** Verified private Pi TUI capabilities required by the experimental fixed editor. @internal */
+export type PiMethodCapability = {
+	target: Record<PropertyKey, unknown>;
+	key: "render" | "doRender" | "write";
+	method: (...args: unknown[]) => unknown;
+	ownDescriptor: PropertyDescriptor | undefined;
+};
+
+export type PiRenderableCapability = {
+	target: Record<PropertyKey, unknown>;
+	render: (width: number) => string[];
+	ownDescriptor: PropertyDescriptor | undefined;
+};
+
+export type PiFixedCluster = {
+	status: PiRenderableCapability | null;
+	aboveWidget: PiRenderableCapability | null;
+	editor: PiRenderableCapability;
+	belowWidget: PiRenderableCapability | null;
+	footer: PiRenderableCapability | null;
+};
+
+export type PiFixedEditorCapabilities = {
+	tui: Record<PropertyKey, unknown>;
+	terminal: Record<PropertyKey, unknown>;
+	cluster: PiFixedCluster;
+	renderMethod: PiMethodCapability;
+	doRenderMethod: PiMethodCapability;
+	writeMethod: PiMethodCapability;
+	rowsOwnDescriptor: PropertyDescriptor | undefined;
+	readRawRows: () => number;
+	getColumns: () => number;
+	hasVisibleOverlay: () => boolean;
+	getCursorBookkeeping: () => { hardwareCursorRow: number; previousViewportTop: number };
+	addInputListener: (
+		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
+	) => unknown;
+	requestRender?: (force?: boolean) => void;
+};
+
+function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
+	return (typeof value === "object" && value !== null) || typeof value === "function";
+}
+
+function ownDescriptor(target: object, key: PropertyKey): PropertyDescriptor | undefined {
+	return Object.getOwnPropertyDescriptor(target, key);
+}
+
+function descriptorInChain(target: object, key: PropertyKey): PropertyDescriptor | undefined {
+	let current: object | null = target;
+	while (current) {
+		const descriptor = Object.getOwnPropertyDescriptor(current, key);
+		if (descriptor) return descriptor;
+		current = Object.getPrototypeOf(current);
+	}
+	return undefined;
+}
+
+function writableMethod(
+	target: Record<PropertyKey, unknown>,
+	key: PiMethodCapability["key"],
+): PiMethodCapability | undefined {
+	const method = Reflect.get(target, key);
+	if (typeof method !== "function") return undefined;
+	const descriptor = ownDescriptor(target, key);
+	if (descriptor) {
+		if (!("value" in descriptor) || descriptor.writable !== true) return undefined;
+	} else if (!Object.isExtensible(target)) {
+		return undefined;
+	}
+	return {
+		target,
+		key,
+		method: method as (...args: unknown[]) => unknown,
+		ownDescriptor: descriptor,
+	};
+}
+
+function renderable(value: unknown): PiRenderableCapability | undefined {
+	if (!isRecord(value)) return undefined;
+	const method = writableMethod(value, "render");
+	if (!method) return undefined;
+	return {
+		target: value,
+		render: method.method as (width: number) => string[],
+		ownDescriptor: method.ownDescriptor,
+	};
+}
+
+function isEditorLike(value: unknown): boolean {
+	return (
+		isRecord(value) &&
+		typeof Reflect.get(value, "getText") === "function" &&
+		typeof Reflect.get(value, "setText") === "function" &&
+		typeof Reflect.get(value, "handleInput") === "function"
+	);
+}
+
+function containerChildren(value: unknown): unknown[] | undefined {
+	if (!isRecord(value)) return undefined;
+	const children = Reflect.get(value, "children");
+	return Array.isArray(children) ? children : undefined;
+}
+
+export function findEditorContainerIndex(
+	children: unknown[],
+	focusedComponent?: unknown,
+): number | undefined {
+	if (focusedComponent && isRecord(focusedComponent)) {
+		const focusedIndex = children.findIndex(
+			(child) => renderable(child) && containerChildren(child)?.includes(focusedComponent),
+		);
+		if (focusedIndex !== -1) return focusedIndex;
+	}
+	const index = children.findIndex(
+		(child) => renderable(child) && containerChildren(child)?.some(isEditorLike),
+	);
+	return index === -1 ? undefined : index;
+}
+
+function clusterCapability(children: unknown[], editorIndex: number): PiFixedCluster | undefined {
+	const editor = renderable(children[editorIndex]);
+	if (!editor) return undefined;
+	const optional = (index: number): PiRenderableCapability | null | undefined => {
+		if (index < 0 || index >= children.length) return null;
+		return renderable(children[index]);
+	};
+	const status = optional(editorIndex - 2);
+	const aboveWidget = optional(editorIndex - 1);
+	const belowWidget = optional(editorIndex + 1);
+	const footer = optional(editorIndex + 2);
+	if (
+		status === undefined ||
+		aboveWidget === undefined ||
+		belowWidget === undefined ||
+		footer === undefined
+	) {
+		return undefined;
+	}
+	return { status, aboveWidget, editor, belowWidget, footer };
+}
+
+function readRowsValue(
+	terminal: Record<PropertyKey, unknown>,
+	descriptor: PropertyDescriptor,
+): unknown {
+	return descriptor.get
+		? descriptor.get.call(terminal)
+		: "value" in descriptor
+			? descriptor.value
+			: Reflect.get(terminal, "rows");
+}
+
+function rowsReader(
+	terminal: Record<PropertyKey, unknown>,
+	descriptor: PropertyDescriptor,
+	fallback: number,
+): () => number {
+	return () => {
+		const value = readRowsValue(terminal, descriptor);
+		return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+	};
+}
+
+export function inspectPiTui(value: unknown): PiFixedEditorCapabilities | undefined {
+	if (!isRecord(value)) return undefined;
+	const terminalValue = Reflect.get(value, "terminal");
+	if (!isRecord(terminalValue)) return undefined;
+
+	const renderMethod = writableMethod(value, "render");
+	const doRenderMethod = writableMethod(value, "doRender");
+	const writeMethod = writableMethod(terminalValue, "write");
+	if (!renderMethod || !doRenderMethod || !writeMethod) return undefined;
+
+	const addInputListenerValue = Reflect.get(value, "addInputListener");
+	if (typeof addInputListenerValue !== "function") return undefined;
+	const children = Reflect.get(value, "children");
+	if (!Array.isArray(children) || children.length < 3) return undefined;
+	const editorIndex = findEditorContainerIndex(children, Reflect.get(value, "focusedComponent"));
+	if (editorIndex === undefined) return undefined;
+	const cluster = clusterCapability(children, editorIndex);
+	if (!cluster) return undefined;
+
+	const rowsOwnDescriptor = ownDescriptor(terminalValue, "rows");
+	if (
+		rowsOwnDescriptor
+			? rowsOwnDescriptor.configurable !== true
+			: !Object.isExtensible(terminalValue)
+	) {
+		return undefined;
+	}
+	const rowsDescriptor = descriptorInChain(terminalValue, "rows");
+	if (!rowsDescriptor) return undefined;
+	const initialRows = readRowsValue(terminalValue, rowsDescriptor);
+	if (typeof initialRows !== "number" || !Number.isFinite(initialRows)) return undefined;
+	const columns = Reflect.get(terminalValue, "columns");
+	if (typeof columns !== "number" || !Number.isFinite(columns)) return undefined;
+
+	const hasOverlayValue = Reflect.get(value, "hasOverlay");
+	const overlayStackValue = Reflect.get(value, "overlayStack");
+	if (typeof hasOverlayValue !== "function" && !Array.isArray(overlayStackValue)) return undefined;
+	const hardwareCursorRow = Reflect.get(value, "hardwareCursorRow");
+	const previousViewportTop = Reflect.get(value, "previousViewportTop");
+	if (
+		typeof hardwareCursorRow !== "number" ||
+		!Number.isFinite(hardwareCursorRow) ||
+		typeof previousViewportTop !== "number" ||
+		!Number.isFinite(previousViewportTop)
+	) {
+		return undefined;
+	}
+
+	const requestRenderValue = Reflect.get(value, "requestRender");
+	return {
+		tui: value,
+		terminal: terminalValue,
+		cluster,
+		renderMethod,
+		doRenderMethod,
+		writeMethod,
+		rowsOwnDescriptor,
+		readRawRows: rowsReader(terminalValue, rowsDescriptor, initialRows),
+		getColumns: () => {
+			const current = Reflect.get(terminalValue, "columns");
+			return typeof current === "number" && Number.isFinite(current) ? current : columns;
+		},
+		hasVisibleOverlay: () => {
+			if (
+				typeof hasOverlayValue === "function" &&
+				Reflect.apply(hasOverlayValue, value, []) === true
+			) {
+				return true;
+			}
+			const stack = Reflect.get(value, "overlayStack");
+			return (
+				Array.isArray(stack) && stack.some((entry) => isRecord(entry) && entry.hidden !== true)
+			);
+		},
+		getCursorBookkeeping: () => {
+			const currentHardwareCursorRow = Reflect.get(value, "hardwareCursorRow");
+			const currentViewportTop = Reflect.get(value, "previousViewportTop");
+			return {
+				hardwareCursorRow:
+					typeof currentHardwareCursorRow === "number" && Number.isFinite(currentHardwareCursorRow)
+						? currentHardwareCursorRow
+						: hardwareCursorRow,
+				previousViewportTop:
+					typeof currentViewportTop === "number" && Number.isFinite(currentViewportTop)
+						? currentViewportTop
+						: previousViewportTop,
+			};
+		},
+		addInputListener: (listener) => Reflect.apply(addInputListenerValue, value, [listener]),
+		requestRender:
+			typeof requestRenderValue === "function"
+				? (force) => Reflect.apply(requestRenderValue, value, [force])
+				: undefined,
+	};
+}

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -35,6 +35,9 @@ export type PiFixedEditorCapabilities = {
 	addInputListener: (
 		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
 	) => unknown;
+	removeInputListener: (
+		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
+	) => void;
 	requestRender?: (force?: boolean) => void;
 };
 
@@ -157,12 +160,16 @@ function rowsReader(
 	fallback: number,
 ): () => number {
 	return () => {
-		const value = readRowsValue(terminal, descriptor);
-		return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+		try {
+			const value = readRowsValue(terminal, descriptor);
+			return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+		} catch {
+			return fallback;
+		}
 	};
 }
 
-export function inspectPiTui(value: unknown): PiFixedEditorCapabilities | undefined {
+function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefined {
 	if (!isRecord(value)) return undefined;
 	const terminalValue = Reflect.get(value, "terminal");
 	if (!isRecord(terminalValue)) return undefined;
@@ -173,7 +180,13 @@ export function inspectPiTui(value: unknown): PiFixedEditorCapabilities | undefi
 	if (!renderMethod || !doRenderMethod || !writeMethod) return undefined;
 
 	const addInputListenerValue = Reflect.get(value, "addInputListener");
-	if (typeof addInputListenerValue !== "function") return undefined;
+	const removeInputListenerValue = Reflect.get(value, "removeInputListener");
+	if (
+		typeof addInputListenerValue !== "function" ||
+		typeof removeInputListenerValue !== "function"
+	) {
+		return undefined;
+	}
 	const children = Reflect.get(value, "children");
 	if (!Array.isArray(children) || children.length < 3) return undefined;
 	const editorIndex = findEditorContainerIndex(children, Reflect.get(value, "focusedComponent"));
@@ -221,39 +234,63 @@ export function inspectPiTui(value: unknown): PiFixedEditorCapabilities | undefi
 		rowsOwnDescriptor,
 		readRawRows: rowsReader(terminalValue, rowsDescriptor, initialRows),
 		getColumns: () => {
-			const current = Reflect.get(terminalValue, "columns");
-			return typeof current === "number" && Number.isFinite(current) ? current : columns;
+			try {
+				const current = Reflect.get(terminalValue, "columns");
+				return typeof current === "number" && Number.isFinite(current) ? current : columns;
+			} catch {
+				return columns;
+			}
 		},
 		hasVisibleOverlay: () => {
-			if (
-				typeof hasOverlayValue === "function" &&
-				Reflect.apply(hasOverlayValue, value, []) === true
-			) {
+			try {
+				if (
+					typeof hasOverlayValue === "function" &&
+					Reflect.apply(hasOverlayValue, value, []) === true
+				) {
+					return true;
+				}
+				const stack = Reflect.get(value, "overlayStack");
+				return (
+					Array.isArray(stack) && stack.some((entry) => isRecord(entry) && entry.hidden !== true)
+				);
+			} catch {
 				return true;
 			}
-			const stack = Reflect.get(value, "overlayStack");
-			return (
-				Array.isArray(stack) && stack.some((entry) => isRecord(entry) && entry.hidden !== true)
-			);
 		},
 		getCursorBookkeeping: () => {
-			const currentHardwareCursorRow = Reflect.get(value, "hardwareCursorRow");
-			const currentViewportTop = Reflect.get(value, "previousViewportTop");
-			return {
-				hardwareCursorRow:
-					typeof currentHardwareCursorRow === "number" && Number.isFinite(currentHardwareCursorRow)
-						? currentHardwareCursorRow
-						: hardwareCursorRow,
-				previousViewportTop:
-					typeof currentViewportTop === "number" && Number.isFinite(currentViewportTop)
-						? currentViewportTop
-						: previousViewportTop,
-			};
+			try {
+				const currentHardwareCursorRow = Reflect.get(value, "hardwareCursorRow");
+				const currentViewportTop = Reflect.get(value, "previousViewportTop");
+				return {
+					hardwareCursorRow:
+						typeof currentHardwareCursorRow === "number" &&
+						Number.isFinite(currentHardwareCursorRow)
+							? currentHardwareCursorRow
+							: hardwareCursorRow,
+					previousViewportTop:
+						typeof currentViewportTop === "number" && Number.isFinite(currentViewportTop)
+							? currentViewportTop
+							: previousViewportTop,
+				};
+			} catch {
+				return { hardwareCursorRow, previousViewportTop };
+			}
 		},
 		addInputListener: (listener) => Reflect.apply(addInputListenerValue, value, [listener]),
+		removeInputListener: (listener) => {
+			Reflect.apply(removeInputListenerValue, value, [listener]);
+		},
 		requestRender:
 			typeof requestRenderValue === "function"
 				? (force) => Reflect.apply(requestRenderValue, value, [force])
 				: undefined,
 	};
+}
+
+export function inspectPiTui(value: unknown): PiFixedEditorCapabilities | undefined {
+	try {
+		return inspectPiTuiUnsafe(value);
+	} catch {
+		return undefined;
+	}
 }

--- a/extensions/zentui/fixed-editor/types.ts
+++ b/extensions/zentui/fixed-editor/types.ts
@@ -35,36 +35,3 @@ export type ClusterRender = {
 	lines: string[];
 	cursor: { row: number; col: number } | null;
 };
-
-/** Loose TUI shape with the internal fields the compositor touches. */
-export type TuiLike = {
-	children: { render(width: number): string[] }[];
-	terminal?: TerminalLike;
-	focusedComponent?: unknown;
-	requestRender?: (force?: boolean) => void;
-	doRender?: () => void;
-	render?: (width: number) => string[];
-	compositeLineAt?: (
-		baseLine: string,
-		overlayLine: string,
-		startCol: number,
-		overlayWidth: number,
-		totalWidth: number,
-	) => string;
-	hardwareCursorRow?: number;
-	cursorRow?: number;
-	previousViewportTop?: number;
-	addInputListener?: (
-		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
-	) => () => void;
-	hasOverlay?: () => boolean;
-	overlayStack?: { hidden?: boolean }[];
-};
-
-/** Loose terminal shape with the fields the compositor patches. */
-export type TerminalLike = {
-	columns: number;
-	rows: number;
-	kittyProtocolActive?: boolean;
-	write(data: string): void;
-};

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -93,7 +93,6 @@ function isTuiContext(ctx: ExtensionContext): boolean {
 export default function (pi: ExtensionAPI) {
 	const state: FooterState = createInitialState(emptyGitStatus());
 	const sessionLifecycle = new SessionLifecycle();
-	const sessionGenerations = new WeakMap<object, number>();
 
 	let currentConfig: PolishedTuiConfig = loadConfig();
 	let activeTheme: Theme | undefined;
@@ -401,11 +400,10 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	const cleanupUi = (ctx?: ExtensionContext) => {
-		if (!ctx) return;
-		const generation = sessionGenerations.get(ctx as object);
-		if (generation === undefined || !sessionLifecycle.isCurrent(generation)) return;
+		if (!ctx || !sessionLifecycle.isCurrent()) return;
+		sessionLifecycle.shutdown();
 		try {
-			disposeFixedEditor();
+			disposeFixedEditor(ctx);
 			if (isTuiContext(ctx)) removeFixedEditorProbe(ctx);
 			uninstallPrototypePatches();
 			stopSessionTimer();
@@ -431,7 +429,7 @@ export default function (pi: ExtensionAPI) {
 			editorInstalled = false;
 			activeTheme = undefined;
 		} finally {
-			sessionLifecycle.shutdown();
+			requestFooterRender = undefined;
 		}
 	};
 
@@ -443,8 +441,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
-		const generation = sessionLifecycle.start();
-		sessionGenerations.set(ctx as object, generation);
+		sessionLifecycle.start();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		lastProjectCwd = undefined;
@@ -503,7 +500,7 @@ export default function (pi: ExtensionAPI) {
 			if (patch.enabled === true) {
 				installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
 			} else if (patch.enabled === false) {
-				disposeFixedEditor();
+				disposeFixedEditor(ctx);
 			}
 			refresh();
 		},

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -51,6 +51,7 @@ import {
 import { applyProjectRefreshToState } from "./project-state";
 import { readRuntimeInfo } from "./runtime";
 import { installSelectorBorderStyle } from "./selector-border";
+import { SessionLifecycle } from "./session-lifecycle";
 import { registerZentuiSettingsCommand } from "./settings-command";
 import { createInitialState, type FooterState, syncState } from "./state";
 import { PolishedEditor, WrappedPolishedEditor } from "./ui";
@@ -91,6 +92,8 @@ function isTuiContext(ctx: ExtensionContext): boolean {
 
 export default function (pi: ExtensionAPI) {
 	const state: FooterState = createInitialState(emptyGitStatus());
+	const sessionLifecycle = new SessionLifecycle();
+	const sessionGenerations = new WeakMap<object, number>();
 
 	let currentConfig: PolishedTuiConfig = loadConfig();
 	let activeTheme: Theme | undefined;
@@ -108,14 +111,19 @@ export default function (pi: ExtensionAPI) {
 	let lastDurationLabel = "";
 	let lastProjectCwd: string | undefined;
 
-	const refresh = () => requestFooterRender?.();
+	const refresh = () => {
+		if (sessionLifecycle.isCurrent()) requestFooterRender?.();
+	};
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
-	const getThinkingLevel = () => pi.getThinkingLevel();
+	const getThinkingLevel = () =>
+		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
 		syncState(state, ctx, currentConfig.icons.cacheHit);
 
-	const refreshProjectState = async (ctx: ExtensionContext) => {
+	type ProjectRefreshTarget = { cwd: string; generation: number };
+	const refreshProjectState = async ({ cwd, generation }: ProjectRefreshTarget) => {
+		if (!sessionLifecycle.isCurrent(generation)) return;
 		const gitCommitConfig = currentConfig.gitCommit;
 		const gitMetricsConfig = currentConfig.gitMetrics;
 		const segments = currentConfig.footerSegments;
@@ -132,16 +140,17 @@ export default function (pi: ExtensionAPI) {
 		const wantMetrics = segments.gitMetrics || formatNeedsMetrics;
 		const wantPackage = segments.packageVersion || formatNeedsPackage;
 		const [git, runtime, packageVersion] = await Promise.all([
-			readGitStatus(ctx.cwd, {
+			readGitStatus(cwd, {
 				readExactTag: wantExactTag,
 				readMetrics: wantMetrics,
 				ignoreSubmodules: gitMetricsConfig.ignoreSubmodules,
 			}),
-			readRuntimeInfo(ctx.cwd),
-			wantPackage ? readPackageVersionResult(ctx.cwd) : Promise.resolve(undefined),
+			readRuntimeInfo(cwd),
+			wantPackage ? readPackageVersionResult(cwd) : Promise.resolve(undefined),
 		]);
+		if (!sessionLifecycle.isCurrent(generation)) return;
 		lastProjectCwd = applyProjectRefreshToState(state, {
-			cwd: ctx.cwd,
+			cwd,
 			previousCwd: lastProjectCwd,
 			git,
 			runtime,
@@ -150,11 +159,18 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	const projectRefreshScheduler = createProjectRefreshScheduler(refreshProjectState, refresh);
-	const scheduleProjectRefresh = (ctx: ExtensionContext, options?: ScheduleProjectRefreshOptions) =>
-		projectRefreshScheduler.schedule(ctx, options);
+	const scheduleProjectRefresh = (
+		ctx: ExtensionContext,
+		options?: ScheduleProjectRefreshOptions,
+	) => {
+		const generation = sessionLifecycle.currentGeneration();
+		if (!sessionLifecycle.isCurrent(generation)) return;
+		const cwd = ctx.cwd;
+		projectRefreshScheduler.schedule({ cwd, generation }, options);
+	};
 
 	const refreshInteractiveState = (ctx: ExtensionContext, project = false) => {
-		if (!ctx.hasUI) return;
+		if (!sessionLifecycle.isCurrent() || !ctx.hasUI) return;
 		syncFooterState(ctx);
 		if (project && currentConfig.features.statusLine) scheduleProjectRefresh(ctx);
 		refresh();
@@ -170,6 +186,7 @@ export default function (pi: ExtensionAPI) {
 		stopSessionTimer();
 		lastDurationLabel = "";
 		const timer = setInterval(() => {
+			if (!sessionLifecycle.isCurrent()) return;
 			const segments = currentConfig.footerSegments;
 			const formatNeedsTimer =
 				currentConfig.footerFormat &&
@@ -216,12 +233,13 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	const makeEditorFactory = (ctx: ExtensionContext): ZentuiEditorFactory => {
+		const sessionTheme = ctx.ui.theme;
 		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
 			new PolishedEditor(
 				tui,
 				theme,
 				keybindings,
-				ctx.ui.theme,
+				sessionTheme,
 				getCurrentConfig,
 				() => ({
 					modelLabel: state.modelLabel,
@@ -237,10 +255,11 @@ export default function (pi: ExtensionAPI) {
 		ctx: ExtensionContext,
 		baseFactory: EditorFactory,
 	): ZentuiEditorFactory => {
+		const sessionTheme = ctx.ui.theme;
 		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
 			new WrappedPolishedEditor(
 				baseFactory(tui, theme, keybindings),
-				ctx.ui.theme,
+				sessionTheme,
 				getCurrentConfig,
 				() => ({
 					modelLabel: state.modelLabel,
@@ -365,50 +384,55 @@ export default function (pi: ExtensionAPI) {
 		stopProjectRefresh();
 		applyConfiguredUi(ctx);
 		if (currentConfig.fixedEditor?.enabled) {
-			installFixedEditorProbe(ctx, getCurrentConfig);
+			installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
 		}
 		refresh();
 	};
 
 	const scheduleEditorReconciliation = (ctx: ExtensionContext) => {
-		setTimeout(() => {
+		sessionLifecycle.defer(() => {
 			if (!isTuiContext(ctx) || !currentConfig.features.editor) return;
 			const currentFactory = ctx.ui.getEditorComponent();
 			if (currentFactory && currentFactory !== installedEditorFactory) {
 				applyConfiguredUi(ctx);
 				refresh();
 			}
-		}, 0);
+		});
 	};
 
 	const cleanupUi = (ctx?: ExtensionContext) => {
-		disposeFixedEditor();
-		if (ctx && isTuiContext(ctx)) {
-			removeFixedEditorProbe(ctx);
-		}
-		uninstallPrototypePatches();
-		stopSessionTimer();
-		stopProjectRefresh();
-		requestFooterRender = undefined;
-		getActiveExtensionStatuses = () => new Map();
-		if (ctx && isTuiContext(ctx)) {
-			ctx.ui.setFooter(undefined);
-			const currentFactory = ctx.ui.getEditorComponent();
-			if (!currentFactory || isZentuiEditorFactory(currentFactory)) {
-				ctx.ui.setEditorComponent(
-					getZentuiEditorBaseFactory(currentFactory) ??
-						(editorInstallMode === "wrapper" && wrappedEditorFactory
-							? wrappedEditorFactory
-							: undefined),
-				);
+		if (!ctx) return;
+		const generation = sessionGenerations.get(ctx as object);
+		if (generation === undefined || !sessionLifecycle.isCurrent(generation)) return;
+		try {
+			disposeFixedEditor();
+			if (isTuiContext(ctx)) removeFixedEditorProbe(ctx);
+			uninstallPrototypePatches();
+			stopSessionTimer();
+			stopProjectRefresh();
+			requestFooterRender = undefined;
+			getActiveExtensionStatuses = () => new Map();
+			if (isTuiContext(ctx)) {
+				ctx.ui.setFooter(undefined);
+				const currentFactory = ctx.ui.getEditorComponent();
+				if (!currentFactory || isZentuiEditorFactory(currentFactory)) {
+					ctx.ui.setEditorComponent(
+						getZentuiEditorBaseFactory(currentFactory) ??
+							(editorInstallMode === "wrapper" && wrappedEditorFactory
+								? wrappedEditorFactory
+								: undefined),
+					);
+				}
 			}
+			wrappedEditorFactory = undefined;
+			installedEditorFactory = undefined;
+			editorInstallMode = "none";
+			footerInstalled = false;
+			editorInstalled = false;
+			activeTheme = undefined;
+		} finally {
+			sessionLifecycle.shutdown();
 		}
-		wrappedEditorFactory = undefined;
-		installedEditorFactory = undefined;
-		editorInstallMode = "none";
-		footerInstalled = false;
-		editorInstalled = false;
-		activeTheme = undefined;
 	};
 
 	const syncInteractiveState = (_event: unknown, ctx: ExtensionContext) => {
@@ -419,6 +443,8 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
+		const generation = sessionLifecycle.start();
+		sessionGenerations.set(ctx as object, generation);
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		lastProjectCwd = undefined;
@@ -427,6 +453,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	registerZentuiSettingsCommand(pi, {
+		sessionLifecycle,
 		getConfig: getCurrentConfig,
 		setColorSources(patch: Partial<ColorSourcesConfig>) {
 			currentConfig = saveColorSourcesPatch(patch);
@@ -474,7 +501,7 @@ export default function (pi: ExtensionAPI) {
 		setFixedEditor(patch: Partial<FixedEditorConfig>, ctx: ExtensionContext) {
 			currentConfig = saveFixedEditorPatch(patch);
 			if (patch.enabled === true) {
-				installFixedEditorProbe(ctx, getCurrentConfig);
+				installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
 			} else if (patch.enabled === false) {
 				disposeFixedEditor();
 			}

--- a/extensions/zentui/prototype-patch-registry.ts
+++ b/extensions/zentui/prototype-patch-registry.ts
@@ -1,0 +1,106 @@
+export const ZENTUI_PROTOTYPE_PATCH_REGISTRY = Symbol.for("pi-zentui.prototype-patch-registry");
+
+type PrototypePatchAdapter =
+	| "user-message-render"
+	| "user-message-invalidate"
+	| "selector-border-render";
+
+type PrototypeMethod = (this: unknown, ...args: unknown[]) => unknown;
+
+type PatchInvocation = {
+	predecessor: PrototypeMethod;
+	receiver: unknown;
+	args: unknown[];
+};
+
+type PatchBehavior = (invocation: PatchInvocation) => unknown;
+
+type Registration = {
+	token: symbol;
+	behavior?: PatchBehavior;
+};
+
+type PatchRecord = {
+	method: "render" | "invalidate";
+	predecessor: PrototypeMethod;
+	wrapper: PrototypeMethod;
+	registration?: Registration;
+};
+
+type PatchRegistry = Map<PrototypePatchAdapter, PatchRecord>;
+
+type PatchTarget = Record<PropertyKey, unknown>;
+
+function registryFor(target: PatchTarget): PatchRegistry {
+	const existing = target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
+	if (existing instanceof Map) return existing as PatchRegistry;
+	const registry: PatchRegistry = new Map();
+	Object.defineProperty(target, ZENTUI_PROTOTYPE_PATCH_REGISTRY, {
+		value: registry,
+		configurable: true,
+	});
+	return registry;
+}
+
+function createCleanup(
+	target: PatchTarget,
+	method: "render" | "invalidate",
+	adapter: PrototypePatchAdapter,
+	registry: PatchRegistry,
+	record: PatchRecord,
+	token: symbol,
+): () => void {
+	let cleaned = false;
+	return () => {
+		if (cleaned) return;
+		cleaned = true;
+		const current = registry.get(adapter);
+		if (current !== record || current.registration?.token !== token) return;
+
+		current.registration.behavior = undefined;
+		current.registration = undefined;
+		if (target[method] === current.wrapper) target[method] = current.predecessor;
+		registry.delete(adapter);
+		if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
+	};
+}
+
+export function installPrototypePatch(
+	targetValue: object,
+	method: "render" | "invalidate",
+	adapter: PrototypePatchAdapter,
+	behavior: PatchBehavior,
+): () => void {
+	const target = targetValue as PatchTarget;
+	const registry = registryFor(target);
+	let record = registry.get(adapter);
+
+	if (!(record && record.method === method && target[method] === record.wrapper)) {
+		const predecessor = target[method];
+		if (typeof predecessor !== "function") {
+			throw new TypeError(`Cannot patch ${method}: predecessor is not a function`);
+		}
+		const nextRecord: PatchRecord = {
+			method,
+			predecessor: predecessor as PrototypeMethod,
+			wrapper: () => undefined,
+		};
+		const wrapper: PrototypeMethod = function zentuiPrototypeWrapper(
+			this: unknown,
+			...args: unknown[]
+		): unknown {
+			const activeBehavior = nextRecord.registration?.behavior;
+			return activeBehavior
+				? activeBehavior({ predecessor: nextRecord.predecessor, receiver: this, args })
+				: Reflect.apply(nextRecord.predecessor, this, args);
+		};
+		nextRecord.wrapper = wrapper;
+		record = nextRecord;
+		registry.set(adapter, record);
+		target[method] = wrapper;
+	}
+
+	const token = Symbol(adapter);
+	record.registration = { token, behavior };
+	return createCleanup(target, method, adapter, registry, record, token);
+}

--- a/extensions/zentui/prototype-patch-registry.ts
+++ b/extensions/zentui/prototype-patch-registry.ts
@@ -54,12 +54,13 @@ function createCleanup(
 	return () => {
 		if (cleaned) return;
 		cleaned = true;
-		const current = registry.get(adapter);
-		if (current !== record || current.registration?.token !== token) return;
+		if (record.registration?.token !== token) return;
+		record.registration.behavior = undefined;
+		record.registration = undefined;
 
-		current.registration.behavior = undefined;
-		current.registration = undefined;
-		if (target[method] === current.wrapper) target[method] = current.predecessor;
+		const current = registry.get(adapter);
+		if (current !== record) return;
+		if (target[method] === record.wrapper) target[method] = record.predecessor;
 		registry.delete(adapter);
 		if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 	};

--- a/extensions/zentui/selector-border.ts
+++ b/extensions/zentui/selector-border.ts
@@ -4,18 +4,11 @@ import {
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
 import type { PolishedTuiConfig } from "./config";
+import { installPrototypePatch } from "./prototype-patch-registry";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, renderEditorBorder } from "./style";
 
-type RenderFn = (width: number) => string[];
-
 type PatchableSelectorPrototype = {
-	render: RenderFn;
-	__zentuiSelectorBorderOriginalRender?: RenderFn;
-	__zentuiSelectorBorderPatched?: boolean;
-	__zentuiSelectorBorderWrapper?: RenderFn;
-	__zentuiSelectorBorderActive?: boolean;
-	__zentuiSelectorBorderGetTheme?: () => Theme | undefined;
-	__zentuiSelectorBorderGetConfig?: () => PolishedTuiConfig;
+	render: (width: number) => string[];
 };
 
 type Cleanup = () => void;
@@ -45,44 +38,22 @@ export function patchSelectorBorderStyle(
 	getTheme?: () => Theme | undefined,
 	getConfig?: () => PolishedTuiConfig,
 ): Cleanup {
-	prototype.__zentuiSelectorBorderGetTheme = getTheme;
-	prototype.__zentuiSelectorBorderGetConfig = getConfig;
-	prototype.__zentuiSelectorBorderActive = true;
+	return installPrototypePatch(
+		prototype,
+		"render",
+		"selector-border-render",
+		({ predecessor, receiver, args }) => {
+			const lines = Reflect.apply(predecessor, receiver, args) as string[];
+			const width = args[0];
+			if (lines.length === 0 || typeof width !== "number" || width <= 0) return lines;
 
-	if (
-		prototype.__zentuiSelectorBorderPatched &&
-		prototype.render === prototype.__zentuiSelectorBorderWrapper
-	) {
-		return () => {
-			prototype.__zentuiSelectorBorderActive = false;
-		};
-	}
-
-	prototype.__zentuiSelectorBorderOriginalRender = prototype.render;
-	const wrapper = function renderWithZentuiSelectorBorders(this: unknown, width: number): string[] {
-		const original = prototype.__zentuiSelectorBorderOriginalRender ?? prototype.render;
-		if (!prototype.__zentuiSelectorBorderActive) return original.call(this, width);
-
-		const lines = original.call(this, width);
-		if (lines.length === 0 || width <= 0) return lines;
-
-		return lines.map((line, index) => {
-			if (index !== 0 && index !== lines.length - 1) return line;
-			if (!isHorizontalBorderLine(line)) return line;
-			return renderBorderLine(
-				width,
-				prototype.__zentuiSelectorBorderGetTheme?.(),
-				prototype.__zentuiSelectorBorderGetConfig?.(),
-			);
-		});
-	};
-	prototype.__zentuiSelectorBorderWrapper = wrapper;
-	prototype.render = wrapper;
-	prototype.__zentuiSelectorBorderPatched = true;
-
-	return () => {
-		prototype.__zentuiSelectorBorderActive = false;
-	};
+			return lines.map((line, index) => {
+				if (index !== 0 && index !== lines.length - 1) return line;
+				if (!isHorizontalBorderLine(line)) return line;
+				return renderBorderLine(width, getTheme?.(), getConfig?.());
+			});
+		},
+	);
 }
 
 export function installSelectorBorderStyle(

--- a/extensions/zentui/session-lifecycle.ts
+++ b/extensions/zentui/session-lifecycle.ts
@@ -28,12 +28,15 @@ export class SessionLifecycle {
 		this.timeouts.add(timeout);
 	}
 
-	queueMicrotask(callback: () => void): void {
-		if (!this.active) return;
+	queueMicrotask(callback: () => void): () => void {
+		let canceled = !this.active;
 		const generation = this.generation;
 		queueMicrotask(() => {
-			if (this.isCurrent(generation)) callback();
+			if (!canceled && this.isCurrent(generation)) callback();
 		});
+		return () => {
+			canceled = true;
+		};
 	}
 
 	shutdown(): void {

--- a/extensions/zentui/session-lifecycle.ts
+++ b/extensions/zentui/session-lifecycle.ts
@@ -1,0 +1,50 @@
+export class SessionLifecycle {
+	private generation = 0;
+	private active = false;
+	private readonly timeouts = new Set<ReturnType<typeof setTimeout>>();
+
+	start(): number {
+		this.cancelTimeouts();
+		this.generation += 1;
+		this.active = true;
+		return this.generation;
+	}
+
+	currentGeneration(): number {
+		return this.generation;
+	}
+
+	isCurrent(generation = this.generation): boolean {
+		return this.active && generation === this.generation;
+	}
+
+	defer(callback: () => void): void {
+		if (!this.active) return;
+		const generation = this.generation;
+		const timeout = setTimeout(() => {
+			this.timeouts.delete(timeout);
+			if (this.isCurrent(generation)) callback();
+		}, 0);
+		this.timeouts.add(timeout);
+	}
+
+	queueMicrotask(callback: () => void): void {
+		if (!this.active) return;
+		const generation = this.generation;
+		queueMicrotask(() => {
+			if (this.isCurrent(generation)) callback();
+		});
+	}
+
+	shutdown(): void {
+		if (!this.active && this.timeouts.size === 0) return;
+		this.active = false;
+		this.generation += 1;
+		this.cancelTimeouts();
+	}
+
+	private cancelTimeouts(): void {
+		for (const timeout of this.timeouts) clearTimeout(timeout);
+		this.timeouts.clear();
+	}
+}

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -33,6 +33,7 @@ import {
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
 import { isIconMode } from "./icons";
+import type { SessionLifecycle } from "./session-lifecycle";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, safeThemeFg } from "./style";
 
 const colorSourceValues: ColorSource[] = ["theme", "terminal"];
@@ -73,6 +74,7 @@ type LayoutSettingId =
 	| "iconMode";
 
 type SettingsCommandDeps = {
+	sessionLifecycle: SessionLifecycle;
 	getConfig: () => PolishedTuiConfig;
 	setColorSources: (patch: Partial<ColorSourcesConfig>) => void;
 	setUiFeatures: (
@@ -697,14 +699,15 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 										// Changing the editor component while ctx.ui.custom() is active clears the
 										// custom component without resolving it, leaving Pi's input loop stuck.
 										// Close the settings UI first, then apply the editor swap on the next tick.
-										setTimeout(() => {
+										const applyEditorChange = () => {
 											try {
 												applyFeatureChange(id, newValue);
 											} catch (error) {
 												const message = error instanceof Error ? error.message : String(error);
 												ctx.ui.notify(`Could not update Zentui settings: ${message}`, "error");
 											}
-										}, 0);
+										};
+										deps.sessionLifecycle.defer(applyEditorChange);
 										return;
 									}
 

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -693,7 +693,6 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 								}
 
 								if (isFeatureSettingId(id) && isFeatureState(newValue)) {
-									settingsList.updateValue(id, newValue);
 									if (id === "editor") {
 										done(undefined);
 										// Changing the editor component while ctx.ui.custom() is active clears the
@@ -712,6 +711,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									}
 
 									applyFeatureChange(id, newValue);
+									settingsList.updateValue(id, newValue);
 									return;
 								}
 
@@ -841,6 +841,8 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									tui.requestRender();
 								}
 							} catch (error) {
+								settingsList = makeSettingsList();
+								tui.requestRender();
 								const message = error instanceof Error ? error.message : String(error);
 								ctx.ui.notify(`Could not update Zentui settings: ${message}`, "error");
 							}

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -6,6 +6,7 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
+import { installPrototypePatch } from "./prototype-patch-registry";
 import {
 	EDITOR_ACCENT_FALLBACK,
 	EDITOR_BORDER_FALLBACK,
@@ -16,22 +17,8 @@ const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
 
-type RenderFn = (width: number) => string[];
-type InvalidateFn = () => void;
-
 type PatchableUserMessagePrototype = {
-	render: RenderFn;
-	invalidate: InvalidateFn;
 	children?: unknown[];
-	__zentuiUserMessageOriginalRender?: RenderFn;
-	__zentuiUserMessageOriginalInvalidate?: InvalidateFn;
-	__zentuiUserMessagePatched?: boolean;
-	__zentuiUserMessageInvalidatePatched?: boolean;
-	__zentuiUserMessageWrapper?: RenderFn;
-	__zentuiUserMessageInvalidateWrapper?: InvalidateFn;
-	__zentuiUserMessageActive?: boolean;
-	__zentuiUserMessageGetTheme?: () => Theme | undefined;
-	__zentuiUserMessageGetConfig?: () => PolishedTuiConfig;
 };
 
 type Cleanup = () => void;
@@ -228,62 +215,39 @@ export function installUserMessageStyle(
 	getTheme: () => Theme | undefined,
 	getConfig: () => PolishedTuiConfig,
 ): Cleanup {
-	const prototype = UserMessageComponent.prototype as unknown as PatchableUserMessagePrototype;
-	prototype.__zentuiUserMessageGetTheme = getTheme;
-	prototype.__zentuiUserMessageGetConfig = getConfig;
-	prototype.__zentuiUserMessageActive = true;
-
-	if (
-		!(
-			prototype.__zentuiUserMessageInvalidatePatched &&
-			prototype.invalidate === prototype.__zentuiUserMessageInvalidateWrapper
-		)
-	) {
-		prototype.__zentuiUserMessageOriginalInvalidate = prototype.invalidate;
-		const invalidateWrapper = function invalidateWithZentuiUserMessage(this: unknown): void {
-			if (isObject(this)) userMessageRenderCache.delete(this);
-			const originalInvalidate = prototype.__zentuiUserMessageOriginalInvalidate;
-			originalInvalidate?.call(this);
-		};
-		prototype.__zentuiUserMessageInvalidateWrapper = invalidateWrapper;
-		prototype.invalidate = invalidateWrapper;
-		prototype.__zentuiUserMessageInvalidatePatched = true;
-	}
-
-	if (
-		prototype.__zentuiUserMessagePatched &&
-		prototype.render === prototype.__zentuiUserMessageWrapper
-	) {
-		return () => {
-			prototype.__zentuiUserMessageActive = false;
-		};
-	}
-
-	prototype.__zentuiUserMessageOriginalRender = prototype.render;
-	const wrapper = function renderWithZentuiUserMessage(this: unknown, width: number): string[] {
-		const original = prototype.__zentuiUserMessageOriginalRender ?? prototype.render;
-		if (!prototype.__zentuiUserMessageActive) return original.call(this, width);
-
-		const config = prototype.__zentuiUserMessageGetConfig?.();
-		if (!config) return original.call(this, width);
-
-		const lines = renderZentuiUserMessage(
-			this as PatchableUserMessagePrototype,
-			width,
-			prototype.__zentuiUserMessageGetTheme?.(),
-			config,
-		);
-
-		if (!lines) return original.call(this, width);
-		if (lines.length === 0) return lines;
-
-		return withPromptZoneMarkers(lines);
-	};
-	prototype.__zentuiUserMessageWrapper = wrapper;
-	prototype.render = wrapper;
-	prototype.__zentuiUserMessagePatched = true;
-
+	const prototype = UserMessageComponent.prototype;
+	const cleanupInvalidate = installPrototypePatch(
+		prototype,
+		"invalidate",
+		"user-message-invalidate",
+		({ predecessor, receiver, args }) => {
+			if (isObject(receiver)) userMessageRenderCache.delete(receiver);
+			return Reflect.apply(predecessor, receiver, args);
+		},
+	);
+	const cleanupRender = installPrototypePatch(
+		prototype,
+		"render",
+		"user-message-render",
+		({ predecessor, receiver, args }) => {
+			const width = args[0];
+			if (typeof width !== "number") return Reflect.apply(predecessor, receiver, args);
+			const lines = renderZentuiUserMessage(
+				receiver as PatchableUserMessagePrototype,
+				width,
+				getTheme(),
+				getConfig(),
+			);
+			if (!lines) return Reflect.apply(predecessor, receiver, args);
+			if (lines.length === 0) return lines;
+			return withPromptZoneMarkers(lines);
+		},
+	);
+	let cleaned = false;
 	return () => {
-		prototype.__zentuiUserMessageActive = false;
+		if (cleaned) return;
+		cleaned = true;
+		cleanupRender();
+		cleanupInvalidate();
 	};
 }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -6,6 +6,7 @@ import {
 	defaultConfig,
 	mergeConfig,
 	saveColorSourcesPatch,
+	saveContextThresholdsPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusPlacement,
 	saveFixedEditorPatch,
@@ -23,6 +24,12 @@ import {
 	renderStyleForSource,
 	renderTerminalStyle,
 } from "../extensions/zentui/style";
+
+function configTempFiles(dir: string): string[] {
+	return readdirSync(dir).filter(
+		(name) => name.startsWith(".zentui.json.") && name.endsWith(".tmp"),
+	);
+}
 
 describe("mergeConfig", () => {
 	it("defaults project refresh polling to 30 seconds and Starship styles", () => {
@@ -172,6 +179,88 @@ describe("mergeConfig", () => {
 				contextStyle: "gauge",
 				separator: "chevron",
 			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses corrupt config without changing its bytes", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		const original = "{ invalid json\n";
+		try {
+			writeFileSync(path, original);
+
+			expect(() => saveSeparatorPatch("dot", path)).toThrow(
+				/Refusing to save Zentui config.*corrupt/,
+			);
+			expect(readFileSync(path, "utf8")).toBe(original);
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("creates missing config atomically and returns the config written to disk", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			expect(existsSync(path)).toBe(false);
+			const config = saveFooterFormatPatch("$cwd $fill $context", path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(raw).toEqual({ footerFormat: "$cwd $fill $context" });
+			expect(config).toEqual(mergeConfig(raw));
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves scalar and nested unknown keys through the shared mutation path", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(
+				path,
+				`${JSON.stringify(
+					{
+						futureScalar: "keep",
+						pathDisplay: { mode: "basename", depth: 2, futureNested: { keep: true } },
+					},
+					null,
+					2,
+				)}\n`,
+			);
+
+			saveSeparatorPatch("dot", path);
+			const config = savePathDisplayPatch({ mode: "full" }, path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+
+			expect(raw.futureScalar).toBe("keep");
+			expect(raw.separator).toBe("dot");
+			expect(raw.pathDisplay).toEqual({
+				mode: "full",
+				depth: 2,
+				futureNested: { keep: true },
+			});
+			expect(config).toEqual(mergeConfig(raw));
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the destination and removes the temp file when serialization fails", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		const original = `${JSON.stringify({ unknown: true }, null, 2)}\n`;
+		try {
+			writeFileSync(path, original);
+
+			expect(() => saveContextThresholdsPatch({ warning: 1n as never }, path)).toThrow();
+			expect(readFileSync(path, "utf8")).toBe(original);
+			expect(configTempFiles(dir)).toEqual([]);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,17 @@
-import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+	chmodSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -25,9 +38,9 @@ import {
 	renderTerminalStyle,
 } from "../extensions/zentui/style";
 
-function configTempFiles(dir: string): string[] {
+function configTempFiles(dir: string, filename = "zentui.json"): string[] {
 	return readdirSync(dir).filter(
-		(name) => name.startsWith(".zentui.json.") && name.endsWith(".tmp"),
+		(name) => name.startsWith(`.${filename}.`) && name.endsWith(".tmp"),
 	);
 }
 
@@ -211,6 +224,71 @@ describe("mergeConfig", () => {
 
 			expect(raw).toEqual({ footerFormat: "$cwd $fill $context" });
 			expect(config).toEqual(mergeConfig(raw));
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("preserves the existing destination mode during atomic replacement", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(path, `${JSON.stringify({ separator: "pipe" }, null, 2)}\n`);
+			chmodSync(path, 0o600);
+
+			saveSeparatorPatch("dot", path);
+
+			expect(statSync(path).mode & 0o777).toBe(0o600);
+			expect(JSON.parse(readFileSync(path, "utf8")).separator).toBe("dot");
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("updates a symlink target atomically without replacing the symlink", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const targetDir = join(dir, "target");
+		const targetPath = join(targetDir, "actual.json");
+		const linkPath = join(dir, "zentui.json");
+		try {
+			mkdirSync(targetDir);
+			writeFileSync(targetPath, `${JSON.stringify({ unknown: true }, null, 2)}\n`);
+			chmodSync(targetPath, 0o600);
+			symlinkSync(targetPath, linkPath);
+			const originalLink = readlinkSync(linkPath);
+
+			const config = saveSeparatorPatch("chevron", linkPath);
+			const raw = JSON.parse(readFileSync(targetPath, "utf8"));
+
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(linkPath)).toBe(originalLink);
+			expect(raw).toEqual({ unknown: true, separator: "chevron" });
+			expect(config).toEqual(mergeConfig(raw));
+			expect(statSync(targetPath).mode & 0o777).toBe(0o600);
+			expect(configTempFiles(targetDir, "actual.json")).toEqual([]);
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses a dangling symlink without changing it", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const targetDir = join(dir, "target");
+		const missingTarget = join(targetDir, "missing.json");
+		const linkPath = join(dir, "zentui.json");
+		try {
+			mkdirSync(targetDir);
+			symlinkSync(missingTarget, linkPath);
+			const originalLink = readlinkSync(linkPath);
+
+			expect(() => saveSeparatorPatch("dot", linkPath)).toThrow(/Refusing to save Zentui config/);
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(linkPath)).toBe(originalLink);
+			expect(existsSync(missingTarget)).toBe(false);
+			expect(configTempFiles(targetDir, "missing.json")).toEqual([]);
 			expect(configTempFiles(dir)).toEqual([]);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -18,6 +18,7 @@ import { installFooter } from "../extensions/zentui/footer";
 import { emptyGitStatus } from "../extensions/zentui/git";
 import zentui from "../extensions/zentui/index";
 import { patchSelectorBorderStyle } from "../extensions/zentui/selector-border";
+import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-command";
 import { createInitialState } from "../extensions/zentui/state";
 import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
@@ -33,6 +34,7 @@ const originalUserMessageRender = UserMessageComponent.prototype.render;
 const originalUserMessageInvalidate = UserMessageComponent.prototype.invalidate;
 const originalModelSelectorRender = ModelSelectorComponent.prototype.render;
 const originalSettingsSelectorRender = SettingsSelectorComponent.prototype.render;
+const inactiveSessionLifecycle = new SessionLifecycle();
 
 function makeTheme(): Theme {
 	return {
@@ -423,11 +425,13 @@ describe("Pi docs compliance", () => {
 			setText() {},
 		});
 		let editorFactory: unknown = existingEditorFactory;
+		let setEditorCalls = 0;
 		const ctx = makeContext({
 			ui: {
 				theme: makeTheme(),
 				setFooter() {},
 				setEditorComponent(factory: unknown) {
+					setEditorCalls += 1;
 					editorFactory = factory;
 				},
 				getEditorComponent() {
@@ -440,8 +444,43 @@ describe("Pi docs compliance", () => {
 		expect(editorFactory).not.toBe(existingEditorFactory);
 
 		await emit(handlers, "session_shutdown", ctx);
+		await emit(handlers, "session_shutdown", ctx);
 
 		expect(editorFactory).toBe(existingEditorFactory);
+		expect(setEditorCalls).toBe(2);
+	});
+
+	it("does not let an old session shutdown clean up the current session UI", async () => {
+		const handlers = loadExtension();
+		const makeSessionContext = () => {
+			let editorFactory: unknown;
+			let footerClears = 0;
+			const ctx = makeContext({
+				ui: {
+					theme: makeTheme(),
+					setFooter(factory: unknown) {
+						if (factory === undefined) footerClears += 1;
+					},
+					setEditorComponent(factory: unknown) {
+						editorFactory = factory;
+					},
+					getEditorComponent() {
+						return editorFactory;
+					},
+				},
+			});
+			return { ctx, getEditor: () => editorFactory, getFooterClears: () => footerClears };
+		};
+		const oldSession = makeSessionContext();
+		const currentSession = makeSessionContext();
+		await emit(handlers, "session_start", oldSession.ctx);
+		await emit(handlers, "session_start", currentSession.ctx);
+		const currentEditor = currentSession.getEditor();
+
+		await emit(handlers, "session_shutdown", oldSession.ctx);
+
+		expect(currentSession.getEditor()).toBe(currentEditor);
+		expect(currentSession.getFooterClears()).toBe(0);
 	});
 
 	it("refreshes a stale Zentui editor factory on extension reload instead of adopting old closures", async () => {
@@ -566,6 +605,48 @@ describe("Pi docs compliance", () => {
 		);
 		expect(editor.render(80).join("\n")).toContain("late vim editor");
 		expect(editor.render(80).join("\n")).toContain("NORMAL");
+	});
+
+	it("does not reconcile an editor after its session shuts down", async () => {
+		vi.useFakeTimers();
+		try {
+			const handlers = loadExtension();
+			const laterEditorFactory = () => ({
+				render: () => ["later"],
+				invalidate() {},
+				handleInput() {},
+				getText: () => "",
+				setText() {},
+			});
+			let editorFactory: unknown;
+			let stale = false;
+			const ctx = makeContext({
+				ui: {
+					theme: makeTheme(),
+					setFooter() {
+						if (stale) throw new Error("stale setFooter");
+					},
+					setEditorComponent(factory: unknown) {
+						if (stale) throw new Error("stale setEditorComponent");
+						editorFactory = factory;
+					},
+					getEditorComponent() {
+						if (stale) throw new Error("stale getEditorComponent");
+						return editorFactory;
+					},
+				},
+			});
+
+			await emit(handlers, "session_start", ctx);
+			editorFactory = laterEditorFactory;
+			await emit(handlers, "session_shutdown", ctx);
+			stale = true;
+
+			expect(() => vi.runAllTimers()).not.toThrow();
+			expect(editorFactory).toBe(laterEditorFactory);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("renders user messages like the ZentUI prompt box", () => {
@@ -1820,6 +1901,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -1865,6 +1947,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -1910,6 +1993,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures(patch) {
@@ -1958,6 +2042,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures(patch) {
@@ -1996,6 +2081,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures(patch) {
@@ -2041,6 +2127,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({
@@ -2087,6 +2174,8 @@ describe("Pi docs compliance", () => {
 			let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 			let doneCalls = 0;
 			const doneCallsAtFeatureChange: number[] = [];
+			const sessionLifecycle = new SessionLifecycle();
+			sessionLifecycle.start();
 
 			registerZentuiSettingsCommand(
 				{
@@ -2095,6 +2184,7 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					sessionLifecycle,
 					getConfig: () => defaultConfig,
 					setColorSources() {},
 					setUiFeatures() {
@@ -2150,6 +2240,78 @@ describe("Pi docs compliance", () => {
 		}
 	});
 
+	it("drops a deferred settings editor swap after session shutdown", async () => {
+		vi.useFakeTimers();
+		try {
+			let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
+			let featureChanges = 0;
+			let stale = false;
+			const sessionLifecycle = new SessionLifecycle();
+			sessionLifecycle.start();
+			registerZentuiSettingsCommand(
+				{
+					registerCommand(_name: string, options: unknown) {
+						command = options as typeof command;
+					},
+				} as never,
+				{
+					sessionLifecycle,
+					getConfig: () => defaultConfig,
+					setColorSources() {},
+					setUiFeatures() {
+						featureChanges += 1;
+						return { applied: true };
+					},
+					setFooterSegments() {},
+					setFooterFormat() {},
+					setIconMode() {},
+					setContextStyle() {},
+					setPathDisplay() {},
+					setGitBranch() {},
+					setSeparator() {},
+					getActiveExtensionStatuses: () => new Map<string, string>(),
+					setExtensionStatusPlacement() {},
+					setExtensionStatusColorMode() {},
+					setFixedEditor() {},
+					requestRender() {},
+					settingsListTheme: {
+						label: (text) => text,
+						value: (text) => text,
+						description: (text) => text,
+						cursor: "> ",
+						hint: (text) => text,
+					},
+				},
+			);
+			const ctx = {
+				hasUI: true,
+				mode: "tui",
+				ui: {
+					theme: makeTaggedTheme(),
+					notify() {
+						if (stale) throw new Error("stale notify");
+					},
+					async custom(factory: (...args: unknown[]) => unknown) {
+						const component = factory({ requestRender() {} }, makeTaggedTheme(), {}, () => {}) as {
+							handleInput?: (data: string) => void;
+						};
+						component.handleInput?.("\t");
+						component.handleInput?.(" ");
+					},
+				},
+			};
+
+			await command?.handler("", ctx);
+			sessionLifecycle.shutdown();
+			stale = true;
+
+			expect(() => vi.runAllTimers()).not.toThrow();
+			expect(featureChanges).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("renders Zentui settings with mode-aware top and bottom borders", async () => {
 		const settingsWidth = 160;
 		async function renderSettings(config: PolishedTuiConfig) {
@@ -2163,6 +2325,7 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					sessionLifecycle: inactiveSessionLifecycle,
 					getConfig: () => config,
 					setColorSources() {},
 					setUiFeatures: () => ({ applied: true }),
@@ -2237,6 +2400,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2294,6 +2458,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2375,6 +2540,7 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					sessionLifecycle: inactiveSessionLifecycle,
 					getConfig: () => ({ ...defaultConfig, gitBranch: { maxLength } }),
 					setColorSources() {},
 					setUiFeatures: () => ({ applied: true }),
@@ -2439,6 +2605,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources(patch) {
 					changes.push(patch);
@@ -2511,6 +2678,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => configWithColorSources({ editor: "theme", userMessages: "terminal" }),
 				setColorSources(patch) {
 					changes.push(patch);
@@ -2580,6 +2748,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2638,6 +2807,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2701,6 +2871,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2764,6 +2935,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
 				setUiFeatures: () => ({ applied: true }),
@@ -2832,6 +3004,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () =>
 					configWithExtensionStatuses({
 						placements: { active: "middle", inactive: "left" },

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -443,37 +443,44 @@ describe("Pi docs compliance", () => {
 		expect(setEditorCalls).toBe(2);
 	});
 
-	it("does not let an old session shutdown clean up the current session UI", async () => {
+	it("cleans up when start and shutdown use distinct context wrappers", async () => {
 		const handlers = loadExtension();
-		const makeSessionContext = () => {
-			let editorFactory: unknown;
-			let footerClears = 0;
-			const ctx = makeContext({
-				ui: {
-					theme: makeTheme(),
-					setFooter(factory: unknown) {
-						if (factory === undefined) footerClears += 1;
-					},
-					setEditorComponent(factory: unknown) {
-						editorFactory = factory;
-					},
-					getEditorComponent() {
-						return editorFactory;
-					},
-				},
-			});
-			return { ctx, getEditor: () => editorFactory, getFooterClears: () => footerClears };
+		const runner = {
+			editorFactory: undefined as unknown,
+			setEditorCalls: 0,
+			footerClears: 0,
 		};
-		const oldSession = makeSessionContext();
-		const currentSession = makeSessionContext();
-		await emit(handlers, "session_start", oldSession.ctx);
-		await emit(handlers, "session_start", currentSession.ctx);
-		const currentEditor = currentSession.getEditor();
+		let startContextStale = false;
+		const makeUiWrapper = (isStale: () => boolean) => ({
+			theme: makeTheme(),
+			setFooter(factory: unknown) {
+				if (isStale()) throw new Error("stale start ctx setFooter");
+				if (factory === undefined) runner.footerClears += 1;
+			},
+			setEditorComponent(factory: unknown) {
+				if (isStale()) throw new Error("stale start ctx setEditorComponent");
+				runner.setEditorCalls += 1;
+				runner.editorFactory = factory;
+			},
+			getEditorComponent() {
+				if (isStale()) throw new Error("stale start ctx getEditorComponent");
+				return runner.editorFactory;
+			},
+		});
+		const startCtx = makeContext({ ui: makeUiWrapper(() => startContextStale) });
+		const shutdownCtx = makeContext({ ui: makeUiWrapper(() => false) });
+		expect(shutdownCtx).not.toBe(startCtx);
+		expect(shutdownCtx.ui).not.toBe(startCtx.ui);
 
-		await emit(handlers, "session_shutdown", oldSession.ctx);
+		await emit(handlers, "session_start", startCtx);
+		expect(runner.editorFactory).toBeTypeOf("function");
+		startContextStale = true;
+		await expect(emit(handlers, "session_shutdown", shutdownCtx)).resolves.toBeUndefined();
+		await emit(handlers, "session_shutdown", shutdownCtx);
 
-		expect(currentSession.getEditor()).toBe(currentEditor);
-		expect(currentSession.getFooterClears()).toBe(0);
+		expect(runner.editorFactory).toBeUndefined();
+		expect(runner.setEditorCalls).toBe(2);
+		expect(runner.footerClears).toBe(1);
 	});
 
 	it("refreshes a stale Zentui editor factory on extension reload instead of adopting old closures", async () => {
@@ -873,6 +880,30 @@ describe("Pi docs compliance", () => {
 		expect(getTheme).not.toHaveBeenCalled();
 	});
 
+	it("deactivates an older selector record hidden inside a third-party predecessor chain", () => {
+		const predecessor = (width: number) => ["─".repeat(width), "body", "─".repeat(width)];
+		const prototype = { render: predecessor };
+		const firstTheme = vi.fn(() => makeTaggedTheme("first:"));
+		const secondTheme = vi.fn(() => makeTaggedTheme("second:"));
+		const cleanupFirst = patchSelectorBorderStyle(prototype, firstTheme, () => defaultConfig);
+		const firstWrapper = prototype.render;
+		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
+			return ["third-party", ...firstWrapper.call(this, width)];
+		};
+		prototype.render = thirdParty;
+		const cleanupSecond = patchSelectorBorderStyle(prototype, secondTheme, () => defaultConfig);
+
+		cleanupFirst();
+		cleanupSecond();
+		firstTheme.mockClear();
+		secondTheme.mockClear();
+
+		expect(prototype.render).toBe(thirdParty);
+		expect(prototype.render(4)).toEqual(["third-party", "────", "body", "────"]);
+		expect(firstTheme).not.toHaveBeenCalled();
+		expect(secondTheme).not.toHaveBeenCalled();
+	});
+
 	it("restores model and settings selector prototypes independently", () => {
 		const modelPredecessor = ModelSelectorComponent.prototype.render;
 		const settingsPredecessor = SettingsSelectorComponent.prototype.render;
@@ -991,6 +1022,37 @@ describe("Pi docs compliance", () => {
 		secondCleanup();
 		expect(UserMessageComponent.prototype.render).toBe(predecessorRender);
 		expect(UserMessageComponent.prototype.invalidate).toBe(predecessorInvalidate);
+	});
+
+	it("deactivates an older user-message record hidden inside a third-party predecessor chain", () => {
+		const prototype = UserMessageComponent.prototype;
+		const predecessorRender = (width: number) => [`base:${width}`];
+		const predecessorInvalidate = vi.fn();
+		prototype.render = predecessorRender;
+		prototype.invalidate = predecessorInvalidate;
+		const firstTheme = vi.fn(() => makeTaggedTheme("first:"));
+		const secondTheme = vi.fn(() => makeTaggedTheme("second:"));
+		const cleanupFirst = installUserMessageStyle(firstTheme, () => defaultConfig);
+		const firstWrapper = prototype.render;
+		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
+			return ["third-party", ...firstWrapper.call(this as never, width)];
+		};
+		prototype.render = thirdParty;
+		const cleanupSecond = installUserMessageStyle(secondTheme, () => defaultConfig);
+
+		cleanupFirst();
+		cleanupSecond();
+		firstTheme.mockClear();
+		secondTheme.mockClear();
+
+		expect(prototype.render).toBe(thirdParty);
+		expect(prototype.invalidate).toBe(predecessorInvalidate);
+		expect(prototype.render.call({ children: [{ text: "hello" }] } as never, 12)).toEqual([
+			"third-party",
+			"base:12",
+		]);
+		expect(firstTheme).not.toHaveBeenCalled();
+		expect(secondTheme).not.toHaveBeenCalled();
 	});
 
 	it("keeps a later user-message replacement and releases old theme closures", () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -17,7 +17,11 @@ import {
 import { installFooter } from "../extensions/zentui/footer";
 import { emptyGitStatus } from "../extensions/zentui/git";
 import zentui from "../extensions/zentui/index";
-import { patchSelectorBorderStyle } from "../extensions/zentui/selector-border";
+import { ZENTUI_PROTOTYPE_PATCH_REGISTRY } from "../extensions/zentui/prototype-patch-registry";
+import {
+	installSelectorBorderStyle,
+	patchSelectorBorderStyle,
+} from "../extensions/zentui/selector-border";
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-command";
 import { createInitialState } from "../extensions/zentui/state";
@@ -261,16 +265,9 @@ function makeContext(overrides: Record<string, unknown> = {}) {
 afterEach(() => {
 	UserMessageComponent.prototype.render = originalUserMessageRender;
 	UserMessageComponent.prototype.invalidate = originalUserMessageInvalidate;
-	const prototype = UserMessageComponent.prototype as unknown as Record<string, unknown>;
-	prototype.__zentuiUserMessageOriginalRender = undefined;
-	prototype.__zentuiUserMessageOriginalInvalidate = undefined;
-	prototype.__zentuiUserMessagePatched = undefined;
-	prototype.__zentuiUserMessageInvalidatePatched = undefined;
-	prototype.__zentuiUserMessageWrapper = undefined;
-	prototype.__zentuiUserMessageInvalidateWrapper = undefined;
-	prototype.__zentuiUserMessageActive = undefined;
-	prototype.__zentuiUserMessageGetTheme = undefined;
-	prototype.__zentuiUserMessageGetConfig = undefined;
+	delete (UserMessageComponent.prototype as unknown as Record<PropertyKey, unknown>)[
+		ZENTUI_PROTOTYPE_PATCH_REGISTRY
+	];
 
 	ModelSelectorComponent.prototype.render = originalModelSelectorRender;
 	SettingsSelectorComponent.prototype.render = originalSettingsSelectorRender;
@@ -278,13 +275,9 @@ afterEach(() => {
 		ModelSelectorComponent.prototype,
 		SettingsSelectorComponent.prototype,
 	]) {
-		const patchable = selectorPrototype as unknown as Record<string, unknown>;
-		patchable.__zentuiSelectorBorderOriginalRender = undefined;
-		patchable.__zentuiSelectorBorderPatched = undefined;
-		patchable.__zentuiSelectorBorderWrapper = undefined;
-		patchable.__zentuiSelectorBorderActive = undefined;
-		patchable.__zentuiSelectorBorderGetTheme = undefined;
-		patchable.__zentuiSelectorBorderGetConfig = undefined;
+		delete (selectorPrototype as unknown as Record<PropertyKey, unknown>)[
+			ZENTUI_PROTOTYPE_PATCH_REGISTRY
+		];
 	}
 });
 
@@ -817,13 +810,13 @@ describe("Pi docs compliance", () => {
 		expect(prototype.render(8)).toEqual(["Selector title", "────────", "help text"]);
 	});
 
-	it("selector cleanup disables patched border styling", () => {
+	it("selector cleanup restores its exact predecessor and is idempotent", () => {
 		const prototype = {
 			render(width: number) {
 				return ["─".repeat(width), "body", "─".repeat(width)];
 			},
 		};
-
+		const predecessor = prototype.render;
 		const cleanup = patchSelectorBorderStyle(
 			prototype,
 			() => makeTaggedTheme(),
@@ -832,7 +825,75 @@ describe("Pi docs compliance", () => {
 
 		expect(prototype.render(8)[0]).toContain("[borderMuted]────────");
 		cleanup();
-		expect(prototype.render(8)).toEqual(["────────", "body", "────────"]);
+		cleanup();
+		expect(prototype.render).toBe(predecessor);
+	});
+
+	it("does not stack selector wrappers and ignores stale cleanup", () => {
+		const predecessor = vi.fn((width: number) => ["─".repeat(width), "body", "─".repeat(width)]);
+		const prototype = { render: predecessor };
+		const firstCleanup = patchSelectorBorderStyle(
+			prototype,
+			() => makeTaggedTheme("first:"),
+			() => defaultConfig,
+		);
+		const wrapper = prototype.render;
+		const secondCleanup = patchSelectorBorderStyle(
+			prototype,
+			() => makeTaggedTheme("second:"),
+			() => defaultConfig,
+		);
+
+		expect(prototype.render).toBe(wrapper);
+		firstCleanup();
+		const rendered = prototype.render(8);
+		expect(rendered[0]).toContain("[second:borderMuted]────────");
+		expect(rendered[0]).not.toContain("first:");
+		expect(predecessor).toHaveBeenCalledTimes(1);
+		secondCleanup();
+		expect(prototype.render).toBe(predecessor);
+	});
+
+	it("preserves a later selector replacement and its predecessor chain", () => {
+		const predecessor = (width: number) => ["─".repeat(width), "body", "─".repeat(width)];
+		const prototype = { render: predecessor };
+		const getTheme = vi.fn(() => makeTaggedTheme());
+		const cleanup = patchSelectorBorderStyle(prototype, getTheme, () => defaultConfig);
+		const zentuiWrapper = prototype.render;
+		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
+			return ["third-party", ...zentuiWrapper.call(this, width)];
+		};
+		prototype.render = thirdParty;
+
+		cleanup();
+		getTheme.mockClear();
+
+		expect(prototype.render).toBe(thirdParty);
+		expect(prototype.render(4)).toEqual(["third-party", "────", "body", "────"]);
+		expect(getTheme).not.toHaveBeenCalled();
+	});
+
+	it("restores model and settings selector prototypes independently", () => {
+		const modelPredecessor = ModelSelectorComponent.prototype.render;
+		const settingsPredecessor = SettingsSelectorComponent.prototype.render;
+		const cleanup = installSelectorBorderStyle(
+			() => makeTaggedTheme(),
+			() => defaultConfig,
+		);
+		const modelZentuiWrapper = ModelSelectorComponent.prototype.render;
+		const thirdPartyModelRender = function thirdPartyModelRender(
+			this: unknown,
+			width: number,
+		): string[] {
+			return modelZentuiWrapper.call(this as never, width);
+		};
+		ModelSelectorComponent.prototype.render = thirdPartyModelRender;
+
+		cleanup();
+
+		expect(ModelSelectorComponent.prototype.render).toBe(thirdPartyModelRender);
+		expect(SettingsSelectorComponent.prototype.render).toBe(settingsPredecessor);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(modelPredecessor);
 	});
 
 	it("renders user-message borders from the user-message color source", () => {
@@ -851,30 +912,37 @@ describe("Pi docs compliance", () => {
 		expect(terminalRendered).toContain("\u001b[90m────");
 	});
 
-	it("user-message cleanup disables patched rendering", () => {
+	it("user-message cleanup restores exact render and invalidate predecessors", () => {
+		const predecessorRender = UserMessageComponent.prototype.render;
+		const predecessorInvalidate = UserMessageComponent.prototype.invalidate;
 		const cleanup = installUserMessageStyle(
 			() => makeTaggedTheme(),
 			() => defaultConfig,
 		);
 
+		expect(UserMessageComponent.prototype.render).not.toBe(predecessorRender);
+		expect(UserMessageComponent.prototype.invalidate).not.toBe(predecessorInvalidate);
 		expect(new UserMessageComponent("hello").render(80).join("\n")).toContain("[borderMuted]────");
-		const prototype = UserMessageComponent.prototype as unknown as Record<string, unknown>;
-		prototype.__zentuiUserMessageOriginalRender = (width: number) => [`original:${width}`];
 		cleanup();
-		expect(new UserMessageComponent("hello").render(80)).toEqual(["original:80"]);
+		cleanup();
+
+		expect(UserMessageComponent.prototype.render).toBe(predecessorRender);
+		expect(UserMessageComponent.prototype.invalidate).toBe(predecessorInvalidate);
 	});
 
-	it("falls back to the original user-message render when text cannot be found", () => {
-		installUserMessageStyle(
+	it("falls back to the predecessor user-message render when text cannot be found", () => {
+		const predecessor = (width: number) => [`fallback:${width}`];
+		UserMessageComponent.prototype.render = predecessor;
+		const cleanup = installUserMessageStyle(
 			() => makeTaggedTheme(),
 			() => defaultConfig,
 		);
-		const prototype = UserMessageComponent.prototype as unknown as Record<string, unknown>;
-		prototype.__zentuiUserMessageOriginalRender = (width: number) => [`fallback:${width}`];
 
 		const lines = UserMessageComponent.prototype.render.call({ children: [] }, 42);
 
 		expect(lines).toEqual(["fallback:42"]);
+		cleanup();
+		expect(UserMessageComponent.prototype.render).toBe(predecessor);
 	});
 
 	it("preserves OSC 133 prompt-zone markers around user-message output", async () => {
@@ -897,21 +965,58 @@ describe("Pi docs compliance", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 12)).toBe(true);
 	});
 
-	it("refreshes user-message render state after extension reload", () => {
-		installUserMessageStyle(
+	it("reuses user-message wrappers while stale cleanup leaves the new registration active", () => {
+		const predecessorRender = UserMessageComponent.prototype.render;
+		const predecessorInvalidate = UserMessageComponent.prototype.invalidate;
+		const firstCleanup = installUserMessageStyle(
 			() => makeTaggedTheme("first:"),
 			() => defaultConfig,
 		);
+		const renderWrapper = UserMessageComponent.prototype.render;
+		const invalidateWrapper = UserMessageComponent.prototype.invalidate;
 		const firstRender = new UserMessageComponent("hello").render(80).join("\n");
 		expect(firstRender).toMatch(/\[first:accent\]│|\u001b\[34m│\u001b\[0m/);
 
-		installUserMessageStyle(
+		const secondCleanup = installUserMessageStyle(
 			() => makeTaggedTheme("second:"),
 			() => defaultConfig,
 		);
+		expect(UserMessageComponent.prototype.render).toBe(renderWrapper);
+		expect(UserMessageComponent.prototype.invalidate).toBe(invalidateWrapper);
+		firstCleanup();
 		const secondRender = new UserMessageComponent("hello").render(80).join("\n");
 		expect(secondRender).not.toContain("[first:accent]│");
 		expect(secondRender).toMatch(/\[second:accent\]│|\u001b\[34m│\u001b\[0m/);
+
+		secondCleanup();
+		expect(UserMessageComponent.prototype.render).toBe(predecessorRender);
+		expect(UserMessageComponent.prototype.invalidate).toBe(predecessorInvalidate);
+	});
+
+	it("keeps a later user-message replacement and releases old theme closures", () => {
+		const prototype = UserMessageComponent.prototype;
+		const predecessorRender = (width: number) => [`base:${width}`];
+		const predecessorInvalidate = vi.fn();
+		prototype.render = predecessorRender;
+		prototype.invalidate = predecessorInvalidate;
+		const getTheme = vi.fn(() => makeTaggedTheme("old:"));
+		const cleanup = installUserMessageStyle(getTheme, () => defaultConfig);
+		const zentuiWrapper = prototype.render;
+		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
+			return ["third-party", ...zentuiWrapper.call(this as never, width)];
+		};
+		prototype.render = thirdParty;
+
+		cleanup();
+		getTheme.mockClear();
+
+		expect(prototype.render).toBe(thirdParty);
+		expect(prototype.invalidate).toBe(predecessorInvalidate);
+		expect(prototype.render.call({ children: [{ text: "hello" }] } as never, 12)).toEqual([
+			"third-party",
+			"base:12",
+		]);
+		expect(getTheme).not.toHaveBeenCalled();
 	});
 
 	it("keeps custom footer output within the requested render width", async () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -2240,6 +2240,74 @@ describe("Pi docs compliance", () => {
 		}
 	});
 
+	it("does not update a settings value when persistence fails", async () => {
+		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
+		const attemptedPatches: Partial<PolishedTuiConfig["features"]>[] = [];
+		const notifications: string[] = [];
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: inactiveSessionLifecycle,
+				getConfig: () => defaultConfig,
+				setColorSources() {},
+				setUiFeatures(patch) {
+					attemptedPatches.push(patch);
+					throw new Error("config is corrupt");
+				},
+				setFooterSegments() {},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				setSeparator() {},
+				getActiveExtensionStatuses: () => new Map<string, string>(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender() {},
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		await command?.handler("", {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: makeTaggedTheme(),
+				notify(message: string) {
+					notifications.push(message);
+				},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					const component = factory({ requestRender() {} }, makeTaggedTheme(), {}, () => {}) as {
+						handleInput?: (data: string) => void;
+					};
+					component.handleInput?.("\t");
+					component.handleInput?.("\x1b[B");
+					component.handleInput?.(" ");
+					component.handleInput?.("\x1b[B");
+					component.handleInput?.(" ");
+				},
+			},
+		});
+
+		expect(attemptedPatches).toEqual([{ statusLine: false }, { statusLine: false }]);
+		expect(notifications).toEqual([
+			"Could not update Zentui settings: config is corrupt",
+			"Could not update Zentui settings: config is corrupt",
+		]);
+	});
+
 	it("drops a deferred settings editor swap after session shutdown", async () => {
 		vi.useFakeTimers();
 		try {

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -1,19 +1,18 @@
 import { CURSOR_MARKER } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
-import {
-	buildCluster,
-	capEditorLines,
-	findEditorContainerIndex,
-	hideRenderable,
-	renderCluster,
-	restoreRenderable,
-} from "../extensions/zentui/fixed-editor/cluster";
+import { describe, expect, it, vi } from "vitest";
+import { capEditorLines, renderCluster } from "../extensions/zentui/fixed-editor/cluster";
+import { TerminalSplitCompositor } from "../extensions/zentui/fixed-editor/compositor";
 import {
 	clampScrollOffset,
 	parseKeyboardScroll,
 	parseMouseEvent,
 	parseMouseScroll,
 } from "../extensions/zentui/fixed-editor/input";
+import {
+	findEditorContainerIndex,
+	inspectPiTui,
+	type PiRenderableCapability,
+} from "../extensions/zentui/fixed-editor/pi-compat";
 import { highlightSelection, SelectionState } from "../extensions/zentui/fixed-editor/selection";
 import {
 	DISABLE_MOUSE,
@@ -23,6 +22,317 @@ import {
 	RESET_SCROLL_REGION,
 	SHOW_CURSOR,
 } from "../extensions/zentui/fixed-editor/terminal-modes";
+
+function makeValidPiFixture() {
+	let rawRows = 24;
+	let inputListener:
+		| ((data: string) => { consume?: boolean; data?: string } | undefined)
+		| undefined;
+	const removeInputListener = vi.fn();
+	const terminalWrite = vi.fn();
+	const makeRenderable = (label: string) => ({
+		render(width: number) {
+			return [`${label}:${width}`];
+		},
+	});
+	const editorComponent = {
+		getText: () => "",
+		setText() {},
+		handleInput() {},
+	};
+	const status = makeRenderable("status");
+	const above = makeRenderable("above");
+	const editor = { ...makeRenderable("editor"), children: [editorComponent] };
+	const below = makeRenderable("below");
+	const footer = makeRenderable("footer");
+	const terminal = {
+		columns: 80,
+		rows: rawRows,
+		write: terminalWrite,
+	};
+	Object.defineProperty(terminal, "rows", {
+		configurable: true,
+		enumerable: true,
+		get: () => rawRows,
+	});
+	const rootRender = vi.fn((width: number) =>
+		Array.from({ length: 30 }, (_, index) => `root-${index}:${width}`),
+	);
+	const doRender = vi.fn();
+	const requestRender = vi.fn();
+	const addInputListener = vi.fn(
+		(listener: (data: string) => { consume?: boolean; data?: string } | undefined) => {
+			inputListener = listener;
+			return removeInputListener;
+		},
+	);
+	const tui = {
+		children: [status, above, editor, below, footer],
+		focusedComponent: editorComponent,
+		terminal,
+		render: rootRender,
+		doRender,
+		requestRender,
+		addInputListener,
+		hasOverlay: () => false,
+		overlayStack: [] as { hidden?: boolean }[],
+		hardwareCursorRow: 4,
+		previousViewportTop: 1,
+	};
+	return {
+		tui,
+		terminal,
+		cluster: [status, above, editor, below, footer],
+		terminalWrite,
+		rootRender,
+		doRender,
+		requestRender,
+		addInputListener,
+		removeInputListener,
+		getInputListener: () => inputListener,
+		setRows: (rows: number) => {
+			rawRows = rows;
+		},
+	};
+}
+
+describe("Pi fixed-editor compatibility", () => {
+	it.each([
+		[
+			"terminal",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "terminal"),
+		],
+		[
+			"terminal write",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.terminal, "write"),
+		],
+		[
+			"terminal rows",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.terminal, "rows"),
+		],
+		[
+			"terminal columns",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.terminal, "columns"),
+		],
+		[
+			"input listener",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "addInputListener"),
+		],
+		[
+			"children",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "children"),
+		],
+		[
+			"editor layout",
+			(fixture: ReturnType<typeof makeValidPiFixture>) => {
+				Reflect.set(fixture.tui.children[2], "children", []);
+			},
+		],
+		[
+			"render",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "render"),
+		],
+		[
+			"doRender",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "doRender"),
+		],
+		[
+			"overlay visibility",
+			(fixture: ReturnType<typeof makeValidPiFixture>) => {
+				Reflect.deleteProperty(fixture.tui, "hasOverlay");
+				Reflect.deleteProperty(fixture.tui, "overlayStack");
+			},
+		],
+		[
+			"hardware cursor row",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "hardwareCursorRow"),
+		],
+		[
+			"viewport top",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "previousViewportTop"),
+		],
+	] as const)("rejects a missing %s capability without side effects", (_name, removeCapability) => {
+		const fixture = makeValidPiFixture();
+		removeCapability(fixture);
+		const render = fixture.tui.render;
+		const doRender = fixture.tui.doRender;
+		const write = fixture.terminal.write;
+
+		expect(inspectPiTui(fixture.tui)).toBeUndefined();
+		expect(fixture.terminalWrite).not.toHaveBeenCalled();
+		expect(fixture.addInputListener).not.toHaveBeenCalled();
+		expect(fixture.tui.render).toBe(render);
+		expect(fixture.tui.doRender).toBe(doRender);
+		expect(fixture.terminal.write).toBe(write);
+	});
+
+	it("rejects non-configurable rows and non-writable render methods before writes", () => {
+		const rowsFixture = makeValidPiFixture();
+		const rowsDescriptor = Object.getOwnPropertyDescriptor(rowsFixture.terminal, "rows");
+		Object.defineProperty(rowsFixture.terminal, "rows", { ...rowsDescriptor, configurable: false });
+		expect(inspectPiTui(rowsFixture.tui)).toBeUndefined();
+		expect(rowsFixture.terminalWrite).not.toHaveBeenCalled();
+
+		const renderFixture = makeValidPiFixture();
+		Object.defineProperty(renderFixture.tui, "render", {
+			value: renderFixture.tui.render,
+			configurable: true,
+			writable: false,
+		});
+		expect(inspectPiTui(renderFixture.tui)).toBeUndefined();
+		expect(renderFixture.terminalWrite).not.toHaveBeenCalled();
+
+		const doRenderFixture = makeValidPiFixture();
+		Object.defineProperty(doRenderFixture.tui, "doRender", {
+			value: doRenderFixture.tui.doRender,
+			configurable: true,
+			writable: false,
+		});
+		expect(inspectPiTui(doRenderFixture.tui)).toBeUndefined();
+		expect(doRenderFixture.terminalWrite).not.toHaveBeenCalled();
+
+		const writeFixture = makeValidPiFixture();
+		Object.defineProperty(writeFixture.terminal, "write", {
+			value: writeFixture.terminal.write,
+			configurable: true,
+			writable: false,
+		});
+		expect(inspectPiTui(writeFixture.tui)).toBeUndefined();
+		expect(writeFixture.terminalWrite).not.toHaveBeenCalled();
+
+		const frozenFixture = makeValidPiFixture();
+		Object.freeze(frozenFixture.tui.children[0]);
+		expect(inspectPiTui(frozenFixture.tui)).toBeUndefined();
+		expect(frozenFixture.terminalWrite).not.toHaveBeenCalled();
+	});
+
+	it("installs from verified capabilities and restores exact identities and descriptors", () => {
+		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		expect(capabilities).toBeDefined();
+		if (!capabilities) return;
+		const render = fixture.tui.render;
+		const doRender = fixture.tui.doRender;
+		const write = fixture.terminal.write;
+		const rowsDescriptor = Object.getOwnPropertyDescriptor(fixture.terminal, "rows");
+		const clusterDescriptors = fixture.cluster.map((component) =>
+			Object.getOwnPropertyDescriptor(component, "render"),
+		);
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+
+		expect(compositor.install()).toBe(true);
+		expect(fixture.tui.render).not.toBe(render);
+		expect(fixture.tui.doRender).not.toBe(doRender);
+		expect(fixture.terminal.write).not.toBe(write);
+		expect(fixture.cluster.every((component) => component.render(80).length === 0)).toBe(true);
+		expect(fixture.addInputListener).toHaveBeenCalledTimes(1);
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(1);
+
+		compositor.dispose();
+		compositor.dispose();
+
+		expect(fixture.tui.render).toBe(render);
+		expect(fixture.tui.doRender).toBe(doRender);
+		expect(fixture.terminal.write).toBe(write);
+		expect(Object.getOwnPropertyDescriptor(fixture.terminal, "rows")).toEqual(rowsDescriptor);
+		expect(
+			fixture.cluster.map((component) => Object.getOwnPropertyDescriptor(component, "render")),
+		).toEqual(clusterDescriptors);
+		expect(fixture.removeInputListener).toHaveBeenCalledTimes(1);
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
+	});
+
+	it("rolls back patches when listener registration does not return cleanup", () => {
+		const fixture = makeValidPiFixture();
+		Reflect.set(
+			fixture.tui,
+			"addInputListener",
+			vi.fn(() => undefined),
+		);
+		const capabilities = inspectPiTui(fixture.tui);
+		expect(capabilities).toBeDefined();
+		if (!capabilities) return;
+		const render = fixture.tui.render;
+		const write = fixture.terminal.write;
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+
+		expect(compositor.install()).toBe(false);
+		expect(fixture.tui.render).toBe(render);
+		expect(fixture.terminal.write).toBe(write);
+		expect(fixture.cluster.every((component) => component.render(80).length > 0)).toBe(true);
+		expect(fixture.terminalWrite).not.toHaveBeenCalled();
+	});
+
+	it("keeps overlays visible and responds to rows, cursor, and wheel input", () => {
+		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		const patchedRender = fixture.tui.render;
+		const narrowRows = fixture.terminal.rows;
+		fixture.setRows(40);
+		expect(fixture.terminal.rows).toBeGreaterThan(narrowRows);
+
+		fixture.tui.overlayStack = [{}];
+		expect(patchedRender(80)).toEqual(fixture.rootRender(80));
+		fixture.tui.overlayStack = [];
+		fixture.setRows(12);
+		patchedRender(80);
+		fixture.terminal.write("update");
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toContain("\u001b[4;1H");
+		fixture.requestRender.mockClear();
+		fixture.getInputListener()?.("\u001b[<64;1;1M");
+		expect(fixture.requestRender).toHaveBeenCalled();
+		compositor.dispose();
+	});
+
+	it("clears the right-click mouse-resume timer on disposal", () => {
+		vi.useFakeTimers();
+		try {
+			const fixture = makeValidPiFixture();
+			const capabilities = inspectPiTui(fixture.tui);
+			if (!capabilities) throw new Error("expected valid fixture");
+			const compositor = new TerminalSplitCompositor(capabilities, () => ({
+				enabled: true,
+				mouseScroll: true,
+				copyNotice: true,
+			}));
+			expect(compositor.install()).toBe(true);
+			fixture.getInputListener()?.("\u001b[<2;1;1M");
+			expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toContain(DISABLE_MOUSE);
+
+			compositor.dispose();
+			const writesAfterDispose = fixture.terminalWrite.mock.calls.length;
+			vi.advanceTimersByTime(1_200);
+			expect(fixture.terminalWrite).toHaveBeenCalledTimes(writesAfterDispose);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});
 
 describe("input", () => {
 	describe("parseMouseScroll", () => {
@@ -155,6 +465,15 @@ describe("cluster", () => {
 		return { render: () => [], invalidate: () => {}, children };
 	}
 
+	function makeCapability(lines: string[]): PiRenderableCapability {
+		const target = makeComponent(lines);
+		return {
+			target,
+			render: target.render,
+			ownDescriptor: Object.getOwnPropertyDescriptor(target, "render"),
+		};
+	}
+
 	function makeEditor() {
 		return {
 			render: () => ["editor"],
@@ -185,36 +504,6 @@ describe("cluster", () => {
 		});
 	});
 
-	describe("buildCluster", () => {
-		it("builds the 5-component cluster", () => {
-			const status = makeComponent(["status"]);
-			const above = makeComponent(["above"]);
-			const editor = makeContainer([makeEditor()]);
-			const below = makeComponent(["below"]);
-			const footer = makeComponent(["footer"]);
-			const children = [status, above, editor, below, footer];
-			const cluster = buildCluster(children, 2);
-			expect(cluster).not.toBeNull();
-			expect(cluster?.status).toBe(status);
-			expect(cluster?.aboveWidget).toBe(above);
-			expect(cluster?.editor).toBe(editor);
-			expect(cluster?.belowWidget).toBe(below);
-			expect(cluster?.footer).toBe(footer);
-		});
-
-		it("handles missing neighbors gracefully", () => {
-			const editor = makeContainer([makeEditor()]);
-			const children = [editor];
-			const cluster = buildCluster(children, 0);
-			expect(cluster).not.toBeNull();
-			expect(cluster?.status).toBeNull();
-			expect(cluster?.aboveWidget).toBeNull();
-			expect(cluster?.editor).toBe(editor);
-			expect(cluster?.belowWidget).toBeNull();
-			expect(cluster?.footer).toBeNull();
-		});
-	});
-
 	describe("capEditorLines", () => {
 		it("keeps last N lines when no cursor marker", () => {
 			const lines = Array.from({ length: 10 }, (_, i) => `line ${i}`);
@@ -240,11 +529,11 @@ describe("cluster", () => {
 	describe("renderCluster", () => {
 		it("renders and concatenates all cluster components", () => {
 			const cluster = {
-				status: makeComponent(["status"]),
-				aboveWidget: makeComponent(["above"]),
-				editor: makeComponent(["editor-line"]),
-				belowWidget: makeComponent(["below"]),
-				footer: makeComponent(["footer"]),
+				status: makeCapability(["status"]),
+				aboveWidget: makeCapability(["above"]),
+				editor: makeCapability(["editor-line"]),
+				belowWidget: makeCapability(["below"]),
+				footer: makeCapability(["footer"]),
 			};
 			const result = renderCluster(cluster, 80, 24);
 			expect(result.lines).toEqual(["status", "above", "editor-line", "below", "footer"]);
@@ -254,7 +543,7 @@ describe("cluster", () => {
 			const cluster = {
 				status: null,
 				aboveWidget: null,
-				editor: makeComponent([`hello${CURSOR_MARKER}world`]),
+				editor: makeCapability([`hello${CURSOR_MARKER}world`]),
 				belowWidget: null,
 				footer: null,
 			};
@@ -268,7 +557,7 @@ describe("cluster", () => {
 			const cluster = {
 				status: null,
 				aboveWidget: null,
-				editor: makeComponent(manyLines),
+				editor: makeCapability(manyLines),
 				belowWidget: null,
 				footer: null,
 			};
@@ -284,7 +573,7 @@ describe("cluster", () => {
 			const cluster = {
 				status: null,
 				aboveWidget: null,
-				editor: makeComponent(editorFrame),
+				editor: makeCapability(editorFrame),
 				belowWidget: null,
 				footer: null,
 			};
@@ -294,60 +583,15 @@ describe("cluster", () => {
 
 		it("strips trailing blank lines from components", () => {
 			const cluster = {
-				status: makeComponent(["status", "", ""]),
+				status: makeCapability(["status", "", ""]),
 				aboveWidget: null,
-				editor: makeComponent(["editor"]),
+				editor: makeCapability(["editor"]),
 				belowWidget: null,
-				footer: makeComponent(["footer", ""]),
+				footer: makeCapability(["footer", ""]),
 			};
 			const result = renderCluster(cluster, 80, 24);
 			// Trailing blanks stripped, but content preserved
 			expect(result.lines).toEqual(["status", "editor", "footer"]);
-		});
-	});
-
-	describe("hideRenderable / restoreRenderable", () => {
-		it("patches render to return [] and saves original", () => {
-			const comp: {
-				render(width: number): string[];
-				__zentuiOriginalRender?: (w: number) => string[];
-			} = {
-				render: () => ["real", "lines"],
-			};
-			hideRenderable(comp);
-			expect(comp.render(80)).toEqual([]);
-			expect(comp.__zentuiOriginalRender).toBeDefined();
-			expect(comp.__zentuiOriginalRender?.(80)).toEqual(["real", "lines"]);
-		});
-
-		it("restores original render on restoreRenderable", () => {
-			const comp: {
-				render(width: number): string[];
-				__zentuiOriginalRender?: (w: number) => string[];
-			} = {
-				render: () => ["real", "lines"],
-			};
-			hideRenderable(comp);
-			restoreRenderable(comp);
-			expect(comp.render(80)).toEqual(["real", "lines"]);
-			expect(comp.__zentuiOriginalRender).toBeUndefined();
-		});
-
-		it("is idempotent (double-hide does not overwrite original)", () => {
-			const comp: {
-				render(width: number): string[];
-				__zentuiOriginalRender?: (w: number) => string[];
-			} = {
-				render: () => ["real"],
-			};
-			hideRenderable(comp);
-			hideRenderable(comp);
-			expect(comp.__zentuiOriginalRender?.(80)).toEqual(["real"]);
-		});
-
-		it("handles null gracefully", () => {
-			hideRenderable(null);
-			restoreRenderable(null);
 		});
 	});
 });

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -28,7 +28,14 @@ function makeValidPiFixture() {
 	let inputListener:
 		| ((data: string) => { consume?: boolean; data?: string } | undefined)
 		| undefined;
-	const removeInputListener = vi.fn();
+	const inputListenerDisposer = vi.fn(() => {
+		inputListener = undefined;
+	});
+	const removeInputListener = vi.fn(
+		(listener: (data: string) => { consume?: boolean; data?: string } | undefined) => {
+			if (inputListener === listener) inputListener = undefined;
+		},
+	);
 	const terminalWrite = vi.fn();
 	const makeRenderable = (label: string) => ({
 		render(width: number) {
@@ -63,7 +70,7 @@ function makeValidPiFixture() {
 	const addInputListener = vi.fn(
 		(listener: (data: string) => { consume?: boolean; data?: string } | undefined) => {
 			inputListener = listener;
-			return removeInputListener;
+			return inputListenerDisposer;
 		},
 	);
 	const tui = {
@@ -74,6 +81,7 @@ function makeValidPiFixture() {
 		doRender,
 		requestRender,
 		addInputListener,
+		removeInputListener,
 		hasOverlay: () => false,
 		overlayStack: [] as { hidden?: boolean }[],
 		hardwareCursorRow: 4,
@@ -88,6 +96,7 @@ function makeValidPiFixture() {
 		doRender,
 		requestRender,
 		addInputListener,
+		inputListenerDisposer,
 		removeInputListener,
 		getInputListener: () => inputListener,
 		setRows: (rows: number) => {
@@ -122,6 +131,11 @@ describe("Pi fixed-editor compatibility", () => {
 			"input listener",
 			(fixture: ReturnType<typeof makeValidPiFixture>) =>
 				Reflect.deleteProperty(fixture.tui, "addInputListener"),
+		],
+		[
+			"input listener removal",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "removeInputListener"),
 		],
 		[
 			"children",
@@ -174,6 +188,21 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.tui.render).toBe(render);
 		expect(fixture.tui.doRender).toBe(doRender);
 		expect(fixture.terminal.write).toBe(write);
+	});
+
+	it("fails closed when a private Pi getter or proxy trap throws", () => {
+		const fixture = makeValidPiFixture();
+		const throwingTui = new Proxy(fixture.tui, {
+			get(target, property, receiver) {
+				if (property === "children") throw new Error("private shape changed");
+				return Reflect.get(target, property, receiver);
+			},
+		});
+
+		expect(() => inspectPiTui(throwingTui)).not.toThrow();
+		expect(inspectPiTui(throwingTui)).toBeUndefined();
+		expect(fixture.terminalWrite).not.toHaveBeenCalled();
+		expect(fixture.addInputListener).not.toHaveBeenCalled();
 	});
 
 	it("rejects non-configurable rows and non-writable render methods before writes", () => {
@@ -252,7 +281,9 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(
 			fixture.cluster.map((component) => Object.getOwnPropertyDescriptor(component, "render")),
 		).toEqual(clusterDescriptors);
-		expect(fixture.removeInputListener).toHaveBeenCalledTimes(1);
+		expect(fixture.inputListenerDisposer).toHaveBeenCalledTimes(1);
+		expect(fixture.removeInputListener).not.toHaveBeenCalled();
+		expect(fixture.getInputListener()).toBeUndefined();
 		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
 	});
 
@@ -261,7 +292,10 @@ describe("Pi fixed-editor compatibility", () => {
 		Reflect.set(
 			fixture.tui,
 			"addInputListener",
-			vi.fn(() => undefined),
+			vi.fn((listener: (data: string) => { consume?: boolean; data?: string } | undefined) => {
+				fixture.addInputListener(listener);
+				return undefined;
+			}),
 		);
 		const capabilities = inspectPiTui(fixture.tui);
 		expect(capabilities).toBeDefined();
@@ -278,6 +312,8 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.tui.render).toBe(render);
 		expect(fixture.terminal.write).toBe(write);
 		expect(fixture.cluster.every((component) => component.render(80).length > 0)).toBe(true);
+		expect(fixture.removeInputListener).toHaveBeenCalledTimes(1);
+		expect(fixture.getInputListener()).toBeUndefined();
 		expect(fixture.terminalWrite).not.toHaveBeenCalled();
 	});
 

--- a/test/session-lifecycle.test.ts
+++ b/test/session-lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { defaultConfig } from "../extensions/zentui/config";
+import { disposeFixedEditor, installFixedEditorProbe } from "../extensions/zentui/fixed-editor";
+import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
+
+afterEach(() => {
+	disposeFixedEditor();
+	vi.useRealTimers();
+});
+
+describe("SessionLifecycle", () => {
+	it("cancels owned timeouts, rejects old generations, and shuts down twice safely", () => {
+		vi.useFakeTimers();
+		const lifecycle = new SessionLifecycle();
+		const calls: string[] = [];
+		const oldGeneration = lifecycle.start();
+		lifecycle.defer(() => calls.push("old"));
+
+		lifecycle.shutdown();
+		lifecycle.shutdown();
+		const currentGeneration = lifecycle.start();
+		lifecycle.defer(() => calls.push("current"));
+		vi.runAllTimers();
+
+		expect(calls).toEqual(["current"]);
+		expect(lifecycle.isCurrent(oldGeneration)).toBe(false);
+		expect(lifecycle.isCurrent(currentGeneration)).toBe(true);
+	});
+
+	it("drops queued microtasks from an old generation", async () => {
+		const lifecycle = new SessionLifecycle();
+		const calls: string[] = [];
+		lifecycle.start();
+		lifecycle.queueMicrotask(() => calls.push("old"));
+		lifecycle.start();
+		lifecycle.queueMicrotask(() => calls.push("current"));
+
+		await Promise.resolve();
+
+		expect(calls).toEqual(["current"]);
+	});
+});
+
+describe("fixed-editor probe lifecycle", () => {
+	it("cannot install from queued probe microtasks after disposal", async () => {
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		let widgetFactory: ((tui: unknown) => { render(): string[] }) | undefined;
+		const terminalWrite = vi.fn();
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(key: string, factory: unknown) {
+					if (key === "zentui-fixed-editor-probe" && typeof factory === "function") {
+						widgetFactory = factory as typeof widgetFactory;
+					}
+				},
+			},
+		};
+		installFixedEditorProbe(
+			ctx as never,
+			() => ({
+				...defaultConfig,
+				fixedEditor: { ...defaultConfig.fixedEditor, enabled: true },
+			}),
+			lifecycle,
+		);
+		const component = widgetFactory?.({ terminal: { write: terminalWrite } });
+		component?.render();
+
+		disposeFixedEditor();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(terminalWrite).not.toHaveBeenCalled();
+	});
+});

--- a/test/session-lifecycle.test.ts
+++ b/test/session-lifecycle.test.ts
@@ -6,6 +6,7 @@ import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 afterEach(() => {
 	disposeFixedEditor();
 	vi.useRealTimers();
+	vi.restoreAllMocks();
 });
 
 describe("SessionLifecycle", () => {
@@ -42,6 +43,58 @@ describe("SessionLifecycle", () => {
 });
 
 describe("fixed-editor probe lifecycle", () => {
+	it("fails closed with one warning when queued compatibility inspection throws", async () => {
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		let widgetFactory: ((tui: unknown) => { render(): string[] }) | undefined;
+		const terminalWrite = vi.fn();
+		const addInputListener = vi.fn(() => () => {});
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const ctx = {
+			hasUI: true,
+			ui: {
+				setWidget(key: string, factory: unknown) {
+					if (key === "zentui-fixed-editor-probe" && typeof factory === "function") {
+						widgetFactory = factory as typeof widgetFactory;
+					}
+				},
+			},
+		};
+		installFixedEditorProbe(
+			ctx as never,
+			() => ({
+				...defaultConfig,
+				fixedEditor: { ...defaultConfig.fixedEditor, enabled: true },
+			}),
+			lifecycle,
+		);
+		const tui = new Proxy(
+			{
+				terminal: { columns: 80, rows: 24, write: terminalWrite },
+				render: () => [],
+				doRender() {},
+				addInputListener,
+				removeInputListener() {},
+			},
+			{
+				get(target, property, receiver) {
+					if (property === "children") throw new Error("private getter changed");
+					return Reflect.get(target, property, receiver);
+				},
+			},
+		);
+		widgetFactory?.(tui).render();
+		widgetFactory?.(tui).render();
+
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(warning).toHaveBeenCalledTimes(1);
+		expect(terminalWrite).not.toHaveBeenCalled();
+		expect(addInputListener).not.toHaveBeenCalled();
+	});
+
 	it("cannot install from queued probe microtasks after disposal", async () => {
 		const lifecycle = new SessionLifecycle();
 		lifecycle.start();


### PR DESCRIPTION
## Summary

- own deferred UI work through a session lifecycle so stale Pi contexts cannot run after reload, fork, resume, or session replacement
- write config updates atomically while preserving corrupt files, permissions, symlinks, and unknown keys
- make user-message and selector prototype patches reversible across hot reload and third-party interleaving
- isolate fixed-editor private Pi capability discovery behind a fail-closed compatibility adapter

## Why

A Pi-doc-grounded architecture review found lifecycle cleanup, config durability, prototype ownership, and private-TUI compatibility risks. This PR addresses the four highest-priority findings without changing Zentui's visual behavior or public configuration schema.

## Validation

- [x] `npm run fmt`
- [x] `npm run verify` — 13 test files, 419 tests
- [x] `npm run pack:check`
- [x] `git diff --check`
- [x] Manual Pi testing: reload/new/resume/fork, editor toggling, fixed editor, overlays, resize, mouse/copy behavior

## Screenshots / recording

N/A — architecture and correctness changes only; no intended visual changes.

## Notes

The fixed editor remains experimental and still relies on private Pi internals by design. Unsupported shapes now fail closed before mutation.
