### PR TITLE
feat: refresh context during streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
-- `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment.
+- `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Layout** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
 - `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
 - `pathDisplay`: controls how the cwd/`$cwd` path is shown. `mode` is `basename` (default, last segment only) or `full` (path with home contracted to `~`). In `full` mode, `depth` keeps only the last N trailing directories (`0` = entire path after `~`, max `5`); when parents are dropped the path is prefixed with `…/` (Starship-style). The `/zentui` **Layout** tab cycles path mode and path depth (`0`–`5`; depth is ignored for basename). Example: `~/Projects/foo/bar` with `depth: 2` → `…/foo/bar`.

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -19,6 +19,7 @@ import {
 	formatUsernameHostLabel,
 } from "./format";
 import { resolveRuntimeSymbol } from "./icons";
+import type { LiveContextOverride } from "./live-context";
 import type { FooterState } from "./state";
 import { renderStyleForSource } from "./style";
 
@@ -155,6 +156,7 @@ export function installFooter(
 		setRequestRender: (fn: (() => void) | undefined) => void;
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
+		getLiveContext?: () => LiveContextOverride | undefined;
 	},
 ): void {
 	ctx.ui.setFooter((tui, theme, footerData) => {
@@ -198,14 +200,20 @@ export function installFooter(
 					? formatGitBranchText(branch, config.gitBranch.maxLength)
 					: undefined;
 				const contextUsage = ctx.getContextUsage();
+				const liveContext = hooks.getLiveContext?.();
 				const contextWindow = ctx.model?.contextWindow ?? contextUsage?.contextWindow;
+				const useLiveContext =
+					liveContext !== undefined && contextWindow !== undefined && contextWindow > 0;
+				const contextPercent = useLiveContext
+					? (liveContext.tokens / contextWindow) * 100
+					: contextUsage?.percent;
 				const contextLabel = buildContextDisplayLabel({
-					percent: contextUsage?.percent,
+					percent: contextPercent,
 					contextWindow,
 					style: config.contextStyle,
 					asciiGauge: iconMode === "ascii",
 				});
-				const tier = contextColorTier(contextUsage?.percent, config.contextThresholds);
+				const tier = contextColorTier(contextPercent, config.contextThresholds);
 				const contextColor =
 					tier === "error"
 						? config.colors.contextError

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -41,6 +41,7 @@ import {
 import { installFooter } from "./footer";
 import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
+import { LiveContextController } from "./live-context";
 import { readPackageVersionResult } from "./package-version";
 import {
 	createProjectRefreshScheduler,
@@ -113,6 +114,7 @@ export default function (pi: ExtensionAPI) {
 	const refresh = () => {
 		if (sessionLifecycle.isCurrent()) requestFooterRender?.();
 	};
+	const liveContext = new LiveContextController(sessionLifecycle, refresh);
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
 	const getThinkingLevel = () =>
@@ -330,6 +332,7 @@ export default function (pi: ExtensionAPI) {
 			setExtensionStatusesGetter(fn) {
 				getActiveExtensionStatuses = fn ?? (() => new Map());
 			},
+			getLiveContext: () => liveContext.get(),
 		});
 		footerInstalled = true;
 		stopProjectRefresh();
@@ -442,6 +445,7 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		sessionLifecycle.start();
+		liveContext.clear();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		lastProjectCwd = undefined;
@@ -510,6 +514,7 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
+		liveContext.clear();
 		cleanupUi(ctx);
 	});
 
@@ -518,12 +523,44 @@ export default function (pi: ExtensionAPI) {
 		refreshInteractiveState(ctx, true);
 	};
 
-	pi.on("agent_start", syncInteractiveState);
-	pi.on("agent_end", syncInteractiveAndProjectState);
-	pi.on("model_select", syncInteractiveState);
+	pi.on("agent_start", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveState(event, ctx);
+	});
+	pi.on("agent_end", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveAndProjectState(event, ctx);
+	});
+	pi.on("model_select", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveState(event, ctx);
+	});
 	pi.on("thinking_level_select", syncInteractiveState);
-	pi.on("message_end", syncInteractiveAndProjectStateWithUsage);
+	pi.on("message_update", (event) => {
+		liveContext.update(event.message);
+	});
+	pi.on("message_end", (event, ctx) => {
+		// Pi notifies extensions before persisting a successful message, so retain its live
+		// context until agent_end; failed messages clear immediately instead of showing stale usage.
+		if (
+			event.message.role === "assistant" &&
+			(event.message.stopReason === "error" || event.message.stopReason === "aborted")
+		) {
+			liveContext.clear();
+		}
+		syncInteractiveAndProjectStateWithUsage(event, ctx);
+	});
+	pi.on("tool_execution_start", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveState(event, ctx);
+	});
 	pi.on("tool_execution_end", syncInteractiveAndProjectState);
-	pi.on("session_compact", syncInteractiveAndProjectStateWithUsage);
-	pi.on("session_tree", syncInteractiveAndProjectStateWithUsage);
+	pi.on("session_compact", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveAndProjectStateWithUsage(event, ctx);
+	});
+	pi.on("session_tree", (event, ctx) => {
+		liveContext.clear();
+		syncInteractiveAndProjectStateWithUsage(event, ctx);
+	});
 }

--- a/extensions/zentui/live-context.ts
+++ b/extensions/zentui/live-context.ts
@@ -1,0 +1,75 @@
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+import type { SessionLifecycle } from "./session-lifecycle";
+
+export type LiveContextOverride = {
+	tokens: number;
+};
+
+function usageComponent(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+export function calculateLiveContextTokens(usage: Usage | undefined): number | undefined {
+	if (!usage) return undefined;
+	const totalTokens = usageComponent(usage.totalTokens);
+	if (totalTokens > 0) return totalTokens;
+	const calculated =
+		usageComponent(usage.input) +
+		usageComponent(usage.output) +
+		usageComponent(usage.cacheRead) +
+		usageComponent(usage.cacheWrite);
+	return calculated > 0 ? calculated : undefined;
+}
+
+export function liveContextFromMessage(message: unknown): LiveContextOverride | undefined {
+	if (!message || typeof message !== "object") return undefined;
+	const assistant = message as Partial<AssistantMessage>;
+	if (assistant.role !== "assistant") return undefined;
+	if (assistant.stopReason === "error" || assistant.stopReason === "aborted") return undefined;
+	const tokens = calculateLiveContextTokens(assistant.usage);
+	return tokens === undefined ? undefined : { tokens };
+}
+
+export class LiveContextController {
+	private readonly lifecycle: SessionLifecycle;
+	private readonly requestRender: () => void;
+	private override: LiveContextOverride | undefined;
+	private cancelScheduledRender: (() => void) | undefined;
+	private scheduledGeneration: number | undefined;
+
+	constructor(lifecycle: SessionLifecycle, requestRender: () => void) {
+		this.lifecycle = lifecycle;
+		this.requestRender = requestRender;
+	}
+
+	get(): LiveContextOverride | undefined {
+		return this.override;
+	}
+
+	update(message: unknown): boolean {
+		const next = liveContextFromMessage(message);
+		if (!next || !this.lifecycle.isCurrent()) return false;
+		this.override = next;
+		const generation = this.lifecycle.currentGeneration();
+		if (this.cancelScheduledRender && this.scheduledGeneration !== generation) {
+			this.cancelScheduledRender = undefined;
+			this.scheduledGeneration = undefined;
+		}
+		if (!this.cancelScheduledRender) {
+			this.scheduledGeneration = generation;
+			this.cancelScheduledRender = this.lifecycle.defer(() => {
+				this.cancelScheduledRender = undefined;
+				this.scheduledGeneration = undefined;
+				if (this.override) this.requestRender();
+			}, 250);
+		}
+		return true;
+	}
+
+	clear(): void {
+		this.override = undefined;
+		this.cancelScheduledRender?.();
+		this.cancelScheduledRender = undefined;
+		this.scheduledGeneration = undefined;
+	}
+}

--- a/extensions/zentui/session-lifecycle.ts
+++ b/extensions/zentui/session-lifecycle.ts
@@ -18,14 +18,21 @@ export class SessionLifecycle {
 		return this.active && generation === this.generation;
 	}
 
-	defer(callback: () => void): void {
-		if (!this.active) return;
+	defer(callback: () => void, delayMs = 0): () => void {
+		if (!this.active) return () => {};
 		const generation = this.generation;
+		let canceled = false;
 		const timeout = setTimeout(() => {
 			this.timeouts.delete(timeout);
-			if (this.isCurrent(generation)) callback();
-		}, 0);
+			if (!canceled && this.isCurrent(generation)) callback();
+		}, delayMs);
 		this.timeouts.add(timeout);
+		return () => {
+			if (canceled) return;
+			canceled = true;
+			clearTimeout(timeout);
+			this.timeouts.delete(timeout);
+		};
 	}
 
 	queueMicrotask(callback: () => void): () => void {

--- a/test/live-context-integration.test.ts
+++ b/test/live-context-integration.test.ts
@@ -1,0 +1,310 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../extensions/zentui/config", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/config")>();
+	return {
+		...actual,
+		ensureConfigExists: () => {},
+		loadConfig: () => ({
+			...actual.defaultConfig,
+			projectRefreshIntervalMs: 0,
+			features: { ...actual.defaultConfig.features, editor: false, statusLine: true },
+		}),
+	};
+});
+
+vi.mock("../extensions/zentui/git", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/git")>();
+	return { ...actual, readGitStatus: async () => actual.emptyGitStatus() };
+});
+
+vi.mock("../extensions/zentui/runtime", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/runtime")>();
+	return { ...actual, readRuntimeInfo: async () => undefined };
+});
+
+vi.mock("../extensions/zentui/package-version", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/package-version")>();
+	return { ...actual, readPackageVersionResult: async () => undefined };
+});
+
+import zentui from "../extensions/zentui/index";
+
+type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
+type Footer = { render(width: number): string[]; dispose?: () => void };
+type FooterFactory = (...args: unknown[]) => Footer;
+
+function makeTheme(): Theme {
+	return {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold(text: string) {
+			return text;
+		},
+		italic(text: string) {
+			return text;
+		},
+		underline(text: string) {
+			return text;
+		},
+		strikethrough(text: string) {
+			return text;
+		},
+		getThinkingBorderColor() {
+			return (text: string) => text;
+		},
+	} as unknown as Theme;
+}
+
+function assistant(totalTokens: number, stopReason = "stop") {
+	return {
+		role: "assistant",
+		content: [],
+		api: "anthropic-messages",
+		provider: "anthropic",
+		model: "test",
+		usage: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		timestamp: 1,
+	};
+}
+
+function persistedEntry(id: string, input: number, output: number, cost: number) {
+	return {
+		type: "message",
+		id,
+		message: {
+			role: "assistant",
+			usage: {
+				input,
+				output,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: input + output,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
+			},
+		},
+	};
+}
+
+function loadExtension() {
+	const handlers = new Map<string, Handler[]>();
+	zentui({
+		on(name: string, handler: Handler) {
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+		},
+		registerCommand() {},
+		getThinkingLevel() {
+			return "off";
+		},
+	} as never);
+	return handlers;
+}
+
+async function emit(
+	handlers: Map<string, Handler[]>,
+	name: string,
+	ctx: unknown,
+	event: unknown = {},
+) {
+	for (const handler of handlers.get(name) ?? []) await handler(event, ctx);
+}
+
+function createHarness(
+	options: {
+		model?: { id: string; provider: string; contextWindow: number };
+		contextUsage?: { tokens: number; contextWindow: number; percent: number } | null;
+	} = {},
+) {
+	let footerFactory: FooterFactory | undefined;
+	let editorFactory: unknown;
+	const requestRender = vi.fn();
+	const entries = [persistedEntry("old", 5, 6, 0.123)];
+	const state = {
+		model:
+			"model" in options
+				? options.model
+				: { id: "test", provider: "anthropic", contextWindow: 10_000 },
+		contextUsage:
+			"contextUsage" in options
+				? options.contextUsage
+				: { tokens: 1_000, contextWindow: 10_000, percent: 10 },
+	};
+	const theme = makeTheme();
+	const ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd: process.cwd(),
+		get model() {
+			return state.model;
+		},
+		sessionManager: {
+			getBranch: () => entries,
+			getEntries: () => entries,
+		},
+		getContextUsage: () => state.contextUsage,
+		ui: {
+			theme,
+			setFooter(factory: FooterFactory | undefined) {
+				footerFactory = factory;
+			},
+			setEditorComponent(factory: unknown) {
+				editorFactory = factory;
+			},
+			getEditorComponent() {
+				return editorFactory;
+			},
+		},
+	};
+	return {
+		ctx,
+		entries,
+		state,
+		requestRender,
+		createFooter() {
+			if (!footerFactory) throw new Error("footer was not installed");
+			return footerFactory({ requestRender }, theme, {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map<string, string>(),
+			});
+		},
+	};
+}
+
+function rendered(footer: Footer): string {
+	return footer.render(160).join("\n");
+}
+
+async function settleProjectRefresh(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("live streaming context event integration", () => {
+	it("coalesces registered updates, uses the newest cumulative total, and finalizes canonically", async () => {
+		vi.useFakeTimers();
+		const handlers = loadExtension();
+		const harness = createHarness();
+		await emit(handlers, "session_start", harness.ctx);
+		await settleProjectRefresh();
+		const footer = harness.createFooter();
+		harness.requestRender.mockClear();
+
+		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_000) });
+		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_100) });
+		vi.advanceTimersByTime(249);
+		expect(harness.requestRender).not.toHaveBeenCalled();
+		vi.advanceTimersByTime(1);
+		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+		expect(rendered(footer)).toContain("11%/10k");
+		expect(rendered(footer)).toContain("↑5 ↓6");
+		expect(rendered(footer)).toContain("$0.123");
+
+		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100) });
+		expect(rendered(footer)).toContain("11%/10k");
+		expect(rendered(footer)).toContain("↑5 ↓6");
+		expect(rendered(footer)).toContain("$0.123");
+
+		harness.state.contextUsage = { tokens: 1_200, contextWindow: 10_000, percent: 12 };
+		harness.entries.push(persistedEntry("new", 7, 8, 0.2));
+		await emit(handlers, "agent_end", harness.ctx);
+		const finalized = rendered(footer);
+		expect(finalized).toContain("12%/10k");
+		expect(finalized).toContain("↑12 ↓14");
+		expect(finalized).toContain("$0.323");
+
+		footer.dispose?.();
+		await emit(handlers, "session_shutdown", harness.ctx);
+	});
+
+	it("uses the official context window when the current model is absent and ignores zero usage", async () => {
+		vi.useFakeTimers();
+		const handlers = loadExtension();
+		const harness = createHarness({ model: undefined });
+		await emit(handlers, "session_start", harness.ctx);
+		await settleProjectRefresh();
+		const footer = harness.createFooter();
+
+		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_100) });
+		vi.advanceTimersByTime(250);
+		expect(rendered(footer)).toContain("11%/10k");
+
+		await emit(handlers, "agent_start", harness.ctx);
+		harness.requestRender.mockClear();
+		await emit(handlers, "message_update", harness.ctx, { message: assistant(0) });
+		vi.advanceTimersByTime(250);
+		expect(harness.requestRender).not.toHaveBeenCalled();
+		expect(rendered(footer)).toContain("10%/10k");
+
+		footer.dispose?.();
+		await emit(handlers, "session_shutdown", harness.ctx);
+	});
+
+	it("clears live usage at wired boundaries and recovers after null compaction", async () => {
+		vi.useFakeTimers();
+		const handlers = loadExtension();
+		const harness = createHarness();
+		await emit(handlers, "session_start", harness.ctx);
+		await settleProjectRefresh();
+		const footer = harness.createFooter();
+		const seedLive = async (tokens = 1_100) => {
+			await emit(handlers, "message_update", harness.ctx, { message: assistant(tokens) });
+			vi.advanceTimersByTime(250);
+			expect(rendered(footer)).toContain(`${Math.round(tokens / 100)}%/10k`);
+		};
+
+		await seedLive();
+		await emit(handlers, "agent_start", harness.ctx);
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		await emit(handlers, "model_select", harness.ctx);
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		await emit(handlers, "tool_execution_start", harness.ctx);
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		await emit(handlers, "session_tree", harness.ctx);
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100, "error") });
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100, "aborted") });
+		expect(rendered(footer)).toContain("10%/10k");
+
+		await seedLive();
+		harness.state.contextUsage = null;
+		await emit(handlers, "session_compact", harness.ctx);
+		expect(rendered(footer)).toContain("?/10k");
+		await seedLive(1_500);
+
+		harness.state.contextUsage = { tokens: 1_000, contextWindow: 10_000, percent: 10 };
+		await emit(handlers, "agent_start", harness.ctx);
+		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_200) });
+		harness.requestRender.mockClear();
+		await emit(handlers, "session_shutdown", harness.ctx);
+		vi.advanceTimersByTime(250);
+		expect(harness.requestRender).not.toHaveBeenCalled();
+		expect(rendered(footer)).toContain("10%/10k");
+	});
+});

--- a/test/live-context.test.ts
+++ b/test/live-context.test.ts
@@ -1,0 +1,139 @@
+import type { AssistantMessage, Usage } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	calculateLiveContextTokens,
+	LiveContextController,
+	liveContextFromMessage,
+} from "../extensions/zentui/live-context";
+import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
+
+function usage(patch: Partial<Usage> = {}): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		...patch,
+	};
+}
+
+function assistant(messageUsage: Usage, stopReason: AssistantMessage["stopReason"] = "stop") {
+	return {
+		role: "assistant" as const,
+		content: [],
+		api: "anthropic-messages" as const,
+		provider: "anthropic",
+		model: "test",
+		usage: messageUsage,
+		stopReason,
+		timestamp: 1,
+	};
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("live context usage", () => {
+	it("prefers totalTokens and otherwise includes cache components", () => {
+		expect(
+			calculateLiveContextTokens(
+				usage({ input: 400, output: 300, cacheRead: 200, cacheWrite: 100, totalTokens: 777 }),
+			),
+		).toBe(777);
+		expect(
+			calculateLiveContextTokens(
+				usage({ input: 400, output: 300, cacheRead: 200, cacheWrite: 100 }),
+			),
+		).toBe(1_000);
+	});
+
+	it("ignores zero usage, non-assistant messages, and failed assistant snapshots", () => {
+		expect(calculateLiveContextTokens(usage())).toBeUndefined();
+		expect(liveContextFromMessage({ role: "user" })).toBeUndefined();
+		expect(liveContextFromMessage(assistant(usage({ totalTokens: 100 }), "error"))).toBeUndefined();
+		expect(
+			liveContextFromMessage(assistant(usage({ totalTokens: 100 }), "aborted")),
+		).toBeUndefined();
+	});
+
+	it("keeps the newest cumulative snapshot instead of summing deltas", () => {
+		vi.useFakeTimers();
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		const render = vi.fn();
+		const controller = new LiveContextController(lifecycle, render);
+
+		controller.update(assistant(usage({ totalTokens: 1_000 })));
+		controller.update(assistant(usage({ totalTokens: 1_100 })));
+		expect(controller.get()).toEqual({ tokens: 1_100 });
+		vi.advanceTimersByTime(250);
+
+		expect(render).toHaveBeenCalledTimes(1);
+		expect(controller.get()).toEqual({ tokens: 1_100 });
+	});
+
+	it("coalesces bursts to at most one render per 250ms with the newest usage", () => {
+		vi.useFakeTimers();
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		const renderedTokens: number[] = [];
+		let controller: LiveContextController;
+		controller = new LiveContextController(lifecycle, () => {
+			renderedTokens.push(controller.get()?.tokens ?? 0);
+		});
+
+		for (const totalTokens of [100, 200, 300, 400]) {
+			controller.update(assistant(usage({ totalTokens })));
+		}
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(249);
+		expect(renderedTokens).toEqual([]);
+		vi.advanceTimersByTime(1);
+		expect(renderedTokens).toEqual([400]);
+
+		controller.update(assistant(usage({ totalTokens: 500 })));
+		vi.advanceTimersByTime(250);
+		expect(renderedTokens).toEqual([400, 500]);
+	});
+
+	it("cancels old generations without suppressing scheduling after direct lifecycle restarts", () => {
+		vi.useFakeTimers();
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		const renderedTokens: number[] = [];
+		let controller: LiveContextController;
+		controller = new LiveContextController(lifecycle, () => {
+			renderedTokens.push(controller.get()?.tokens ?? 0);
+		});
+
+		controller.update(assistant(usage({ totalTokens: 100 })));
+		lifecycle.shutdown();
+		vi.advanceTimersByTime(250);
+		expect(renderedTokens).toEqual([]);
+
+		lifecycle.start();
+		controller.update(assistant(usage({ totalTokens: 200 })));
+		vi.advanceTimersByTime(250);
+		expect(renderedTokens).toEqual([200]);
+
+		controller.update(assistant(usage({ totalTokens: 300 })));
+		lifecycle.start();
+		controller.update(assistant(usage({ totalTokens: 400 })));
+		vi.advanceTimersByTime(250);
+		expect(renderedTokens).toEqual([200, 400]);
+	});
+
+	it("recovers from a cleared compaction boundary when live usage resumes", () => {
+		const lifecycle = new SessionLifecycle();
+		lifecycle.start();
+		const controller = new LiveContextController(lifecycle, () => {});
+		controller.update(assistant(usage({ totalTokens: 100 })));
+		controller.clear();
+		expect(controller.get()).toBeUndefined();
+		controller.update(assistant(usage({ totalTokens: 150 })));
+		expect(controller.get()).toEqual({ tokens: 150 });
+	});
+});


### PR DESCRIPTION
## Summary

- refresh the context segment from cumulative assistant usage while a response streams
- coalesce streaming updates to one footer render every 250 ms
- keep token and cost totals canonical at turn boundaries
- cancel queued renders across reloads and session replacement

## Why

Pi's normal `getContextUsage()` excludes the assistant message currently being streamed, so Zentui's context gauge stayed visually stale during long responses. Pi's official `message_update` event exposes the cumulative in-progress assistant usage needed for a live estimate.

This is always enabled. No configuration field or compatibility toggle is added.

Closes #31.

## Validation

- [x] `npm run fmt`
- [x] `npm run verify` — 13 test files, 428 tests
- [x] `npm run pack:check`
- [x] `git diff --check`
- [x] Manual Pi testing with streaming assistant output and tool execution
- [x] Two independent reviews approved the implementation

## Screenshots / recording

N/A — the existing context segment now refreshes during streaming; its visual design is unchanged.

## Notes

Tool execution progress does not increase the gauge line by line. The finalized tool result enters model context after execution, matching Pi's native behavior.
