### PR TITLE
fix: match pi cumulative usage totals

### DIFF
--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -1,5 +1,4 @@
 import { homedir, hostname, userInfo } from "node:os";
-import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type {
@@ -81,14 +80,29 @@ export type UsageTotals = {
 
 export type ContextColorTier = "normal" | "warning" | "error";
 
+type SessionUsage = {
+	input?: unknown;
+	output?: unknown;
+	cacheRead?: unknown;
+	cacheWrite?: unknown;
+	cost?: unknown;
+};
+
 type SessionEntry = {
 	type?: string;
 	id?: string | number;
 	timestamp?: string | number;
+	usage?: SessionUsage;
 	message?: {
 		role?: string;
-		usage?: AssistantMessage["usage"];
+		usage?: SessionUsage;
 	};
+};
+
+type SelectedUsage = {
+	usage: SessionUsage | undefined;
+	location: "message" | "entry";
+	isAssistant: boolean;
 };
 
 type UsageCacheEntry = {
@@ -96,8 +110,10 @@ type UsageCacheEntry = {
 	totals: UsageTotals;
 };
 
+const MAX_USAGE_TOTAL = Number.MAX_VALUE;
+
 let usageTotalsCache: UsageCacheEntry | undefined;
-let usageTotalsComputeCount = 0;
+let usageTotalsAggregationPassCount = 0;
 
 export function formatCount(value: number): string {
 	if (value < 1000) return value.toString();
@@ -130,26 +146,78 @@ function calculateCacheHitRate(
 	cacheWrite: number,
 ): number | undefined {
 	const promptTokens = input + cacheRead + cacheWrite;
-	return promptTokens > 0 ? (cacheRead / promptTokens) * 100 : undefined;
+	if (promptTokens === 0) return undefined;
+	if (Number.isFinite(promptTokens)) return (cacheRead / promptTokens) * 100;
+
+	const scale = Math.max(input, cacheRead, cacheWrite);
+	const scaledPromptTokens = input / scale + cacheRead / scale + cacheWrite / scale;
+	return (cacheRead / scale / scaledPromptTokens) * 100;
 }
 
-function entryIdentity(entry: SessionEntry | undefined): string {
-	if (!entry) return "";
-	const usage = entry.message?.usage;
-	const usageKey = usage
-		? `${usage.input ?? 0}:${usage.output ?? 0}:${usage.cacheRead ?? 0}:${usage.cacheWrite ?? 0}:${usage.cost?.total ?? 0}`
-		: "";
-	return `${entry.id ?? ""}|${entry.timestamp ?? ""}|${entry.type ?? ""}|${entry.message?.role ?? ""}|${usageKey}`;
+function normalizeUsageNumber(value: unknown): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function usageCostTotal(usage: SessionUsage | undefined): number {
+	if (typeof usage?.cost !== "object" || usage.cost === null) return 0;
+	return normalizeUsageNumber((usage.cost as { total?: unknown }).total);
+}
+
+function addUsageTotal(total: number, value: number): number {
+	const sum = total + value;
+	return Number.isFinite(sum) ? sum : MAX_USAGE_TOTAL;
+}
+
+function usageForEntry(entry: SessionEntry): SelectedUsage | undefined {
+	if (entry.type === "message") {
+		const role = entry.message?.role;
+		if (role !== "assistant" && role !== "toolResult") return undefined;
+		return {
+			usage: entry.message?.usage,
+			location: "message",
+			isAssistant: role === "assistant",
+		};
+	}
+	if (entry.type === "compaction" || entry.type === "branch_summary") {
+		return { usage: entry.usage, location: "entry", isAssistant: false };
+	}
+	return undefined;
+}
+
+function normalizedUsage(usage: SessionUsage | undefined) {
+	return {
+		input: normalizeUsageNumber(usage?.input),
+		output: normalizeUsageNumber(usage?.output),
+		cacheRead: normalizeUsageNumber(usage?.cacheRead),
+		cacheWrite: normalizeUsageNumber(usage?.cacheWrite),
+		cost: usageCostTotal(usage),
+	};
+}
+
+function entryIdentity(entry: SessionEntry): string {
+	const selected = usageForEntry(entry);
+	if (!selected) return "unsupported";
+	const usage = normalizedUsage(selected.usage);
+	return JSON.stringify([
+		entry.id ?? null,
+		entry.timestamp ?? null,
+		entry.type ?? null,
+		entry.message?.role ?? null,
+		selected.location,
+		usage.input,
+		usage.output,
+		usage.cacheRead,
+		usage.cacheWrite,
+		usage.cost,
+	]);
 }
 
 function buildUsageFingerprint(entries: readonly SessionEntry[]): string {
-	const first = entries[0];
-	const last = entries[entries.length - 1];
-	return `${entries.length}\0${entryIdentity(first)}\0${entryIdentity(last)}`;
+	return entries.map(entryIdentity).join("\0");
 }
 
 function computeUsageTotals(entries: readonly SessionEntry[]): UsageTotals {
-	usageTotalsComputeCount += 1;
+	usageTotalsAggregationPassCount += 1;
 	let input = 0;
 	let output = 0;
 	let cacheRead = 0;
@@ -158,18 +226,18 @@ function computeUsageTotals(entries: readonly SessionEntry[]): UsageTotals {
 	let cost = 0;
 
 	for (const entry of entries) {
-		if (entry.type !== "message" || entry.message?.role !== "assistant") continue;
-		const usage = entry.message.usage;
-		const entryInput = usage?.input ?? 0;
-		const entryCacheRead = usage?.cacheRead ?? 0;
-		const entryCacheWrite = usage?.cacheWrite ?? 0;
+		const selected = usageForEntry(entry);
+		if (!selected) continue;
+		const usage = normalizedUsage(selected.usage);
 
-		input += entryInput;
-		output += usage?.output ?? 0;
-		cacheRead += entryCacheRead;
-		cacheWrite += entryCacheWrite;
-		cost += usage?.cost?.total ?? 0;
-		latestCacheHitRate = calculateCacheHitRate(entryInput, entryCacheRead, entryCacheWrite);
+		input = addUsageTotal(input, usage.input);
+		output = addUsageTotal(output, usage.output);
+		cacheRead = addUsageTotal(cacheRead, usage.cacheRead);
+		cacheWrite = addUsageTotal(cacheWrite, usage.cacheWrite);
+		cost = addUsageTotal(cost, usage.cost);
+		if (selected.isAssistant) {
+			latestCacheHitRate = calculateCacheHitRate(usage.input, usage.cacheRead, usage.cacheWrite);
+		}
 	}
 
 	return Object.freeze({ input, output, cacheRead, cacheWrite, latestCacheHitRate, cost });
@@ -179,23 +247,26 @@ export function invalidateUsageTotalsCache(): void {
 	usageTotalsCache = undefined;
 }
 
-/** Test helper: number of full usage scans performed since process start / last reset. */
-export function __usageTotalsComputeCount(): number {
-	return usageTotalsComputeCount;
+/** Test helper: counts aggregation passes only; every cache lookup still fingerprints all entries. */
+export function __usageTotalsAggregationPassCount(): number {
+	return usageTotalsAggregationPassCount;
 }
 
-/** Test helper: reset memoization counters/cache. */
+/** Test helper: reset the aggregation-pass counter and cached totals. */
 export function __resetUsageTotalsCacheForTests(): void {
 	usageTotalsCache = undefined;
-	usageTotalsComputeCount = 0;
+	usageTotalsAggregationPassCount = 0;
 }
 
 export function getUsageTotals(ctx: ExtensionContext): UsageTotals {
 	const sessionManager = ctx.sessionManager as {
-		getEntries?: () => SessionEntry[];
-		getBranch: () => SessionEntry[];
+		getEntries?: () => readonly SessionEntry[];
+		getBranch: () => readonly SessionEntry[];
 	};
-	const entries = sessionManager.getEntries?.() ?? sessionManager.getBranch();
+	const entries =
+		typeof sessionManager.getEntries === "function"
+			? sessionManager.getEntries()
+			: sessionManager.getBranch();
 	const key = buildUsageFingerprint(entries);
 	if (usageTotalsCache?.key === key) return usageTotalsCache.totals;
 

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -2,7 +2,7 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	__resetUsageTotalsCacheForTests,
-	__usageTotalsComputeCount,
+	__usageTotalsAggregationPassCount,
 	buildContextDisplayLabel,
 	buildContextGauge,
 	buildCostLabel,
@@ -28,6 +28,24 @@ import {
 
 const cacheHitIcon = "󰆼";
 
+type TestUsage = {
+	input?: unknown;
+	output?: unknown;
+	cacheRead?: unknown;
+	cacheWrite?: unknown;
+	cost?: { total?: unknown } | null;
+};
+
+function makeUsage(
+	input: unknown,
+	output: unknown,
+	cost: unknown,
+	cacheRead: unknown = 0,
+	cacheWrite: unknown = 0,
+): TestUsage {
+	return { input, output, cacheRead, cacheWrite, cost: { total: cost } };
+}
+
 function makeAssistantEntry(
 	input: number,
 	output: number,
@@ -35,19 +53,18 @@ function makeAssistantEntry(
 	cacheRead = 0,
 	cacheWrite = 0,
 ) {
-	return {
-		type: "message",
-		message: {
-			role: "assistant",
-			usage: {
-				input,
-				output,
-				cacheRead,
-				cacheWrite,
-				cost: { total: cost },
-			},
-		},
-	};
+	return makeMessageUsageEntry("assistant", makeUsage(input, output, cost, cacheRead, cacheWrite));
+}
+
+function makeMessageUsageEntry(role: string, usage: TestUsage | undefined) {
+	return { type: "message", message: { role, usage } };
+}
+
+function makeSummaryUsageEntry(
+	type: "compaction" | "branch_summary",
+	usage: TestUsage | undefined,
+) {
+	return { type, usage };
 }
 
 function makeSessionContext(entries: unknown[], branch = entries) {
@@ -139,6 +156,153 @@ describe("usage formatting", () => {
 		expect(totals.cacheWrite).toBe(500);
 		expect(totals.latestCacheHitRate).toBe(30);
 		expect(buildTokenLabel(totals, cacheHitIcon)).toBe("↑300 ↓30 󰆼 30.0%");
+	});
+
+	it("aggregates assistant, tool-result LLM, compaction, and branch-summary usage", () => {
+		const entries = [
+			makeMessageUsageEntry("assistant", makeUsage(10, 2, 0.1, 30, 8)),
+			makeMessageUsageEntry("toolResult", makeUsage(20, 4, 0.2, 40, 9)),
+			makeSummaryUsageEntry("compaction", makeUsage(30, 6, 0.3, 50, 10)),
+			makeSummaryUsageEntry("branch_summary", makeUsage(40, 8, 0.4, 60, 11)),
+		];
+
+		const totals = getUsageTotals(makeSessionContext(entries) as never);
+
+		expect(totals).toEqual({
+			input: 100,
+			output: 20,
+			cacheRead: 180,
+			cacheWrite: 38,
+			latestCacheHitRate: 62.5,
+			cost: 1,
+		});
+		expect(buildTokenLabel(totals, cacheHitIcon)).toBe("↑100 ↓20 󰆼 62.5%");
+		expect(buildCostLabel(totals)).toBe("$1.000");
+	});
+
+	it("selects only one usage location and ignores unsupported entry shapes", () => {
+		const hybridMessage = {
+			...makeMessageUsageEntry("assistant", makeUsage(1, 2, 0.1)),
+			usage: makeUsage(100, 200, 10),
+		};
+		const hybridCompaction = {
+			...makeSummaryUsageEntry("compaction", makeUsage(3, 4, 0.2)),
+			message: { role: "assistant", usage: makeUsage(300, 400, 20) },
+		};
+		const entries = [
+			hybridMessage,
+			hybridCompaction,
+			makeMessageUsageEntry("user", makeUsage(1_000, 1_000, 30)),
+			{ type: "custom", usage: makeUsage(2_000, 2_000, 40) },
+		];
+
+		expect(getUsageTotals(makeSessionContext(entries) as never)).toEqual({
+			input: 4,
+			output: 6,
+			cacheRead: 0,
+			cacheWrite: 0,
+			latestCacheHitRate: 0,
+			cost: 0.30000000000000004,
+		});
+	});
+
+	it("normalizes missing, zero, and malformed optional numbers independently", () => {
+		const entries = [
+			makeMessageUsageEntry("assistant", {
+				input: "10",
+				output: -1,
+				cacheRead: Number.NaN,
+				cacheWrite: Number.POSITIVE_INFINITY,
+				cost: { total: Number.NEGATIVE_INFINITY },
+			}),
+			makeMessageUsageEntry("toolResult", {
+				input: 5,
+				output: 0,
+				cacheRead: 7,
+				cacheWrite: -2,
+				cost: null,
+			}),
+			makeSummaryUsageEntry("compaction", {}),
+			makeSummaryUsageEntry("branch_summary", undefined),
+		];
+
+		const totals = getUsageTotals(makeSessionContext(entries) as never);
+
+		expect(totals).toEqual({
+			input: 5,
+			output: 0,
+			cacheRead: 7,
+			cacheWrite: 0,
+			latestCacheHitRate: undefined,
+			cost: 0,
+		});
+		for (const value of [
+			totals.input,
+			totals.output,
+			totals.cacheRead,
+			totals.cacheWrite,
+			totals.cost,
+		]) {
+			expect(Number.isFinite(value)).toBe(true);
+			expect(value).toBeGreaterThanOrEqual(0);
+		}
+	});
+
+	it("adds distinct duplicate-looking persisted entries without deduplication", () => {
+		const entries = [
+			makeAssistantEntry(10, 2, 0.1),
+			makeAssistantEntry(10, 2, 0.1),
+			makeMessageUsageEntry("toolResult", makeUsage(10, 2, 0.1)),
+		];
+
+		expect(getUsageTotals(makeSessionContext(entries) as never)).toMatchObject({
+			input: 30,
+			output: 6,
+			cost: 0.30000000000000004,
+		});
+	});
+
+	it("saturates huge aggregates and calculates huge prompt rates without overflow", () => {
+		const entries = [
+			makeAssistantEntry(
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+			),
+			makeAssistantEntry(
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+				Number.MAX_VALUE,
+			),
+		];
+
+		const totals = getUsageTotals(makeSessionContext(entries) as never);
+
+		expect(totals).toMatchObject({
+			input: Number.MAX_VALUE,
+			output: Number.MAX_VALUE,
+			cacheRead: Number.MAX_VALUE,
+			cacheWrite: Number.MAX_VALUE,
+			cost: Number.MAX_VALUE,
+		});
+		expect(totals.latestCacheHitRate).toBeCloseTo(100 / 3);
+		expect(Number.isFinite(totals.latestCacheHitRate ?? Number.NaN)).toBe(true);
+		expect(buildTokenLabel(totals, cacheHitIcon)).toBe(
+			`↑${formatCount(Number.MAX_VALUE)} ↓${formatCount(Number.MAX_VALUE)} ${cacheHitIcon} 33.3%`,
+		);
+		expect(buildCostLabel(totals)).toBe(`$${Number.MAX_VALUE.toFixed(3)}`);
+		expect(buildTokenLabel(totals, cacheHitIcon)).not.toMatch(/Infinity|NaN/);
+		expect(buildCostLabel(totals)).not.toMatch(/Infinity|NaN/);
+	});
+
+	it("falls back to the active branch when getEntries is unavailable", () => {
+		const ctx = { sessionManager: { getBranch: () => [makeAssistantEntry(12, 3, 0.4)] } };
+
+		expect(getUsageTotals(ctx as never)).toMatchObject({ input: 12, output: 3, cost: 0.4 });
 	});
 });
 
@@ -325,8 +489,8 @@ describe("context helpers", () => {
 	});
 });
 
-describe("getUsageTotals memoization", () => {
-	it("reuses totals for unchanged entries and recomputes after invalidate", () => {
+describe("getUsageTotals caching", () => {
+	it("reuses totals without another aggregation pass and recomputes after invalidate", () => {
 		__resetUsageTotalsCacheForTests();
 
 		const entries = [makeAssistantEntry(10, 1, 0.1)];
@@ -335,18 +499,59 @@ describe("getUsageTotals memoization", () => {
 		const first = getUsageTotals(ctx);
 		const second = getUsageTotals(ctx);
 		expect(second).toBe(first);
-		expect(__usageTotalsComputeCount()).toBe(1);
+		expect(__usageTotalsAggregationPassCount()).toBe(1);
 
 		entries.push(makeAssistantEntry(20, 2, 0.2));
 		const third = getUsageTotals(ctx);
 		expect(third.input).toBe(30);
-		expect(__usageTotalsComputeCount()).toBe(2);
+		expect(__usageTotalsAggregationPassCount()).toBe(2);
 
 		invalidateUsageTotalsCache();
 		const fourth = getUsageTotals(ctx);
 		expect(fourth).toEqual(third);
 		expect(fourth).not.toBe(third);
-		expect(__usageTotalsComputeCount()).toBe(3);
+		expect(__usageTotalsAggregationPassCount()).toBe(3);
+	});
+
+	it("recomputes when relevant middle usage changes with unchanged endpoints", () => {
+		__resetUsageTotalsCacheForTests();
+		const entries = [
+			makeAssistantEntry(1, 1, 0.1),
+			makeMessageUsageEntry("toolResult", makeUsage(2, 2, 0.2)),
+			makeSummaryUsageEntry("compaction", makeUsage(3, 3, 0.3)),
+		];
+		const ctx = makeSessionContext(entries) as never;
+		expect(getUsageTotals(ctx).input).toBe(6);
+
+		entries[1] = makeMessageUsageEntry("toolResult", makeUsage(20, 2, 0.2));
+
+		expect(getUsageTotals(ctx).input).toBe(24);
+		expect(__usageTotalsAggregationPassCount()).toBe(2);
+	});
+
+	it.each([
+		["assistant", () => makeMessageUsageEntry("assistant", makeUsage(1, 1, 0.1))],
+		["tool result", () => makeMessageUsageEntry("toolResult", makeUsage(1, 1, 0.1))],
+		["compaction", () => makeSummaryUsageEntry("compaction", makeUsage(1, 1, 0.1))],
+		["branch summary", () => makeSummaryUsageEntry("branch_summary", makeUsage(1, 1, 0.1))],
+	])("invalidates for appended and changed %s usage", (_label, makeEntry) => {
+		__resetUsageTotalsCacheForTests();
+		const entries: unknown[] = [makeAssistantEntry(10, 1, 1)];
+		const ctx = makeSessionContext(entries) as never;
+		const initial = getUsageTotals(ctx);
+
+		entries.push(makeEntry());
+		const appended = getUsageTotals(ctx);
+		expect(appended).not.toBe(initial);
+		expect(appended.input).toBe(11);
+
+		const entry = entries[1] as { message?: { usage?: TestUsage }; usage?: TestUsage };
+		const usage = entry.message?.usage ?? entry.usage;
+		if (usage) usage.input = 5;
+		const changed = getUsageTotals(ctx);
+		expect(changed).not.toBe(appended);
+		expect(changed.input).toBe(15);
+		expect(__usageTotalsAggregationPassCount()).toBe(3);
 	});
 });
 


### PR DESCRIPTION
## Summary

- include assistant, tool-result, compaction, and branch-summary usage in session totals
- preserve all-session semantics and count each persisted operation exactly once
- invalidate cached totals for every supported usage-bearing entry mutation
- keep cumulative values, labels, and prompt-rate math finite under numeric overflow

## Compatibility

- matches Pi `0.82.1` footer traversal
- retains the Pi `0.80.3` branch fallback
- no footer presentation or telemetry-field changes

## Validation

- `npm run fmt`
- Node 24 isolated-HOME `npm run verify` — 559 tests passed
- `npm run pack:check`
- approved by independent Pi-parity, cache, coverage, and overflow reviews

Closes #65