### PR TITLE
feat: add configurable editor metadata format

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Default config values — copy this and change any value you want:
 {
 	"projectRefreshIntervalMs": 30000,
 	"footerFormat": "",
+	"editorMetadataFormat": "$model  $provider(  $thinking)",
 	"separator": "pipe",
 	"contextStyle": "text",
 	"editorModelLabel": "id",
@@ -280,6 +281,7 @@ Default config values — copy this and change any value you want:
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
 - `editorModelLabel`: controls the model shown in the editor frame. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
+- `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Layout** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
 - `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
 - `pathDisplay`: controls how the cwd/`$cwd` path is shown. `mode` is `basename` (default, last segment only) or `full` (path with home contracted to `~`). In `full` mode, `depth` keeps only the last N trailing directories (`0` = entire path after `~`, max `5`); when parents are dropped the path is prefixed with `…/` (Starship-style). The `/zentui` **Layout** tab cycles path mode and path depth (`0`–`5`; depth is ignored for basename). Example: `~/Projects/foo/bar` with `depth: 2` → `…/foo/bar`.
@@ -299,6 +301,31 @@ Default config values — copy this and change any value you want:
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
+
+## Editor Metadata Format
+
+Set `editorMetadataFormat` in `~/.pi/agent/zentui.json` to customize the left side of the editor metadata row:
+
+```json
+{
+	"editorMetadataFormat": "$model_name ($model_id)( · $provider)( · $thinking)( · $session_name)"
+}
+```
+
+The syntax follows the relevant `footerFormat` conventions: `$variable` and `${variable}` references, literal text and spaces, and conditional groups `( ... )` that disappear when all variables inside are empty. Unknown variables and `$fill` render empty; `$fill` never creates an editor layout zone because the right side remains reserved for structural Vim status.
+
+| Token           | Renders                                                                                       |
+| --------------- | --------------------------------------------------------------------------------------------- |
+| `$model`        | label selected by `editorModelLabel` (`id`, or name with ID fallback)                        |
+| `$model_id`     | active Pi model ID                                                                            |
+| `$model_name`   | active Pi model display name; empty when no name is set                                       |
+| `$provider`     | provider label using Zentui's existing formatting                                             |
+| `$thinking`     | current thinking level; empty when thinking is `off`                                          |
+| `$session_name` | current Pi session name; empty when unnamed                                                    |
+
+Model variables use `editorModel`, provider uses `editorProvider`, and thinking uses the matching `editorThinking*` style. Literal text and `$session_name` use the neutral editor border theme style. The template controls spacing. ANSI/VT sequences, control characters, and line-breaking whitespace are sanitized before rendering without collapsing ordinary spaces.
+
+Missing, non-string, or empty values use the default `$model  $provider(  $thinking)`. A non-empty format that resolves to no visible metadata keeps the normal blank spacer and metadata rows so the editor frame height remains stable. This option is configured only through JSON in its first version; `/zentui format` continues to control the footer only.
 
 ## Footer Format Template
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -122,10 +122,12 @@ export type ExtensionStatusesConfig = {
 
 const DEFAULT_PROJECT_REFRESH_INTERVAL_MS = 30_000;
 const MIN_PROJECT_REFRESH_INTERVAL_MS = 5_000;
+export const DEFAULT_EDITOR_METADATA_FORMAT = "$model  $provider(  $thinking)";
 
 export type PolishedTuiConfig = {
 	projectRefreshIntervalMs: number;
 	footerFormat: string;
+	editorMetadataFormat: string;
 	separator: SeparatorStyle;
 	contextStyle: ContextStyle;
 	editorModelLabel: ModelLabelSource;
@@ -223,6 +225,7 @@ export const configPath = join(getAgentDir(), "zentui.json");
 export const defaultConfig: PolishedTuiConfig = {
 	projectRefreshIntervalMs: DEFAULT_PROJECT_REFRESH_INTERVAL_MS,
 	footerFormat: "",
+	editorMetadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
 	separator: "pipe",
 	contextStyle: "text",
 	editorModelLabel: "id",
@@ -769,9 +772,14 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const fixedEditor = isRecord(config.fixedEditor)
 		? normalizeFixedEditorConfig(config.fixedEditor as Record<string, unknown>)
 		: defaultConfig.fixedEditor;
+	const editorMetadataFormat = stringValue(config, "editorMetadataFormat");
 	return {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
 		footerFormat: stringValue(config, "footerFormat") ?? "",
+		editorMetadataFormat:
+			editorMetadataFormat && editorMetadataFormat.length > 0
+				? editorMetadataFormat
+				: DEFAULT_EDITOR_METADATA_FORMAT,
 		separator: parseSeparatorStyle(config.separator),
 		contextStyle: parseContextStyle(config.contextStyle),
 		editorModelLabel: parseEditorModelLabel(config.editorModelLabel),

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -1,0 +1,259 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { PolishedTuiConfig } from "./config";
+import { type FormatToken, parseFooterFormat } from "./footer-format";
+import { EDITOR_ACCENT_FALLBACK, renderStyleForSourceOrFallback, safeThemeFg } from "./style";
+
+export type EditorMetadataValues = {
+	model: string;
+	modelId: string;
+	modelName: string;
+	provider: string;
+	thinking: string;
+	sessionName: string;
+};
+
+type RenderedTokens = {
+	styled: string;
+	hasDynamic: boolean;
+	hasNonEmptyDynamic: boolean;
+};
+
+const ESC = 0x1b;
+const BEL = 0x07;
+const CAN = 0x18;
+const SUB = 0x1a;
+const C1_DCS = 0x90;
+const C1_CSI = 0x9b;
+const C1_ST = 0x9c;
+const C1_OSC = 0x9d;
+const C1_SOS = 0x98;
+const C1_PM = 0x9e;
+const C1_APC = 0x9f;
+
+function consumeCsi(value: string, start: number): number {
+	for (let index = start; index < value.length; index++) {
+		const code = value.charCodeAt(index);
+		if (code === CAN || code === SUB) return index + 1;
+		if (code >= 0x40 && code <= 0x7e) return index + 1;
+	}
+	return value.length;
+}
+
+function consumeControlString(value: string, start: number, allowBel: boolean): number {
+	for (let index = start; index < value.length; index++) {
+		const code = value.charCodeAt(index);
+		if (code === CAN || code === SUB) return index + 1;
+		if (allowBel && code === BEL) return index + 1;
+		if (code === C1_ST) return index + 1;
+		if (code === ESC && value.charCodeAt(index + 1) === 0x5c) return index + 2;
+	}
+	return value.length;
+}
+
+function consumeEscape(value: string, start: number): number {
+	if (start + 1 >= value.length) return value.length;
+	const next = value.charCodeAt(start + 1);
+	if (next === 0x5b) return consumeCsi(value, start + 2);
+	if (next === 0x5d) return consumeControlString(value, start + 2, true);
+	if (next === 0x50 || next === 0x58 || next === 0x5e || next === 0x5f) {
+		return consumeControlString(value, start + 2, false);
+	}
+
+	let index = start + 1;
+	while (index < value.length) {
+		const code = value.charCodeAt(index);
+		if (code >= 0x20 && code <= 0x2f) {
+			index += 1;
+			continue;
+		}
+		return code >= 0x30 && code <= 0x7e ? index + 1 : index;
+	}
+	return value.length;
+}
+
+function isNormalizedWhitespace(code: number): boolean {
+	return (
+		code === 0x09 ||
+		code === 0x0a ||
+		code === 0x0b ||
+		code === 0x0c ||
+		code === 0x0d ||
+		code === 0x85 ||
+		code === 0x2028 ||
+		code === 0x2029
+	);
+}
+
+export function sanitizeEditorMetadataText(value: string): string {
+	let sanitized = "";
+	for (let index = 0; index < value.length; ) {
+		const code = value.charCodeAt(index);
+		if (code === ESC) {
+			index = consumeEscape(value, index);
+			continue;
+		}
+		if (code === C1_CSI) {
+			index = consumeCsi(value, index + 1);
+			continue;
+		}
+		if (code === C1_OSC) {
+			index = consumeControlString(value, index + 1, true);
+			continue;
+		}
+		if (code === C1_DCS || code === C1_SOS || code === C1_PM || code === C1_APC) {
+			index = consumeControlString(value, index + 1, false);
+			continue;
+		}
+		if (isNormalizedWhitespace(code)) {
+			sanitized += " ";
+			do index += 1;
+			while (index < value.length && isNormalizedWhitespace(value.charCodeAt(index)));
+			continue;
+		}
+		if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) {
+			index += 1;
+			continue;
+		}
+		sanitized += value[index];
+		index += 1;
+	}
+	return sanitized;
+}
+
+function editorThinkingStyle(config: PolishedTuiConfig, level: string): string | undefined {
+	switch (level.toLowerCase()) {
+		case "minimal":
+			return config.colors.editorThinkingMinimal ?? config.colors.editorThinking;
+		case "low":
+			return config.colors.editorThinkingLow ?? config.colors.editorThinking;
+		case "medium":
+			return config.colors.editorThinkingMedium ?? config.colors.editorThinking;
+		case "high":
+			return config.colors.editorThinkingHigh ?? config.colors.editorThinking;
+		case "xhigh":
+			return config.colors.editorThinkingXhigh ?? config.colors.editorThinking;
+		default:
+			return config.colors.editorThinking;
+	}
+}
+
+function renderVariable(
+	name: string,
+	values: EditorMetadataValues,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): { plain: string; styled: string } {
+	const colorSource = config.colorSources.editor;
+	const thinking = values.thinking.toLowerCase() === "off" ? "" : values.thinking;
+	const raw =
+		name === "model"
+			? values.model
+			: name === "model_id"
+				? values.modelId
+				: name === "model_name"
+					? values.modelName
+					: name === "provider"
+						? values.provider
+						: name === "thinking"
+							? thinking
+							: name === "session_name"
+								? values.sessionName
+								: "";
+	const plain = sanitizeEditorMetadataText(raw);
+	if (!plain) return { plain: "", styled: "" };
+
+	if (name === "model" || name === "model_id" || name === "model_name") {
+		return {
+			plain,
+			styled: renderStyleForSourceOrFallback(
+				uiTheme,
+				colorSource,
+				config.colors.editorModel,
+				EDITOR_ACCENT_FALLBACK,
+				plain,
+			),
+		};
+	}
+	if (name === "provider") {
+		return {
+			plain,
+			styled: renderStyleForSourceOrFallback(
+				uiTheme,
+				colorSource,
+				config.colors.editorProvider,
+				"text",
+				plain,
+			),
+		};
+	}
+	if (name === "thinking") {
+		return {
+			plain,
+			styled: renderStyleForSourceOrFallback(
+				uiTheme,
+				colorSource,
+				editorThinkingStyle(config, plain),
+				"muted",
+				plain,
+			),
+		};
+	}
+	if (name === "session_name") {
+		return { plain, styled: safeThemeFg(uiTheme, "border", plain) };
+	}
+	return { plain: "", styled: "" };
+}
+
+function renderTokens(
+	tokens: FormatToken[],
+	values: EditorMetadataValues,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): RenderedTokens {
+	let styled = "";
+	let hasDynamic = false;
+	let hasNonEmptyDynamic = false;
+
+	for (const token of tokens) {
+		if (token.kind === "text") {
+			const plain = sanitizeEditorMetadataText(token.value);
+			if (plain) styled += safeThemeFg(uiTheme, "border", plain);
+			continue;
+		}
+		if (token.kind === "fill") {
+			hasDynamic = true;
+			continue;
+		}
+		if (token.kind === "var") {
+			hasDynamic = true;
+			const rendered = renderVariable(token.name, values, uiTheme, config);
+			styled += rendered.styled;
+			if (rendered.plain) hasNonEmptyDynamic = true;
+			continue;
+		}
+
+		const rendered = renderTokens(token.tokens, values, uiTheme, config);
+		const visible = !rendered.hasDynamic || rendered.hasNonEmptyDynamic;
+		hasDynamic = true;
+		if (visible) {
+			styled += rendered.styled;
+			hasNonEmptyDynamic = true;
+		}
+	}
+
+	return { styled, hasDynamic, hasNonEmptyDynamic };
+}
+
+export function renderEditorMetadataFormat(
+	format: string,
+	values: EditorMetadataValues,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): string {
+	return renderTokens(
+		parseFooterFormat(sanitizeEditorMetadataText(format)),
+		values,
+		uiTheme,
+		config,
+	).styled;
+}

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -244,7 +244,10 @@ export default function (pi: ExtensionAPI) {
 				getCurrentConfig,
 				() => ({
 					modelLabel: state.modelLabel,
+					modelId: state.modelId,
+					modelName: state.modelName,
 					providerLabel: state.providerLabel,
+					sessionName: ctx.sessionManager.getSessionName() ?? "",
 				}),
 				getThinkingLevel,
 			)) as ZentuiEditorFactory;
@@ -264,7 +267,10 @@ export default function (pi: ExtensionAPI) {
 				getCurrentConfig,
 				() => ({
 					modelLabel: state.modelLabel,
+					modelId: state.modelId,
+					modelName: state.modelName,
 					providerLabel: state.providerLabel,
+					sessionName: ctx.sessionManager.getSessionName() ?? "",
 				}),
 				getThinkingLevel,
 			)) as ZentuiEditorFactory;

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -13,6 +13,8 @@ import type { RuntimeInfo } from "./runtime";
 
 export type FooterState = GitStatusSummary & {
 	modelLabel: string;
+	modelId: string;
+	modelName: string;
 	providerLabel: string;
 	contextLabel: string;
 	tokenLabel: string;
@@ -25,6 +27,8 @@ export type FooterState = GitStatusSummary & {
 export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 	return {
 		modelLabel: "no-model",
+		modelId: "",
+		modelName: "",
 		providerLabel: "Unknown",
 		contextLabel: "--",
 		tokenLabel: "↑0 ↓0",
@@ -44,6 +48,8 @@ export function syncState(
 ): void {
 	const totals = getUsageTotals(ctx);
 	const m = ctx.model;
+	state.modelId = m?.id ?? "";
+	state.modelName = m?.name ?? "";
 	state.modelLabel = (modelLabelSource === "name" ? m?.name || m?.id : m?.id) ?? "no-model";
 	state.providerLabel = formatProviderLabel(ctx.model?.provider);
 	state.contextLabel = buildContextLabel(ctx);

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -9,12 +9,20 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
+import { renderEditorMetadataFormat } from "./editor-metadata-format";
 import {
 	EDITOR_ACCENT_FALLBACK,
 	EDITOR_BORDER_FALLBACK,
 	renderStyleForSourceOrFallback,
 	safeThemeFg,
 } from "./style";
+
+const SPLIT_POLISHED_FRAME: unique symbol = Symbol.for("pi-zentui.polished-frame");
+
+type PolishedFrameSplit = {
+	editorLines: string[];
+	trailingLines: string[];
+};
 
 type AutocompleteEditorInternals = {
 	autocompleteList?: Pick<Component, "render">;
@@ -42,11 +50,15 @@ type WrappedEditor = EditorComponent &
 		setAutocompleteProvider?: (provider: AutocompleteProvider) => void;
 		setPaddingX?: (padding: number) => void;
 		setAutocompleteMaxVisible?: (maxVisible: number) => void;
+		[SPLIT_POLISHED_FRAME]?: (lines: string[]) => PolishedFrameSplit | undefined;
 	};
 
 type EditorMeta = {
 	modelLabel: string;
+	modelId?: string;
+	modelName?: string;
 	providerLabel: string;
+	sessionName?: string;
 };
 
 type PolishedFrameOptions = {
@@ -56,9 +68,9 @@ type PolishedFrameOptions = {
 	uiTheme: Theme;
 	config: PolishedTuiConfig;
 	modelMeta: EditorMeta;
-	previousModelMeta?: EditorMeta;
 	thinkingLevel: string | undefined;
 	rightStatus?: string;
+	splitBaseFrame?: (lines: string[]) => PolishedFrameSplit | undefined;
 };
 
 function clampRenderedLines(lines: string[], width: number): string[] {
@@ -70,23 +82,6 @@ function fillLine(content: string, width: number): string {
 	const truncated = truncateToWidth(content, Math.max(0, width), "");
 	const pad = " ".repeat(Math.max(0, width - visibleWidth(truncated)));
 	return `${truncated}${pad}`;
-}
-
-function editorThinkingStyle(config: PolishedTuiConfig, level: string): string | undefined {
-	switch (level.toLowerCase()) {
-		case "minimal":
-			return config.colors.editorThinkingMinimal ?? config.colors.editorThinking;
-		case "low":
-			return config.colors.editorThinkingLow ?? config.colors.editorThinking;
-		case "medium":
-			return config.colors.editorThinkingMedium ?? config.colors.editorThinking;
-		case "high":
-			return config.colors.editorThinkingHigh ?? config.colors.editorThinking;
-		case "xhigh":
-			return config.colors.editorThinkingXhigh ?? config.colors.editorThinking;
-		default:
-			return config.colors.editorThinking;
-	}
 }
 
 function copyFriendlyPrompt(config: PolishedTuiConfig, uiTheme: Theme, reset: string): string {
@@ -137,7 +132,7 @@ function plainRenderedText(line: string): string {
 	return line
 		.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
 		.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
-		.replace(/\[[/?][^\]]+\]/g, "");
+		.replace(/\[\/?[^\]]+\]/g, "");
 }
 
 function isHorizontalBorder(line: string): boolean {
@@ -145,70 +140,67 @@ function isHorizontalBorder(line: string): boolean {
 	return plain.length > 0 && /^─+$/.test(plain);
 }
 
-function isRenderedModelMetaLine(line: string, modelMeta: EditorMeta): boolean {
-	const plain = plainRenderedText(line);
-	return plain.includes(modelMeta.modelLabel) && plain.includes(modelMeta.providerLabel);
-}
-
-function matchesAnyModelMeta(
-	line: string,
-	modelMeta: EditorMeta,
-	previousMeta?: EditorMeta,
-): boolean {
-	if (isRenderedModelMetaLine(line, modelMeta)) return true;
-	if (previousMeta && isRenderedModelMetaLine(line, previousMeta)) return true;
-	return false;
-}
-
-function hasRenderedModelMetaLine(
+function unwrapPolishedFrameOnly(
 	lines: string[],
-	modelMeta: EditorMeta,
-	previousMeta?: EditorMeta,
-): boolean {
-	return lines.some((line) => matchesAnyModelMeta(line, modelMeta, previousMeta));
-}
+	config: PolishedTuiConfig,
+	uiTheme: Theme,
+): string[] | undefined {
+	if (
+		lines.length < 5 ||
+		!isHorizontalBorder(lines[0] ?? "") ||
+		!isHorizontalBorder(lines.at(-1) ?? "")
+	)
+		return undefined;
 
-function isAlreadyPolishedFrame(
-	lines: string[],
-	modelMeta: EditorMeta,
-	previousMeta?: EditorMeta,
-): boolean {
-	return (
-		lines.length >= 3 &&
-		isHorizontalBorder(lines[0] ?? "") &&
-		isHorizontalBorder(lines.at(-1) ?? "") &&
-		hasRenderedModelMetaLine(lines.slice(1, -1), modelMeta, previousMeta)
-	);
-}
+	const interior = lines.slice(1, -1);
+	if (interior.length < 3) return undefined;
 
-function removeRenderedModelMetaLines(
-	lines: string[],
-	modelMeta: EditorMeta,
-	previousMeta?: EditorMeta,
-): string[] {
-	const result: string[] = [];
-	for (let index = 0; index < lines.length; index++) {
-		const line = lines[index] ?? "";
-		if (matchesAnyModelMeta(line, modelMeta, previousMeta)) continue;
+	if (config.features.copyFriendly) {
+		if (
+			plainRenderedText(interior[0] ?? "").trim() !== "" ||
+			plainRenderedText(interior.at(-2) ?? "").trim() !== "" ||
+			!(interior.at(-1) ?? "").startsWith(" ")
+		)
+			return undefined;
 
-		const plain = plainRenderedText(line).trim();
-		const previousWasMeta =
-			index > 0 && matchesAnyModelMeta(lines[index - 1] ?? "", modelMeta, previousMeta);
-		const nextIsMeta =
-			index < lines.length - 1 &&
-			matchesAnyModelMeta(lines[index + 1] ?? "", modelMeta, previousMeta);
-		if (!plain && (previousWasMeta || nextIsMeta)) continue;
-
-		result.push(line);
+		const { prompt, promptWidth } = getEditorChromeWidths(config, uiTheme, "\x1b[0m");
+		const continuation = " ".repeat(promptWidth);
+		const content = interior.slice(1, -2);
+		const unwrapped: string[] = [];
+		for (let index = 0; index < content.length; index++) {
+			const prefix = index === 0 ? prompt : continuation;
+			const line = content[index] ?? "";
+			if (prefix && !line.startsWith(prefix)) return undefined;
+			unwrapped.push(prefix ? line.slice(prefix.length) : line);
+		}
+		return unwrapped;
 	}
-	return result;
+
+	const { rail } = getEditorChromeWidths(config, uiTheme, "\x1b[0m");
+	if (!rail || interior.some((line) => !line.startsWith(rail))) return undefined;
+	const unrailed = interior.map((line) => line.slice(rail.length));
+	if (
+		plainRenderedText(unrailed[0] ?? "").trim() !== "" ||
+		plainRenderedText(unrailed.at(-2) ?? "").trim() !== ""
+	)
+		return undefined;
+	return unrailed.slice(1, -2);
 }
 
-function removeStalePolishedLeadingSpacer(lines: string[], shouldRemove: boolean): string[] {
-	if (!shouldRemove || lines.length === 0) return lines;
-	const firstLine = lines[0] ?? "";
-	if (plainRenderedText(firstLine).trim()) return lines;
-	return lines.slice(1);
+function splitPolishedFrame(
+	lines: string[],
+	config: PolishedTuiConfig,
+	uiTheme: Theme,
+): PolishedFrameSplit | undefined {
+	if (!isHorizontalBorder(lines[0] ?? "")) return undefined;
+	for (let bottomIndex = lines.length - 1; bottomIndex >= 4; bottomIndex--) {
+		if (!isHorizontalBorder(lines[bottomIndex] ?? "")) continue;
+		const editorLines = unwrapPolishedFrameOnly(lines.slice(0, bottomIndex + 1), config, uiTheme);
+		if (editorLines) {
+			return { editorLines, trailingLines: lines.slice(bottomIndex + 1) };
+		}
+	}
+	return undefined;
 }
 
 function vimModeColor(mode: string): string {
@@ -244,9 +236,9 @@ function renderPolishedFrame({
 	uiTheme,
 	config,
 	modelMeta,
-	previousModelMeta,
 	thinkingLevel,
 	rightStatus,
+	splitBaseFrame,
 }: PolishedFrameOptions): string[] {
 	if (width <= 2) return clampRenderedLines(baseRendered, width);
 
@@ -262,56 +254,37 @@ function renderPolishedFrame({
 
 	if (baseRendered.length < 2) return clampRenderedLines(baseRendered, width);
 
+	const ownedFrame = splitBaseFrame?.(baseRendered);
 	const { autocompleteList } = autocompleteSource;
 	const autocompleteCount =
-		isShowingAutocomplete && typeof autocompleteList?.render === "function"
+		!ownedFrame && isShowingAutocomplete && typeof autocompleteList?.render === "function"
 			? autocompleteList.render(innerWidth).length
 			: 0;
 	const editorFrame =
-		autocompleteCount > 0 && autocompleteCount < baseRendered.length
+		!ownedFrame && autocompleteCount > 0 && autocompleteCount < baseRendered.length
 			? baseRendered.slice(0, -autocompleteCount)
 			: baseRendered;
-	const autocompleteLines =
-		autocompleteCount > 0 && autocompleteCount < baseRendered.length
+	const autocompleteLines = ownedFrame
+		? ownedFrame.trailingLines
+		: autocompleteCount > 0 && autocompleteCount < baseRendered.length
 			? baseRendered.slice(-autocompleteCount)
 			: [];
 	if (editorFrame.length < 2) return clampRenderedLines(baseRendered, width);
 
-	const stalePolishedFrame = isAlreadyPolishedFrame(editorFrame, modelMeta, previousModelMeta);
-	const editorLines = removeStalePolishedLeadingSpacer(
-		removeRenderedModelMetaLines(editorFrame.slice(1, -1), modelMeta, previousModelMeta),
-		stalePolishedFrame,
-	);
-	const model = renderStyleForSourceOrFallback(
+	const editorLines = ownedFrame?.editorLines ?? editorFrame.slice(1, -1);
+	const meta = renderEditorMetadataFormat(
+		config.editorMetadataFormat,
+		{
+			model: modelMeta.modelLabel,
+			modelId: modelMeta.modelId ?? "",
+			modelName: modelMeta.modelName ?? "",
+			provider: modelMeta.providerLabel,
+			thinking: thinkingLevel ?? "",
+			sessionName: modelMeta.sessionName ?? "",
+		},
 		uiTheme,
-		colorSource,
-		config.colors.editorModel,
-		EDITOR_ACCENT_FALLBACK,
-		modelMeta.modelLabel,
+		config,
 	);
-	const provider = renderStyleForSourceOrFallback(
-		uiTheme,
-		colorSource,
-		config.colors.editorProvider,
-		"text",
-		modelMeta.providerLabel,
-	);
-	const renderedModelMeta = [model, provider]
-		.filter(Boolean)
-		.join(safeThemeFg(uiTheme, "borderMuted", "  "));
-	const metaParts = [renderedModelMeta];
-	if (thinkingLevel && thinkingLevel !== "off") {
-		metaParts.push(
-			renderStyleForSourceOrFallback(
-				uiTheme,
-				colorSource,
-				editorThinkingStyle(config, thinkingLevel),
-				"muted",
-				thinkingLevel,
-			),
-		);
-	}
-	const meta = metaParts.filter(Boolean).join(safeThemeFg(uiTheme, "border", "  "));
 	const copyFriendlyMeta = composeMetadataLine(meta, rightStatus, Math.max(0, width - 1));
 	const railedMeta = composeMetadataLine(meta, rightStatus, innerWidth);
 
@@ -358,7 +331,6 @@ export class PolishedEditor extends CustomEditor {
 	private readonly getThinkingLevel: () => string | undefined;
 	private readonly getConfig: () => PolishedTuiConfig;
 	private readonly uiTheme: Theme;
-	private previousModelMeta?: EditorMeta;
 
 	constructor(
 		tui: TUI,
@@ -394,17 +366,17 @@ export class PolishedEditor extends CustomEditor {
 			uiTheme: this.uiTheme,
 			config,
 			modelMeta,
-			previousModelMeta: this.previousModelMeta,
 			thinkingLevel: this.getThinkingLevel(),
 		});
-		this.previousModelMeta = modelMeta;
 		return result;
+	}
+
+	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
+		return splitPolishedFrame(lines, this.getConfig(), this.uiTheme);
 	}
 }
 
 export class WrappedPolishedEditor implements EditorComponent {
-	private previousModelMeta?: EditorMeta;
-
 	constructor(
 		private readonly base: WrappedEditor,
 		private readonly uiTheme: Theme,
@@ -499,19 +471,21 @@ export class WrappedPolishedEditor implements EditorComponent {
 		const rendered = this.base.render(innerWidth);
 		const vimStatus = readVimStatus(this.base, this.uiTheme);
 		const modelMeta = this.getModelMeta();
-		const result = renderPolishedFrame({
+		return renderPolishedFrame({
 			width,
 			baseRendered: rendered,
 			autocompleteSource: this.base,
 			uiTheme: this.uiTheme,
 			config,
 			modelMeta,
-			previousModelMeta: this.previousModelMeta,
 			thinkingLevel: this.getThinkingLevel(),
 			rightStatus: vimStatus,
+			splitBaseFrame: this.base[SPLIT_POLISHED_FRAME]?.bind(this.base),
 		});
-		this.previousModelMeta = modelMeta;
-		return result;
+	}
+
+	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
+		return splitPolishedFrame(lines, this.getConfig(), this.uiTheme);
 	}
 
 	invalidate(): void {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	DEFAULT_EDITOR_METADATA_FORMAT,
 	defaultConfig,
 	mergeConfig,
 	saveColorSourcesPatch,
@@ -137,6 +138,19 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ footerFormat: "$cwd on $git_branch $fill $cost" }).footerFormat).toBe(
 			"$cwd on $git_branch $fill $cost",
 		);
+	});
+
+	it("defaults editorMetadataFormat and preserves non-empty strings", () => {
+		expect(defaultConfig.editorMetadataFormat).toBe(DEFAULT_EDITOR_METADATA_FORMAT);
+		for (const value of [undefined, null, 123, true, ""]) {
+			expect(mergeConfig({ editorMetadataFormat: value }).editorMetadataFormat).toBe(
+				DEFAULT_EDITOR_METADATA_FORMAT,
+			);
+		}
+		expect(mergeConfig({ editorMetadataFormat: "$model · $provider" }).editorMetadataFormat).toBe(
+			"$model · $provider",
+		);
+		expect(mergeConfig({ editorMetadataFormat: "   " }).editorMetadataFormat).toBe("   ");
 	});
 
 	it("ignores non-string footerFormat values", () => {

--- a/test/editor-metadata-format.test.ts
+++ b/test/editor-metadata-format.test.ts
@@ -1,0 +1,168 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { defaultConfig } from "../extensions/zentui/config";
+import {
+	type EditorMetadataValues,
+	renderEditorMetadataFormat,
+	sanitizeEditorMetadataText,
+} from "../extensions/zentui/editor-metadata-format";
+
+function makeTheme(): Theme {
+	return {
+		fg(color: string, text: string) {
+			return `[${color}]${text}`;
+		},
+		bold(text: string) {
+			return text;
+		},
+		italic(text: string) {
+			return text;
+		},
+		underline(text: string) {
+			return text;
+		},
+	} as unknown as Theme;
+}
+
+const values: EditorMetadataValues = {
+	model: "Model Label",
+	modelId: "model-id",
+	modelName: "Model Name",
+	provider: "Provider",
+	thinking: "high",
+	sessionName: "Session",
+};
+
+function render(format: string, overrides: Partial<EditorMetadataValues> = {}): string {
+	return renderEditorMetadataFormat(
+		format,
+		{ ...values, ...overrides },
+		makeTheme(),
+		defaultConfig,
+	);
+}
+
+describe("renderEditorMetadataFormat", () => {
+	it("renders all supported variables in both syntaxes", () => {
+		expect(render(`$model|\${model_id}|$model_name|\${provider}|$thinking|\${session_name}`)).toBe(
+			"[accent]Model Label[border]|[accent]model-id[border]|[accent]Model Name[border]|[text]Provider[border]|[muted]high[border]|[border]Session",
+		);
+	});
+
+	it("uses conditional groups for optional values", () => {
+		expect(render("$model( · $thinking)", { thinking: "off" })).toBe("[accent]Model Label");
+		expect(render("$model( · $thinking)")).toBe("[accent]Model Label[border] · [muted]high");
+		expect(
+			render("$model( · $model_name)( · $session_name)", { modelName: "", sessionName: "" }),
+		).toBe("[accent]Model Label");
+		expect(render("before((literal))after")).toBe("[border]before[border]literal[border]after");
+	});
+
+	it("renders unknown variables and fill as empty", () => {
+		expect(render("a$unknown-b$fill-c($unknown)($fill)")).toBe("[border]a[border]-b[border]-c");
+	});
+
+	it("preserves the default layout and hides thinking when off", () => {
+		expect(render(defaultConfig.editorMetadataFormat, { thinking: "off" })).toBe(
+			"[accent]Model Label[border]  [text]Provider",
+		);
+		expect(render(defaultConfig.editorMetadataFormat)).toBe(
+			"[accent]Model Label[border]  [text]Provider[border]  [muted]high",
+		);
+	});
+
+	it("routes semantic and neutral styles", () => {
+		const config = {
+			...defaultConfig,
+			colors: {
+				...defaultConfig.colors,
+				editorModel: "success",
+				editorProvider: "syntaxKeyword",
+				editorThinking: "thinkingText",
+				editorThinkingHigh: "thinkingHigh",
+			},
+		};
+		const rendered = renderEditorMetadataFormat(
+			"$model $model_id $model_name $provider $thinking $session_name literal",
+			values,
+			makeTheme(),
+			config,
+		);
+		expect(rendered).toContain("[success]Model Label");
+		expect(rendered).toContain("[success]model-id");
+		expect(rendered).toContain("[success]Model Name");
+		expect(rendered).toContain("[syntaxKeyword]Provider");
+		expect(rendered).toContain("[thinkingHigh]high");
+		expect(rendered).toContain("[border]Session");
+		expect(rendered).toContain("[border] literal");
+	});
+
+	it("falls back to the shared thinking color", () => {
+		const config = {
+			...defaultConfig,
+			colors: { ...defaultConfig.colors, editorThinking: "thinkingText" },
+		};
+		expect(
+			renderEditorMetadataFormat("$thinking", { ...values, thinking: "low" }, makeTheme(), config),
+		).toBe("[thinkingText]low");
+	});
+
+	it("sanitizes literals and values without collapsing ordinary spaces", () => {
+		const rendered = render(
+			"\u001b]8;;https://example.com/$provider\u0007lit\u001b]8;;\u0007  x\n\ty:$model",
+			{
+				model: "\u001b]8;;https://example.com\u0007bad\u001b]8;;\u0007\r\n  model\u0000",
+			},
+		);
+		expect(rendered).toBe("[border]lit  x y:[accent]bad   model");
+		expect(rendered).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
+	});
+});
+
+describe("sanitizeEditorMetadataText", () => {
+	it("removes SGR and BEL while preserving regular spaces", () => {
+		expect(sanitizeEditorMetadataText("a  b\r\n\tc\u0000\u0007\u001b[31md\u001b[0m")).toBe(
+			"a  b cd",
+		);
+	});
+
+	it("preserves hyperlink labels between ST-terminated OSC 8 sequences", () => {
+		expect(
+			sanitizeEditorMetadataText(
+				"before \u001b]8;;https://example.com\u001b\\visible label\u001b]8;;\u001b\\ after",
+			),
+		).toBe("before visible label after");
+	});
+
+	it("removes C1 OSC, DCS, and CSI payloads", () => {
+		expect(
+			sanitizeEditorMetadataText(
+				"a\u009d8;;https://example.com\u009cb\u0090hidden payload\u009cc\u009b31md",
+			),
+		).toBe("abcd");
+	});
+
+	it("resumes after CAN or SUB cancels ESC-prefixed control sequences", () => {
+		expect(sanitizeEditorMetadataText("safe\u001b]8;;url\u0018 visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u001bPpayload\u001a visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u001b[31\u0018 visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u001b[31\u001a visible")).toBe("safe visible");
+	});
+
+	it("resumes after CAN or SUB cancels C1 control sequences", () => {
+		expect(sanitizeEditorMetadataText("safe\u009d8;;url\u001a visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u0090payload\u0018 visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u009b31\u0018 visible")).toBe("safe visible");
+		expect(sanitizeEditorMetadataText("safe\u009b31\u001a visible")).toBe("safe visible");
+	});
+
+	it("drops unterminated control sequences conservatively", () => {
+		expect(sanitizeEditorMetadataText("safe\u001b]8;;https://example.com/unsafe")).toBe("safe");
+		expect(sanitizeEditorMetadataText("safe\u0090unsafe payload")).toBe("safe");
+		expect(sanitizeEditorMetadataText("safe\u009b31")).toBe("safe");
+	});
+
+	it("normalizes NEL, line separators, and paragraph separators", () => {
+		expect(sanitizeEditorMetadataText("a\u0085\u2028\u2029b  c")).toBe("a b  c");
+	});
+});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1111,6 +1111,7 @@ describe("Pi docs compliance", () => {
 	it("does not crash when config colors contain Starship modifiers", () => {
 		let footerFactory: FooterFactory | undefined;
 		const ctx = makeContext({
+			cwd: "/tmp/project",
 			ui: {
 				theme: makeStrictTheme(),
 				setFooter(factory: FooterFactory | undefined) {
@@ -1709,6 +1710,143 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("[text]Anthropic");
 	});
 
+	it("renders custom editor metadata variables", () => {
+		const editor = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTaggedTheme(),
+			() => ({
+				...defaultConfig,
+				editorMetadataFormat: "$model|$model_id|$model_name|$provider|$thinking|$session_name",
+			}),
+			() => ({
+				modelLabel: "selected-model",
+				modelId: "model-id",
+				modelName: "Model Name",
+				providerLabel: "Provider",
+				sessionName: "Session",
+			}),
+			() => "high",
+		);
+
+		const rendered = editor.render(240).join("\n");
+		expect(rendered).toContain("[accent]selected-model");
+		expect(rendered).toContain("[accent]model-id");
+		expect(rendered).toContain("[accent]Model Name");
+		expect(rendered).toContain("[text]Provider");
+		expect(rendered).toContain("[muted]high");
+		expect(rendered).toContain("[border]Session");
+	});
+
+	it("keeps custom metadata output identical in standalone and wrapped editors", () => {
+		const config = {
+			...defaultConfig,
+			editorMetadataFormat: "meta:$model|$provider|$thinking|$session_name",
+		};
+		const getMeta = () => ({
+			modelLabel: "parity-model",
+			providerLabel: "parity-provider",
+			sessionName: "parity-session",
+		});
+		const standalone = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 200 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTaggedTheme(),
+			() => config,
+			getMeta,
+			() => "medium",
+		);
+		const wrapped = new WrappedPolishedEditor(
+			{
+				render: (width: number) => ["─".repeat(width), "", "─".repeat(width)],
+				invalidate() {},
+				handleInput() {},
+				getText: () => "",
+				setText() {},
+			},
+			makeTaggedTheme(),
+			() => config,
+			getMeta,
+			() => "medium",
+		);
+
+		const standaloneMeta = standalone.render(200).find((line) => line.includes("parity-model"));
+		const wrappedMeta = wrapped.render(200).find((line) => line.includes("parity-model"));
+		expect(standaloneMeta).toBe(wrappedMeta);
+	});
+
+	it("renders Unicode and sanitized ANSI metadata safely at narrow widths", () => {
+		const editor = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 16 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTheme(),
+			() => ({ ...defaultConfig, editorMetadataFormat: "界🙂:$model" }),
+			() => ({
+				modelLabel: "\u001b]8;;https://example.com\u001b\\表示\u001b]8;;\u001b\\\u001b[31m危険",
+				providerLabel: "provider",
+			}),
+			() => "off",
+		);
+
+		const lines = editor.render(16);
+		const metadata = lines.find((line) => line.includes("界")) ?? "";
+		expect(metadata).toContain("表示");
+		expect(metadata).not.toContain("\u001b]");
+		expect(lines.every((line) => visibleWidth(line) <= 16)).toBe(true);
+	});
+
+	it("keeps Vim status when long custom metadata collides in rail and copy-friendly modes", () => {
+		for (const copyFriendly of [false, true]) {
+			const config = {
+				...configWithFeatures({ copyFriendly }),
+				editorMetadataFormat: "very-long-custom-metadata-$model-$provider",
+			};
+			const editor = new WrappedPolishedEditor(
+				{
+					render: (width: number) => ["─".repeat(width), "", "─".repeat(width)],
+					invalidate() {},
+					handleInput() {},
+					getText: () => "",
+					setText() {},
+					getMode: () => "insert",
+				},
+				makeTheme(),
+				() => config,
+				() => ({ modelLabel: "model-with-long-name", providerLabel: "provider-with-long-name" }),
+				() => "off",
+			);
+
+			const lines = editor.render(32);
+			const metadata = lines.find((line) => line.includes("INSERT")) ?? "";
+			expect(metadata.trimEnd().endsWith("INSERT")).toBe(true);
+			expect(metadata).not.toContain("provider-with-long-name");
+			expect(lines.every((line) => visibleWidth(line) <= 32)).toBe(true);
+		}
+	});
+
+	it("keeps blank structural metadata rows in copy-friendly mode", () => {
+		const editor = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTaggedTheme(),
+			() => ({
+				...configWithFeatures({ copyFriendly: true }),
+				editorMetadataFormat: "($unknown)",
+			}),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+		);
+
+		const lines = editor.render(120);
+		expect(stripTestTags(lines.at(-2) ?? "").trim()).toBe("");
+		expect(stripTestTags(lines.at(-3) ?? "").trim()).toBe("");
+		expect(lines.at(-2)).toBe(" ");
+	});
+
 	it("uses custom copy-friendly editor prompt icon and color", () => {
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
@@ -1840,146 +1978,232 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("[accent]claude-sonnet");
 	});
 
-	it("does not add another model line when wrapping an editor that already includes Zentui chrome", () => {
-		const meta = "[accent]claude-sonnet  [text]Anthropic  [muted]medium";
-		const base = {
-			render: (width: number) => ["─".repeat(width), "", meta, meta, "─".repeat(width)],
-			invalidate() {},
-			handleInput() {},
-			getText: () => "",
-			setText() {},
-		};
-		const editor = new WrappedPolishedEditor(
-			base,
+	it("unwraps a branded nested editor without duplicating literal-only metadata", () => {
+		const config = { ...defaultConfig, editorMetadataFormat: "literal-only" };
+		const inner = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
 			makeTaggedTheme(),
-			() => defaultConfig,
-			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
-			() => "medium",
+			() => config,
+			() => ({ modelLabel: "old-model", providerLabel: "old-provider" }),
+			() => "off",
+		);
+		inner.setText("typed text");
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "new-model", providerLabel: "new-provider" }),
+			() => "off",
 		);
 
 		const lines = editor.render(120);
 		const rendered = lines.join("\n");
 
-		expect(rendered.match(/claude-sonnet/g)).toHaveLength(1);
-		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
-		expect(rendered.match(/medium/g)).toHaveLength(1);
-		expect(lines).toHaveLength(5);
+		expect(rendered.match(/literal-only/g)).toHaveLength(1);
+		expect(rendered).toContain("typed text");
+		expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
 	});
 
-	it("drops the stale leading spacer when wrapping an already-polished editor with text", () => {
-		const staleMeta = "claude-sonnet  Anthropic  xhigh";
-		const base = {
-			render: (width: number) => [
-				"─".repeat(width),
-				"",
-				"typed text",
-				"",
-				staleMeta,
-				"─".repeat(width),
-			],
-			invalidate() {},
-			handleInput() {},
-			getText: () => "typed text",
-			setText() {},
+	it("unwraps branded copy-friendly frames without duplicating metadata", () => {
+		const config = {
+			...configWithFeatures({ copyFriendly: true }),
+			editorMetadataFormat: "copy-meta",
 		};
-		const editor = new WrappedPolishedEditor(
-			base,
+		const inner = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
 			makeTaggedTheme(),
-			() => defaultConfig,
-			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
-			() => "xhigh",
+			() => config,
+			() => ({ modelLabel: "old-model", providerLabel: "old-provider" }),
+			() => "off",
+		);
+		inner.setText("typed text");
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "new-model", providerLabel: "new-provider" }),
+			() => "off",
+		);
+
+		const rendered = editor.render(120).join("\n");
+		expect(rendered.match(/copy-meta/g)).toHaveLength(1);
+		expect(rendered.match(/typed text/g)).toHaveLength(1);
+		expect(rendered).not.toContain("│");
+	});
+
+	it("unwraps branded frames when metadata resolves blank", () => {
+		const config = { ...defaultConfig, editorMetadataFormat: "($unknown)" };
+		const inner = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "old-model", providerLabel: "old-provider" }),
+			() => "off",
+		);
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "new-model", providerLabel: "new-provider" }),
+			() => "off",
 		);
 
 		const lines = editor.render(120);
-		const textIndex = lines.findIndex((line) => line.includes("typed text"));
-
-		expect(textIndex).toBe(2);
 		expect(lines).toHaveLength(6);
-		expect(stripTestTags(lines[textIndex - 2] ?? "").trim()).toMatch(/^─+$/);
-		expect(stripTestTags(lines[textIndex - 1] ?? "").trim()).toBe("│");
+		expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
+		expect(lines.slice(1, -1).every((line) => stripTestTags(line).trim() === "│")).toBe(true);
 	});
 
-	it("preserves a user blank line after removing stale polished editor spacing", () => {
-		const staleMeta = "claude-sonnet  Anthropic  xhigh";
-		const base = {
-			render: (width: number) => [
-				"─".repeat(width),
-				"",
-				"",
-				"typed text",
-				"",
-				staleMeta,
-				"─".repeat(width),
-			],
-			invalidate() {},
-			handleInput() {},
-			getText: () => "\ntyped text",
-			setText() {},
-		};
-		const editor = new WrappedPolishedEditor(
-			base,
+	it("preserves a user blank line while unwrapping branded editor chrome", () => {
+		const inner = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
 			makeTaggedTheme(),
 			() => defaultConfig,
-			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
-			() => "xhigh",
+			() => ({ modelLabel: "old-model", providerLabel: "old-provider" }),
+			() => "off",
+		);
+		inner.setText("\ntyped text");
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => defaultConfig,
+			() => ({ modelLabel: "new-model", providerLabel: "new-provider" }),
+			() => "off",
 		);
 
 		const lines = editor.render(120);
 		const textIndex = lines.findIndex((line) => line.includes("typed text"));
 
 		expect(textIndex).toBe(3);
-		expect(lines).toHaveLength(7);
-		expect(stripTestTags(lines[textIndex - 3] ?? "").trim()).toMatch(/^─+$/);
 		expect(stripTestTags(lines[textIndex - 2] ?? "").trim()).toBe("│");
 		expect(stripTestTags(lines[textIndex - 1] ?? "").trim()).toBe("│");
 	});
 
-	it("collapses accumulated model and vim status lines from a nested polished editor", () => {
-		const staleMeta = "claude-sonnet  Anthropic  xhigh                               INSERT";
-		const base = {
-			render: (width: number) => [
-				"─".repeat(width),
-				"",
-				staleMeta,
-				"",
-				staleMeta,
-				"",
-				staleMeta,
-				"─".repeat(width),
-			],
-			invalidate() {},
-			handleInput() {},
-			getText: () => "",
-			setText() {},
-			getMode: () => "insert",
+	it("does not accumulate stale metadata or chrome across repeated nested renders", () => {
+		let config = { ...defaultConfig, editorMetadataFormat: "first:$model:$session_name" };
+		let meta = {
+			modelLabel: "model-one",
+			providerLabel: "provider-one",
+			sessionName: "session-one",
 		};
-		const editor = new WrappedPolishedEditor(
-			base,
+		let thinking = "low";
+		const inner = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
 			makeTaggedTheme(),
-			() => defaultConfig,
-			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
-			() => "xhigh",
+			() => config,
+			() => meta,
+			() => thinking,
 		);
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => config,
+			() => meta,
+			() => thinking,
+		);
+		const assertSingleFrame = (lines: string[]) => {
+			expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
+		};
 
-		const lines = editor.render(120);
-		const rendered = lines.join("\n");
+		const first = editor.render(120);
+		expect(first.join("\n")).toContain("first:");
+		expect(first.join("\n")).toContain("model-one");
+		assertSingleFrame(first);
 
-		expect(rendered.match(/claude-sonnet/g)).toHaveLength(1);
-		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
-		expect(rendered.match(/xhigh/g)).toHaveLength(1);
-		expect(rendered.match(/INSERT/g)).toHaveLength(1);
-		expect(lines).toHaveLength(5);
+		config = { ...config, editorMetadataFormat: "second:$provider:$thinking:$session_name" };
+		meta = {
+			modelLabel: "model-two",
+			providerLabel: "provider-two",
+			sessionName: "session-two",
+		};
+		thinking = "xhigh";
+		const second = editor.render(120);
+		const secondText = second.join("\n");
+		expect(secondText).toContain("second:");
+		expect(secondText).toContain("provider-two");
+		expect(secondText).toContain("xhigh");
+		expect(secondText).toContain("session-two");
+		expect(secondText).not.toContain("first:");
+		expect(secondText).not.toContain("model-one");
+		expect(secondText).not.toContain("session-one");
+		assertSingleFrame(second);
+
+		config = { ...config, editorMetadataFormat: "$model($model_name)($session_name)" };
+		meta = { modelLabel: "model-three", providerLabel: "", sessionName: "" };
+		thinking = "off";
+		const third = editor.render(120);
+		const thirdText = third.join("\n");
+		expect(thirdText.match(/model-three/g)).toHaveLength(1);
+		expect(thirdText).not.toContain("second:");
+		expect(thirdText).not.toContain("provider-two");
+		expect(thirdText).not.toContain("session-two");
+		assertSingleFrame(third);
 	});
 
-	it("replaces nested model lines with the current model and vim status line", () => {
-		const staleMeta = "claude-sonnet  Anthropic  xhigh                               INSERT";
+	it("preserves every autocomplete row outside multiply wrapped branded frames", () => {
+		const config = { ...defaultConfig, editorMetadataFormat: "autocomplete-meta" };
+		const base = new PolishedEditor(
+			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+		);
+		base.setText("typed");
+		const autocomplete = base as unknown as {
+			autocompleteState: string;
+			autocompleteList: { render: (width: number) => string[] };
+		};
+		autocomplete.autocompleteState = "force";
+		autocomplete.autocompleteList = {
+			render: () => ["suggestion-one", "suggestion-two", "suggestion-three"],
+		};
+		const inner = new WrappedPolishedEditor(
+			base as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+		);
+		const outer = new WrappedPolishedEditor(
+			inner as never,
+			makeTaggedTheme(),
+			() => config,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+		);
+
+		const lines = outer.render(120);
+		const rendered = lines.join("\n");
+		const bottom = lines.findLastIndex((line) => /^─+$/.test(stripTestTags(line).trim()));
+		expect(rendered.match(/autocomplete-meta/g)).toHaveLength(1);
+		expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
+		for (const suggestion of ["suggestion-one", "suggestion-two", "suggestion-three"]) {
+			expect(rendered.match(new RegExp(suggestion, "g"))).toHaveLength(1);
+			expect(lines.findIndex((line) => line.includes(suggestion))).toBeGreaterThan(bottom);
+		}
+	});
+
+	it("does not delete metadata-like content from an unbranded third-party editor", () => {
+		const staleMeta = "claude-sonnet  Anthropic  xhigh";
 		const base = {
-			render: () => ["not a plain border", staleMeta, "not a plain border"],
+			render: (width: number) => ["─".repeat(width), staleMeta, "─".repeat(width)],
 			invalidate() {},
 			handleInput() {},
-			getText: () => "",
+			getText: () => staleMeta,
 			setText() {},
-			getMode: () => "insert",
 		};
 		const editor = new WrappedPolishedEditor(
 			base,
@@ -1990,11 +2214,9 @@ describe("Pi docs compliance", () => {
 		);
 
 		const rendered = editor.render(120).join("\n");
-
-		expect(rendered.match(/claude-sonnet/g)).toHaveLength(1);
-		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
-		expect(rendered.match(/xhigh/g)).toHaveLength(1);
-		expect(rendered.match(/INSERT/g)).toHaveLength(1);
+		expect(rendered.match(/claude-sonnet/g)).toHaveLength(2);
+		expect(rendered.match(/Anthropic/g)).toHaveLength(2);
+		expect(rendered.match(/xhigh/g)).toHaveLength(2);
 	});
 
 	it("proxies mutable editor callbacks and app-action state to the wrapped editor", () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -13,10 +13,12 @@ function makeCtx(model: unknown) {
 const model = { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" };
 
 describe("syncState model label", () => {
-	it("shows the model id when the label source is 'id'", () => {
+	it("shows the model id when the label source is 'id' and retains raw model fields", () => {
 		const state = createInitialState(emptyGitStatus());
 		syncState(state, makeCtx(model), "", "id");
 		expect(state.modelLabel).toBe("gpt-5.6-terra");
+		expect(state.modelId).toBe("gpt-5.6-terra");
+		expect(state.modelName).toBe("GPT-5.6 Terra");
 	});
 
 	it("shows the model name when the label source is 'name'", () => {
@@ -25,15 +27,19 @@ describe("syncState model label", () => {
 		expect(state.modelLabel).toBe("GPT-5.6 Terra");
 	});
 
-	it("falls back to the id when the name is empty", () => {
+	it("falls back to the id when the name is empty without changing the raw name", () => {
 		const state = createInitialState(emptyGitStatus());
 		syncState(state, makeCtx({ ...model, name: "" }), "", "name");
 		expect(state.modelLabel).toBe("gpt-5.6-terra");
+		expect(state.modelId).toBe("gpt-5.6-terra");
+		expect(state.modelName).toBe("");
 	});
 
-	it("shows no-model when there is no active model", () => {
+	it("shows no-model when there is no active model and clears raw fields", () => {
 		const state = createInitialState(emptyGitStatus());
 		syncState(state, makeCtx(undefined), "", "name");
 		expect(state.modelLabel).toBe("no-model");
+		expect(state.modelId).toBe("");
+		expect(state.modelName).toBe("");
 	});
 });


### PR DESCRIPTION
> [!NOTE]
> PR #50 has been merged, and this branch has been rebased onto its `editorModelLabel` implementation.

## Summary

- Add the JSON-only `editorMetadataFormat` option for customizing the left side of the editor metadata row while leaving borders, prompts, layout, autocomplete, and right-aligned Vim status structural.
- Support `$var` and `${var}`, literals, conditional groups, empty/unknown variables, and `$fill` as an empty value without creating a layout zone.
- Provide `$model`, `$model_id`, `$model_name`, `$provider`, `$thinking`, and `$session_name`; `$model` respects `editorModelLabel`.
- Preserve the existing default layout for missing, non-string, or empty config values and retain blank structural rows when a non-empty format resolves to no metadata.
- Preserve per-variable styling while rendering literals and session names with the neutral editor border style.
- Sanitize ANSI/VT sequences, control characters, and line-breaking whitespace before ANSI/Unicode-aware truncation.
- Replace model/provider-text-based frame cleanup with owned frame splitting, preventing stale or nested chrome while preserving autocomplete rows, user blank lines, copy-friendly behavior, third-party content, and Vim-status width priority.
- Document the format, variables, defaults, styling, edge cases, examples, and JSON-only v1 scope in `README.md`.

Closes #52

## Screenshots / recordings

Manually tested in a live Pi TUI session using the feature worktree; model ID/name, provider, thinking, and session-name formatting rendered correctly.

## Testing

- [x] `npm run verify` — 17 test files, 465 tests passed after rebasing onto merged PR #50
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev`
- [x] Added or updated tests where practical
- [x] `npm run fmt`
- [x] Independent code, rebase, and test reviews completed

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no icon changes).
- [x] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in a focused module.
- [x] Used a conventional commit-style PR title (e.g. `feat: add ...`, `fix: handle ...`).

