### PR TITLE
fix: preserve editor content across replacement

### DIFF
--- a/extensions/zentui/editor-transfer.ts
+++ b/extensions/zentui/editor-transfer.ts
@@ -1,0 +1,73 @@
+export type EditorComponentFactory = (...args: never[]) => unknown;
+
+export type EditorTransferUi<Factory = EditorComponentFactory> = {
+	getEditorText?: () => unknown;
+	setEditorText?: (text: string) => void;
+	setEditorComponent?: (factory: Factory | undefined) => void;
+	getEditorComponent?: () => Factory | undefined;
+};
+
+export type EditorTransferFailureReason =
+	| "unsupported-transfer-api"
+	| "editor-factory-snapshot-failed"
+	| "editor-text-snapshot-failed"
+	| "editor-text-preparation-failed"
+	| "editor-replacement-failed-with-rollback"
+	| "editor-replacement-rollback-failed";
+
+export type EditorTransferResult =
+	| { ok: true }
+	| { ok: false; reason: EditorTransferFailureReason };
+
+/**
+ * Prepare the active editor's public expanded text before Pi replaces its factory.
+ * This intentionally transfers prompt contents only; editor-private state is never inspected.
+ */
+export function replaceEditorComponentWithExpandedText<Factory>(
+	ui: EditorTransferUi<Factory>,
+	factory: Factory | undefined,
+): EditorTransferResult {
+	if (
+		typeof ui.getEditorText !== "function" ||
+		typeof ui.setEditorText !== "function" ||
+		typeof ui.setEditorComponent !== "function" ||
+		typeof ui.getEditorComponent !== "function"
+	) {
+		return { ok: false, reason: "unsupported-transfer-api" };
+	}
+
+	let previousFactory: Factory | undefined;
+	try {
+		previousFactory = ui.getEditorComponent();
+	} catch {
+		return { ok: false, reason: "editor-factory-snapshot-failed" };
+	}
+
+	let expandedText: unknown;
+	try {
+		expandedText = ui.getEditorText();
+	} catch {
+		return { ok: false, reason: "editor-text-snapshot-failed" };
+	}
+	if (typeof expandedText !== "string") {
+		return { ok: false, reason: "editor-text-snapshot-failed" };
+	}
+
+	try {
+		ui.setEditorText(expandedText);
+	} catch {
+		return { ok: false, reason: "editor-text-preparation-failed" };
+	}
+
+	try {
+		ui.setEditorComponent(factory);
+	} catch {
+		try {
+			ui.setEditorComponent(previousFactory);
+			return { ok: false, reason: "editor-replacement-failed-with-rollback" };
+		} catch {
+			return { ok: false, reason: "editor-replacement-rollback-failed" };
+		}
+	}
+	return { ok: true };
+}

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -43,6 +43,10 @@ import {
 	type UiFeaturesConfig,
 } from "./config";
 import {
+	type EditorTransferFailureReason,
+	replaceEditorComponentWithExpandedText,
+} from "./editor-transfer";
+import {
 	disposeFixedEditor,
 	installFixedEditorProbe,
 	removeFixedEditorProbe,
@@ -80,9 +84,29 @@ type ZentuiEditorFactory = EditorFactory & {
 
 type ApplyUiResult = {
 	editorBlocked: boolean;
+	editorReason?: string;
 };
 
+type EditorChangeResult = { ok: true } | { ok: false; reason: string };
+
 type EditorInstallMode = "none" | "standalone" | "wrapper";
+
+function editorTransferFailureMessage(reason: EditorTransferFailureReason): string {
+	switch (reason) {
+		case "unsupported-transfer-api":
+			return "this Pi version cannot safely transfer expanded editor text; reload Pi to apply this change";
+		case "editor-factory-snapshot-failed":
+			return "the current editor factory could not be read safely; reload Pi to apply this change";
+		case "editor-text-snapshot-failed":
+			return "expanded editor text could not be read safely; reload Pi to apply this change";
+		case "editor-text-preparation-failed":
+			return "expanded editor text could not be prepared safely; reload Pi to apply this change";
+		case "editor-replacement-failed-with-rollback":
+			return "the editor replacement failed; the previous factory was reapplied, but editor instance identity is not guaranteed";
+		case "editor-replacement-rollback-failed":
+			return "the editor replacement and previous-factory rollback both failed; reload Pi before editing";
+	}
+}
 
 function isZentuiEditorFactory(factory: EditorFactory | undefined): boolean {
 	return Boolean((factory as ZentuiEditorFactory | undefined)?.[ZENTUI_EDITOR_FACTORY]);
@@ -266,21 +290,71 @@ export default function (pi: ExtensionAPI) {
 		if (footerInstalled) scheduleProjectRefresh(ctx, { force: true });
 	};
 
-	const installPrototypePatches = () => {
-		if (prototypePatchesInstalled) return;
-		const cleanupSelectorBorderStyle = installSelectorBorderStyle(getActiveTheme, getCurrentConfig);
-		const cleanupUserMessageStyle = installUserMessageStyle(getActiveTheme, getCurrentConfig);
-		cleanupPrototypePatches = () => {
-			cleanupSelectorBorderStyle();
-			cleanupUserMessageStyle();
-		};
-		prototypePatchesInstalled = true;
+	const installPrototypePatches = (): boolean => {
+		if (prototypePatchesInstalled) return true;
+		let cleanupSelectorBorderStyle: (() => void) | undefined;
+		try {
+			cleanupSelectorBorderStyle = installSelectorBorderStyle(getActiveTheme, getCurrentConfig);
+			const cleanupUserMessageStyle = installUserMessageStyle(getActiveTheme, getCurrentConfig);
+			cleanupPrototypePatches = () => {
+				cleanupSelectorBorderStyle?.();
+				cleanupUserMessageStyle();
+			};
+			prototypePatchesInstalled = true;
+			return true;
+		} catch {
+			try {
+				cleanupSelectorBorderStyle?.();
+			} catch {
+				// Best effort: each installer is locally transactional as well.
+			}
+			cleanupPrototypePatches = () => {};
+			prototypePatchesInstalled = false;
+			return false;
+		}
 	};
 
 	const uninstallPrototypePatches = () => {
 		cleanupPrototypePatches();
 		cleanupPrototypePatches = () => {};
 		prototypePatchesInstalled = false;
+	};
+
+	const clearEditorOwnership = () => {
+		wrappedEditorFactory = undefined;
+		installedEditorFactory = undefined;
+		editorInstallMode = "none";
+		editorInstalled = false;
+	};
+
+	const trackZentuiEditorFactory = (factory: EditorFactory) => {
+		const baseFactory = getZentuiEditorBaseFactory(factory);
+		wrappedEditorFactory = baseFactory;
+		installedEditorFactory = factory;
+		editorInstallMode = baseFactory ? "wrapper" : "standalone";
+		editorInstalled = true;
+	};
+
+	const observeEditorFactory = (
+		ctx: ExtensionContext,
+	): { known: true; factory: EditorFactory | undefined } | { known: false } => {
+		try {
+			return { known: true, factory: ctx.ui.getEditorComponent() };
+		} catch {
+			return { known: false };
+		}
+	};
+
+	const reconcileObservedEditorOwnership = (ctx: ExtensionContext) => {
+		const observed = observeEditorFactory(ctx);
+		if (!observed.known) return observed;
+		if (observed.factory && isZentuiEditorFactory(observed.factory)) {
+			trackZentuiEditorFactory(observed.factory);
+		} else {
+			uninstallPrototypePatches();
+			clearEditorOwnership();
+		}
+		return observed;
 	};
 
 	const makeEditorFactory = (ctx: ExtensionContext): ZentuiEditorFactory => {
@@ -329,53 +403,73 @@ export default function (pi: ExtensionAPI) {
 		return factory;
 	};
 
-	const installEditor = (ctx: ExtensionContext): boolean => {
+	const replaceEditor = (
+		ctx: ExtensionContext,
+		factory: EditorFactory | undefined,
+	): EditorChangeResult => {
+		const result = replaceEditorComponentWithExpandedText(ctx.ui, factory);
+		return result.ok ? result : { ok: false, reason: editorTransferFailureMessage(result.reason) };
+	};
+
+	const installEditor = (ctx: ExtensionContext): EditorChangeResult => {
 		const currentFactory = ctx.ui.getEditorComponent();
 		if (currentFactory && currentFactory === installedEditorFactory) {
 			editorInstalled = true;
-			return true;
+			return { ok: true };
 		}
 
-		installPrototypePatches();
 		const currentZentuiBaseFactory = getZentuiEditorBaseFactory(currentFactory);
-		if (currentFactory && isZentuiEditorFactory(currentFactory)) {
-			wrappedEditorFactory = currentZentuiBaseFactory;
-			const nextFactory = currentZentuiBaseFactory
-				? makeWrappedEditorFactory(ctx, currentZentuiBaseFactory)
-				: makeEditorFactory(ctx);
-			ctx.ui.setEditorComponent(nextFactory);
-			installedEditorFactory = nextFactory;
-			editorInstallMode = currentZentuiBaseFactory ? "wrapper" : "standalone";
-		} else if (currentFactory) {
-			wrappedEditorFactory = currentFactory;
-			const nextFactory = makeWrappedEditorFactory(ctx, currentFactory);
-			ctx.ui.setEditorComponent(nextFactory);
-			installedEditorFactory = nextFactory;
-			editorInstallMode = "wrapper";
-		} else {
-			wrappedEditorFactory = undefined;
-			const nextFactory = makeEditorFactory(ctx);
-			ctx.ui.setEditorComponent(nextFactory);
-			installedEditorFactory = nextFactory;
-			editorInstallMode = "standalone";
+		const baseFactory =
+			currentZentuiBaseFactory ??
+			(currentFactory && !isZentuiEditorFactory(currentFactory) ? currentFactory : undefined);
+		const nextFactory = baseFactory
+			? makeWrappedEditorFactory(ctx, baseFactory)
+			: makeEditorFactory(ctx);
+		const replacement = replaceEditor(ctx, nextFactory);
+		if (!replacement.ok) return replacement;
+		if (!installPrototypePatches()) {
+			const rollback = replaceEditor(ctx, currentFactory);
+			reconcileObservedEditorOwnership(ctx);
+			return {
+				ok: false,
+				reason: rollback.ok
+					? "editor chrome patch installation failed; the previous factory was reapplied, but editor instance identity is not guaranteed"
+					: "editor chrome patch installation failed and the previous factory could not be restored; reload Pi before editing",
+			};
 		}
-		editorInstalled = true;
-		return true;
+
+		trackZentuiEditorFactory(nextFactory);
+		return { ok: true };
 	};
 
-	const uninstallEditor = (ctx: ExtensionContext): boolean => {
-		const currentFactory = ctx.ui.getEditorComponent();
-		if (currentFactory && !isZentuiEditorFactory(currentFactory)) return false;
+	const uninstallEditor = (ctx: ExtensionContext): EditorChangeResult => {
+		const observed = observeEditorFactory(ctx);
+		if (!observed.known) {
+			return {
+				ok: false,
+				reason:
+					"the current editor factory could not be observed safely; reload Pi to apply this change",
+			};
+		}
+		const currentFactory = observed.factory;
+		if (!currentFactory || !isZentuiEditorFactory(currentFactory)) {
+			uninstallPrototypePatches();
+			clearEditorOwnership();
+			return { ok: true };
+		}
+
+		const replacement = replaceEditor(
+			ctx,
+			getZentuiEditorBaseFactory(currentFactory) ??
+				(editorInstallMode === "wrapper" && wrappedEditorFactory
+					? wrappedEditorFactory
+					: undefined),
+		);
+		if (!replacement.ok) return replacement;
 
 		uninstallPrototypePatches();
-		ctx.ui.setEditorComponent(
-			editorInstallMode === "wrapper" && wrappedEditorFactory ? wrappedEditorFactory : undefined,
-		);
-		wrappedEditorFactory = undefined;
-		installedEditorFactory = undefined;
-		editorInstallMode = "none";
-		editorInstalled = false;
-		return true;
+		clearEditorOwnership();
+		return { ok: true };
 	};
 
 	const installStatusLine = (ctx: ExtensionContext) => {
@@ -413,12 +507,17 @@ export default function (pi: ExtensionAPI) {
 		const result: ApplyUiResult = { editorBlocked: false };
 		if (!isTuiContext(ctx)) return result;
 		activeTheme = ctx.ui.theme;
+		let editorChange: EditorChangeResult | undefined;
 		if (currentConfig.features.editor) {
 			const currentFactory = ctx.ui.getEditorComponent();
 			const editorMissingOrReplaced = !editorInstalled || !isZentuiEditorFactory(currentFactory);
-			if (editorMissingOrReplaced) result.editorBlocked = !installEditor(ctx);
+			if (editorMissingOrReplaced) editorChange = installEditor(ctx);
 		} else if (editorInstalled || prototypePatchesInstalled) {
-			result.editorBlocked = !uninstallEditor(ctx);
+			editorChange = uninstallEditor(ctx);
+		}
+		if (editorChange && !editorChange.ok) {
+			result.editorBlocked = true;
+			result.editorReason = editorChange.reason;
 		}
 
 		if (currentConfig.features.statusLine) {
@@ -450,11 +549,16 @@ export default function (pi: ExtensionAPI) {
 	const scheduleEditorReconciliation = (ctx: ExtensionContext) => {
 		sessionLifecycle.defer(() => {
 			if (!isTuiContext(ctx) || !currentConfig.features.editor) return;
-			const currentFactory = ctx.ui.getEditorComponent();
-			if (currentFactory && currentFactory !== installedEditorFactory) {
-				applyConfiguredUi(ctx);
+			const observed = observeEditorFactory(ctx);
+			if (!observed.known || observed.factory === installedEditorFactory) return;
+			if (!observed.factory || !isZentuiEditorFactory(observed.factory)) {
+				uninstallPrototypePatches();
+				clearEditorOwnership();
 				refresh();
+				return;
 			}
+			trackZentuiEditorFactory(observed.factory);
+			refresh();
 		});
 	};
 
@@ -464,28 +568,29 @@ export default function (pi: ExtensionAPI) {
 		try {
 			disposeFixedEditor(ctx);
 			if (isTuiContext(ctx)) removeFixedEditorProbe(ctx);
-			uninstallPrototypePatches();
 			stopSessionTimer();
 			stopProjectRefresh();
 			requestFooterRender = undefined;
 			getActiveExtensionStatuses = () => new Map();
 			if (isTuiContext(ctx)) {
 				ctx.ui.setFooter(undefined);
-				const currentFactory = ctx.ui.getEditorComponent();
-				if (!currentFactory || isZentuiEditorFactory(currentFactory)) {
-					ctx.ui.setEditorComponent(
-						getZentuiEditorBaseFactory(currentFactory) ??
-							(editorInstallMode === "wrapper" && wrappedEditorFactory
-								? wrappedEditorFactory
-								: undefined),
-					);
+				const before = observeEditorFactory(ctx);
+				if (before.known) {
+					const currentFactory = before.factory;
+					if (currentFactory && isZentuiEditorFactory(currentFactory)) {
+						replaceEditor(
+							ctx,
+							getZentuiEditorBaseFactory(currentFactory) ??
+								(editorInstallMode === "wrapper" && wrappedEditorFactory
+									? wrappedEditorFactory
+									: undefined),
+						);
+					}
+					reconcileObservedEditorOwnership(ctx);
 				}
 			}
-			wrappedEditorFactory = undefined;
-			installedEditorFactory = undefined;
-			editorInstallMode = "none";
+			uninstallPrototypePatches();
 			footerInstalled = false;
-			editorInstalled = false;
 			activeTheme = undefined;
 		} finally {
 			requestFooterRender = undefined;
@@ -520,9 +625,7 @@ export default function (pi: ExtensionAPI) {
 			const result = applyConfiguredUi(ctx);
 			return {
 				applied: !(patch.editor !== undefined && result.editorBlocked),
-				reason: result.editorBlocked
-					? "another extension is currently managing the editor; reload Pi to apply this change"
-					: undefined,
+				reason: result.editorBlocked ? result.editorReason : undefined,
 			};
 		},
 		setFooterSegments(patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) {

--- a/extensions/zentui/prototype-patch-registry.ts
+++ b/extensions/zentui/prototype-patch-registry.ts
@@ -79,6 +79,7 @@ export function installPrototypePatch(
 	if (!(record && record.method === method && target[method] === record.wrapper)) {
 		const predecessor = target[method];
 		if (typeof predecessor !== "function") {
+			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 			throw new TypeError(`Cannot patch ${method}: predecessor is not a function`);
 		}
 		const nextRecord: PatchRecord = {
@@ -98,7 +99,13 @@ export function installPrototypePatch(
 		nextRecord.wrapper = wrapper;
 		record = nextRecord;
 		registry.set(adapter, record);
-		target[method] = wrapper;
+		try {
+			target[method] = wrapper;
+		} catch (error) {
+			registry.delete(adapter);
+			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
+			throw error;
+		}
 	}
 
 	const token = Symbol(adapter);

--- a/extensions/zentui/selector-border.ts
+++ b/extensions/zentui/selector-border.ts
@@ -65,11 +65,17 @@ export function installSelectorBorderStyle(
 		getTheme,
 		getConfig,
 	);
-	const cleanupSettings = patchSelectorBorderStyle(
-		SettingsSelectorComponent.prototype as unknown as PatchableSelectorPrototype,
-		getTheme,
-		getConfig,
-	);
+	let cleanupSettings: Cleanup;
+	try {
+		cleanupSettings = patchSelectorBorderStyle(
+			SettingsSelectorComponent.prototype as unknown as PatchableSelectorPrototype,
+			getTheme,
+			getConfig,
+		);
+	} catch (error) {
+		cleanupModel();
+		throw error;
+	}
 	return () => {
 		cleanupModel();
 		cleanupSettings();

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -17,7 +17,7 @@ import {
 	safeThemeFg,
 } from "./style";
 
-const SPLIT_POLISHED_FRAME: unique symbol = Symbol.for("pi-zentui.polished-frame");
+const LEGACY_SPLIT_POLISHED_FRAME = Symbol.for("pi-zentui.polished-frame");
 
 type ViewportCounts = {
 	above?: string;
@@ -30,7 +30,12 @@ type PolishedFrameSplit = {
 	viewport: ViewportCounts;
 };
 
-const POLISHED_FRAME_SPLITS = new WeakMap<string[], PolishedFrameSplit>();
+type PolishedFrameProvenance = {
+	rows: readonly string[];
+	split: PolishedFrameSplit;
+};
+
+const POLISHED_FRAME_SPLITS = new WeakMap<string[], PolishedFrameProvenance>();
 
 type AutocompleteEditorInternals = {
 	autocompleteList?: Pick<Component, "render">;
@@ -58,7 +63,6 @@ type WrappedEditor = EditorComponent &
 		setAutocompleteProvider?: (provider: AutocompleteProvider) => void;
 		setPaddingX?: (padding: number) => void;
 		setAutocompleteMaxVisible?: (maxVisible: number) => void;
-		[SPLIT_POLISHED_FRAME]?: (lines: string[]) => PolishedFrameSplit | undefined;
 	};
 
 type EditorMeta = {
@@ -78,8 +82,57 @@ type PolishedFrameOptions = {
 	modelMeta: EditorMeta;
 	thinkingLevel: string | undefined;
 	rightStatus?: string;
-	splitBaseFrame?: (lines: string[]) => PolishedFrameSplit | undefined;
+	ownedFrame?: PolishedFrameSplit;
+	trustedBaseFrame?: boolean;
 };
+
+type PolishedFrameResult = { lines: string[]; decorated: boolean };
+
+type AutocompleteCount = { known: true; count: number } | { known: false };
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((line) => typeof line === "string");
+}
+
+function isViewportCounts(value: unknown): value is ViewportCounts {
+	if (!value || typeof value !== "object") return false;
+	const counts = value as Record<string, unknown>;
+	return [counts.above, counts.below].every(
+		(count) => count === undefined || (typeof count === "string" && /^[1-9]\d*$/.test(count)),
+	);
+}
+
+function isPolishedFrameSplit(value: unknown, baseLineCount: number): value is PolishedFrameSplit {
+	if (!value || typeof value !== "object") return false;
+	const split = value as Record<string, unknown>;
+	return (
+		isStringArray(split.editorLines) &&
+		isStringArray(split.trailingLines) &&
+		split.trailingLines.length <= baseLineCount &&
+		isViewportCounts(split.viewport)
+	);
+}
+
+function readAutocompleteCount(
+	source: AutocompleteEditorInternals,
+	width: number,
+	baseLineCount: number,
+): AutocompleteCount {
+	try {
+		const showing = source.isShowingAutocomplete;
+		if (typeof showing !== "function") return { known: true, count: 0 };
+		if (!showing.call(source)) return { known: true, count: 0 };
+		const list = source.autocompleteList;
+		if (!list || typeof list.render !== "function") return { known: false };
+		const rendered = list.render(width);
+		if (!isStringArray(rendered) || rendered.length <= 0 || rendered.length >= baseLineCount) {
+			return { known: false };
+		}
+		return { known: true, count: rendered.length };
+	} catch {
+		return { known: false };
+	}
+}
 
 function clampRenderedLines(lines: string[], width: number): string[] {
 	const maxWidth = Math.max(0, width);
@@ -264,42 +317,49 @@ function renderPolishedFrame({
 	modelMeta,
 	thinkingLevel,
 	rightStatus,
-	splitBaseFrame,
-}: PolishedFrameOptions): string[] {
-	if (width <= 2) return clampRenderedLines(baseRendered, width);
+	ownedFrame,
+	trustedBaseFrame = false,
+}: PolishedFrameOptions): PolishedFrameResult {
+	if (width <= 2) return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 
 	const reset = "\x1b[0m";
 	const colorSource = config.colorSources.editor;
 	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
 	const innerWidth = Math.max(0, width - railWidth);
 	const copyFriendlyContinuation = " ".repeat(promptWidth);
-	const isShowingAutocomplete =
-		typeof autocompleteSource.isShowingAutocomplete === "function"
-			? Boolean(autocompleteSource.isShowingAutocomplete())
-			: false;
 
-	if (baseRendered.length < 2) return clampRenderedLines(baseRendered, width);
+	if (baseRendered.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	if (ownedFrame && !isPolishedFrameSplit(ownedFrame, baseRendered.length)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
 
-	const ownedFrame = splitBaseFrame?.(baseRendered);
-	const { autocompleteList } = autocompleteSource;
-	const autocompleteCount =
-		!ownedFrame && isShowingAutocomplete && typeof autocompleteList?.render === "function"
-			? autocompleteList.render(innerWidth).length
-			: 0;
+	const autocomplete = ownedFrame
+		? { known: true, count: ownedFrame.trailingLines.length }
+		: readAutocompleteCount(autocompleteSource, innerWidth, baseRendered.length);
+	if (!autocomplete.known) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
 	const editorFrame =
-		!ownedFrame && autocompleteCount > 0 && autocompleteCount < baseRendered.length
-			? baseRendered.slice(0, -autocompleteCount)
+		!ownedFrame && autocomplete.count > 0
+			? baseRendered.slice(0, -autocomplete.count)
 			: baseRendered;
 	const autocompleteLines = ownedFrame
 		? ownedFrame.trailingLines
-		: autocompleteCount > 0 && autocompleteCount < baseRendered.length
-			? baseRendered.slice(-autocompleteCount)
+		: autocomplete.count > 0
+			? baseRendered.slice(-autocomplete.count)
 			: [];
-	if (editorFrame.length < 2) return clampRenderedLines(baseRendered, width);
+	if (editorFrame.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
 
-	const editorLines = ownedFrame?.editorLines ?? editorFrame.slice(1, -1);
 	const parsedTop = parseEditorBorder(editorFrame[0] ?? "", "above");
 	const parsedBottom = parseEditorBorder(editorFrame.at(-1) ?? "", "below");
+	if (!ownedFrame && !trustedBaseFrame && (!parsedTop || !parsedBottom)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const editorLines = ownedFrame?.editorLines ?? editorFrame.slice(1, -1);
 	const viewport = ownedFrame?.viewport ?? {
 		above: parsedTop?.count,
 		below: parsedBottom?.count,
@@ -365,11 +425,14 @@ function renderPolishedFrame({
 
 	const clamped = clampRenderedLines(renderedLines, width);
 	POLISHED_FRAME_SPLITS.set(clamped, {
-		editorLines,
-		trailingLines: autocompleteLines.length > 0 ? clamped.slice(-autocompleteLines.length) : [],
-		viewport,
+		rows: Object.freeze([...clamped]),
+		split: {
+			editorLines,
+			trailingLines: autocompleteLines.length > 0 ? clamped.slice(-autocompleteLines.length) : [],
+			viewport,
+		},
 	});
-	return clamped;
+	return { lines: clamped, decorated: true };
 }
 
 export class PolishedEditor extends CustomEditor {
@@ -404,34 +467,53 @@ export class PolishedEditor extends CustomEditor {
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
 		const rendered = super.render(innerWidth);
-		const modelMeta = this.getModelMeta();
-		const result = renderPolishedFrame({
-			width,
-			baseRendered: rendered,
-			autocompleteSource: this as unknown as AutocompleteEditorInternals,
-			uiTheme: this.uiTheme,
-			config,
-			modelMeta,
-			thinkingLevel: this.getThinkingLevel(),
-		});
-		return result;
-	}
-
-	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
-		return (
-			POLISHED_FRAME_SPLITS.get(lines) ?? splitPolishedFrame(lines, this.getConfig(), this.uiTheme)
-		);
+		try {
+			return renderPolishedFrame({
+				width,
+				baseRendered: rendered,
+				autocompleteSource: this as unknown as AutocompleteEditorInternals,
+				uiTheme: this.uiTheme,
+				config,
+				modelMeta: this.getModelMeta(),
+				thinkingLevel: this.getThinkingLevel(),
+				trustedBaseFrame: true,
+			}).lines;
+		} catch {
+			return clampRenderedLines(rendered, width);
+		}
 	}
 }
 
 export class WrappedPolishedEditor implements EditorComponent {
+	declare readonly addToHistory?: (text: string) => void;
+	declare readonly insertTextAtCursor?: (text: string) => void;
+	declare readonly setAutocompleteProvider?: (provider: AutocompleteProvider) => void;
+	declare readonly setPaddingX?: (padding: number) => void;
+	declare readonly setAutocompleteMaxVisible?: (maxVisible: number) => void;
+
 	constructor(
 		private readonly base: WrappedEditor,
 		private readonly uiTheme: Theme,
 		private readonly getConfig: () => PolishedTuiConfig,
 		private readonly getModelMeta: () => EditorMeta,
 		private readonly getThinkingLevel: () => string | undefined,
-	) {}
+	) {
+		if (typeof base.addToHistory === "function") {
+			this.addToHistory = (text) => base.addToHistory?.(text);
+		}
+		if (typeof base.insertTextAtCursor === "function") {
+			this.insertTextAtCursor = (text) => base.insertTextAtCursor?.(text);
+		}
+		if (typeof base.setAutocompleteProvider === "function") {
+			this.setAutocompleteProvider = (provider) => base.setAutocompleteProvider?.(provider);
+		}
+		if (typeof base.setPaddingX === "function") {
+			this.setPaddingX = (padding) => base.setPaddingX?.(padding);
+		}
+		if (typeof base.setAutocompleteMaxVisible === "function") {
+			this.setAutocompleteMaxVisible = (maxVisible) => base.setAutocompleteMaxVisible?.(maxVisible);
+		}
+	}
 
 	get focused(): boolean {
 		return Boolean(this.base.focused);
@@ -516,26 +598,42 @@ export class WrappedPolishedEditor implements EditorComponent {
 		const config = this.getConfig();
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
-		const rendered = this.base.render(innerWidth);
-		const vimStatus = readVimStatus(this.base, this.uiTheme);
-		const modelMeta = this.getModelMeta();
-		return renderPolishedFrame({
-			width,
-			baseRendered: rendered,
-			autocompleteSource: this.base,
-			uiTheme: this.uiTheme,
-			config,
-			modelMeta,
-			thinkingLevel: this.getThinkingLevel(),
-			rightStatus: vimStatus,
-			splitBaseFrame: this.base[SPLIT_POLISHED_FRAME]?.bind(this.base),
-		});
-	}
-
-	[SPLIT_POLISHED_FRAME](lines: string[]): PolishedFrameSplit | undefined {
-		return (
-			POLISHED_FRAME_SPLITS.get(lines) ?? splitPolishedFrame(lines, this.getConfig(), this.uiTheme)
-		);
+		let rendered: string[];
+		try {
+			rendered = this.base.render(innerWidth);
+		} catch {
+			return clampRenderedLines(this.base.render(width), width);
+		}
+		let result: PolishedFrameResult | undefined;
+		try {
+			const provenance = POLISHED_FRAME_SPLITS.get(rendered);
+			const provenanceMatches = Boolean(
+				provenance &&
+					provenance.rows.length === rendered.length &&
+					provenance.rows.every((line, index) => line === rendered[index]),
+			);
+			const ownedFrame = provenanceMatches ? provenance?.split : undefined;
+			const hasMutatedProvenance = Boolean(provenance && !provenanceMatches);
+			const hasUntrustedLegacySplitter = LEGACY_SPLIT_POLISHED_FRAME in this.base;
+			const hasUnprovenPolishedFrame =
+				!ownedFrame && Boolean(splitPolishedFrame(rendered, config, this.uiTheme));
+			if (!hasMutatedProvenance && !hasUntrustedLegacySplitter && !hasUnprovenPolishedFrame) {
+				result = renderPolishedFrame({
+					width,
+					baseRendered: rendered,
+					autocompleteSource: this.base,
+					uiTheme: this.uiTheme,
+					config,
+					modelMeta: this.getModelMeta(),
+					thinkingLevel: this.getThinkingLevel(),
+					rightStatus: readVimStatus(this.base, this.uiTheme),
+					ownedFrame,
+				});
+			}
+		} catch {
+			// Decoration is optional; re-render the base at the caller's width below.
+		}
+		return result?.decorated ? result.lines : clampRenderedLines(this.base.render(width), width);
 	}
 
 	invalidate(): void {
@@ -554,28 +652,8 @@ export class WrappedPolishedEditor implements EditorComponent {
 		this.base.setText(text);
 	}
 
-	addToHistory(text: string): void {
-		this.base.addToHistory?.(text);
-	}
-
-	insertTextAtCursor(text: string): void {
-		this.base.insertTextAtCursor?.(text);
-	}
-
 	getExpandedText(): string {
 		return this.base.getExpandedText?.() ?? this.base.getText();
-	}
-
-	setAutocompleteProvider(provider: AutocompleteProvider): void {
-		this.base.setAutocompleteProvider?.(provider);
-	}
-
-	setPaddingX(padding: number): void {
-		this.base.setPaddingX?.(padding);
-	}
-
-	setAutocompleteMaxVisible(maxVisible: number): void {
-		this.base.setAutocompleteMaxVisible?.(maxVisible);
 	}
 
 	getLines(): string[] {

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -225,24 +225,30 @@ export function installUserMessageStyle(
 			return Reflect.apply(predecessor, receiver, args);
 		},
 	);
-	const cleanupRender = installPrototypePatch(
-		prototype,
-		"render",
-		"user-message-render",
-		({ predecessor, receiver, args }) => {
-			const width = args[0];
-			if (typeof width !== "number") return Reflect.apply(predecessor, receiver, args);
-			const lines = renderZentuiUserMessage(
-				receiver as PatchableUserMessagePrototype,
-				width,
-				getTheme(),
-				getConfig(),
-			);
-			if (!lines) return Reflect.apply(predecessor, receiver, args);
-			if (lines.length === 0) return lines;
-			return withPromptZoneMarkers(lines);
-		},
-	);
+	let cleanupRender: Cleanup;
+	try {
+		cleanupRender = installPrototypePatch(
+			prototype,
+			"render",
+			"user-message-render",
+			({ predecessor, receiver, args }) => {
+				const width = args[0];
+				if (typeof width !== "number") return Reflect.apply(predecessor, receiver, args);
+				const lines = renderZentuiUserMessage(
+					receiver as PatchableUserMessagePrototype,
+					width,
+					getTheme(),
+					getConfig(),
+				);
+				if (!lines) return Reflect.apply(predecessor, receiver, args);
+				if (lines.length === 0) return lines;
+				return withPromptZoneMarkers(lines);
+			},
+		);
+	} catch (error) {
+		cleanupInvalidate();
+		throw error;
+	}
 	let cleaned = false;
 	return () => {
 		if (cleaned) return;

--- a/test/editor-transfer.test.ts
+++ b/test/editor-transfer.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from "vitest";
+import { replaceEditorComponentWithExpandedText } from "../extensions/zentui/editor-transfer";
+
+type Editor = {
+	getText(): string;
+	setText(text: string): void;
+	getExpandedText?: () => string;
+};
+
+type Factory = () => Editor;
+
+function piLikeUi(initialEditor: Editor, operations: string[], initialFactory?: Factory) {
+	let active = initialEditor;
+	let configuredFactory = initialFactory;
+	return {
+		get active() {
+			return active;
+		},
+		get configuredFactory() {
+			return configuredFactory;
+		},
+		getEditorComponent() {
+			operations.push("getEditorComponent");
+			return configuredFactory;
+		},
+		getEditorText() {
+			operations.push("getEditorText");
+			return active.getExpandedText?.() ?? active.getText();
+		},
+		setEditorText(text: string) {
+			operations.push(`setEditorText:${text}`);
+			active.setText(text);
+		},
+		setEditorComponent(factory: Factory | undefined) {
+			operations.push("setEditorComponent");
+			configuredFactory = factory;
+			const currentText = active.getText();
+			if (!factory) return;
+			const next = factory();
+			next.setText(currentText);
+			active = next;
+		},
+	};
+}
+
+function textEditor(initial = ""): Editor {
+	let text = initial;
+	return {
+		getText: () => text,
+		setText(next) {
+			text = next;
+		},
+	};
+}
+
+describe("safe editor component transfer", () => {
+	it("expands a collapsed paste before Pi snapshots the replaced editor", () => {
+		const marker = "[paste #1 +12 lines]";
+		const expanded = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n");
+		let oldText = marker;
+		const operations: string[] = [];
+		const oldEditor: Editor = {
+			getText: () => oldText,
+			getExpandedText: () => (oldText === marker ? expanded : oldText),
+			setText(text) {
+				oldText = text;
+			},
+		};
+		const ui = piLikeUi(oldEditor, operations);
+		const next = textEditor();
+
+		const result = replaceEditorComponentWithExpandedText(ui, () => next);
+
+		expect(result).toEqual({ ok: true });
+		expect(operations).toEqual([
+			"getEditorComponent",
+			"getEditorText",
+			`setEditorText:${expanded}`,
+			"setEditorComponent",
+		]);
+		expect(ui.active).toBe(next);
+		expect(next.getText()).toBe(expanded);
+		expect(next.getText()).not.toContain(marker);
+	});
+
+	it.each(["ordinary prompt", ""])("transfers normal prompt text: %j", (text) => {
+		const operations: string[] = [];
+		const ui = piLikeUi(textEditor(text), operations);
+		const next = textEditor();
+
+		expect(replaceEditorComponentWithExpandedText(ui, () => next)).toEqual({ ok: true });
+		expect(next.getText()).toBe(text);
+	});
+
+	it("uses the public getText fallback for a third-party editor without getExpandedText", () => {
+		const operations: string[] = [];
+		const ui = piLikeUi(textEditor("third-party draft"), operations);
+		const next = textEditor();
+
+		expect(replaceEditorComponentWithExpandedText(ui, () => next)).toEqual({ ok: true });
+		expect(next.getText()).toBe("third-party draft");
+	});
+
+	it("does not replace when the public transfer API is unavailable", () => {
+		const setEditorComponent = vi.fn();
+		expect(replaceEditorComponentWithExpandedText({ setEditorComponent }, undefined)).toEqual({
+			ok: false,
+			reason: "unsupported-transfer-api",
+		});
+		expect(setEditorComponent).not.toHaveBeenCalled();
+	});
+
+	it("does not replace when the previous factory cannot be snapshotted", () => {
+		const getEditorText = vi.fn();
+		const setEditorComponent = vi.fn();
+		const result = replaceEditorComponentWithExpandedText(
+			{
+				getEditorComponent() {
+					throw new Error("factory snapshot failed");
+				},
+				getEditorText,
+				setEditorText() {},
+				setEditorComponent,
+			},
+			undefined,
+		);
+
+		expect(result).toEqual({ ok: false, reason: "editor-factory-snapshot-failed" });
+		expect(getEditorText).not.toHaveBeenCalled();
+		expect(setEditorComponent).not.toHaveBeenCalled();
+	});
+
+	it("does not replace when expanded text snapshotting fails", () => {
+		const setEditorText = vi.fn();
+		const setEditorComponent = vi.fn();
+		const result = replaceEditorComponentWithExpandedText(
+			{
+				getEditorComponent: () => undefined,
+				getEditorText() {
+					throw new Error("snapshot failed");
+				},
+				setEditorText,
+				setEditorComponent,
+			},
+			undefined,
+		);
+
+		expect(result).toEqual({ ok: false, reason: "editor-text-snapshot-failed" });
+		expect(setEditorText).not.toHaveBeenCalled();
+		expect(setEditorComponent).not.toHaveBeenCalled();
+	});
+
+	it("rejects a non-string snapshot without replacing", () => {
+		const setEditorComponent = vi.fn();
+		const result = replaceEditorComponentWithExpandedText(
+			{
+				getEditorComponent: () => undefined,
+				getEditorText: () => undefined,
+				setEditorText() {},
+				setEditorComponent,
+			},
+			undefined,
+		);
+		expect(result).toEqual({ ok: false, reason: "editor-text-snapshot-failed" });
+		expect(setEditorComponent).not.toHaveBeenCalled();
+	});
+
+	it("does not replace when writing expanded text back fails", () => {
+		const setEditorComponent = vi.fn();
+		const result = replaceEditorComponentWithExpandedText(
+			{
+				getEditorComponent: () => undefined,
+				getEditorText: () => "expanded",
+				setEditorText() {
+					throw new Error("write failed");
+				},
+				setEditorComponent,
+			},
+			undefined,
+		);
+
+		expect(result).toEqual({ ok: false, reason: "editor-text-preparation-failed" });
+		expect(setEditorComponent).not.toHaveBeenCalled();
+	});
+
+	it("restores the previous factory after an assignment-first replacement failure", () => {
+		const operations: string[] = [];
+		const previousEditor = textEditor("marker");
+		const previousFactory = () => previousEditor;
+		const ui = piLikeUi(previousEditor, operations, previousFactory);
+		const failingFactory = () => {
+			throw new Error("replacement failed after assignment");
+		};
+
+		const result = replaceEditorComponentWithExpandedText(ui, failingFactory);
+
+		expect(result).toEqual({
+			ok: false,
+			reason: "editor-replacement-failed-with-rollback",
+		});
+		expect(ui.configuredFactory).toBe(previousFactory);
+		expect(ui.active.getText()).toBe("marker");
+		expect(operations).toEqual([
+			"getEditorComponent",
+			"getEditorText",
+			"setEditorText:marker",
+			"setEditorComponent",
+			"setEditorComponent",
+		]);
+	});
+
+	it("reports when assignment-first replacement rollback also throws", () => {
+		const previousFactory = () => textEditor("previous");
+		let configuredFactory: Factory | undefined = previousFactory;
+		let setterCalls = 0;
+		const result = replaceEditorComponentWithExpandedText(
+			{
+				getEditorComponent: () => configuredFactory,
+				getEditorText: () => "expanded payload",
+				setEditorText() {},
+				setEditorComponent(factory) {
+					configuredFactory = factory;
+					setterCalls += 1;
+					throw new Error(setterCalls === 1 ? "replacement failed" : "rollback failed");
+				},
+			},
+			() => textEditor("next"),
+		);
+
+		expect(result).toEqual({
+			ok: false,
+			reason: "editor-replacement-rollback-failed",
+		});
+		expect(setterCalls).toBe(2);
+	});
+
+	it("submits the exact original multiline paste payload after replacement", () => {
+		const marker = "[paste #7 +4 lines]";
+		const payload = "alpha\nbeta\ngamma\ndelta";
+		let oldText = marker;
+		const submitted: string[] = [];
+		const oldEditor: Editor = {
+			getText: () => oldText,
+			getExpandedText: () => (oldText === marker ? payload : oldText),
+			setText(text) {
+				oldText = text;
+			},
+		};
+		const operations: string[] = [];
+		const ui = piLikeUi(oldEditor, operations);
+		const next = textEditor();
+
+		expect(replaceEditorComponentWithExpandedText(ui, () => next)).toEqual({ ok: true });
+		const onSubmit = (text: string) => submitted.push(text);
+		onSubmit(next.getText());
+
+		expect(submitted).toEqual([payload]);
+		expect(submitted[0]).not.toContain("[paste #");
+	});
+});

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
 import { WrappedPolishedEditor } from "../extensions/zentui/ui";
 
@@ -148,11 +148,233 @@ describe("editor viewport indicators", () => {
 		"─── ↑ 07 more ─────────",
 		"prefix ─── ↑ 7 more ─────────",
 		"[muted]─── ↑ 7 more ─────────[/muted]",
-	])("fails closed for an unknown top border form: %s", (malformedTop) => {
+	])("fails open for an unknown top border form: %s", (malformedTop) => {
 		const lines = wrapped(baseEditor({ below: 2, malformedTop })).render(80);
-		expect(lines[0]).toMatch(/^─+$/);
-		expect(lines[0]).not.toContain("more");
+		expect(lines[0]).toBe(malformedTop);
+		expect(lines).toContain("typed text");
 		expect(lines.at(-1)).toContain("↓ 2 more");
+	});
+
+	it("preserves every row from a minimal public-contract third-party editor", () => {
+		let text = "draft";
+		const inputs: string[] = [];
+		const base = {
+			render: () => ["third-party header", text, "third-party help"],
+			invalidate() {},
+			handleInput(data: string) {
+				inputs.push(data);
+				text += data;
+			},
+			getText: () => text,
+			setText(next: string) {
+				text = next;
+			},
+		};
+		const editor = wrapped(base as never);
+
+		expect(editor.render(80)).toEqual(["third-party header", "draft", "third-party help"]);
+		editor.handleInput("!");
+		expect(editor.getText()).toBe("draft!");
+		expect(inputs).toEqual(["!"]);
+	});
+
+	it("preserves autocomplete rows when Pi-private inspection fields are absent", () => {
+		const base = {
+			render: (width: number) => [
+				nativeBorder(width, "above"),
+				"typed text",
+				nativeBorder(width, "below"),
+				"suggestion-one",
+				"suggestion-two",
+			],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+
+		const lines = wrapped(base as never).render(80);
+		expect(lines).toContain("typed text");
+		expect(lines).toContain("suggestion-one");
+		expect(lines).toContain("suggestion-two");
+		expect(lines).toHaveLength(5);
+	});
+
+	it.each(["visibility method", "autocomplete getter", "autocomplete render"])(
+		"returns base rows when %s throws",
+		(failure) => {
+			const rendered = ["header", "typed text", "suggestion"];
+			const base: Record<string, unknown> = {
+				render: () => rendered,
+				invalidate() {},
+				handleInput() {},
+				getText: () => "typed text",
+				setText() {},
+			};
+			if (failure === "visibility method") {
+				base.isShowingAutocomplete = () => {
+					throw new Error("visibility failed");
+				};
+			} else {
+				base.isShowingAutocomplete = () => true;
+				if (failure === "autocomplete getter") {
+					Object.defineProperty(base, "autocompleteList", {
+						get() {
+							throw new Error("getter failed");
+						},
+					});
+				} else {
+					base.autocompleteList = {
+						render() {
+							throw new Error("render failed");
+						},
+					};
+				}
+			}
+
+			expect(wrapped(base as never).render(80)).toEqual(rendered);
+		},
+	);
+
+	it("does not trust or invoke a generic editor's spoofed polished-frame splitter", () => {
+		const widths: number[] = [];
+		const spoofedSplit = vi.fn(() => ({
+			editorLines: ["spoofed"],
+			trailingLines: [],
+			viewport: {},
+		}));
+		const base = {
+			render(width: number) {
+				widths.push(width);
+				return [nativeBorder(width, "above"), "typed text", nativeBorder(width, "below")];
+			},
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+			[Symbol.for("pi-zentui.polished-frame")]: spoofedSplit,
+		};
+		expect(wrapped(base as never).render(80)).toEqual([
+			nativeBorder(80, "above"),
+			"typed text",
+			nativeBorder(80, "below"),
+		]);
+		expect(widths).toEqual([78, 80]);
+		expect(spoofedSplit).not.toHaveBeenCalled();
+	});
+
+	it("fails open for polished-looking rows without exact module-owned array provenance", () => {
+		const trusted = wrapped(baseEditor({ above: 2, below: 3 })).render(80);
+		const staleClone = trusted.slice();
+		const base = {
+			render: () => staleClone,
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+
+		const lines = wrapped(base as never).render(80);
+		expect(lines).toEqual(staleClone);
+		expect(lines.join("\n").match(/model/g)).toHaveLength(1);
+	});
+
+	it("rejects in-place mutation of an otherwise provenance-owned rendered array", () => {
+		const rendered = wrapped(baseEditor({ above: 2, below: 3 })).render(80);
+		rendered[1] = "changed-row";
+		rendered.splice(2, 0, "added-row");
+		const base = {
+			render: () => rendered,
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+
+		const lines = wrapped(base as never).render(80);
+		expect(lines).toEqual(rendered);
+		expect(lines).toContain("changed-row");
+		expect(lines).toContain("added-row");
+	});
+
+	it("falls back to caller-width rendering when the inner-width probe throws", () => {
+		const widths: number[] = [];
+		const base = {
+			render(width: number) {
+				widths.push(width);
+				if (width < 80) throw new Error("inner-width render failed");
+				return ["caller-width-header", "x".repeat(width + 4), "caller-width-help"];
+			},
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+
+		const lines = wrapped(base as never).render(80);
+		expect(widths).toEqual([78, 80]);
+		expect(lines[0]).toBe("caller-width-header");
+		expect(lines.at(-1)).toBe("caller-width-help");
+		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+	});
+
+	it("re-renders unknown third-party output at the caller width before failing open", () => {
+		const widths: number[] = [];
+		const base = {
+			render(width: number) {
+				widths.push(width);
+				return [`header-${width}`, "x".repeat(width + 5), `help-${width}`];
+			},
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+
+		const lines = wrapped(base as never).render(80);
+		expect(widths).toEqual([78, 80]);
+		expect(lines[0]).toBe("header-80");
+		expect(lines.at(-1)).toBe("help-80");
+		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+	});
+
+	it("only exposes optional editor methods implemented by the base", () => {
+		const withoutCapabilities = wrapped({
+			render: () => ["plain"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+		} as never);
+		for (const method of [
+			"addToHistory",
+			"insertTextAtCursor",
+			"setAutocompleteProvider",
+			"setPaddingX",
+			"setAutocompleteMaxVisible",
+		]) {
+			expect(method in withoutCapabilities).toBe(false);
+		}
+
+		const calls: string[] = [];
+		const withCapabilities = wrapped({
+			render: () => ["plain"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+			addToHistory: () => calls.push("history"),
+			insertTextAtCursor: () => calls.push("insert"),
+			setAutocompleteProvider: () => calls.push("autocomplete"),
+			setPaddingX: () => calls.push("padding"),
+			setAutocompleteMaxVisible: () => calls.push("max-visible"),
+		} as never);
+		withCapabilities.addToHistory?.("history");
+		withCapabilities.insertTextAtCursor?.("insert");
+		withCapabilities.setAutocompleteProvider?.({} as never);
+		withCapabilities.setPaddingX?.(1);
+		withCapabilities.setAutocompleteMaxVisible?.(5);
+		expect(calls).toEqual(["history", "insert", "autocomplete", "padding", "max-visible"]);
 	});
 
 	it("keeps every rendered line within narrow ANSI-aware widths in both chrome modes", () => {
@@ -169,7 +391,6 @@ describe("editor viewport indicators", () => {
 	it("matches Pi's complete native form rather than reconstructing a truncated count", () => {
 		const truncatedNativeTop = truncateToWidth("─── ↑ 12 more ", 10, "");
 		const lines = wrapped(baseEditor({ below: 1, malformedTop: truncatedNativeTop })).render(40);
-		expect(lines[0]).toMatch(/^─+$/);
-		expect(lines[0]).not.toContain("↑");
+		expect(lines[0]).toBe(truncatedNativeTop);
 	});
 });

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
@@ -7,7 +7,7 @@ import {
 	UserMessageComponent,
 } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
 	defaultConfig,
 	type ExtensionStatusPlacement,
@@ -27,6 +27,16 @@ import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-com
 import { createInitialState } from "../extensions/zentui/state";
 import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
 import { installUserMessageStyle } from "../extensions/zentui/user-message";
+
+const isolatedAgentDir = vi.hoisted(() => {
+	const previous = process.env.PI_CODING_AGENT_DIR;
+	const path = `/tmp/pi-zentui-extension-compliance-${process.pid}`;
+	const fs = process.getBuiltinModule("node:fs");
+	fs.rmSync(path, { recursive: true, force: true });
+	fs.mkdirSync(path, { recursive: true });
+	process.env.PI_CODING_AGENT_DIR = path;
+	return { path, previous };
+});
 
 type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
 type FooterFactory = (...args: unknown[]) => {
@@ -138,9 +148,16 @@ function makeStrictTheme(): Theme {
 
 function makeUi(prefix = "") {
 	let editorComponent: unknown;
+	let editorText = "";
 	return {
 		theme: makeTaggedTheme(prefix),
 		setFooter() {},
+		getEditorText() {
+			return editorText;
+		},
+		setEditorText(text: string) {
+			editorText = text;
+		},
 		setEditorComponent(factory: unknown) {
 			editorComponent = factory;
 		},
@@ -238,9 +255,16 @@ async function emit(handlers: Map<string, Handler[]>, eventName: string, ctx: un
 function makeContext(overrides: Record<string, unknown> = {}) {
 	const theme = makeTheme();
 	let editorComponent: unknown;
+	let editorText = "";
 	const ui = {
 		theme,
 		setFooter() {},
+		getEditorText() {
+			return editorText;
+		},
+		setEditorText(text: string) {
+			editorText = text;
+		},
 		setEditorComponent(factory: unknown) {
 			editorComponent = factory;
 		},
@@ -262,7 +286,14 @@ function makeContext(overrides: Record<string, unknown> = {}) {
 	};
 }
 
+afterAll(() => {
+	rmSync(isolatedAgentDir.path, { recursive: true, force: true });
+	if (isolatedAgentDir.previous === undefined) delete process.env.PI_CODING_AGENT_DIR;
+	else process.env.PI_CODING_AGENT_DIR = isolatedAgentDir.previous;
+});
+
 afterEach(() => {
+	rmSync(join(isolatedAgentDir.path, "zentui.json"), { force: true });
 	UserMessageComponent.prototype.render = originalUserMessageRender;
 	UserMessageComponent.prototype.invalidate = originalUserMessageInvalidate;
 	delete (UserMessageComponent.prototype as unknown as Record<PropertyKey, unknown>)[
@@ -384,6 +415,261 @@ describe("Pi docs compliance", () => {
 		await emit(handlers, "session_start", ctx);
 
 		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+	});
+
+	it("expands collapsed paste content across install, reload, toggle, and cleanup replacements", async () => {
+		const firstHandlers = loadExtension();
+		const marker = "[paste #1 +12 lines]";
+		const expanded = Array.from({ length: 12 }, (_, index) => `line ${index + 1}`).join("\n");
+		let editorFactory: unknown;
+		let editorText = marker;
+		const transferred: string[] = [];
+		const operations: string[] = [];
+		const patchPresenceDuringReplacements: boolean[] = [];
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				getEditorText() {
+					operations.push("getEditorText");
+					return editorText === marker ? expanded : editorText;
+				},
+				setEditorText(text: string) {
+					operations.push("setEditorText");
+					editorText = text;
+				},
+				setEditorComponent(factory: unknown) {
+					operations.push("setEditorComponent");
+					patchPresenceDuringReplacements.push(
+						UserMessageComponent.prototype.render !== originalUserMessageRender ||
+							ModelSelectorComponent.prototype.render !== originalModelSelectorRender,
+					);
+					transferred.push(editorText);
+					editorFactory = factory;
+				},
+				getEditorComponent() {
+					return editorFactory;
+				},
+				notify() {},
+			},
+		});
+
+		await emit(firstHandlers, "session_start", ctx);
+		expect(patchPresenceDuringReplacements).toEqual([false]);
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+		await new Promise((resolve) => setTimeout(resolve, 1));
+
+		editorText = marker;
+		const commands = new Map<string, unknown>();
+		const reloadedHandlers = loadExtension({ commands });
+		await emit(reloadedHandlers, "session_start", ctx);
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		const command = commands.get("zentui") as {
+			handler(args: string, ctx: unknown): Promise<void>;
+		};
+
+		editorText = marker;
+		await command.handler("editor disable", ctx);
+		editorText = marker;
+		await command.handler("editor enable", ctx);
+		editorText = marker;
+		await emit(reloadedHandlers, "session_shutdown", ctx);
+
+		expect(operations).toEqual(
+			Array.from({ length: 5 }, () => [
+				"getEditorText",
+				"setEditorText",
+				"setEditorComponent",
+			]).flat(),
+		);
+		expect(transferred).toEqual(Array.from({ length: 5 }, () => expanded));
+		expect(transferred).not.toContain(marker);
+		expect(patchPresenceDuringReplacements).toEqual([false, true, true, false, true]);
+	});
+
+	it("keeps the active factory when expanded editor text cannot be read", async () => {
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		const existingFactory = () => ({
+			render: () => ["third-party"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "draft",
+			setText() {},
+		});
+		const editorFactory: unknown = existingFactory;
+		let setEditorCalls = 0;
+		const notifications: string[] = [];
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				getEditorText() {
+					throw new Error("unavailable");
+				},
+				setEditorText() {},
+				setEditorComponent() {
+					setEditorCalls += 1;
+				},
+				getEditorComponent() {
+					return editorFactory;
+				},
+				notify(message: string) {
+					notifications.push(message);
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		const command = commands.get("zentui") as {
+			handler(args: string, ctx: unknown): Promise<void>;
+		};
+		await command.handler("editor enable", ctx);
+
+		expect(setEditorCalls).toBe(0);
+		expect(editorFactory).toBe(existingFactory);
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		expect(notifications.at(-1)).toContain("expanded editor text could not be read safely");
+	});
+
+	it("rolls back editor activation and all prototype patches when patch installation fails", async () => {
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		let setEditorCalls = 0;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				getEditorText: () => "draft",
+				setEditorText() {},
+				setEditorComponent(factory: unknown) {
+					setEditorCalls += 1;
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+		});
+		const userPrototype = UserMessageComponent.prototype as unknown as {
+			render: typeof originalUserMessageRender | undefined;
+		};
+		userPrototype.render = undefined;
+		try {
+			await emit(handlers, "session_start", ctx);
+			expect(editorFactory).toBeUndefined();
+			expect(setEditorCalls).toBe(2);
+			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+			expect(SettingsSelectorComponent.prototype.render).toBe(originalSettingsSelectorRender);
+			expect(UserMessageComponent.prototype.invalidate).toBe(originalUserMessageInvalidate);
+			for (const prototype of [
+				ModelSelectorComponent.prototype,
+				SettingsSelectorComponent.prototype,
+				UserMessageComponent.prototype,
+			]) {
+				expect(
+					(prototype as unknown as Record<PropertyKey, unknown>)[ZENTUI_PROTOTYPE_PATCH_REGISTRY],
+				).toBeUndefined();
+			}
+			await emit(handlers, "session_shutdown", ctx);
+		} finally {
+			userPrototype.render = originalUserMessageRender;
+		}
+	});
+
+	it("tracks the active Zentui factory after nested patch-rollback failure", async () => {
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		const existingFactory = () => ({
+			render: () => ["existing"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "draft",
+			setText() {},
+		});
+		let editorFactory: unknown = existingFactory;
+		const assignedFactories: unknown[] = [];
+		let failedPreviousFactoryRestore = false;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				getEditorText: () => "draft",
+				setEditorText() {},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+					assignedFactories.push(factory);
+					if (factory === existingFactory && !failedPreviousFactoryRestore) {
+						failedPreviousFactoryRestore = true;
+						throw new Error("previous factory construction failed after assignment");
+					}
+				},
+				getEditorComponent: () => editorFactory,
+				notify() {},
+			},
+		});
+		const userPrototype = UserMessageComponent.prototype as unknown as {
+			render: typeof originalUserMessageRender | undefined;
+		};
+		userPrototype.render = undefined;
+		try {
+			await emit(handlers, "session_start", ctx);
+			expect(editorFactory).toBeTypeOf("function");
+			expect(editorFactory).not.toBe(existingFactory);
+			expect(assignedFactories).toHaveLength(3);
+			userPrototype.render = originalUserMessageRender;
+
+			const command = commands.get("zentui") as {
+				handler(args: string, ctx: unknown): Promise<void>;
+			};
+			await command.handler("editor disable", ctx);
+			expect(editorFactory).toBe(existingFactory);
+			expect(assignedFactories).toHaveLength(4);
+			await emit(handlers, "session_shutdown", ctx);
+		} finally {
+			userPrototype.render = originalUserMessageRender;
+		}
+	});
+
+	it("retains shutdown ownership when restoration fails and rollback leaves Zentui active", async () => {
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		let editorFactory: unknown;
+		const assignedFactories: unknown[] = [];
+		let failNextDefaultRestore = false;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				getEditorText: () => "draft",
+				setEditorText() {},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+					assignedFactories.push(factory);
+					if (factory === undefined && failNextDefaultRestore) {
+						failNextDefaultRestore = false;
+						throw new Error("default restoration failed after assignment");
+					}
+				},
+				getEditorComponent: () => editorFactory,
+				notify() {},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		const zentuiFactory = editorFactory;
+		expect(zentuiFactory).toBeTypeOf("function");
+		failNextDefaultRestore = true;
+		await emit(handlers, "session_shutdown", ctx);
+		expect(editorFactory).toBe(zentuiFactory);
+		expect(assignedFactories).toHaveLength(3);
+
+		const command = commands.get("zentui") as {
+			handler(args: string, ctx: unknown): Promise<void>;
+		};
+		await command.handler("editor disable", ctx);
+		expect(editorFactory).toBeUndefined();
+		expect(assignedFactories).toHaveLength(4);
 	});
 
 	it("wraps an editor component already installed by another extension", async () => {
@@ -583,47 +869,67 @@ describe("Pi docs compliance", () => {
 		expect(rendered.match(/Anthropic/g)).toHaveLength(1);
 	});
 
-	it("re-wraps an editor component that loads after Zentui", async () => {
-		const handlers = loadExtension();
-		const laterEditorFactory = () => ({
-			render: (width: number) => ["─".repeat(width), "late vim editor", "─".repeat(width)],
-			invalidate() {},
-			handleInput() {},
-			getText: () => "",
-			setText() {},
-			getMode: () => "normal",
-		});
-		let editorFactory: unknown;
-		const ctx = makeContext({
-			ui: {
-				theme: makeTheme(),
-				setFooter() {},
-				setEditorComponent(factory: unknown) {
-					editorFactory = factory;
+	it.each([
+		["the default editor", undefined],
+		[
+			"a non-Zentui editor",
+			() => ({
+				render: () => ["external editor"],
+				invalidate() {},
+				handleInput() {},
+				getText: () => "",
+				setText() {},
+			}),
+		],
+	] as const)(
+		"preserves post-start takeover by %s through reconciliation, disable, and shutdown",
+		async (_label, takeoverFactory) => {
+			const commands = new Map<string, unknown>();
+			const handlers = loadExtension({ commands });
+			let editorFactory: unknown;
+			let setEditorCalls = 0;
+			const ctx = makeContext({
+				ui: {
+					theme: makeTheme(),
+					setFooter() {},
+					setEditorComponent(factory: unknown) {
+						setEditorCalls += 1;
+						editorFactory = factory;
+					},
+					getEditorComponent() {
+						return editorFactory;
+					},
+					notify() {},
 				},
-				getEditorComponent() {
-					return editorFactory;
-				},
-			},
-		});
+			});
 
-		await emit(handlers, "session_start", ctx);
-		const originalZentuiFactory = editorFactory;
-		editorFactory = laterEditorFactory;
+			await emit(handlers, "session_start", ctx);
+			expect(editorFactory).toBeTypeOf("function");
+			expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+			editorFactory = takeoverFactory;
 
-		await new Promise((resolve) => setTimeout(resolve, 1));
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			expect(editorFactory).toBe(takeoverFactory);
+			expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
 
-		expect(editorFactory).not.toBe(originalZentuiFactory);
-		expect(editorFactory).not.toBe(laterEditorFactory);
-		expect(editorFactory).toBeTypeOf("function");
-		const editor = (editorFactory as (...args: unknown[]) => ReturnType<typeof laterEditorFactory>)(
-			{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
-			{ borderColor: (text: string) => text, selectList: {} } as never,
-			{} as never,
-		);
-		expect(editor.render(80).join("\n")).toContain("late vim editor");
-		expect(editor.render(80).join("\n")).toContain("NORMAL");
-	});
+			const command = commands.get("zentui") as {
+				handler(args: string, ctx: unknown): Promise<void>;
+			};
+			await command.handler("editor enable", ctx);
+			expect(editorFactory).toBeTypeOf("function");
+			expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+			editorFactory = takeoverFactory;
+			await command.handler("editor disable", ctx);
+			expect(editorFactory).toBe(takeoverFactory);
+			expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+			await emit(handlers, "session_shutdown", ctx);
+			expect(editorFactory).toBe(takeoverFactory);
+			expect(setEditorCalls).toBe(2);
+		},
+	);
 
 	it("does not reconcile an editor after its session shuts down", async () => {
 		vi.useFakeTimers();
@@ -2111,7 +2417,7 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("[thinkingText]low");
 	});
 
-	it("wraps a vim editor by delegating input and rendering a mode segment", () => {
+	it("delegates vim input and leaves an unrecognized vim frame untouched", () => {
 		const inputs: string[] = [];
 		let text = "hello";
 		let mode = "normal";
@@ -2151,9 +2457,9 @@ describe("Pi docs compliance", () => {
 		expect(inputs).toEqual(["i", "j", "k"]);
 		expect(editor.getText()).toBe("changed");
 		expect(rendered).toContain("changed");
-		expect(rendered).toContain("[success]INSERT");
-		expect(rendered).toMatch(/ {2,}\[success\]INSERT/);
-		expect(rendered).toContain("[accent]claude-sonnet");
+		expect(rendered).toContain("NORMAL");
+		expect(rendered).not.toContain("[success]INSERT");
+		expect(rendered).not.toContain("[accent]claude-sonnet");
 	});
 
 	it("unwraps a branded nested editor without duplicating literal-only metadata", () => {


### PR DESCRIPTION
## Summary

- transfer expanded prompt content before editor factory replacement so collapsed pastes cannot become orphan markers
- add best-effort assignment-first rollback and truthful ownership reconciliation
- preserve external/default editor takeovers and make prototype patch installation transactional
- fail open for unknown third-party renderers at caller width
- expose only capabilities supported by wrapped editors and trust polished frame metadata through owned provenance

## Compatibility

- minimum supported Pi version remains `0.80.3`
- verified against Pi `0.80.3` APIs and development baseline `0.82.1`
- unsupported private state such as cursor, undo/history, scroll, and autocomplete state is not guessed or serialized

## Validation

- `npm run fmt`
- Node 24 isolated-HOME `npm run verify` — 548 tests passed
- `npm run pack:check`
- manually tested editor typing, history, autocomplete, paste, toggling, shell input, restart, and session switching
- approved by independent lifecycle and rendering reviews

Closes #66