### PR TITLE
feat: add adaptive editor border colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or
 The interactive `/zentui` menu is split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. Every listed control patches the shown JSON equivalent:
 
 1. **Appearance** — Starship/footer colors (`colorSources.starship`); editor + previous-message colors (`colorSources.editor` and `colorSources.userMessages`); separator (`separator`); icon mode (`icons.mode`).
-2. **Editor** — editor enabled (`features.editor`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
+2. **Editor** — editor enabled (`features.editor`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
 3. **Footer** — status line enabled (`features.statusLine`); responsive footer (`responsiveFooter`); compact footer rows (`compactFooterMaxLines`); context style (`contextStyle`); path display (`pathDisplay.mode`); path depth (`pathDisplay.depth`).
 4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
 5. **Git** — Git branch visibility (`footerSegments.gitBranch`); branch length (`gitBranch.maxLength`); Git status visibility (`footerSegments.gitStatus`); Git counts visibility (`footerSegments.gitCounts`); Git commit visibility (`footerSegments.gitCommit`); commit-only-detached (`gitCommit.onlyDetached`); exact-match tag (`gitCommit.showTag`); Git metrics visibility (`footerSegments.gitMetrics`); hide zero metrics (`gitMetrics.onlyNonzero`); ignore submodules (`gitMetrics.ignoreSubmodules`).
@@ -176,6 +176,7 @@ Default config values — copy this and change any value you want:
 	"separator": "pipe",
 	"contextStyle": "text",
 	"editorModelLabel": "id",
+	"editorBorderColorMode": "static",
 	"contextThresholds": {
 		"warning": 70,
 		"error": 90
@@ -297,6 +298,7 @@ Default config values — copy this and change any value you want:
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
 - `editorModelLabel`: controls the model shown in the editor frame. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
+- `editorBorderColorMode`: `static` (default) uses `colors.editorBorder`; `adaptive` follows Pi's current shell-mode and thinking-level editor border color. Cycle it from the `/zentui` **Editor** tab.
 - `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Appearance** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
 - `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
@@ -316,7 +318,7 @@ Default config values — copy this and change any value you want:
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
 - `editorPrompt` styles the copy-friendly editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
-- `editorBorder` styles the active editor and previous user-message top/bottom border color only; the border glyph stays `─`.
+- `editorBorder` styles previous user-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -33,6 +33,7 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
+export type EditorBorderColorMode = "static" | "adaptive";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
 
 export const DEFAULT_COMPACT_FOOTER_FORMAT =
@@ -139,6 +140,7 @@ export type PolishedTuiConfig = {
 	separator: SeparatorStyle;
 	contextStyle: ContextStyle;
 	editorModelLabel: ModelLabelSource;
+	editorBorderColorMode: EditorBorderColorMode;
 	contextThresholds: ContextThresholds;
 	pathDisplay: PathDisplayConfig;
 	gitBranch: GitBranchConfig;
@@ -240,6 +242,7 @@ export const defaultConfig: PolishedTuiConfig = {
 	separator: "pipe",
 	contextStyle: "text",
 	editorModelLabel: "id",
+	editorBorderColorMode: "static",
 	contextThresholds: { warning: 70, error: 90 },
 	pathDisplay: { mode: "basename", depth: 0 },
 	gitBranch: { maxLength: "full" },
@@ -348,6 +351,11 @@ function parseContextStyle(value: unknown): ContextStyle {
 function parseEditorModelLabel(value: unknown): ModelLabelSource {
 	if (value === "id" || value === "name") return value;
 	return defaultConfig.editorModelLabel;
+}
+
+function parseEditorBorderColorMode(value: unknown): EditorBorderColorMode {
+	if (value === "static" || value === "adaptive") return value;
+	return defaultConfig.editorBorderColorMode;
 }
 
 export function isSeparatorStyle(value: unknown): value is SeparatorStyle {
@@ -815,6 +823,7 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		separator: parseSeparatorStyle(config.separator),
 		contextStyle: parseContextStyle(config.contextStyle),
 		editorModelLabel: parseEditorModelLabel(config.editorModelLabel),
+		editorBorderColorMode: parseEditorBorderColorMode(config.editorBorderColorMode),
 		contextThresholds: parseContextThresholds(config.contextThresholds),
 		pathDisplay: parsePathDisplay(config.pathDisplay),
 		gitBranch,
@@ -1004,6 +1013,15 @@ export function saveEditorModelLabel(
 ): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
 		record.editorModelLabel = parseEditorModelLabel(value);
+	});
+}
+
+export function saveEditorBorderColorMode(
+	value: EditorBorderColorMode,
+	path = configPath,
+): PolishedTuiConfig {
+	return mutateConfig(path, (record) => {
+		record.editorBorderColorMode = parseEditorBorderColorMode(value);
 	});
 }
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -8,6 +8,7 @@ import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import {
 	type ColorSourcesConfig,
 	type ContextStyle,
+	type EditorBorderColorMode,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	ensureConfigExists,
@@ -25,6 +26,7 @@ import {
 	type SeparatorStyle,
 	saveColorSourcesPatch,
 	saveContextStylePatch,
+	saveEditorBorderColorMode,
 	saveEditorModelLabel,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
@@ -658,6 +660,9 @@ export default function (pi: ExtensionAPI) {
 		setEditorModelLabel(value: ModelLabelSource, ctx: ExtensionContext) {
 			currentConfig = saveEditorModelLabel(value);
 			syncFooterState(ctx);
+		},
+		setEditorBorderColorMode(value: EditorBorderColorMode) {
+			currentConfig = saveEditorBorderColorMode(value);
 		},
 		setGitCommit(
 			patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -15,6 +15,7 @@ import {
 	type ColorSourcesConfig,
 	type CompactFooterMaxLines,
 	type ContextStyle,
+	type EditorBorderColorMode,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FixedEditorConfig,
@@ -56,6 +57,7 @@ const pathDepthValues = ["0", "1", "2", "3", "4", "5"] as const;
 const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"] as const;
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
+const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
 const compactFooterMaxLineValues = ["1", "2", "3", "unlimited"] as const;
 type FeatureState = "enabled" | "disabled";
 
@@ -83,6 +85,7 @@ type BoundedSettingId =
 	| "branchLength"
 	| "iconMode"
 	| "editorModelLabel"
+	| "editorBorderColorMode"
 	| "gitCommitOnlyDetached"
 	| "gitCommitShowTag"
 	| "gitMetricsOnlyNonzero"
@@ -109,6 +112,7 @@ type SettingsCommandDeps = {
 	setPathDisplay: (patch: Partial<PathDisplayConfig>) => void;
 	setGitBranch: (patch: Partial<GitBranchConfig>) => void;
 	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
+	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
 	setGitCommit?: (
 		patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,
 		ctx: ExtensionContext,
@@ -314,6 +318,7 @@ function isBoundedSettingId(value: string): value is BoundedSettingId {
 		value === "branchLength" ||
 		value === "iconMode" ||
 		value === "editorModelLabel" ||
+		value === "editorBorderColorMode" ||
 		value === "gitCommitOnlyDetached" ||
 		value === "gitCommitShowTag" ||
 		value === "gitMetricsOnlyNonzero" ||
@@ -508,13 +513,24 @@ function buildItems(
 			currentValue: featureValue(config.features[key]),
 			values: featureStateValues,
 		}));
-		items.splice(1, 0, {
-			id: "editorModelLabel",
-			label: "Editor model label",
-			description: "Show the model id or display name in the editor frame.",
-			currentValue: config.editorModelLabel,
-			values: modelLabelValues,
-		});
+		items.splice(
+			1,
+			0,
+			{
+				id: "editorBorderColorMode",
+				label: "Editor border color",
+				description: "Keep Zentui's configured border color or follow Pi's shell/thinking color.",
+				currentValue: config.editorBorderColorMode,
+				values: editorBorderColorModeValues,
+			},
+			{
+				id: "editorModelLabel",
+				label: "Editor model label",
+				description: "Show the model id or display name in the editor frame.",
+				currentValue: config.editorModelLabel,
+				values: modelLabelValues,
+			},
+		);
 		items.push({
 			id: "fixedEditor",
 			label: "Fixed editor (experimental)",
@@ -888,6 +904,19 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 										settingsList.updateValue(id, newValue);
 										deps.requestRender();
 										ctx.ui.notify(`Editor model label: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
+									if (
+										id === "editorBorderColorMode" &&
+										(newValue === "static" || newValue === "adaptive")
+									) {
+										if (!deps.setEditorBorderColorMode) return;
+										deps.setEditorBorderColorMode(newValue);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Editor border color: ${newValue}`, "info");
 										tui.requestRender();
 										return;
 									}

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -84,6 +84,7 @@ type PolishedFrameOptions = {
 	rightStatus?: string;
 	ownedFrame?: PolishedFrameSplit;
 	trustedBaseFrame?: boolean;
+	borderColor?: (text: string) => string;
 };
 
 type PolishedFrameResult = { lines: string[]; decorated: boolean };
@@ -319,6 +320,7 @@ function renderPolishedFrame({
 	rightStatus,
 	ownedFrame,
 	trustedBaseFrame = false,
+	borderColor,
 }: PolishedFrameOptions): PolishedFrameResult {
 	if (width <= 2) return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 
@@ -380,22 +382,33 @@ function renderPolishedFrame({
 	const copyFriendlyMeta = composeMetadataLine(meta, rightStatus, Math.max(0, width - 1));
 	const railedMeta = composeMetadataLine(meta, rightStatus, innerWidth);
 
-	const top = renderStyleForSourceOrFallback(
-		uiTheme,
-		colorSource,
-		config.colors.editorBorder,
-		EDITOR_BORDER_FALLBACK,
+	const renderStaticBorder = (text: string) =>
+		renderStyleForSourceOrFallback(
+			uiTheme,
+			colorSource,
+			config.colors.editorBorder,
+			EDITOR_BORDER_FALLBACK,
+			text,
+		);
+	const renderBorder = (text: string) => {
+		if (config.editorBorderColorMode !== "adaptive" || typeof borderColor !== "function") {
+			return renderStaticBorder(text);
+		}
+		try {
+			const rendered = borderColor(text);
+			return typeof rendered === "string" ? rendered : renderStaticBorder(text);
+		} catch {
+			return renderStaticBorder(text);
+		}
+	};
+	const top = renderBorder(
 		renderEditorBorder(
 			width,
 			"above",
 			config.features.viewportIndicators ? viewport.above : undefined,
 		),
 	);
-	const bottom = renderStyleForSourceOrFallback(
-		uiTheme,
-		colorSource,
-		config.colors.editorBorder,
-		EDITOR_BORDER_FALLBACK,
+	const bottom = renderBorder(
 		renderEditorBorder(
 			width,
 			"below",
@@ -477,6 +490,7 @@ export class PolishedEditor extends CustomEditor {
 				modelMeta: this.getModelMeta(),
 				thinkingLevel: this.getThinkingLevel(),
 				trustedBaseFrame: true,
+				borderColor: this.borderColor,
 			}).lines;
 		} catch {
 			return clampRenderedLines(rendered, width);
@@ -628,6 +642,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 					thinkingLevel: this.getThinkingLevel(),
 					rightStatus: readVimStatus(this.base, this.uiTheme),
 					ownedFrame,
+					borderColor: this.borderColor,
 				});
 			}
 		} catch {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -22,6 +22,7 @@ import {
 	mergeConfig,
 	saveColorSourcesPatch,
 	saveContextThresholdsPatch,
+	saveEditorBorderColorMode,
 	saveEditorModelLabel,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
@@ -443,6 +444,42 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ editorModelLabel: "name" }).editorModelLabel).toBe("name");
 		expect(mergeConfig({ editorModelLabel: "id" }).editorModelLabel).toBe("id");
 		expect(mergeConfig({ editorModelLabel: "title" }).editorModelLabel).toBe("id");
+	});
+
+	it("defaults and normalizes editor border color mode", () => {
+		expect(defaultConfig.editorBorderColorMode).toBe("static");
+		expect(mergeConfig({}).editorBorderColorMode).toBe("static");
+		expect(mergeConfig({ editorBorderColorMode: "static" }).editorBorderColorMode).toBe("static");
+		expect(mergeConfig({ editorBorderColorMode: "adaptive" }).editorBorderColorMode).toBe(
+			"adaptive",
+		);
+		for (const value of ["dynamic", "", 1, null, true]) {
+			expect(mergeConfig({ editorBorderColorMode: value }).editorBorderColorMode).toBe("static");
+		}
+	});
+
+	it("saves editor border color mode without erasing sibling config", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(
+				path,
+				`${JSON.stringify({ unknown: { keep: true }, editorModelLabel: "name" }, null, 2)}\n`,
+			);
+
+			const config = saveEditorBorderColorMode("adaptive", path);
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(raw).toEqual({
+				unknown: { keep: true },
+				editorModelLabel: "name",
+				editorBorderColorMode: "adaptive",
+			});
+			expect(config.editorBorderColorMode).toBe("adaptive");
+			expect(config.editorModelLabel).toBe("name");
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("defaults pathDisplay and accepts mode/depth overrides", () => {

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -2,7 +2,7 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
-import { WrappedPolishedEditor } from "../extensions/zentui/ui";
+import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
 
 function theme(): Theme {
 	return {
@@ -17,8 +17,15 @@ function theme(): Theme {
 	} as Theme;
 }
 
-function config(features: Partial<PolishedTuiConfig["features"]> = {}): PolishedTuiConfig {
-	return { ...defaultConfig, features: { ...defaultConfig.features, ...features } };
+function config(
+	features: Partial<PolishedTuiConfig["features"]> = {},
+	editorBorderColorMode: PolishedTuiConfig["editorBorderColorMode"] = "static",
+): PolishedTuiConfig {
+	return {
+		...defaultConfig,
+		editorBorderColorMode,
+		features: { ...defaultConfig.features, ...features },
+	};
 }
 
 function nativeBorder(
@@ -64,15 +71,132 @@ function baseEditor(options: {
 function wrapped(
 	base: ReturnType<typeof baseEditor> | WrappedPolishedEditor,
 	features: Partial<PolishedTuiConfig["features"]> = {},
+	editorBorderColorMode: PolishedTuiConfig["editorBorderColorMode"] = "static",
 ): WrappedPolishedEditor {
 	return new WrappedPolishedEditor(
 		base as never,
 		theme(),
-		() => config(features),
+		() => config(features, editorBorderColorMode),
 		() => ({ modelLabel: "model", providerLabel: "provider" }),
 		() => "off",
 	);
 }
+
+const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+type SemanticBorderState = (typeof thinkingLevels)[number] | "shell";
+
+const semanticBorderCodes: Record<SemanticBorderState, number> = {
+	off: 30,
+	minimal: 31,
+	low: 32,
+	medium: 33,
+	high: 34,
+	xhigh: 35,
+	shell: 36,
+};
+
+function semanticTheme(): Theme {
+	const base = theme();
+	return {
+		...base,
+		getThinkingBorderColor(level) {
+			const code = semanticBorderCodes[level as (typeof thinkingLevels)[number]] ?? 37;
+			return (text: string) => `\x1b[${code}m${text}\x1b[0m`;
+		},
+		getBashModeBorderColor() {
+			return (text: string) => `\x1b[${semanticBorderCodes.shell}m${text}\x1b[0m`;
+		},
+	} as Theme;
+}
+
+describe("adaptive editor border colors", () => {
+	it("keeps static wrapped-editor rendering independent of Pi's callback", () => {
+		const editor = wrapped(baseEditor({ above: 2, below: 3 }));
+		editor.borderColor = (text) => `\x1b[35m${text}\x1b[0m`;
+
+		const lines = editor.render(80);
+		expect(lines[0]).not.toContain("\x1b[35m");
+		expect(lines.at(-1)).not.toContain("\x1b[35m");
+		expect(lines[0]).toContain("↑ 2 more");
+		expect(lines.at(-1)).toContain("↓ 3 more");
+	});
+
+	it.each(["standalone", "wrapped"] as const)(
+		"follows Pi thinking and shell callback transitions in the %s editor path",
+		(editorKind) => {
+			const piTheme = semanticTheme();
+			let thinkingLevel: (typeof thinkingLevels)[number] = "off";
+			const editor =
+				editorKind === "standalone"
+					? new PolishedEditor(
+							{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+							{ borderColor: (text: string) => text, selectList: {} } as never,
+							{} as never,
+							piTheme,
+							() => config({}, "adaptive"),
+							() => ({ modelLabel: "model", providerLabel: "provider" }),
+							() => thinkingLevel,
+						)
+					: new WrappedPolishedEditor(
+							baseEditor({ above: 2, below: 3 }) as never,
+							piTheme,
+							() => config({}, "adaptive"),
+							() => ({ modelLabel: "model", providerLabel: "provider" }),
+							() => thinkingLevel,
+						);
+			if (editorKind === "standalone") editor.setText("draft");
+
+			const transitions: SemanticBorderState[] = [...thinkingLevels, "shell", "xhigh", "off"];
+			for (const state of transitions) {
+				if (state === "shell") {
+					editor.borderColor = piTheme.getBashModeBorderColor();
+				} else {
+					thinkingLevel = state;
+					editor.borderColor = piTheme.getThinkingBorderColor(state);
+				}
+
+				const lines = editor.render(80);
+				const expectedCode = semanticBorderCodes[state];
+				for (const border of [lines[0] ?? "", lines.at(-1) ?? ""]) {
+					expect(border).toMatch(new RegExp(`^\\x1b\\[${expectedCode}m`));
+					for (const code of Object.values(semanticBorderCodes)) {
+						if (code !== expectedCode) expect(border).not.toContain(`\x1b[${code}m`);
+					}
+				}
+				expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+			}
+		},
+	);
+
+	it("does not double-apply adaptive colors through nested branded frames", () => {
+		const inner = wrapped(baseEditor({ above: 3, below: 8 }), {}, "adaptive");
+		inner.borderColor = (text) => `\x1b[32m${text}\x1b[0m`;
+		const outer = wrapped(inner, {}, "adaptive");
+
+		const rendered = outer.render(80).join("\n");
+		expect(rendered.match(/\x1b\[32m/g)).toHaveLength(2);
+		expect(rendered.match(/↑ 3 more/g)).toHaveLength(1);
+		expect(rendered.match(/↓ 8 more/g)).toHaveLength(1);
+		expect(rendered.match(/model/g)).toHaveLength(1);
+	});
+
+	it("preserves copy-friendly viewport layout, clamping, and static fallback", () => {
+		const editor = wrapped(
+			baseEditor({ above: 123456, below: 654321, ansi: true }),
+			{ copyFriendly: true },
+			"adaptive",
+		);
+		editor.borderColor = () => {
+			throw new Error("theme callback failed");
+		};
+
+		const lines = editor.render(12);
+		expect(lines[0]).toContain("↑");
+		expect(lines.at(-1)).toContain("↓");
+		expect(lines.join("\n")).not.toContain("│");
+		expect(lines.every((line) => visibleWidth(line) <= 12)).toBe(true);
+	});
+});
 
 describe("editor viewport indicators", () => {
 	it.each([

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -1,5 +1,7 @@
-import { CURSOR_MARKER } from "@earendil-works/pi-tui";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
+import { defaultConfig } from "../extensions/zentui/config";
 import { capEditorLines, renderCluster } from "../extensions/zentui/fixed-editor/cluster";
 import { TerminalSplitCompositor } from "../extensions/zentui/fixed-editor/compositor";
 import {
@@ -22,6 +24,7 @@ import {
 	RESET_SCROLL_REGION,
 	SHOW_CURSOR,
 } from "../extensions/zentui/fixed-editor/terminal-modes";
+import { WrappedPolishedEditor } from "../extensions/zentui/ui";
 
 function makeValidPiFixture() {
 	let rawRows = 24;
@@ -342,6 +345,74 @@ describe("Pi fixed-editor compatibility", () => {
 		fixture.requestRender.mockClear();
 		fixture.getInputListener()?.("\u001b[<64;1;1M");
 		expect(fixture.requestRender).toHaveBeenCalled();
+		compositor.dispose();
+	});
+
+	it("repaints adaptive polished borders through the fixed-editor cluster without stale color", () => {
+		const fixture = makeValidPiFixture();
+		const uiTheme = {
+			fg: (_color: string, text: string) => text,
+			bold: (text: string) => text,
+			italic: (text: string) => text,
+			underline: (text: string) => text,
+			strikethrough: (text: string) => text,
+			inverse: (text: string) => text,
+		} as Theme;
+		const renderWidths: number[] = [];
+		const base = {
+			borderColor: undefined as ((text: string) => string) | undefined,
+			render(width: number) {
+				renderWidths.push(width);
+				return ["─".repeat(width), "fixed editor draft", "─".repeat(width)];
+			},
+			invalidate: vi.fn(),
+			handleInput() {},
+			getText: () => "fixed editor draft",
+			setText() {},
+			isShowingAutocomplete: () => false,
+		};
+		const editor = new WrappedPolishedEditor(
+			base,
+			uiTheme,
+			() => ({ ...defaultConfig, editorBorderColorMode: "adaptive" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "high",
+		);
+		const thinkingBorder = (text: string) => `\x1b[34m${text}\x1b[0m`;
+		const shellBorder = (text: string) => `\x1b[36m${text}\x1b[0m`;
+		editor.borderColor = thinkingBorder;
+		Reflect.set(fixture.cluster[2], "render", (width: number) => editor.render(width));
+
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		fixture.terminalWrite.mockClear();
+
+		fixture.tui.doRender();
+		const thinkingPaint = String(fixture.terminalWrite.mock.calls.at(-1)?.[0] ?? "");
+		expect(thinkingPaint.match(/\x1b\[34m/g)).toHaveLength(2);
+		expect(thinkingPaint).not.toContain("\x1b[36m");
+		expect(fixture.tui.render(80)).toHaveLength(14);
+
+		editor.borderColor = shellBorder;
+		editor.invalidate();
+		fixture.tui.doRender();
+		const shellPaint = String(fixture.terminalWrite.mock.calls.at(-1)?.[0] ?? "");
+		expect(shellPaint.match(/\x1b\[36m/g)).toHaveLength(2);
+		expect(shellPaint).not.toContain("\x1b[34m");
+		expect(base.invalidate).toHaveBeenCalledTimes(1);
+		expect(renderWidths).toEqual([78, 78]);
+		for (const frame of [thinkingPaint, shellPaint]) {
+			const paintedRows = frame.split("\x1b[2K").slice(1);
+			expect(paintedRows).toHaveLength(10);
+			expect(paintedRows.every((row) => visibleWidth(row) <= 80)).toBe(true);
+		}
+
 		compositor.dispose();
 	});
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -155,6 +155,161 @@ describe("bounded /zentui settings", () => {
 		expect(requestRender).toHaveBeenCalledTimes(6);
 	});
 
+	it("cycles editor border color mode live and reopens with the persisted value", async () => {
+		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+		const config = cloneConfig();
+		const values: string[] = [];
+		const rows: string[] = [];
+		const notifications: string[] = [];
+		const requestRender = vi.fn();
+		const tuiRequestRender = vi.fn();
+		let liveTuiRenderCalls = 0;
+		let closeCalls = 0;
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: new SessionLifecycle(),
+				getConfig: () => config,
+				setColorSources() {},
+				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setSeparator() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				setEditorBorderColorMode(value) {
+					values.push(value);
+					config.editorBorderColorMode = value;
+				},
+				getActiveExtensionStatuses: () => new Map(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender,
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		let invocation = 0;
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: theme(),
+				notify(message: string) {
+					notifications.push(message);
+				},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					invocation += 1;
+					const component = factory({ requestRender: tuiRequestRender }, theme(), {}, () => {
+						closeCalls += 1;
+					}) as Component;
+					goToSection(component, "Editor");
+					rows.push(renderedValue(component, "Editor border color"));
+					if (invocation === 1) {
+						tuiRequestRender.mockClear();
+						component.handleInput(" ");
+						liveTuiRenderCalls = tuiRequestRender.mock.calls.length;
+						rows.push(renderedValue(component, "Editor border color"));
+					}
+				},
+			},
+		};
+
+		await command?.handler("", ctx);
+		await command?.handler("", ctx);
+
+		expect(values).toEqual(["adaptive"]);
+		expect(config.editorBorderColorMode).toBe("adaptive");
+		expect(rows[0]).toContain("static");
+		expect(rows[1]).toContain("adaptive");
+		expect(rows[2]).toContain("adaptive");
+		expect(requestRender).toHaveBeenCalledTimes(1);
+		expect(liveTuiRenderCalls).toBe(1);
+		expect(notifications).toEqual(["Editor border color: adaptive"]);
+		expect(closeCalls).toBe(0);
+	});
+
+	it("keeps editor border color unchanged when persistence fails", async () => {
+		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+		const config = cloneConfig();
+		const rows: string[] = [];
+		const notifications: Array<{ message: string; level: string }> = [];
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: new SessionLifecycle(),
+				getConfig: () => config,
+				setColorSources() {},
+				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments() {},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setSeparator() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				setEditorBorderColorMode() {
+					throw new Error("config is read-only");
+				},
+				getActiveExtensionStatuses: () => new Map(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender() {},
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		await command?.handler("", {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: theme(),
+				notify(message: string, level: string) {
+					notifications.push({ message, level });
+				},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
+					goToSection(component, "Editor");
+					rows.push(renderedValue(component, "Editor border color"));
+					component.handleInput(" ");
+					rows.push(renderedValue(component, "Editor border color"));
+				},
+			},
+		});
+
+		expect(config.editorBorderColorMode).toBe("static");
+		expect(rows.every((row) => row.includes("static") && !row.includes("adaptive"))).toBe(true);
+		expect(notifications).toEqual([
+			{ message: "Could not update Zentui settings: config is read-only", level: "error" },
+		]);
+	});
+
 	it("keeps every active section visible and every line width-safe at 40 columns", async () => {
 		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
 		const config = cloneConfig();


### PR DESCRIPTION
## Summary

- add `editorBorderColorMode` with backward-compatible `static` and semantic `adaptive` modes
- preserve Pi shell-mode and thinking-level colors in Zentui polished borders
- add a live `/zentui` Editor-section control with atomic persistence
- cover standalone, wrapped, nested, copy-friendly, viewport, fixed-editor, and narrow-width rendering

## Compatibility

- default remains `static`
- uses Pi’s public optional `borderColor` callback
- minimum supported Pi version remains `0.80.3`

## Validation

- `npm run fmt`
- Node 24 isolated-HOME `npm run verify` — 569 tests passed
- `npm run pack:check`
- manually tested shell/thinking transitions and `/zentui` persistence
- approved by independent rendering, config, and acceptance reviews

Closes #62