### PR TITLE
feat: add Pi session name footer segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Default config values — copy this and change any value you want:
 	},
 	"footerSegments": {
 		"cwd": true,
-		"sessionName": false,
+		"sessionName": true,
 		"gitBranch": true,
 		"gitStatus": true,
 		"gitCounts": false,
@@ -413,7 +413,7 @@ Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable
 
 ## Requirements
 
-- [Pi](https://pi.dev) coding agent 0.80 or newer
+- [Pi](https://pi.dev) coding agent 0.80.3 or newer
 - A [Nerd Font](https://www.nerdfonts.com/) for icons (or set `icons.mode` to `"ascii"`)
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Zentui brings two popular aesthetics to Pi:
 - `on  branch` — git branch with icon
 - `[!?↑]` — git status indicators (modified, untracked, ahead/behind, stashed, etc.)
 - `via  v5.5.0` — runtime detection with version and Starship-style Nerd Font runtime/language modules
-- Optional segments (off by default): `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
+- Optional segments (off by default): session name, `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
 - Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
@@ -194,6 +194,7 @@ Default config values — copy this and change any value you want:
 	},
 	"colors": {
 		"cwd": "bold cyan",
+		"sessionName": "bold green",
 		"gitBranch": "bold purple",
 		"gitStatus": "bold red",
 		"contextNormal": "bright-black",
@@ -236,6 +237,7 @@ Default config values — copy this and change any value you want:
 	},
 	"footerSegments": {
 		"cwd": true,
+		"sessionName": false,
 		"gitBranch": true,
 		"gitStatus": true,
 		"gitCounts": false,
@@ -283,7 +285,7 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `sessionName`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures context style, separator, path display mode/depth, branch length, and icon mode; set or clear custom formats with `/zentui format`.
 - `gitCommit`: Starship [`git_commit`](https://starship.rs/config/#git-commit)-style options for the `gitCommit` footer segment. `hashLength` (default `7`, clamped to `4`–`40`) controls the short-hash display length. `onlyDetached` (default `true`) shows the hash mainly on detached HEAD. `showTag` (default `true`) appends an exact-match tag (`git describe --tags --exact-match HEAD`). The tag probe piggybacks on the existing git refresh — it only runs when both the segment and `showTag` are on, and misses/failures degrade silently.
 - `gitMetrics`: Starship [`git_metrics`](https://starship.rs/config/#git-metrics)-style options for the `gitMetrics` footer segment. Uses `git diff HEAD --numstat` (staged + unstaged combined — the Starship “total dirty” view) to show aggregate `+added −deleted` line counts. `onlyNonzero` (default `true`) omits each zero component independently and hides the segment entirely at `0/0`. `ignoreSubmodules` (default `false`) adds `--ignore-submodules=all`. The numstat diff piggybacks on the existing git refresh and uses a hard 2s timeout; a metrics-only failure degrades silently without discarding fresh branch/status data. On very large monorepos the diff may lag or be omitted on timeout.
@@ -304,7 +306,7 @@ A second `$fill` creates a **centered middle zone** — content between the two 
 
 ```json
 {
-	"footerFormat": "$os $username $cwd( on $git_branch)( $git_status)( via $runtime)$fill($context)($sep$tokens)($sep$cost)($sep$time)"
+	"footerFormat": "$os $username $cwd($sep$session_name)( on $git_branch)( $git_status)( via $runtime)$fill($context)($sep$tokens)($sep$cost)($sep$time)"
 }
 ```
 
@@ -321,6 +323,7 @@ Center the branch between directory and cost:
 | Token               | Aliases      | Renders                                                             |
 | ------------------- | ------------ | ------------------------------------------------------------------- |
 | `$cwd`              | `$directory` | current directory                                                   |
+| `$session_name`     |              | current Pi session name                                             |
 | `$git_branch`       | `$branch`    | git branch with icon                                                |
 | `$git_status`       | `$status`    | `[!?↑]` status block                                                |
 | `$git_state`        | `$state`     | `REBASING` / `MERGING` / … (optional `n/m`)                         |
@@ -354,6 +357,7 @@ Center the branch between directory and cost:
 - Literal text (`on branch`, `using`, `\|`, spaces) is rendered verbatim — you control all spacing.
 - Each variable renders its core value only (no `on`/`via` prefixes); add those words as literal text.
 - Conditional groups: wrap optional pieces in parentheses, e.g. `$cwd( on $git_branch)($git_status)$fill($context)`. If every `$var` inside a group is empty, the whole group (including its literals) is dropped.
+- `$session_name` is available whenever `footerFormat` is set, independently of `footerSegments.sessionName`; use a conditional group such as `($sep$session_name)` so unnamed sessions leave no separator.
 - Unknown `$variables` render empty.
 - Set or clear at runtime: `/zentui format "<template>"` and `/zentui format clear`.
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -264,7 +264,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	},
 	footerSegments: {
 		cwd: true,
-		sessionName: false,
+		sessionName: true,
 		gitBranch: true,
 		gitStatus: true,
 		gitCounts: false,

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -66,6 +66,7 @@ export type UiFeaturesConfig = {
 
 export type FooterSegmentsConfig = {
 	cwd: boolean;
+	sessionName: boolean;
 	gitBranch: boolean;
 	gitStatus: boolean;
 	gitCounts: boolean;
@@ -132,6 +133,7 @@ export type PolishedTuiConfig = {
 	icons: ResolvedIcons;
 	colors: {
 		cwd: ColorSpec;
+		sessionName: ColorSpec;
 		gitBranch: ColorSpec;
 		gitStatus: ColorSpec;
 		contextNormal: ColorSpec;
@@ -177,6 +179,7 @@ export type PolishedTuiConfig = {
  */
 export const FOOTER_FORMAT_VARIABLES = [
 	"cwd",
+	"session_name",
 	"git_branch",
 	"git_status",
 	"git_state",
@@ -229,6 +232,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	},
 	colors: {
 		cwd: "bold cyan",
+		sessionName: "bold green",
 		gitBranch: "bold purple",
 		gitStatus: "bold red",
 		contextNormal: "bright-black",
@@ -260,6 +264,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	},
 	footerSegments: {
 		cwd: true,
+		sessionName: false,
 		gitBranch: true,
 		gitStatus: true,
 		gitCounts: false,
@@ -431,6 +436,7 @@ function normalizeIconOverrides(record: Record<string, unknown>): Partial<IconGl
 function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiConfig["colors"]> {
 	return definedColors({
 		cwd: colorValue(record, "cwd") ?? colorValue(record, "cwdText"),
+		sessionName: colorValue(record, "sessionName"),
 		gitBranch: colorValue(record, "gitBranch") ?? colorValue(record, "git"),
 		gitStatus: colorValue(record, "gitStatus"),
 		contextNormal: colorValue(record, "contextNormal"),
@@ -482,6 +488,7 @@ function normalizeUiFeatures(record: Record<string, unknown>): UiFeaturesConfig 
 function normalizeFooterSegments(record: Record<string, unknown>): FooterSegmentsConfig {
 	return {
 		cwd: footerSegmentValue(record, "cwd"),
+		sessionName: footerSegmentValue(record, "sessionName"),
 		gitBranch: footerSegmentValue(record, "gitBranch"),
 		gitStatus: footerSegmentValue(record, "gitStatus"),
 		gitCounts: footerSegmentValue(record, "gitCounts"),
@@ -593,6 +600,7 @@ function isUiFeatureKey(value: string): value is keyof UiFeaturesConfig {
 function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig {
 	return (
 		value === "cwd" ||
+		value === "sessionName" ||
 		value === "gitBranch" ||
 		value === "gitStatus" ||
 		value === "gitCounts" ||

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -195,6 +195,10 @@ export function installFooter(
 						depth: config.pathDisplay.depth,
 					}),
 				);
+				const sessionName = ctx.sessionManager.getSessionName() ?? "";
+				const sessionNameLabel = sessionName
+					? renderStyleForSource(theme, colorSource, config.colors.sessionName, sessionName)
+					: "";
 				const branch = state.branch;
 				const branchText = branch
 					? formatGitBranchText(branch, config.gitBranch.maxLength)
@@ -263,6 +267,8 @@ export function installFooter(
 					switch (canonical) {
 						case "cwd":
 							return cwdLabel;
+						case "session_name":
+							return sessionNameLabel;
 						case "git_branch":
 							return branchText
 								? gitIcon
@@ -491,6 +497,7 @@ export function installFooter(
 					osSegment,
 					usernameSegment,
 					config.footerSegments.cwd ? cwdLabel : "",
+					config.footerSegments.sessionName ? sessionNameLabel : "",
 					branchLabel,
 					gitCommitLabel,
 					gitMetricsLabel,

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -2,7 +2,11 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig, SeparatorStyle } from "./config";
 import { FOOTER_FORMAT_ALIASES } from "./config";
-import { collectExtensionStatusSegments, type ExtensionStatusSegment } from "./extension-status";
+import {
+	collectExtensionStatusSegments,
+	type ExtensionStatusSegment,
+	sanitizeExtensionStatusText,
+} from "./extension-status";
 import { parseFooterFormat, renderFormatSplit, stripOrphanSeparators } from "./footer-format";
 import {
 	buildContextDisplayLabel,
@@ -195,10 +199,16 @@ export function installFooter(
 						depth: config.pathDisplay.depth,
 					}),
 				);
-				const sessionName = ctx.sessionManager.getSessionName() ?? "";
+				const needsSessionName = config.footerFormat
+					? /(?:\$session_name\b|\$\{session_name\})/.test(config.footerFormat)
+					: config.footerSegments.sessionName;
+				const sessionName = needsSessionName
+					? sanitizeExtensionStatusText(ctx.sessionManager.getSessionName() ?? "")
+					: "";
 				const sessionNameLabel = sessionName
 					? renderStyleForSource(theme, colorSource, config.colors.sessionName, sessionName)
 					: "";
+				const builtInSessionNameLabel = sessionNameLabel ? `in ${sessionNameLabel}` : "";
 				const branch = state.branch;
 				const branchText = branch
 					? formatGitBranchText(branch, config.gitBranch.maxLength)
@@ -497,7 +507,7 @@ export function installFooter(
 					osSegment,
 					usernameSegment,
 					config.footerSegments.cwd ? cwdLabel : "",
-					config.footerSegments.sessionName ? sessionNameLabel : "",
+					config.footerSegments.sessionName ? builtInSessionNameLabel : "",
 					branchLabel,
 					gitCommitLabel,
 					gitMetricsLabel,

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -536,6 +536,7 @@ export default function (pi: ExtensionAPI) {
 		syncInteractiveState(event, ctx);
 	});
 	pi.on("thinking_level_select", syncInteractiveState);
+	pi.on("session_info_changed", syncInteractiveState);
 	pi.on("message_update", (event) => {
 		liveContext.update(event.message);
 	});

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -124,6 +124,7 @@ const featureSettingDescriptions: Record<FeatureSettingId, string> = {
 
 const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	cwd: "Current directory",
+	sessionName: "Session name",
 	gitBranch: "Git branch",
 	gitStatus: "Git status",
 	gitCounts: "Git counts",
@@ -142,6 +143,7 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 
 const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
 	cwd: "Show or hide the current working directory segment on the left.",
+	sessionName: "Show or hide the current Pi session name on the left, after the current directory.",
 	gitBranch: "Show or hide the git branch name on the left.",
 	gitStatus: "Show or hide git status icons and ahead/behind markers.",
 	gitCounts:
@@ -207,6 +209,7 @@ function isFeatureSettingId(value: string): value is FeatureSettingId {
 function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingId {
 	return (
 		value === "cwd" ||
+		value === "sessionName" ||
 		value === "gitBranch" ||
 		value === "gitStatus" ||
 		value === "gitCounts" ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
 				"vitest": "^4.1.8"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-ai": ">=0.80",
-				"@earendil-works/pi-coding-agent": ">=0.80",
-				"@earendil-works/pi-tui": ">=0.80"
+				"@earendil-works/pi-ai": ">=0.80.3",
+				"@earendil-works/pi-coding-agent": ">=0.80.3",
+				"@earendil-works/pi-tui": ">=0.80.3"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
 		"prepublishOnly": "npm run verify && npm run pack:check"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-ai": ">=0.80",
-		"@earendil-works/pi-coding-agent": ">=0.80",
-		"@earendil-works/pi-tui": ">=0.80"
+		"@earendil-works/pi-ai": ">=0.80.3",
+		"@earendil-works/pi-coding-agent": ">=0.80.3",
+		"@earendil-works/pi-tui": ">=0.80.3"
 	},
 	"pi": {
 		"extensions": [

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -74,7 +74,7 @@ describe("mergeConfig", () => {
 		});
 		expect(config.footerSegments).toEqual({
 			cwd: true,
-			sessionName: false,
+			sessionName: true,
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
@@ -661,7 +661,7 @@ describe("mergeConfig", () => {
 	it("accepts valid footer segment preferences and ignores invalid values", () => {
 		expect(mergeConfig({ footerSegments: { cwd: false, tokens: false } }).footerSegments).toEqual({
 			cwd: false,
-			sessionName: false,
+			sessionName: true,
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
@@ -682,7 +682,7 @@ describe("mergeConfig", () => {
 				.footerSegments,
 		).toEqual({
 			cwd: true,
-			sessionName: false,
+			sessionName: true,
 			gitBranch: false,
 			gitStatus: false,
 			runtime: true,
@@ -702,14 +702,14 @@ describe("mergeConfig", () => {
 
 	it("normalizes session-name preferences", () => {
 		expect(mergeConfig({ colors: { sessionName: "success" } }).colors.sessionName).toBe("success");
-		expect(mergeConfig({ footerSegments: { sessionName: true } }).footerSegments.sessionName).toBe(
-			true,
+		expect(mergeConfig({ footerSegments: { sessionName: false } }).footerSegments.sessionName).toBe(
+			false,
 		);
 		expect(mergeConfig({ colors: { sessionName: "not-a-color" } }).colors.sessionName).toBe(
 			"bold green",
 		);
 		expect(mergeConfig({ footerSegments: { sessionName: "on" } }).footerSegments.sessionName).toBe(
-			false,
+			true,
 		);
 	});
 
@@ -896,7 +896,7 @@ describe("mergeConfig", () => {
 
 			expect(config.footerSegments).toEqual({
 				cwd: true,
-				sessionName: false,
+				sessionName: true,
 				gitBranch: true,
 				gitStatus: true,
 				runtime: true,
@@ -933,7 +933,7 @@ describe("mergeConfig", () => {
 
 			expect(config.footerSegments).toEqual({
 				cwd: true,
-				sessionName: false,
+				sessionName: true,
 				gitBranch: true,
 				gitStatus: true,
 				runtime: false,

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,6 +55,7 @@ describe("mergeConfig", () => {
 		expect(config.colors.gitCommit).toBe("bold green");
 		expect(config.colors.gitMetricsAdded).toBe("bold green");
 		expect(config.colors.gitMetricsDeleted).toBe("bold red");
+		expect(config.colors.sessionName).toBe("bold green");
 		expect(config.colors.contextNormal).toBe("bright-black");
 		expect(config.colors.tokens).toBe("bright-black");
 		expect(config.colors.extensionStatus).toBe("bright-black");
@@ -73,6 +74,7 @@ describe("mergeConfig", () => {
 		});
 		expect(config.footerSegments).toEqual({
 			cwd: true,
+			sessionName: false,
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
@@ -659,6 +661,7 @@ describe("mergeConfig", () => {
 	it("accepts valid footer segment preferences and ignores invalid values", () => {
 		expect(mergeConfig({ footerSegments: { cwd: false, tokens: false } }).footerSegments).toEqual({
 			cwd: false,
+			sessionName: false,
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
@@ -679,6 +682,7 @@ describe("mergeConfig", () => {
 				.footerSegments,
 		).toEqual({
 			cwd: true,
+			sessionName: false,
 			gitBranch: false,
 			gitStatus: false,
 			runtime: true,
@@ -694,6 +698,19 @@ describe("mergeConfig", () => {
 			tokens: true,
 			cost: true,
 		});
+	});
+
+	it("normalizes session-name preferences", () => {
+		expect(mergeConfig({ colors: { sessionName: "success" } }).colors.sessionName).toBe("success");
+		expect(mergeConfig({ footerSegments: { sessionName: true } }).footerSegments.sessionName).toBe(
+			true,
+		);
+		expect(mergeConfig({ colors: { sessionName: "not-a-color" } }).colors.sessionName).toBe(
+			"bold green",
+		);
+		expect(mergeConfig({ footerSegments: { sessionName: "on" } }).footerSegments.sessionName).toBe(
+			false,
+		);
 	});
 
 	it("saves color source patches without erasing unknown user config", () => {
@@ -879,6 +896,7 @@ describe("mergeConfig", () => {
 
 			expect(config.footerSegments).toEqual({
 				cwd: true,
+				sessionName: false,
 				gitBranch: true,
 				gitStatus: true,
 				runtime: true,
@@ -915,6 +933,7 @@ describe("mergeConfig", () => {
 
 			expect(config.footerSegments).toEqual({
 				cwd: true,
+				sessionName: false,
 				gitBranch: true,
 				gitStatus: true,
 				runtime: false,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -3290,25 +3290,31 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("middle");
 		expect(rendered).not.toContain("inactive");
 	});
-	function renderSessionNameFooter({
-		name,
-		width,
-		theme = makeTheme(),
-		footerFormat = "",
-		segmentEnabled = true,
-		sessionNameColor = "success",
-	}: {
-		name: string | undefined;
-		width: number;
+	type SessionNameFooterOptions = {
+		name?: string;
+		getSessionName?: () => string | undefined;
 		theme?: Theme;
 		footerFormat?: string;
 		segmentEnabled?: boolean;
 		sessionNameColor?: string;
-	}): string[] {
+		branch?: string;
+		branchEnabled?: boolean;
+	};
+
+	function createSessionNameFooter({
+		name,
+		getSessionName = () => name,
+		theme = makeTheme(),
+		footerFormat = "",
+		segmentEnabled = true,
+		sessionNameColor = "success",
+		branch,
+		branchEnabled = false,
+	}: SessionNameFooterOptions) {
 		let footerFactory: FooterFactory | undefined;
 		const ctx = makeContext({
 			cwd: "/tmp/project",
-			sessionManager: { getBranch: () => [], getSessionName: () => name },
+			sessionManager: { getBranch: () => [], getSessionName },
 			ui: {
 				theme,
 				setFooter(factory: FooterFactory | undefined) {
@@ -3325,7 +3331,7 @@ describe("Pi docs compliance", () => {
 				...defaultConfig.footerSegments,
 				cwd: true,
 				sessionName: segmentEnabled,
-				gitBranch: false,
+				gitBranch: branchEnabled,
 				gitStatus: false,
 				runtime: false,
 				context: false,
@@ -3333,25 +3339,36 @@ describe("Pi docs compliance", () => {
 				cost: false,
 			},
 		};
-		installFooter(ctx as never, createInitialState(emptyGitStatus()), () => config, {
+		installFooter(ctx as never, createInitialState({ ...emptyGitStatus(), branch }), () => config, {
 			setRequestRender() {},
 			scheduleProjectRefresh() {},
 		});
-		const footer = footerFactory?.({ requestRender() {} }, theme, {
+		return footerFactory?.({ requestRender() {} }, theme, {
 			onBranchChange: () => () => {},
 			getExtensionStatuses: () => new Map<string, string>(),
 		});
-		return footer?.render(width) ?? [];
 	}
 
-	it("renders the opt-in session name immediately after cwd with its dedicated color", () => {
+	function renderSessionNameFooter({
+		width,
+		...options
+	}: SessionNameFooterOptions & { width: number }): string[] {
+		return createSessionNameFooter(options)?.render(width) ?? [];
+	}
+
+	it("renders the default session name as 'in <name>' between cwd and branch", () => {
 		const rendered = renderSessionNameFooter({
 			name: "release prep",
-			width: 120,
+			width: 500,
 			theme: makeTaggedTheme(),
+			branch: "feat/session-name-footer",
+			branchEnabled: true,
 		}).join("\n");
+		expect(rendered).toContain("project in [success]release prep on");
 		expect(rendered.indexOf("project")).toBeLessThan(rendered.indexOf("release prep"));
-		expect(rendered).toContain("[success]release prep");
+		expect(rendered.indexOf("release prep")).toBeLessThan(
+			rendered.indexOf("feat/session-name-footer"),
+		);
 	});
 
 	it("omits absent names and keeps Unicode names within narrow footer widths", () => {
@@ -3362,11 +3379,60 @@ describe("Pi docs compliance", () => {
 		}).join("\n");
 		expect(absent).not.toContain("undefined");
 		expect(absent).not.toContain("[success]");
+		expect(absent).not.toContain(" in ");
 		const lines = renderSessionNameFooter({ name: "研究 🚀 ".repeat(20), width: 18 });
 		expect(lines.every((line) => visibleWidth(line) <= 18)).toBe(true);
 	});
 
-	it("renders $session_name in footerFormat when the built-in segment is disabled", () => {
+	it("sanitizes terminal controls while preserving ordinary Unicode session names", () => {
+		const rendered = renderSessionNameFooter({
+			name: "\x1b[31mrelease\x1b[0m\tprep\x07\x1b]0;owned\x07研究 🚀",
+			width: 120,
+			theme: makeTaggedTheme(),
+		}).join("\n");
+		expect(rendered).toContain("release prep研究 🚀");
+		expect(rendered).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+		expect(rendered).not.toContain("owned");
+
+		const controlsOnly = renderSessionNameFooter({
+			name: "\x1b[2J\x1b]0;owned\x07\t\x07",
+			width: 120,
+			theme: makeTaggedTheme(),
+		}).join("\n");
+		expect(controlsOnly).not.toContain("[success]");
+		expect(controlsOnly).not.toContain("owned");
+		expect(controlsOnly).not.toContain(" in ");
+	});
+
+	it("respects an explicit disabled setting and skips unused session-name lookups", () => {
+		const getSessionName = vi.fn(() => "hidden");
+		const disabled = renderSessionNameFooter({
+			getSessionName,
+			width: 120,
+			segmentEnabled: false,
+		}).join("\n");
+		expect(disabled).not.toContain("hidden");
+		expect(disabled).not.toContain(" in ");
+		expect(getSessionName).not.toHaveBeenCalled();
+
+		renderSessionNameFooter({
+			getSessionName,
+			width: 120,
+			footerFormat: "$cwd",
+			segmentEnabled: true,
+		});
+		expect(getSessionName).not.toHaveBeenCalled();
+
+		renderSessionNameFooter({
+			getSessionName,
+			width: 120,
+			footerFormat: "${" + "session_name}",
+			segmentEnabled: false,
+		});
+		expect(getSessionName).toHaveBeenCalledOnce();
+	});
+
+	it("renders raw session-name tokens in custom formats without the built-in prefix", () => {
 		const named = renderSessionNameFooter({
 			name: "release prep",
 			width: 120,
@@ -3374,6 +3440,15 @@ describe("Pi docs compliance", () => {
 			segmentEnabled: false,
 		}).join("\n");
 		expect(named).toContain("release prep");
+		expect(named).not.toContain("in release prep");
+		const braced = renderSessionNameFooter({
+			name: "release prep",
+			width: 120,
+			footerFormat: "$cwd ${" + "session_name}",
+			segmentEnabled: false,
+		}).join("\n");
+		expect(braced).toContain("project release prep");
+		expect(braced).not.toContain("in release prep");
 		const unnamed = renderSessionNameFooter({
 			name: undefined,
 			width: 120,
@@ -3382,6 +3457,17 @@ describe("Pi docs compliance", () => {
 		}).join("\n");
 		expect(unnamed).toContain("project");
 		expect(unnamed).not.toContain(" | ");
+	});
+
+	it("reads an updated session name on the next footer render", () => {
+		let sessionName = "draft";
+		const footer = createSessionNameFooter({ getSessionName: () => sessionName });
+		expect(footer?.render(120).join("\n")).toContain("draft");
+
+		sessionName = "release prep";
+		const renamed = footer?.render(120).join("\n") ?? "";
+		expect(renamed).toContain("release prep");
+		expect(renamed).not.toContain("draft");
 	});
 
 	it("requests one footer render on session_info_changed", async () => {
@@ -3412,7 +3498,7 @@ describe("Pi docs compliance", () => {
 		);
 		const handler = handlers.get("session_info_changed")?.[0];
 		const before = renderRequests;
-		expect(handler?.({}, ctx)).toBeUndefined();
+		expect(handler?.({ type: "session_info_changed", name: "release prep" }, ctx)).toBeUndefined();
 		expect(renderRequests).toBe(before + 1);
 		await emit(handlers, "session_shutdown", ctx);
 	});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -254,7 +254,7 @@ function makeContext(overrides: Record<string, unknown> = {}) {
 		mode: "tui",
 		cwd: process.cwd(),
 		model: { id: "claude-sonnet", provider: "anthropic", contextWindow: 200_000 },
-		sessionManager: { getBranch: () => [] },
+		sessionManager: { getBranch: () => [], getSessionName: () => undefined },
 		getContextUsage: () => ({ tokens: 1000, contextWindow: 200_000, percent: 0.5 }),
 		ui: overrideUi ? { ...ui, ...overrideUi } : ui,
 		...overrides,
@@ -3289,5 +3289,131 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("active");
 		expect(rendered).toContain("middle");
 		expect(rendered).not.toContain("inactive");
+	});
+	function renderSessionNameFooter({
+		name,
+		width,
+		theme = makeTheme(),
+		footerFormat = "",
+		segmentEnabled = true,
+		sessionNameColor = "success",
+	}: {
+		name: string | undefined;
+		width: number;
+		theme?: Theme;
+		footerFormat?: string;
+		segmentEnabled?: boolean;
+		sessionNameColor?: string;
+	}): string[] {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			sessionManager: { getBranch: () => [], getSessionName: () => name },
+			ui: {
+				theme,
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const config: PolishedTuiConfig = {
+			...defaultConfig,
+			footerFormat,
+			colors: { ...defaultConfig.colors, sessionName: sessionNameColor },
+			footerSegments: {
+				...defaultConfig.footerSegments,
+				cwd: true,
+				sessionName: segmentEnabled,
+				gitBranch: false,
+				gitStatus: false,
+				runtime: false,
+				context: false,
+				tokens: false,
+				cost: false,
+			},
+		};
+		installFooter(ctx as never, createInitialState(emptyGitStatus()), () => config, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const footer = footerFactory?.({ requestRender() {} }, theme, {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+		return footer?.render(width) ?? [];
+	}
+
+	it("renders the opt-in session name immediately after cwd with its dedicated color", () => {
+		const rendered = renderSessionNameFooter({
+			name: "release prep",
+			width: 120,
+			theme: makeTaggedTheme(),
+		}).join("\n");
+		expect(rendered.indexOf("project")).toBeLessThan(rendered.indexOf("release prep"));
+		expect(rendered).toContain("[success]release prep");
+	});
+
+	it("omits absent names and keeps Unicode names within narrow footer widths", () => {
+		const absent = renderSessionNameFooter({
+			name: undefined,
+			width: 120,
+			theme: makeTaggedTheme(),
+		}).join("\n");
+		expect(absent).not.toContain("undefined");
+		expect(absent).not.toContain("[success]");
+		const lines = renderSessionNameFooter({ name: "研究 🚀 ".repeat(20), width: 18 });
+		expect(lines.every((line) => visibleWidth(line) <= 18)).toBe(true);
+	});
+
+	it("renders $session_name in footerFormat when the built-in segment is disabled", () => {
+		const named = renderSessionNameFooter({
+			name: "release prep",
+			width: 120,
+			footerFormat: "$cwd($sep$session_name)",
+			segmentEnabled: false,
+		}).join("\n");
+		expect(named).toContain("release prep");
+		const unnamed = renderSessionNameFooter({
+			name: undefined,
+			width: 120,
+			footerFormat: "$cwd$sep$session_name",
+			segmentEnabled: false,
+		}).join("\n");
+		expect(unnamed).toContain("project");
+		expect(unnamed).not.toContain(" | ");
+	});
+
+	it("requests one footer render on session_info_changed", async () => {
+		const handlers = loadExtension();
+		let footerFactory: FooterFactory | undefined;
+		let renderRequests = 0;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		await emit(handlers, "session_start", ctx);
+		footerFactory?.(
+			{
+				requestRender() {
+					renderRequests += 1;
+				},
+			},
+			makeTheme(),
+			{
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			},
+		);
+		const handler = handlers.get("session_info_changed")?.[0];
+		const before = renderRequests;
+		expect(handler?.({}, ctx)).toBeUndefined();
+		expect(renderRequests).toBe(before + 1);
+		await emit(handlers, "session_shutdown", ctx);
 	});
 });

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -93,6 +93,7 @@ describe("renderFormatSplit", () => {
 	const renderVar = (name: string): string => {
 		const map: Record<string, string> = {
 			cwd: "DIR",
+			session_name: "Session name",
 			git_branch: "BRANCH",
 			cost: "$0",
 			time: "12:00",
@@ -131,6 +132,16 @@ describe("renderFormatSplit", () => {
 		expect(left).toBe("DIR");
 		expect(middle).toBe("$0");
 		expect(right).toBe("12:00");
+	});
+
+	it("renders session-name variables in plain and braced forms", () => {
+		expect(renderFormatSplit(parseFooterFormat("$session_name"), renderVar).left).toBe(
+			"Session name",
+		);
+		const bracedSessionName = "${" + "session_name}";
+		expect(renderFormatSplit(parseFooterFormat(bracedSessionName), renderVar).left).toBe(
+			"Session name",
+		);
 	});
 
 	it("renders unknown variables as empty string", () => {
@@ -233,6 +244,11 @@ describe("conditional groups", () => {
 		const tokens = parseFooterFormat("($git_status)$cwd");
 		expect(renderFormatSplit(tokens, renderVar).left).toBe("[!]DIR");
 	});
+	it("drops a conditional session-name group when the name is empty", () => {
+		const noSessionName = (name: string) => (name === "sep" ? " | " : "");
+		const raw = renderFormatSplit(parseFooterFormat("($sep$session_name)"), noSessionName).left;
+		expect(stripOrphanSeparators(raw)).toBe("");
+	});
 });
 
 describe("joinNonEmpty", () => {
@@ -284,8 +300,9 @@ describe("stripOrphanSeparators", () => {
 			};
 			return map[name] ?? "";
 		};
-		// Empty content vars drop their groups even when $sep is present.
 		const tokens = parseFooterFormat("($context)($sep$tokens)($sep$cost)");
+
+		// Empty content vars drop their groups even when $sep is present.
 		const raw = renderFormatSplit(tokens, renderVar).left;
 		expect(raw).toBe(" | $0");
 		expect(stripOrphanSeparators(raw)).toBe("$0");

--- a/test/live-context-integration.test.ts
+++ b/test/live-context-integration.test.ts
@@ -150,6 +150,7 @@ function createHarness(
 		sessionManager: {
 			getBranch: () => entries,
 			getEntries: () => entries,
+			getSessionName: () => undefined,
 		},
 		getContextUsage: () => state.contextUsage,
 		ui: {


### PR DESCRIPTION
## Summary
- Add an opt-in session-name segment immediately after the current directory.
- Add configurable session-name color and the `$session_name` custom footer-format token.
- Refresh the footer when Pi session information changes.
- Update configuration documentation and coverage tests.

## Compatibility warning
This change raises the minimum peer dependency versions from `>=0.80` to `>=0.80.3`. Users on Pi version 0.80 through 0.80.2 will need to upgrade Pi before installing or using this release. The newer minimum is required for the session name APIs and session information update event.

## Screenshots / recordings
N/A — no recording available; the change is covered by rendering and integration tests.

## Testing
- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev` (confirmed by author)
- [x] Added or updated tests where practical

## Checklist
- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Updated `README.md` and configuration docs.
- [x] Kept the diff surgical.
- [x] Kept `extensions/zentui/index.ts` orchestration-only.
- [x] Used a conventional commit-style PR title.
