### PR TITLE
feat: add modelLabel option to show model name in editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Default config values — copy this and change any value you want:
 	"footerFormat": "",
 	"separator": "pipe",
 	"contextStyle": "text",
+	"modelLabel": "id",
 	"contextThresholds": {
 		"warning": 70,
 		"error": 90
@@ -278,6 +279,7 @@ Default config values — copy this and change any value you want:
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
+- `modelLabel`: controls the model shown in the editor frame. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Layout** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
 - `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
 - `pathDisplay`: controls how the cwd/`$cwd` path is shown. `mode` is `basename` (default, last segment only) or `full` (path with home contracted to `~`). In `full` mode, `depth` keeps only the last N trailing directories (`0` = entire path after `~`, max `5`); when parents are dropped the path is prefixed with `…/` (Starship-style). The `/zentui` **Layout** tab cycles path mode and path depth (`0`–`5`; depth is ignored for basename). Example: `~/Projects/foo/bar` with `depth: 2` → `…/foo/bar`.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -32,6 +32,7 @@ export type { IconMode } from "./icons";
 
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
+export type ModelLabelSource = "id" | "name";
 
 export type ContextThresholds = {
 	warning: number;
@@ -127,6 +128,7 @@ export type PolishedTuiConfig = {
 	footerFormat: string;
 	separator: SeparatorStyle;
 	contextStyle: ContextStyle;
+	modelLabel: ModelLabelSource;
 	contextThresholds: ContextThresholds;
 	pathDisplay: PathDisplayConfig;
 	gitBranch: GitBranchConfig;
@@ -223,6 +225,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	footerFormat: "",
 	separator: "pipe",
 	contextStyle: "text",
+	modelLabel: "id",
 	contextThresholds: { warning: 70, error: 90 },
 	pathDisplay: { mode: "basename", depth: 0 },
 	gitBranch: { maxLength: "full" },
@@ -325,6 +328,11 @@ function clampPercent(value: number): number {
 function parseContextStyle(value: unknown): ContextStyle {
 	if (value === "text" || value === "gauge" || value === "text+gauge") return value;
 	return defaultConfig.contextStyle;
+}
+
+function parseModelLabel(value: unknown): ModelLabelSource {
+	if (value === "id" || value === "name") return value;
+	return defaultConfig.modelLabel;
 }
 
 export function isSeparatorStyle(value: unknown): value is SeparatorStyle {
@@ -766,6 +774,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		footerFormat: stringValue(config, "footerFormat") ?? "",
 		separator: parseSeparatorStyle(config.separator),
 		contextStyle: parseContextStyle(config.contextStyle),
+		modelLabel: parseModelLabel(config.modelLabel),
 		contextThresholds: parseContextThresholds(config.contextThresholds),
 		pathDisplay: parsePathDisplay(config.pathDisplay),
 		gitBranch,

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -120,7 +120,7 @@ export default function (pi: ExtensionAPI) {
 	const getThinkingLevel = () =>
 		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
-		syncState(state, ctx, currentConfig.icons.cacheHit);
+		syncState(state, ctx, currentConfig.icons.cacheHit, currentConfig.modelLabel);
 
 	type ProjectRefreshTarget = { cwd: string; generation: number };
 	const refreshProjectState = async ({ cwd, generation }: ProjectRefreshTarget) => {

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -1,4 +1,5 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ModelLabelSource } from "./config";
 import {
 	buildContextLabel,
 	buildCostLabel,
@@ -35,9 +36,15 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 	};
 }
 
-export function syncState(state: FooterState, ctx: ExtensionContext, cacheHitIcon: string): void {
+export function syncState(
+	state: FooterState,
+	ctx: ExtensionContext,
+	cacheHitIcon: string,
+	modelLabelSource: ModelLabelSource,
+): void {
 	const totals = getUsageTotals(ctx);
-	state.modelLabel = ctx.model?.id ?? "no-model";
+	const m = ctx.model;
+	state.modelLabel = (modelLabelSource === "name" ? m?.name || m?.id : m?.id) ?? "no-model";
 	state.providerLabel = formatProviderLabel(ctx.model?.provider);
 	state.contextLabel = buildContextLabel(ctx);
 	state.tokenLabel = buildTokenLabel(totals, cacheHitIcon);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -360,6 +360,13 @@ describe("mergeConfig", () => {
 		).toEqual({ warning: 70, error: 90 });
 	});
 
+	it("defaults modelLabel to id and accepts valid overrides", () => {
+		expect(mergeConfig({}).modelLabel).toBe("id");
+		expect(mergeConfig({ modelLabel: "name" }).modelLabel).toBe("name");
+		expect(mergeConfig({ modelLabel: "id" }).modelLabel).toBe("id");
+		expect(mergeConfig({ modelLabel: "title" }).modelLabel).toBe("id");
+	});
+
 	it("defaults pathDisplay and accepts mode/depth overrides", () => {
 		expect(mergeConfig({}).pathDisplay).toEqual({ mode: "basename", depth: 0 });
 		expect(mergeConfig({ pathDisplay: { mode: "full" } }).pathDisplay).toEqual({

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { emptyGitStatus } from "../extensions/zentui/git";
+import { createInitialState, syncState } from "../extensions/zentui/state";
+
+function makeCtx(model: unknown) {
+	return {
+		model,
+		sessionManager: { getBranch: () => [] },
+		getContextUsage: () => undefined,
+	} as never;
+}
+
+const model = { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" };
+
+describe("syncState modelLabel", () => {
+	it("shows the model id when modelLabel is 'id'", () => {
+		const state = createInitialState(emptyGitStatus());
+		syncState(state, makeCtx(model), "", "id");
+		expect(state.modelLabel).toBe("gpt-5.6-terra");
+	});
+
+	it("shows the model name when modelLabel is 'name'", () => {
+		const state = createInitialState(emptyGitStatus());
+		syncState(state, makeCtx(model), "", "name");
+		expect(state.modelLabel).toBe("GPT-5.6 Terra");
+	});
+
+	it("falls back to the id when the name is empty", () => {
+		const state = createInitialState(emptyGitStatus());
+		syncState(state, makeCtx({ ...model, name: "" }), "", "name");
+		expect(state.modelLabel).toBe("gpt-5.6-terra");
+	});
+
+	it("shows no-model when there is no active model", () => {
+		const state = createInitialState(emptyGitStatus());
+		syncState(state, makeCtx(undefined), "", "name");
+		expect(state.modelLabel).toBe("no-model");
+	});
+});


### PR DESCRIPTION
## Summary
Add a `modelLabel` config option that controls what the editor frame shows for
the active model: `id` (default, current behavior) or `name` (the model's
display name, e.g. custom `name` values from `models.json`, falling back to the
id when unset). Opt-in and fully backward compatible.

## Screenshots / recordings
Editor frame model segment, same model on Volcengine:

| `modelLabel` | shows |
| ------------ | ------------ |
| `id` (default) | `kimi-k2.6` |
| `name` | `Kimi K2.6` |

**before**
<img width="1278" height="135" alt="image" src="https://github.com/user-attachments/assets/3705cfd0-9361-4c92-a9eb-470b839c6975" />

**after**
<img width="1275" height="114" alt="image" src="https://github.com/user-attachments/assets/d8468811-7cb3-4a91-ae9b-a8f1d9a6e979" />

## Testing
- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test (editor frame, `id` vs `name`)
- [x] Added tests (config parse + `syncState` behavior)

## Checklist
- [x] Preserved Nerd Font / private-use icon glyphs (no icon changes)
- [x] Updated `README.md` config docs
- [x] Kept the diff surgical
- [x] `index.ts` stays orchestration; logic lives in `state.ts` / `config.ts`
- [x] Conventional commit-style PR title
