### PR TITLE
chore: release v0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.14.0",
+			"version": "0.15.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bump package version from `0.14.0` to `0.15.0`
- prepare the release containing editor viewport indicators and the reorganized `/zentui` bounded settings menu

## Validation

- clean install under Node 24.13.0
- `npm run fmt`
- isolated-HOME `npm run verify` — 519 tests passed
- `npm run pack:check`

After merge, tag `v0.15.0` will trigger the established npm publish and GitHub release workflow.