### PR TITLE
feat: add optional footer model info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Zentui brings two popular aesthetics to Pi:
 - `on  branch` — git branch with icon
 - `[!?↑]` — git status indicators (modified, untracked, ahead/behind, stashed, etc.)
 - `via  v5.5.0` — runtime detection with version and Starship-style Nerd Font runtime/language modules
-- Optional segments (off by default): session name, `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
+- Optional segments (off by default): selected model/provider, `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
 - Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
@@ -135,7 +135,7 @@ The interactive `/zentui` menu is split into exactly six sections, in this order
 1. **Appearance** — Starship/footer colors (`colorSources.starship`); editor + previous-message colors (`colorSources.editor` and `colorSources.userMessages`); separator (`separator`); icon mode (`icons.mode`).
 2. **Editor** — editor enabled (`features.editor`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
 3. **Footer** — status line enabled (`features.statusLine`); responsive footer (`responsiveFooter`); compact footer rows (`compactFooterMaxLines`); context style (`contextStyle`); path display (`pathDisplay.mode`); path depth (`pathDisplay.depth`).
-4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
+4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `modelInfo`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
 5. **Git** — Git branch visibility (`footerSegments.gitBranch`); branch length (`gitBranch.maxLength`); Git status visibility (`footerSegments.gitStatus`); Git counts visibility (`footerSegments.gitCounts`); Git commit visibility (`footerSegments.gitCommit`); commit-only-detached (`gitCommit.onlyDetached`); exact-match tag (`gitCommit.showTag`); Git metrics visibility (`footerSegments.gitMetrics`); hide zero metrics (`gitMetrics.onlyNonzero`); ignore submodules (`gitMetrics.ignoreSubmodules`).
 6. **Extensions** — default placement (`extensionStatuses.defaultPlacement`) first, followed by placement (`extensionStatuses.placements[key]`) and color (`extensionStatuses.colorModes[key]`) controls for currently active status keys.
 
@@ -261,6 +261,7 @@ Default config values — copy this and change any value you want:
 		"gitStatus": true,
 		"gitCounts": false,
 		"runtime": true,
+		"modelInfo": false,
 		"context": true,
 		"tokens": true,
 		"cost": true,
@@ -297,7 +298,7 @@ Default config values — copy this and change any value you want:
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Finite context percentages use one decimal place. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
-- `editorModelLabel`: controls the model shown in the editor frame. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
+- `editorModelLabel`: controls the model shown in the editor frame, built-in model-info footer segment, and footer `$model` variable. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
 - `editorBorderColorMode`: `static` (default) uses `colors.editorBorder`; `adaptive` follows Pi's current shell-mode and thinking-level editor border color. Cycle it from the `/zentui` **Editor** tab.
 - `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Appearance** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
@@ -307,7 +308,7 @@ Default config values — copy this and change any value you want:
 - `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
 - `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
 - `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. `viewportIndicators` preserves Pi's native `↑ N more` / `↓ N more` wrapped-row counts in Zentui's editor borders (default `true`). All four can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `sessionName`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). Toggle non-Git segments from **Segments** and Git segments from **Git** in `/zentui`.
+- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `sessionName`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `modelInfo`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). `modelInfo` is off by default and shows the selected model plus the provider unless the model label already contains it. Toggle non-Git segments from **Segments** and Git segments from **Git** in `/zentui`.
 - `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Footer** tab configures responsive behavior, compact rows, context style, and path display mode/depth; **Appearance** configures separator and icon mode; **Git** configures branch length; set or clear custom formats with `/zentui format`.
 - `responsiveFooter`: enabled by default. Zentui keeps the current aligned one-row footer while every settings-resolved left/middle/right zone fits without layout truncation. Otherwise it tries two complete left-aligned rows, preferring `left` / `middle right` and then `left middle` / `right`. Only when neither split fits does it use `compactFooterFormat`. Set `false` to restore the legacy one-row fitting behavior. Selection uses measured terminal-cell width, not fixed device breakpoints.
 - `compactFooterFormat`: JSON-only template used by the compact stage. The default keeps cwd, session name, git branch/status, context, and abbreviated token/cache metrics. A top-level `$wrap` is an automatic wrap opportunity: one space on the same row or no space at a row break. `$wrap_sep` is the same kind of boundary but renders the styled ` | ` divider only when its adjacent chunks share a row. Nested uses of either boundary remain empty variables. `$fill` is ignored. A standalone `$extensions` chunk inserts active non-`off` extension statuses in left/middle/right placement order; embedded uses render empty. Custom `footerFormat` values use this built-in compact fallback unless this key is also customized.
@@ -383,6 +384,8 @@ Center the branch between directory and cost:
 | `$git_added`        |              | added line count (`+N`)                                             |
 | `$git_deleted`      |              | deleted line count (`−N`)                                           |
 | `$runtime`          |              | runtime icon + version                                              |
+| `$model`            |              | selected model label (`editorModelLabel`)                           |
+| `$provider`         |              | formatted provider label                                            |
 | `$package`          |              | project package version, `is <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)                               |
 | `$session_duration` | `$duration`  | session running time                                                |
@@ -413,7 +416,7 @@ Center the branch between directory and cost:
 - Conditional groups: wrap optional pieces in parentheses, e.g. `$cwd( on $git_branch)($git_status)$fill($context)`. If every `$var` inside a group is empty, the whole group (including its literals) is dropped.
 - `$session_name` is available whenever `footerFormat` is set, independently of `footerSegments.sessionName`; use a conditional group such as `($sep$session_name)` so unnamed sessions leave no separator.
 - The built-in wide footer appends cache totals to the token segment, `(sub)` to cost, and `(auto)` to context when available. Custom formats keep `$tokens`, `$cost`, and `$context` backward-compatible and include telemetry only through the atomic variables above.
-- `DEFAULT_COMPACT_FOOTER_FORMAT` is unchanged and omits the atomic telemetry. Add the variables explicitly to `compactFooterFormat` to opt in at narrow widths.
+- `DEFAULT_COMPACT_FOOTER_FORMAT` omits model/provider and atomic telemetry. Add their variables explicitly to `compactFooterFormat` to opt in at narrow widths.
 - Auto-compaction settings refresh on the next normal footer synchronization event. Unsupported Pi capabilities or settings-read errors safely omit optional markers.
 - Unknown `$variables` render empty.
 - Set or clear at runtime: `/zentui format "<template>"` and `/zentui format clear`.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -80,6 +80,7 @@ export type FooterSegmentsConfig = {
 	gitCommit: boolean;
 	gitMetrics: boolean;
 	runtime: boolean;
+	modelInfo: boolean;
 	context: boolean;
 	tokens: boolean;
 	cost: boolean;
@@ -198,6 +199,8 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"git_status",
 	"git_state",
 	"runtime",
+	"model",
+	"provider",
 	"session_duration",
 	"username",
 	"os",
@@ -294,6 +297,7 @@ export const defaultConfig: PolishedTuiConfig = {
 		gitStatus: true,
 		gitCounts: false,
 		runtime: true,
+		modelInfo: false,
 		context: true,
 		tokens: true,
 		cost: true,
@@ -533,6 +537,7 @@ function normalizeFooterSegments(record: Record<string, unknown>): FooterSegment
 		gitStatus: footerSegmentValue(record, "gitStatus"),
 		gitCounts: footerSegmentValue(record, "gitCounts"),
 		runtime: footerSegmentValue(record, "runtime"),
+		modelInfo: footerSegmentValue(record, "modelInfo"),
 		context: footerSegmentValue(record, "context"),
 		tokens: footerSegmentValue(record, "tokens"),
 		cost: footerSegmentValue(record, "cost"),
@@ -650,6 +655,7 @@ function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig 
 		value === "gitStatus" ||
 		value === "gitCounts" ||
 		value === "runtime" ||
+		value === "modelInfo" ||
 		value === "context" ||
 		value === "tokens" ||
 		value === "cost" ||

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -51,6 +51,18 @@ function joinStatusTexts(statusTexts: string[], separator: string): string {
 	return statusTexts.filter(Boolean).join(separator);
 }
 
+function normalizeModelInfoPart(value: string): string {
+	return value.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function composeModelInfoLabel(model: string, provider: string): string {
+	const normalizedModel = normalizeModelInfoPart(model);
+	const normalizedProvider = normalizeModelInfoPart(provider);
+	const providerIsDuplicated =
+		normalizedProvider.length > 0 && normalizedModel.includes(normalizedProvider);
+	return [model, providerIsDuplicated ? "" : provider].filter(Boolean).join(" ");
+}
+
 function fitStatusTexts(statusTexts: string[], maxWidth: number, separator: string): string {
 	if (maxWidth <= 0) return "";
 
@@ -337,6 +349,10 @@ export function installFooter(
 							const label = state.runtime.version ? `${symbol} ${state.runtime.version}` : symbol;
 							return renderStyleForSource(theme, colorSource, state.runtime.style, label);
 						}
+						case "model":
+							return sanitizeExtensionStatusText(state.modelLabel);
+						case "provider":
+							return sanitizeExtensionStatusText(state.providerLabel);
 						case "session_duration":
 							return state.sessionStartEpoch
 								? renderStyleForSource(
@@ -564,6 +580,12 @@ export function installFooter(
 					.filter(Boolean)
 					.join(" ");
 
+				const modelInfoSegment = config.footerSegments.modelInfo
+					? composeModelInfoLabel(
+							sanitizeExtensionStatusText(state.modelLabel),
+							sanitizeExtensionStatusText(state.providerLabel),
+						)
+					: "";
 				const timeSegment = config.footerSegments.time
 					? renderStyleForSource(
 							theme,
@@ -592,6 +614,7 @@ export function installFooter(
 					.filter(Boolean)
 					.join(" ");
 				const right = [
+					modelInfoSegment,
 					config.footerSegments.context ? builtInContextLabel : "",
 					config.footerSegments.tokens ? builtInTokenLabel : "",
 					config.footerSegments.cost ? builtInCostLabel : "",

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -166,6 +166,7 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 	time: "Current time",
 	os: "OS icon",
 	runtime: "Runtime",
+	modelInfo: "Model info",
 	context: "Context usage",
 	tokens: "Token counts",
 	cost: "Session cost",
@@ -186,6 +187,7 @@ const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> =
 	time: "Show the current time (HH:MM) on the right.",
 	os: "Show an operating-system icon on the left.",
 	runtime: "Show or hide the detected runtime/language segment on the left.",
+	modelInfo: "Show the selected model and non-duplicate provider on the right.",
 	context: "Show or hide context usage on the right.",
 	tokens: "Show or hide input/output token counts on the right.",
 	cost: "Show or hide session cost on the right.",
@@ -257,6 +259,7 @@ function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingI
 		value === "gitCounts" ||
 		value === "sessionDuration" ||
 		value === "runtime" ||
+		value === "modelInfo" ||
 		value === "context" ||
 		value === "tokens" ||
 		value === "cost" ||
@@ -612,6 +615,7 @@ function buildItems(
 		"cwd",
 		"sessionName",
 		"runtime",
+		"modelInfo",
 		"context",
 		"tokens",
 		"cost",

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -88,6 +88,7 @@ describe("mergeConfig", () => {
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
+			modelInfo: false,
 			context: true,
 			gitCounts: false,
 			sessionDuration: false,
@@ -800,12 +801,16 @@ describe("mergeConfig", () => {
 	});
 
 	it("accepts valid footer segment preferences and ignores invalid values", () => {
-		expect(mergeConfig({ footerSegments: { cwd: false, tokens: false } }).footerSegments).toEqual({
+		expect(
+			mergeConfig({ footerSegments: { cwd: false, modelInfo: true, tokens: false } })
+				.footerSegments,
+		).toEqual({
 			cwd: false,
 			sessionName: true,
 			gitBranch: true,
 			gitStatus: true,
 			runtime: true,
+			modelInfo: true,
 			context: true,
 			gitCounts: false,
 			sessionDuration: false,
@@ -819,14 +824,16 @@ describe("mergeConfig", () => {
 			cost: true,
 		});
 		expect(
-			mergeConfig({ footerSegments: { cost: "off", gitBranch: false, gitStatus: false } })
-				.footerSegments,
+			mergeConfig({
+				footerSegments: { cost: "off", gitBranch: false, gitStatus: false, modelInfo: "on" },
+			}).footerSegments,
 		).toEqual({
 			cwd: true,
 			sessionName: true,
 			gitBranch: false,
 			gitStatus: false,
 			runtime: true,
+			modelInfo: false,
 			context: true,
 			gitCounts: false,
 			sessionDuration: false,
@@ -1035,7 +1042,7 @@ describe("mergeConfig", () => {
 				)}\n`,
 			);
 
-			const config = saveFooterSegmentsPatch({ tokens: false, cost: false }, path);
+			const config = saveFooterSegmentsPatch({ modelInfo: true, tokens: false, cost: false }, path);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.footerSegments).toEqual({
@@ -1044,6 +1051,7 @@ describe("mergeConfig", () => {
 				gitBranch: true,
 				gitStatus: true,
 				runtime: true,
+				modelInfo: true,
 				context: true,
 				gitCounts: false,
 				sessionDuration: false,
@@ -1060,8 +1068,25 @@ describe("mergeConfig", () => {
 			expect(raw.footerSegments).toEqual({
 				cwd: true,
 				futureKey: "future",
+				modelInfo: true,
 				tokens: false,
 				cost: false,
+			});
+			expect(mergeConfig(raw).footerSegments.modelInfo).toBe(true);
+
+			const disabled = saveFooterSegmentsPatch({ modelInfo: false }, path);
+			const disabledRaw = JSON.parse(readFileSync(path, "utf8"));
+			expect(disabled.footerSegments.modelInfo).toBe(false);
+			expect(mergeConfig(disabledRaw).footerSegments.modelInfo).toBe(false);
+			expect(disabledRaw).toEqual({
+				unknown: true,
+				footerSegments: {
+					cwd: true,
+					futureKey: "future",
+					modelInfo: false,
+					tokens: false,
+					cost: false,
+				},
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -1081,6 +1106,7 @@ describe("mergeConfig", () => {
 				gitBranch: true,
 				gitStatus: true,
 				runtime: false,
+				modelInfo: false,
 				context: true,
 				gitCounts: false,
 				sessionDuration: false,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1526,6 +1526,110 @@ describe("Pi docs compliance", () => {
 		expect(compact).not.toContain("(auto)");
 	});
 
+	it("renders opt-in model info, independent variables, and omits it from compact fallback", () => {
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: "/tmp/project",
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const state = createInitialState(emptyGitStatus());
+		state.modelLabel = "GPT-5.6 Terra";
+		state.providerLabel = "OpenAI";
+		state.contextLabel = "0.5%/200k";
+		state.tokenLabel = "↑1 ↓2";
+		state.costLabel = "$0.001";
+		const createFooter = () =>
+			footerFactory?.({ requestRender() {} }, makeTheme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map<string, string>(),
+			});
+
+		installFooter(ctx as never, state, () => ({ ...defaultConfig, responsiveFooter: false }), {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		expect(createFooter()?.render(200).join("\n")).not.toContain("GPT-5.6 Terra");
+
+		const enabled = {
+			...defaultConfig,
+			footerSegments: { ...defaultConfig.footerSegments, modelInfo: true },
+		};
+		installFooter(ctx as never, state, () => enabled, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const aligned = createFooter()?.render(200) ?? [];
+		expect(aligned).toHaveLength(1);
+		expect(aligned.join("\n")).toContain("GPT-5.6 Terra OpenAI");
+		expect(aligned.every((line) => visibleWidth(line) <= 200)).toBe(true);
+
+		installFooter(ctx as never, state, () => enabled, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const reflowed = createFooter()?.render(55) ?? [];
+		expect(reflowed).toHaveLength(2);
+		expect(reflowed.join("\n")).toContain("GPT-5.6 Terra OpenAI");
+		expect(reflowed.every((line) => visibleWidth(line) <= 55)).toBe(true);
+
+		installFooter(ctx as never, state, () => enabled, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		state.modelLabel = "openai/gpt-5";
+		expect(createFooter()?.render(200).join("\n")).toContain("openai/gpt-5 | 0.5%/200k");
+		expect(createFooter()?.render(200).join("\n")).not.toContain("openai/gpt-5 OpenAI");
+		state.providerLabel = "";
+		expect(createFooter()?.render(200).join("\n")).toContain("openai/gpt-5 | 0.5%/200k");
+
+		state.modelLabel = "custom-model";
+		state.providerLabel = "Provider X";
+		installFooter(
+			ctx as never,
+			state,
+			() => ({
+				...defaultConfig,
+				responsiveFooter: false,
+				footerFormat: "$model|$provider",
+			}),
+			{ setRequestRender() {}, scheduleProjectRefresh() {} },
+		);
+		expect(createFooter()?.render(200).join("\n")).toContain("custom-model|Provider X");
+		for (const [format, expected, omitted] of [
+			["$model", "custom-model", "Provider X"],
+			["$provider", "Provider X", "custom-model"],
+			["$provider$fill$model", "Provider X", ""],
+		] as const) {
+			installFooter(
+				ctx as never,
+				state,
+				() => ({ ...defaultConfig, responsiveFooter: false, footerFormat: format }),
+				{ setRequestRender() {}, scheduleProjectRefresh() {} },
+			);
+			const custom = createFooter()?.render(200).join("\n") ?? "";
+			expect(custom).toContain(expected);
+			if (omitted) expect(custom).not.toContain(omitted);
+			if (format.includes("$fill")) {
+				expect(custom.indexOf("Provider X")).toBeLessThan(custom.indexOf("custom-model"));
+			}
+		}
+
+		installFooter(ctx as never, state, () => enabled, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const compact = createFooter()?.render(40) ?? [];
+		expect(compact.join("\n")).not.toContain("custom-model");
+		expect(compact.join("\n")).not.toContain("Provider X");
+		expect(compact.every((line) => visibleWidth(line) <= 40)).toBe(true);
+	});
+
 	it("keeps built-in telemetry controlled by parent segment enablement", () => {
 		let footerFactory: FooterFactory | undefined;
 		const ctx = makeContext({

--- a/test/footer-format.test.ts
+++ b/test/footer-format.test.ts
@@ -19,6 +19,14 @@ describe("parseFooterFormat", () => {
 		expect(parseFooterFormat("$cwd")).toEqual([{ kind: "var", name: "cwd" }]);
 	});
 
+	it("parses model-info variables independently", () => {
+		expect(parseFooterFormat("$model $provider")).toEqual([
+			{ kind: "var", name: "model" },
+			{ kind: "text", value: " " },
+			{ kind: "var", name: "provider" },
+		]);
+	});
+
 	it("parses $package and $package_version as package-version vars", () => {
 		expect(parseFooterFormat("$package")).toEqual([{ kind: "var", name: "package" }]);
 		expect(parseFooterFormat("$package_version")).toEqual([
@@ -341,10 +349,12 @@ describe("compact footer format", () => {
 	it("collects canonical data references and excludes layout variables", () => {
 		expect(
 			collectFooterFormatReferences(
-				parseFooterFormat("$directory $branch $wrap $wrap_sep $extensions $fill $duration"),
+				parseFooterFormat(
+					"$directory $branch $model $provider $wrap $wrap_sep $extensions $fill $duration",
+				),
 				FOOTER_FORMAT_ALIASES,
 			),
-		).toEqual(new Set(["cwd", "git_branch", "session_duration"]));
+		).toEqual(new Set(["cwd", "git_branch", "model", "provider", "session_duration"]));
 	});
 });
 

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -289,7 +289,7 @@ describe("responsive footer dependency reconciliation", () => {
 			component.handleInput?.("\t");
 			component.handleInput?.("\t");
 			component.handleInput?.("\t");
-			for (let index = 0; index < 10; index++) component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 11; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -374,6 +374,7 @@ describe("bounded /zentui settings", () => {
 			"Current directory",
 			"Session name",
 			"Runtime",
+			"Model info",
 			"Context usage",
 			"Token counts",
 			"Session cost",
@@ -518,6 +519,161 @@ describe("bounded /zentui settings", () => {
 		expect(closeCalls).toBe(2);
 		expect(rows[0]).toContain("name");
 		expect(rows[1]).toContain("enabled");
+	});
+
+	it("toggles model info, persists each change, and reopens with the effective value", async () => {
+		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+		const config = cloneConfig();
+		const patches: Array<Record<string, boolean>> = [];
+		const rows: string[] = [];
+		let invocation = 0;
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: new SessionLifecycle(),
+				getConfig: () => config,
+				setColorSources() {},
+				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments(patch) {
+					patches.push(patch as Record<string, boolean>);
+					Object.assign(config.footerSegments, patch);
+				},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setSeparator() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				getActiveExtensionStatuses: () => new Map(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender() {},
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: theme(),
+				notify() {},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					invocation += 1;
+					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
+					goToSection(component, "Segments");
+					selectLabel(component, "Model info");
+					if (invocation === 1) {
+						rows.push(renderedValue(component, "Model info"));
+						component.handleInput(" ");
+						rows.push(renderedValue(component, "Model info"));
+						component.handleInput(" ");
+						rows.push(renderedValue(component, "Model info"));
+						component.handleInput(" ");
+					}
+					rows.push(renderedValue(component, "Model info"));
+					component.handleInput("\x1b");
+				},
+			},
+		};
+
+		await command?.handler("", ctx);
+		await command?.handler("", ctx);
+
+		expect(patches).toEqual([{ modelInfo: true }, { modelInfo: false }, { modelInfo: true }]);
+		expect(config.footerSegments.modelInfo).toBe(true);
+		expect(rows).toEqual([
+			expect.stringContaining("disabled"),
+			expect.stringContaining("enabled"),
+			expect.stringContaining("disabled"),
+			expect.stringContaining("enabled"),
+			expect.stringContaining("enabled"),
+		]);
+	});
+
+	it("rolls back the model-info control when persistence fails", async () => {
+		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+		const config = cloneConfig();
+		const patches: Array<Record<string, boolean>> = [];
+		const rows: string[] = [];
+		const notifications: Array<{ message: string; level: string }> = [];
+
+		registerZentuiSettingsCommand(
+			{
+				registerCommand(_name: string, options: unknown) {
+					command = options as typeof command;
+				},
+			} as never,
+			{
+				sessionLifecycle: new SessionLifecycle(),
+				getConfig: () => config,
+				setColorSources() {},
+				setUiFeatures: () => ({ applied: true }),
+				setFooterSegments(patch) {
+					patches.push(patch as Record<string, boolean>);
+					throw new Error("config is read-only");
+				},
+				setFooterFormat() {},
+				setIconMode() {},
+				setContextStyle() {},
+				setSeparator() {},
+				setPathDisplay() {},
+				setGitBranch() {},
+				getActiveExtensionStatuses: () => new Map(),
+				setExtensionStatusPlacement() {},
+				setExtensionStatusColorMode() {},
+				setFixedEditor() {},
+				requestRender() {},
+				settingsListTheme: {
+					label: (text) => text,
+					value: (text) => text,
+					description: (text) => text,
+					cursor: "> ",
+					hint: (text) => text,
+				},
+			},
+		);
+
+		await command?.handler("", {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				theme: theme(),
+				notify(message: string, level: string) {
+					notifications.push({ message, level });
+				},
+				async custom(factory: (...args: unknown[]) => unknown) {
+					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
+					goToSection(component, "Segments");
+					selectLabel(component, "Model info");
+					rows.push(renderedValue(component, "Model info"));
+					component.handleInput(" ");
+					rows.push(renderedValue(component, "Model info"));
+				},
+			},
+		});
+
+		expect(patches).toEqual([{ modelInfo: true }]);
+		expect(config.footerSegments.modelInfo).toBe(false);
+		expect(rows).toEqual([
+			expect.stringContaining("disabled"),
+			expect.stringContaining("disabled"),
+		]);
+		expect(notifications).toEqual([
+			{ message: "Could not update Zentui settings: config is read-only", level: "error" },
+		]);
 	});
 
 	it("keeps a new control unchanged when persistence fails", async () => {

--- a/test/telemetry-lifecycle-integration.test.ts
+++ b/test/telemetry-lifecycle-integration.test.ts
@@ -35,6 +35,7 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 			...actual.defaultConfig,
 			projectRefreshIntervalMs: 0,
 			features: { ...actual.defaultConfig.features, editor: false, statusLine: true },
+			footerSegments: { ...actual.defaultConfig.footerSegments, modelInfo: true },
 		}),
 	};
 });
@@ -172,13 +173,20 @@ describe("telemetry lifecycle integration", () => {
 
 		await emit(handlers, "session_start", harness.ctx);
 		const footer = harness.createFooter();
+		expect(rendered(footer)).toContain("telemetry-events-model Test");
 		expect(rendered(footer)).toContain("$0.000 (sub)");
 		expect(rendered(footer)).not.toContain("(auto)");
 
-		harness.state.model = { ...harness.state.model, provider: "changed" };
+		harness.state.model = {
+			...harness.state.model,
+			id: "selected-model",
+			provider: "changed-provider",
+		};
 		capabilities.subscription = false;
 		capabilities.autoCompaction = false;
 		await emit(handlers, "model_select", harness.ctx);
+		expect(rendered(footer)).toContain("selected-model Changed Provider");
+		expect(rendered(footer)).not.toContain("telemetry-events-model Test");
 		expect(rendered(footer)).not.toContain("(sub)");
 
 		capabilities.subscription = false;


### PR DESCRIPTION
## Summary

- add independent `$model` and `$provider` footer-format variables
- add a default-off built-in model-info footer segment
- expose model info through the `/zentui` Segments menu
- keep model/provider visible with the editor disabled and update after model selection
- preserve editor metadata and default compact behavior

## Compatibility

- model info remains disabled by default
- uses existing FooterState data and introduces no new Pi API dependency
- minimum supported Pi version remains `0.80.3`

## Validation

- `npm run fmt`
- Node 24 isolated-HOME `npm run verify` — 588 tests passed
- `npm run pack:check`
- approved by independent rendering, config, settings, responsive, and documentation reviews

Closes #64