### PR TITLE
feat: preserve editor viewport indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Useful slash-command shortcuts:
 /zentui copy-friendly enable
 /zentui copy-friendly disable
 /zentui copy-friendly toggle
+/zentui viewport-indicators enable
+/zentui viewport-indicators disable
+/zentui viewport-indicators toggle
 /zentui fixed-editor enable
 /zentui fixed-editor disable
 /zentui fixed-editor toggle
@@ -238,7 +241,8 @@ Default config values — copy this and change any value you want:
 	"features": {
 		"editor": true,
 		"statusLine": true,
-		"copyFriendly": false
+		"copyFriendly": false,
+		"viewportIndicators": true
 	},
 	"footerSegments": {
 		"cwd": true,
@@ -291,7 +295,7 @@ Default config values — copy this and change any value you want:
 - `gitBranch.maxLength`: visible width of the built-in branch name and `$git_branch` / `$branch`. The default `full` preserves the complete name; any positive integer uses that width including the trailing `…`. `/zentui` **Layout** cycles `full`, `10`, `20`, `30`, `40`, and `50`; custom positive integers can be set in JSON.
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
-- `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. All three can be changed from `/zentui` or direct slash-command arguments.
+- `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. `viewportIndicators` preserves Pi's native `↑ N more` / `↓ N more` wrapped-row counts in Zentui's editor borders (default `true`). All four can be changed from `/zentui` or direct slash-command arguments.
 - `footerSegments`: show or hide individual built-in footer segments (`cwd`, `sessionName`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle them from the `Built-in segments` tab in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Layout** tab configures responsive behavior, compact rows, context style, separator, path display mode/depth, branch length, and icon mode; set or clear custom formats with `/zentui format`.
 - `responsiveFooter`: enabled by default. Zentui keeps the current aligned one-row footer while every settings-resolved left/middle/right zone fits without layout truncation. Otherwise it tries two complete left-aligned rows, preferring `left` / `middle right` and then `left middle` / `right`. Only when neither split fits does it use `compactFooterFormat`. Set `false` to restore the legacy one-row fitting behavior. Selection uses measured terminal-cell width, not fixed device breakpoints.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -67,6 +67,7 @@ export type UiFeaturesConfig = {
 	editor: boolean;
 	statusLine: boolean;
 	copyFriendly: boolean;
+	viewportIndicators: boolean;
 };
 
 export type FooterSegmentsConfig = {
@@ -277,6 +278,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		editor: true,
 		statusLine: true,
 		copyFriendly: false,
+		viewportIndicators: true,
 	},
 	footerSegments: {
 		cwd: true,
@@ -507,6 +509,7 @@ function normalizeUiFeatures(record: Record<string, unknown>): UiFeaturesConfig 
 		editor: booleanValue(record, "editor"),
 		statusLine: booleanValue(record, "statusLine"),
 		copyFriendly: booleanValue(record, "copyFriendly"),
+		viewportIndicators: booleanValue(record, "viewportIndicators"),
 	};
 }
 
@@ -619,7 +622,12 @@ function isColorSourceKey(value: string): value is keyof ColorSourcesConfig {
 }
 
 function isUiFeatureKey(value: string): value is keyof UiFeaturesConfig {
-	return value === "editor" || value === "statusLine" || value === "copyFriendly";
+	return (
+		value === "editor" ||
+		value === "statusLine" ||
+		value === "copyFriendly" ||
+		value === "viewportIndicators"
+	);
 }
 
 function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig {

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -120,6 +120,7 @@ const featureSettingLabels: Record<FeatureSettingId, string> = {
 	editor: "Editor",
 	statusLine: "Status line",
 	copyFriendly: "Copy-friendly mode",
+	viewportIndicators: "Editor viewport indicators",
 };
 
 const featureSettingDescriptions: Record<FeatureSettingId, string> = {
@@ -128,6 +129,7 @@ const featureSettingDescriptions: Record<FeatureSettingId, string> = {
 	statusLine: "Enable or disable Zentui's custom footer/status line.",
 	copyFriendly:
 		"Hide editor and previous-message rail glyphs for cleaner native terminal selection.",
+	viewportIndicators: "Show Pi's native wrapped-row counts in the editor's top and bottom borders.",
 };
 
 const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
@@ -182,6 +184,9 @@ const directCommandSuggestions = [
 	"copy-friendly enable",
 	"copy-friendly disable",
 	"copy-friendly toggle",
+	"viewport-indicators enable",
+	"viewport-indicators disable",
+	"viewport-indicators toggle",
 	"fixed-editor enable",
 	"fixed-editor disable",
 	"fixed-editor toggle",
@@ -211,7 +216,12 @@ function isColorSettingId(value: string): value is ColorSettingId {
 }
 
 function isFeatureSettingId(value: string): value is FeatureSettingId {
-	return value === "editor" || value === "statusLine" || value === "copyFriendly";
+	return (
+		value === "editor" ||
+		value === "statusLine" ||
+		value === "copyFriendly" ||
+		value === "viewportIndicators"
+	);
 }
 
 function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingId {
@@ -322,7 +332,7 @@ function footerSegmentPatch(
 }
 
 function usageText(): string {
-	return 'Usage: /zentui [editor|statusline|copy-friendly] [enable|disable|toggle] or /zentui format "<template>"';
+	return 'Usage: /zentui [editor|statusline|copy-friendly|viewport-indicators] [enable|disable|toggle] or /zentui format "<template>"';
 }
 
 function featureNotification(
@@ -343,13 +353,16 @@ function parseDirectFeatureCommand(
 
 	const words = normalized.split(/\s+/g).filter(Boolean);
 	const hasWord = (value: string) => words.includes(value);
-	const feature = hasWord("editor")
-		? "editor"
-		: hasWord("footer") || hasWord("statusline") || hasWord("status")
-			? "statusLine"
-			: hasWord("copyfriendly") || hasWord("copy")
-				? "copyFriendly"
-				: undefined;
+	const feature =
+		hasWord("viewportindicators") || (hasWord("viewport") && hasWord("indicators"))
+			? "viewportIndicators"
+			: hasWord("editor")
+				? "editor"
+				: hasWord("footer") || hasWord("statusline") || hasWord("status")
+					? "statusLine"
+					: hasWord("copyfriendly") || hasWord("copy")
+						? "copyFriendly"
+						: undefined;
 	const action = hasWord("toggle")
 		? "toggle"
 		: hasWord("enable") || hasWord("enabled") || hasWord("on")

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -19,10 +19,18 @@ import {
 
 const SPLIT_POLISHED_FRAME: unique symbol = Symbol.for("pi-zentui.polished-frame");
 
+type ViewportCounts = {
+	above?: string;
+	below?: string;
+};
+
 type PolishedFrameSplit = {
 	editorLines: string[];
 	trailingLines: string[];
+	viewport: ViewportCounts;
 };
+
+const POLISHED_FRAME_SPLITS = new WeakMap<string[], PolishedFrameSplit>();
 
 type AutocompleteEditorInternals = {
 	autocompleteList?: Pick<Component, "render">;
@@ -128,30 +136,48 @@ function composeMetadataLine(left: string, right: string | undefined, width: num
 	return `${leftText}${gap}${right}`;
 }
 
-function plainRenderedText(line: string): string {
-	return line
-		.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "")
-		.replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "")
-		.replace(/\[\/?[^\]]+\]/g, "");
+function ansiStrippedText(line: string): string {
+	return line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, "").replace(/\x1b\][^\x07]*(?:\x07|\x1b\\)/g, "");
 }
 
-function isHorizontalBorder(line: string): boolean {
-	const plain = plainRenderedText(line).trim();
-	return plain.length > 0 && /^─+$/.test(plain);
+function plainRenderedText(line: string): string {
+	return ansiStrippedText(line).replace(/\[\/?[^\]]+\]/g, "");
+}
+
+function parseEditorBorder(
+	line: string,
+	direction: keyof ViewportCounts,
+): { count?: string } | undefined {
+	const plain = ansiStrippedText(line);
+	if (/^─+$/.test(plain)) return {};
+
+	const arrow = direction === "above" ? "↑" : "↓";
+	const match = new RegExp(`^─── ${arrow} ([1-9]\\d*) more ─*$`).exec(plain);
+	return match?.[1] ? { count: match[1] } : undefined;
+}
+
+function renderEditorBorder(
+	width: number,
+	direction: keyof ViewportCounts,
+	count: string | undefined,
+): string {
+	if (!count) return "─".repeat(width);
+	const arrow = direction === "above" ? "↑" : "↓";
+	const indicator = `─── ${arrow} ${count} more `;
+	return `${indicator}${"─".repeat(Math.max(0, width - visibleWidth(indicator)))}`;
 }
 
 function unwrapPolishedFrameOnly(
 	lines: string[],
 	config: PolishedTuiConfig,
 	uiTheme: Theme,
-): string[] | undefined {
-	if (
-		lines.length < 5 ||
-		!isHorizontalBorder(lines[0] ?? "") ||
-		!isHorizontalBorder(lines.at(-1) ?? "")
-	)
-		return undefined;
+): { editorLines: string[]; viewport: ViewportCounts } | undefined {
+	if (lines.length < 5) return undefined;
+	const top = parseEditorBorder(lines[0] ?? "", "above");
+	const bottom = parseEditorBorder(lines.at(-1) ?? "", "below");
+	if (!top || !bottom) return undefined;
 
+	const viewport = { above: top.count, below: bottom.count };
 	const interior = lines.slice(1, -1);
 	if (interior.length < 3) return undefined;
 
@@ -173,7 +199,7 @@ function unwrapPolishedFrameOnly(
 			if (prefix && !line.startsWith(prefix)) return undefined;
 			unwrapped.push(prefix ? line.slice(prefix.length) : line);
 		}
-		return unwrapped;
+		return { editorLines: unwrapped, viewport };
 	}
 
 	const { rail } = getEditorChromeWidths(config, uiTheme, "\x1b[0m");
@@ -184,7 +210,7 @@ function unwrapPolishedFrameOnly(
 		plainRenderedText(unrailed.at(-2) ?? "").trim() !== ""
 	)
 		return undefined;
-	return unrailed.slice(1, -2);
+	return { editorLines: unrailed.slice(1, -2), viewport };
 }
 
 function splitPolishedFrame(
@@ -192,12 +218,12 @@ function splitPolishedFrame(
 	config: PolishedTuiConfig,
 	uiTheme: Theme,
 ): PolishedFrameSplit | undefined {
-	if (!isHorizontalBorder(lines[0] ?? "")) return undefined;
+	if (!parseEditorBorder(lines[0] ?? "", "above")) return undefined;
 	for (let bottomIndex = lines.length - 1; bottomIndex >= 4; bottomIndex--) {
-		if (!isHorizontalBorder(lines[bottomIndex] ?? "")) continue;
-		const editorLines = unwrapPolishedFrameOnly(lines.slice(0, bottomIndex + 1), config, uiTheme);
-		if (editorLines) {
-			return { editorLines, trailingLines: lines.slice(bottomIndex + 1) };
+		if (!parseEditorBorder(lines[bottomIndex] ?? "", "below")) continue;
+		const frame = unwrapPolishedFrameOnly(lines.slice(0, bottomIndex + 1), config, uiTheme);
+		if (frame) {
+			return { ...frame, trailingLines: lines.slice(bottomIndex + 1) };
 		}
 	}
 	return undefined;
@@ -272,6 +298,12 @@ function renderPolishedFrame({
 	if (editorFrame.length < 2) return clampRenderedLines(baseRendered, width);
 
 	const editorLines = ownedFrame?.editorLines ?? editorFrame.slice(1, -1);
+	const parsedTop = parseEditorBorder(editorFrame[0] ?? "", "above");
+	const parsedBottom = parseEditorBorder(editorFrame.at(-1) ?? "", "below");
+	const viewport = ownedFrame?.viewport ?? {
+		above: parsedTop?.count,
+		below: parsedBottom?.count,
+	};
 	const meta = renderEditorMetadataFormat(
 		config.editorMetadataFormat,
 		{
@@ -293,14 +325,22 @@ function renderPolishedFrame({
 		colorSource,
 		config.colors.editorBorder,
 		EDITOR_BORDER_FALLBACK,
-		"─".repeat(width),
+		renderEditorBorder(
+			width,
+			"above",
+			config.features.viewportIndicators ? viewport.above : undefined,
+		),
 	);
 	const bottom = renderStyleForSourceOrFallback(
 		uiTheme,
 		colorSource,
 		config.colors.editorBorder,
 		EDITOR_BORDER_FALLBACK,
-		"─".repeat(width),
+		renderEditorBorder(
+			width,
+			"below",
+			config.features.viewportIndicators ? viewport.below : undefined,
+		),
 	);
 	const lines = ["", ...editorLines, "", railedMeta];
 	const renderedLines = config.features.copyFriendly
@@ -323,7 +363,13 @@ function renderPolishedFrame({
 				...autocompleteLines,
 			];
 
-	return clampRenderedLines(renderedLines, width);
+	const clamped = clampRenderedLines(renderedLines, width);
+	POLISHED_FRAME_SPLITS.set(clamped, {
+		editorLines,
+		trailingLines: autocompleteLines.length > 0 ? clamped.slice(-autocompleteLines.length) : [],
+		viewport,
+	});
+	return clamped;
 }
 
 export class PolishedEditor extends CustomEditor {
@@ -372,7 +418,9 @@ export class PolishedEditor extends CustomEditor {
 	}
 
 	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
-		return splitPolishedFrame(lines, this.getConfig(), this.uiTheme);
+		return (
+			POLISHED_FRAME_SPLITS.get(lines) ?? splitPolishedFrame(lines, this.getConfig(), this.uiTheme)
+		);
 	}
 }
 
@@ -485,7 +533,9 @@ export class WrappedPolishedEditor implements EditorComponent {
 	}
 
 	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
-		return splitPolishedFrame(lines, this.getConfig(), this.uiTheme);
+		return (
+			POLISHED_FRAME_SPLITS.get(lines) ?? splitPolishedFrame(lines, this.getConfig(), this.uiTheme)
+		);
 	}
 
 	invalidate(): void {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -74,6 +74,7 @@ describe("mergeConfig", () => {
 			editor: true,
 			statusLine: true,
 			copyFriendly: false,
+			viewportIndicators: true,
 		});
 		expect(config.footerSegments).toEqual({
 			cwd: true,
@@ -727,15 +728,26 @@ describe("mergeConfig", () => {
 			editor: false,
 			statusLine: true,
 			copyFriendly: false,
+			viewportIndicators: true,
 		});
 		expect(
-			mergeConfig({ features: { editor: "off", statusLine: false, copyFriendly: true } }).features,
+			mergeConfig({
+				features: {
+					editor: "off",
+					statusLine: false,
+					copyFriendly: true,
+					viewportIndicators: false,
+				},
+			}).features,
 		).toEqual({
 			editor: true,
 			statusLine: false,
 			copyFriendly: true,
+			viewportIndicators: false,
 		});
-		expect(mergeConfig({ features: { copyFriendly: "on" } }).features.copyFriendly).toBe(false);
+		expect(
+			mergeConfig({ features: { copyFriendly: "on", viewportIndicators: "off" } }).features,
+		).toMatchObject({ copyFriendly: false, viewportIndicators: true });
 	});
 
 	it("accepts valid footer segment preferences and ignores invalid values", () => {
@@ -915,19 +927,21 @@ describe("mergeConfig", () => {
 				)}\n`,
 			);
 
-			const config = saveUiFeaturesPatch({ statusLine: false }, path);
+			const config = saveUiFeaturesPatch({ statusLine: false, viewportIndicators: false }, path);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.features).toEqual({
 				editor: true,
 				statusLine: false,
 				copyFriendly: false,
+				viewportIndicators: false,
 			});
 			expect(raw.unknown).toBe(true);
 			expect(raw.features).toEqual({
 				editor: true,
 				futureKey: "future",
 				statusLine: false,
+				viewportIndicators: false,
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -945,6 +959,7 @@ describe("mergeConfig", () => {
 				editor: false,
 				statusLine: true,
 				copyFriendly: false,
+				viewportIndicators: true,
 			});
 			expect(raw).toEqual({ features: { editor: false } });
 		} finally {

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -1,0 +1,175 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import { WrappedPolishedEditor } from "../extensions/zentui/ui";
+
+function theme(): Theme {
+	return {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+		inverse: (text: string) => text,
+	} as Theme;
+}
+
+function config(features: Partial<PolishedTuiConfig["features"]> = {}): PolishedTuiConfig {
+	return { ...defaultConfig, features: { ...defaultConfig.features, ...features } };
+}
+
+function nativeBorder(
+	width: number,
+	direction: "above" | "below",
+	count?: number,
+	ansi = false,
+): string {
+	const plain = count
+		? `─── ${direction === "above" ? "↑" : "↓"} ${count} more ${"─".repeat(
+				Math.max(0, width - `─── ↑ ${count} more `.length),
+			)}`
+		: "─".repeat(width);
+	return ansi ? `\x1b[90m${plain}\x1b[0m` : plain;
+}
+
+function baseEditor(options: {
+	above?: number;
+	below?: number;
+	ansi?: boolean;
+	malformedTop?: string;
+	autocomplete?: string[];
+}) {
+	const autocomplete = options.autocomplete ?? [];
+	return {
+		render(width: number) {
+			return [
+				options.malformedTop ?? nativeBorder(width, "above", options.above, options.ansi),
+				"typed text",
+				nativeBorder(width, "below", options.below, options.ansi),
+				...autocomplete,
+			];
+		},
+		invalidate() {},
+		handleInput() {},
+		getText: () => "typed text",
+		setText() {},
+		isShowingAutocomplete: () => autocomplete.length > 0,
+		autocompleteList: { render: () => autocomplete },
+	};
+}
+
+function wrapped(
+	base: ReturnType<typeof baseEditor> | WrappedPolishedEditor,
+	features: Partial<PolishedTuiConfig["features"]> = {},
+): WrappedPolishedEditor {
+	return new WrappedPolishedEditor(
+		base as never,
+		theme(),
+		() => config(features),
+		() => ({ modelLabel: "model", providerLabel: "provider" }),
+		() => "off",
+	);
+}
+
+describe("editor viewport indicators", () => {
+	it.each([
+		[7, undefined, "↑ 7 more", undefined],
+		[undefined, 11, undefined, "↓ 11 more"],
+		[7, 11, "↑ 7 more", "↓ 11 more"],
+	] as const)(
+		"preserves top and bottom native counts (above=%s, below=%s)",
+		(above, below, topText, bottomText) => {
+			const lines = wrapped(baseEditor({ above, below, ansi: true })).render(80);
+			if (topText) expect(lines[0]).toContain(topText);
+			else expect(lines[0]).not.toContain("more");
+			if (bottomText) expect(lines.at(-1)).toContain(bottomText);
+			else expect(lines.at(-1)).not.toContain("more");
+		},
+	);
+
+	it("preserves large counts at ample width and clamps them at narrow ANSI-aware widths", () => {
+		const count = 123456789;
+		const editor = wrapped(baseEditor({ above: count, below: count, ansi: true }));
+
+		const ampleLines = editor.render(80);
+		expect(ampleLines[0]).toContain(`↑ ${count} more`);
+		expect(ampleLines.at(-1)).toContain(`↓ ${count} more`);
+
+		const narrowLines = editor.render(12);
+		expect(visibleWidth(narrowLines[0] ?? "")).toBe(12);
+		expect(visibleWidth(narrowLines.at(-1) ?? "")).toBe(12);
+		expect(narrowLines[0]).toContain("↑");
+		expect(narrowLines.at(-1)).toContain("↓");
+		expect(narrowLines[0]).not.toContain(`${count} more`);
+		expect(narrowLines.at(-1)).not.toContain(`${count} more`);
+	});
+
+	it("uses plain polished borders when viewport indicators are disabled", () => {
+		const lines = wrapped(baseEditor({ above: 4, below: 9 }), {
+			viewportIndicators: false,
+		}).render(80);
+		expect(lines[0]).not.toContain("more");
+		expect(lines.at(-1)).not.toContain("more");
+		expect(lines[0]).toMatch(/^─+$/);
+		expect(lines.at(-1)).toMatch(/^─+$/);
+	});
+
+	it("carries counts through nested polished wrappers without double-framing", () => {
+		const inner = wrapped(baseEditor({ above: 3, below: 8 }));
+		const lines = wrapped(inner).render(80);
+		const rendered = lines.join("\n");
+		expect(rendered.match(/↑ 3 more/g)).toHaveLength(1);
+		expect(rendered.match(/↓ 8 more/g)).toHaveLength(1);
+		expect(lines.filter((line) => line.startsWith("───") || /^─+$/.test(line))).toHaveLength(2);
+		expect(rendered.match(/model/g)).toHaveLength(1);
+
+		const narrowLines = wrapped(inner).render(8);
+		expect(narrowLines).toHaveLength(6);
+		expect(narrowLines[0]).toContain("↑");
+		expect(narrowLines.at(-1)).toContain("↓");
+	});
+
+	it("keeps autocomplete rows after the counted bottom border", () => {
+		const suggestions = ["suggestion-one", "suggestion-two"];
+		const lines = wrapped(baseEditor({ below: 5, autocomplete: suggestions })).render(80);
+		const bottom = lines.findIndex((line) => line.includes("↓ 5 more"));
+		expect(bottom).toBeGreaterThanOrEqual(0);
+		for (const suggestion of suggestions) {
+			expect(lines.findIndex((line) => line.includes(suggestion))).toBeGreaterThan(bottom);
+		}
+	});
+
+	it.each([
+		"── ↑ 7 more ─────────",
+		"─── ↓ 7 more ─────────",
+		"─── ↑ 07 more ─────────",
+		"prefix ─── ↑ 7 more ─────────",
+		"[muted]─── ↑ 7 more ─────────[/muted]",
+	])("fails closed for an unknown top border form: %s", (malformedTop) => {
+		const lines = wrapped(baseEditor({ below: 2, malformedTop })).render(80);
+		expect(lines[0]).toMatch(/^─+$/);
+		expect(lines[0]).not.toContain("more");
+		expect(lines.at(-1)).toContain("↓ 2 more");
+	});
+
+	it("keeps every rendered line within narrow ANSI-aware widths in both chrome modes", () => {
+		for (const copyFriendly of [false, true]) {
+			for (const width of [3, 8, 12, 16]) {
+				const lines = wrapped(baseEditor({ above: 12, below: 34, ansi: true }), {
+					copyFriendly,
+				}).render(width);
+				expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			}
+		}
+	});
+
+	it("matches Pi's complete native form rather than reconstructing a truncated count", () => {
+		const truncatedNativeTop = truncateToWidth("─── ↑ 12 more ", 10, "");
+		const lines = wrapped(baseEditor({ below: 1, malformedTop: truncatedNativeTop })).render(40);
+		expect(lines[0]).toMatch(/^─+$/);
+		expect(lines[0]).not.toContain("↑");
+	});
+});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -2684,6 +2684,55 @@ describe("Pi docs compliance", () => {
 		expect(notifications).toEqual([{ message: "Copy-friendly mode: enabled", level: "info" }]);
 	});
 
+	it("toggles viewport indicators from direct Zentui slash-command arguments", async () => {
+		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
+		const featureChanges: Partial<PolishedTuiConfig["features"]>[] = [];
+		const notifications: Array<{ message: string; level: string }> = [];
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: inactiveSessionLifecycle,
+				getConfig: () => defaultConfig,
+				setColorSources() {},
+				setUiFeatures(patch) {
+					featureChanges.push(patch);
+					return { applied: true };
+				},
+				setFooterSegments() {},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				setSeparator() {},
+				getActiveExtensionStatuses: () => new Map<string, string>(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender() {},
+			},
+		);
+
+		await command?.handler("viewport-indicators toggle", {
+			hasUI: true,
+			ui: {
+				notify(message: string, level: string) {
+					notifications.push({ message, level });
+				},
+			},
+		});
+
+		expect(featureChanges).toEqual([{ viewportIndicators: false }]);
+		expect(notifications).toEqual([
+			{ message: "Editor viewport indicators: disabled", level: "info" },
+		]);
+	});
+
 	it("shows when an editor toggle needs reload because another extension owns the editor", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 		const notifications: Array<{ message: string; level: string }> = [];


### PR DESCRIPTION
## Summary

- preserve Pi native `↑ N more` and `↓ N more` input viewport counts in Zentui polished borders
- add an enabled-by-default `/zentui` toggle and direct commands
- add regression coverage for nested frames, autocomplete, malformed borders, large counts, and narrow widths

## Validation

- `npm run fmt`
- `npm run verify`
- `npm run pack:check`
- manually tested in Pi
- approved by independent review

Closes #58