### PR TITLE
Fix/fixed editor separator

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ Center the branch between directory and cost:
 
 ## Fixed editor (experimental, opt-in)
 
-The fixed editor pins the Zentui editor and footer at the bottom of the terminal while the transcript scrolls above. This enables composing follow-up messages while referencing earlier conversation history.
+The fixed editor pins the Zentui editor and footer at the bottom of the terminal while the transcript scrolls above. This enables composing follow-up messages while referencing earlier conversation history. It preserves a single blank separator above the editor so live status text and the transcript do not visually run into the input frame.
 
 ### How to enable
 

--- a/README.md
+++ b/README.md
@@ -469,6 +469,7 @@ Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable
 - **Incompatible with** `pi-powerline-footer`, `@tifan/pi-fixed-editor`, and `pi-sticky-input`. These packages patch the same Pi TUI internals; only one rendering owner can be active at a time.
 - **Alternate screen**: Uses the terminal's alternate screen buffer. Native scrollback history is not accessible while the fixed editor is active.
 - **Pi version fragility**: Patches internal TUI methods (`doRender`, `render`, `terminal.write`, `terminal.rows`) that may change across Pi versions. If the TUI layout is unsupported, Zentui falls back to normal rendering with a console warning.
+- **Extension custom UIs**: Full-screen custom components such as `/anycopy` temporarily suspend the fixed layout and use Pi's normal renderer; the fixed editor resumes when the component closes.
 - If your terminal is stuck after a crash, run `reset` or restart the terminal.
 
 ## Requirements

--- a/extensions/zentui/fixed-editor/cluster.ts
+++ b/extensions/zentui/fixed-editor/cluster.ts
@@ -47,6 +47,12 @@ function sanitizeLines(lines: string[], width: number): string[] {
 	);
 }
 
+function stripLeadingBlankLines(lines: string[]): string[] {
+	let start = 0;
+	while (start < lines.length && visibleWidth(lines[start] ?? "") === 0) start++;
+	return lines.slice(start);
+}
+
 /**
  * Render the full cluster (status + widgets + editor + footer) and extract
  * the cursor position from the CURSOR_MARKER.
@@ -59,14 +65,24 @@ export function renderCluster(
 	const w = Math.max(1, width);
 	const maxRows = Math.max(1, maxHeight - 1);
 
-	const statusLines = sanitizeLines(renderComponent(cluster.status, w), w);
+	// Pi's Loader intentionally starts with a blank line so the live status is
+	// separated from the transcript. The fixed-editor cluster owns the bottom
+	// layout, so discard that status-internal blank here; the editor separator is
+	// preserved from Pi's above-editor widget or supplied explicitly below.
+	const statusLines = stripLeadingBlankLines(sanitizeLines(renderComponent(cluster.status, w), w));
 	const aboveLines = sanitizeLines(renderComponent(cluster.aboveWidget, w), w);
 	const editorSource = sanitizeLines(renderComponent(cluster.editor, w), w);
 	const belowLines = sanitizeLines(renderComponent(cluster.belowWidget, w), w);
 	const footerLines = sanitizeLines(renderComponent(cluster.footer, w), w);
 
-	const editorLines = capEditorLines(editorSource, maxRows);
-	let remaining = maxRows - editorLines.length;
+	// Pi normally supplies a one-line above-editor Spacer. Do not add a second
+	// separator when that widget is present; add one only for layouts where the
+	// widget is absent or ends in visible content.
+	const aboveEditorSpacerPresent =
+		aboveLines.length > 0 && visibleWidth(aboveLines.at(-1) ?? "") === 0;
+	const editorGapRows = editorSource.length > 0 ? 1 : 0;
+	const editorLines = capEditorLines(editorSource, Math.max(0, maxRows - editorGapRows));
+	let remaining = maxRows - editorLines.length - editorGapRows;
 
 	const footer = footerLines.slice(-remaining);
 	remaining -= footer.length;
@@ -79,12 +95,14 @@ export function renderCluster(
 
 	const status = statusLines.slice(-remaining);
 
-	let allLines = [...status, ...above, ...editorLines, ...below, ...footer];
-
-	// Strip leading blank lines (e.g. empty status line above the editor border).
-	let start = 0;
-	while (start < allLines.length - 1 && visibleWidth(allLines[start]) === 0) start++;
-	allLines = allLines.slice(start);
+	const allLines = [
+		...status,
+		...above,
+		...(editorLines.length > 0 && !aboveEditorSpacerPresent ? [""] : []),
+		...editorLines,
+		...below,
+		...footer,
+	];
 
 	let cursor: { row: number; col: number } | null = null;
 	const cleaned = allLines.map((line, row) => {

--- a/extensions/zentui/fixed-editor/cluster.ts
+++ b/extensions/zentui/fixed-editor/cluster.ts
@@ -47,12 +47,6 @@ function sanitizeLines(lines: string[], width: number): string[] {
 	);
 }
 
-function stripLeadingBlankLines(lines: string[]): string[] {
-	let start = 0;
-	while (start < lines.length && visibleWidth(lines[start] ?? "") === 0) start++;
-	return lines.slice(start);
-}
-
 /**
  * Render the full cluster (status + widgets + editor + footer) and extract
  * the cursor position from the CURSOR_MARKER.
@@ -66,10 +60,9 @@ export function renderCluster(
 	const maxRows = Math.max(1, maxHeight - 1);
 
 	// Pi's Loader intentionally starts with a blank line so the live status is
-	// separated from the transcript. The fixed-editor cluster owns the bottom
-	// layout, so discard that status-internal blank here; the editor separator is
-	// preserved from Pi's above-editor widget or supplied explicitly below.
-	const statusLines = stripLeadingBlankLines(sanitizeLines(renderComponent(cluster.status, w), w));
+	// separated from the transcript. Preserve that leading line; the editor
+	// separator is handled independently below.
+	const statusLines = sanitizeLines(renderComponent(cluster.status, w), w);
 	const aboveLines = sanitizeLines(renderComponent(cluster.aboveWidget, w), w);
 	const editorSource = sanitizeLines(renderComponent(cluster.editor, w), w);
 	const belowLines = sanitizeLines(renderComponent(cluster.belowWidget, w), w);
@@ -82,18 +75,18 @@ export function renderCluster(
 		aboveLines.length > 0 && visibleWidth(aboveLines.at(-1) ?? "") === 0;
 	const editorGapRows = editorSource.length > 0 ? 1 : 0;
 	const editorLines = capEditorLines(editorSource, Math.max(0, maxRows - editorGapRows));
-	let remaining = maxRows - editorLines.length - editorGapRows;
+	let remaining = maxRows - editorLines.length;
 
-	const footer = footerLines.slice(-remaining);
+	const footer = remaining > 0 ? footerLines.slice(-remaining) : [];
 	remaining -= footer.length;
 
-	const below = belowLines.slice(-remaining);
+	const below = remaining > 0 ? belowLines.slice(-remaining) : [];
 	remaining -= below.length;
 
-	const above = aboveLines.slice(-remaining);
+	const above = remaining > 0 ? aboveLines.slice(-remaining) : [];
 	remaining -= above.length;
 
-	const status = statusLines.slice(-remaining);
+	const status = remaining > 0 ? statusLines.slice(-remaining) : [];
 
 	const allLines = [
 		...status,

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -83,6 +83,11 @@ function sanitizeLine(line: string, width: number): string {
 	return visibleWidth(line) > width ? truncateToWidth(line, width, "", true) : line;
 }
 
+function anchorLinesToBottom(lines: string[], rows: number): string[] {
+	if (lines.length >= rows) return lines;
+	return [...Array.from({ length: rows - lines.length }, () => ""), ...lines];
+}
+
 export class TerminalSplitCompositor {
 	private readonly capabilities: PiFixedEditorCapabilities;
 	private readonly getConfig: () => CompositorConfig;
@@ -376,7 +381,15 @@ export class TerminalSplitCompositor {
 		if (this.disposed) return this.callOriginalRender(width);
 
 		if (this.hasVisibleOverlay()) {
-			return this.withNativeComponents(() => this.callOriginalRender(width));
+			return this.withNativeComponents(() => {
+				const lines = this.callOriginalRender(width);
+				// Non-overlay custom UIs replace the editor container. Keep them in
+				// the same bottom-anchored viewport as the fixed editor instead of
+				// letting the native container render them from row 1.
+				return this.capabilities.hasCustomUi()
+					? anchorLinesToBottom(lines, this.getRawRows())
+					: lines;
+			});
 		}
 
 		const rawRows = this.getRawRows();

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -98,6 +98,7 @@ export class TerminalSplitCompositor {
 	private writing = false;
 	private renderingCluster = false;
 	private checkingOverlay = false;
+	private restoringComponents = false;
 
 	private scrollOffset = 0;
 	private maxScrollOffset = 0;
@@ -120,6 +121,42 @@ export class TerminalSplitCompositor {
 	private readonly onDismissNotice: (() => void) | null;
 
 	private cachedClusterRender: { width: number; rows: number; render: ClusterRender } | null = null;
+
+	/**
+	 * The fixed compositor hides Pi's bottom cluster from the normal TUI render and
+	 * paints it separately. Extension custom UIs (ctx.ui.custom without overlay
+	 * mode) live inside editorContainer, though, so they must be rendered by the
+	 * normal TUI while active. Temporarily restore the original component methods
+	 * for that render, then re-hide them before fixed-layout rendering resumes.
+	 */
+	private withNativeComponents<T>(fn: () => T): T {
+		if (this.restoringComponents) return fn();
+		this.restoringComponents = true;
+		const cluster = this.capabilities.cluster;
+		for (const component of [
+			cluster.status,
+			cluster.aboveWidget,
+			cluster.editor,
+			cluster.belowWidget,
+			cluster.footer,
+		]) {
+			restoreRenderable(component);
+		}
+		try {
+			return fn();
+		} finally {
+			for (const component of [
+				cluster.status,
+				cluster.aboveWidget,
+				cluster.editor,
+				cluster.belowWidget,
+				cluster.footer,
+			]) {
+				hideRenderable(component);
+			}
+			this.restoringComponents = false;
+		}
+	}
 
 	constructor(
 		capabilities: PiFixedEditorCapabilities,
@@ -157,7 +194,11 @@ export class TerminalSplitCompositor {
 			replaceMethod(this.capabilities.doRenderMethod, () => {
 				this.cachedClusterRender = null;
 				try {
-					this.callOriginalDoRender();
+					if (this.hasVisibleOverlay()) {
+						this.withNativeComponents(() => this.callOriginalDoRender());
+					} else {
+						this.callOriginalDoRender();
+					}
 					this.requestRepaint();
 				} catch {
 					// If doRender throws, the original write already happened.
@@ -334,7 +375,9 @@ export class TerminalSplitCompositor {
 	private renderScrollableRoot(width: number): string[] {
 		if (this.disposed) return this.callOriginalRender(width);
 
-		if (this.hasVisibleOverlay()) return this.callOriginalRender(width);
+		if (this.hasVisibleOverlay()) {
+			return this.withNativeComponents(() => this.callOriginalRender(width));
+		}
 
 		const rawRows = this.getRawRows();
 		const cluster = this.getClusterRender(Math.max(1, width), rawRows);

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -31,6 +31,7 @@ export type PiFixedEditorCapabilities = {
 	readRawRows: () => number;
 	getColumns: () => number;
 	hasVisibleOverlay: () => boolean;
+	hasCustomUi: () => boolean;
 	getCursorBookkeeping: () => { hardwareCursorRow: number; previousViewportTop: number };
 	addInputListener: (
 		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
@@ -256,6 +257,16 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 				const stack = Reflect.get(value, "overlayStack");
 				return (
 					Array.isArray(stack) && stack.some((entry) => isRecord(entry) && entry.hidden !== true)
+				);
+			} catch {
+				return true;
+			}
+		},
+		hasCustomUi: () => {
+			try {
+				const editorChildren = containerChildren(cluster.editor.target);
+				return (
+					Array.isArray(editorChildren) && editorChildren.some((child) => !isEditorLike(child))
 				);
 			} catch {
 				return true;

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -243,6 +243,10 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 		},
 		hasVisibleOverlay: () => {
 			try {
+				const editorChildren = containerChildren(cluster.editor.target);
+				if (Array.isArray(editorChildren) && editorChildren.some((child) => !isEditorLike(child))) {
+					return true;
+				}
 				if (
 					typeof hasOverlayValue === "function" &&
 					Reflect.apply(hasOverlayValue, value, []) === true

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -419,7 +419,10 @@ function renderPolishedFrame({
 	const renderedLines = config.features.copyFriendly
 		? [
 				top,
-				"",
+				// With an empty editor there is no editor-content row to pad, so
+				// the metadata separator below is the single blank row inside the
+				// frame. Avoid rendering two blank rows before the model label.
+				...(editorLines.length > 0 ? [""] : []),
 				...editorLines.map(
 					(line, index) =>
 						`${index === 0 ? prompt : copyFriendlyContinuation}${fillLine(line, innerWidth)}`,

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -338,6 +338,16 @@ describe("Pi fixed-editor compatibility", () => {
 		fixture.tui.overlayStack = [{}];
 		expect(patchedRender(80)).toEqual(fixture.rootRender(80));
 		fixture.tui.overlayStack = [];
+		// Extension custom UIs (for example /anycopy) replace the editor-container
+		// child without using Pi's overlay stack. They must suspend the fixed layout
+		// as well, otherwise their full-screen component is clipped into the editor.
+		Reflect.set(fixture.cluster[2], "children", [
+			{ render: () => ["custom UI"], handleInput() {} },
+		]);
+		expect(patchedRender(80)).toEqual(fixture.rootRender(80));
+		Reflect.set(fixture.cluster[2], "children", [
+			{ getText: () => "", setText() {}, handleInput() {} },
+		]);
 		fixture.setRows(12);
 		patchedRender(80);
 		fixture.terminal.write("update");
@@ -726,6 +736,18 @@ describe("cluster", () => {
 			};
 			const result = renderCluster(cluster, 80, 24);
 			expect(result.lines).toEqual(["", "editor"]);
+		});
+
+		it("preserves Pi's leading status spacer before live status", () => {
+			const cluster = {
+				status: makeCapability(["", "Working..."]),
+				aboveWidget: null,
+				editor: makeCapability(["editor"]),
+				belowWidget: null,
+				footer: null,
+			};
+			const result = renderCluster(cluster, 80, 24);
+			expect(result.lines).toEqual(["", "Working...", "", "editor"]);
 		});
 	});
 });

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -397,7 +397,7 @@ describe("Pi fixed-editor compatibility", () => {
 		const thinkingPaint = String(fixture.terminalWrite.mock.calls.at(-1)?.[0] ?? "");
 		expect(thinkingPaint.match(/\x1b\[34m/g)).toHaveLength(2);
 		expect(thinkingPaint).not.toContain("\x1b[36m");
-		expect(fixture.tui.render(80)).toHaveLength(14);
+		expect(fixture.tui.render(80)).toHaveLength(13);
 
 		editor.borderColor = shellBorder;
 		editor.invalidate();
@@ -409,7 +409,7 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(renderWidths).toEqual([78, 78]);
 		for (const frame of [thinkingPaint, shellPaint]) {
 			const paintedRows = frame.split("\x1b[2K").slice(1);
-			expect(paintedRows).toHaveLength(10);
+			expect(paintedRows).toHaveLength(11);
 			expect(paintedRows.every((row) => visibleWidth(row) <= 80)).toBe(true);
 		}
 
@@ -643,7 +643,7 @@ describe("cluster", () => {
 				footer: makeCapability(["footer"]),
 			};
 			const result = renderCluster(cluster, 80, 24);
-			expect(result.lines).toEqual(["status", "above", "editor-line", "below", "footer"]);
+			expect(result.lines).toEqual(["status", "above", "", "editor-line", "below", "footer"]);
 		});
 
 		it("extracts cursor position", () => {
@@ -655,8 +655,8 @@ describe("cluster", () => {
 				footer: null,
 			};
 			const result = renderCluster(cluster, 80, 24);
-			expect(result.cursor).toEqual({ row: 0, col: 5 });
-			expect(result.lines[0]).toBe("helloworld");
+			expect(result.cursor).toEqual({ row: 1, col: 5 });
+			expect(result.lines[1]).toBe("helloworld");
 		});
 
 		it("caps editor lines when total exceeds maxHeight", () => {
@@ -673,6 +673,21 @@ describe("cluster", () => {
 			expect(result.lines.length).toBeLessThanOrEqual(9);
 		});
 
+		it("reserves the editor separator when above widget already supplies it", () => {
+			const manyLines = Array.from({ length: 30 }, (_, i) => `ed-${i}`);
+			const cluster = {
+				status: null,
+				aboveWidget: makeCapability([""]),
+				editor: makeCapability(manyLines),
+				belowWidget: null,
+				footer: null,
+			};
+			const result = renderCluster(cluster, 80, 10);
+			expect(result.lines).toHaveLength(9);
+			expect(result.lines[0]).toBe("");
+			expect(result.lines.at(-1)).toBe("ed-29");
+		});
+
 		it("preserves internal blank lines (copy-friendly editor padding)", () => {
 			// In copy-friendly mode the editor renders truly empty strings as
 			// padding: [border, "", text, "", meta, border]. These must survive.
@@ -685,7 +700,7 @@ describe("cluster", () => {
 				footer: null,
 			};
 			const result = renderCluster(cluster, 80, 24);
-			expect(result.lines).toEqual(editorFrame);
+			expect(result.lines).toEqual(["", ...editorFrame]);
 		});
 
 		it("strips trailing blank lines from components", () => {
@@ -698,7 +713,19 @@ describe("cluster", () => {
 			};
 			const result = renderCluster(cluster, 80, 24);
 			// Trailing blanks stripped, but content preserved
-			expect(result.lines).toEqual(["status", "editor", "footer"]);
+			expect(result.lines).toEqual(["status", "", "editor", "footer"]);
+		});
+
+		it("keeps one separator above the editor when the status is empty", () => {
+			const cluster = {
+				status: makeCapability([]),
+				aboveWidget: null,
+				editor: makeCapability(["editor"]),
+				belowWidget: null,
+				footer: null,
+			};
+			const result = renderCluster(cluster, 80, 24);
+			expect(result.lines).toEqual(["", "editor"]);
 		});
 	});
 });

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -344,7 +344,10 @@ describe("Pi fixed-editor compatibility", () => {
 		Reflect.set(fixture.cluster[2], "children", [
 			{ render: () => ["custom UI"], handleInput() {} },
 		]);
-		expect(patchedRender(80)).toEqual(fixture.rootRender(80));
+		expect(patchedRender(80)).toEqual([
+			...Array.from({ length: 10 }, () => ""),
+			...fixture.rootRender(80),
+		]);
 		Reflect.set(fixture.cluster[2], "children", [
 			{ getText: () => "", setText() {}, handleInput() {} },
 		]);


### PR DESCRIPTION
## Summary

- Preserve the spacer before live `Working...` status and above the fixed editor.
- Avoid duplicate blank rows inside the copy-friendly editor.
- Suspend fixed-editor rendering while extension custom UIs such as `/anycopy` are active.
- Added regression coverage and updated fixed-editor documentation.

## Screenshots / recordings

N/A — no recording attached. The layout behavior is covered by fixed-editor tests.

## Testing

- [X] `npm run verify`
- [ ] `npm run pack:check`
- [X] Manual Pi test via `npm run pi:dev`
- [X] Added or updated tests where practical

## Checklist

- [X] Preserved Nerd Font / private-use icon glyphs.
- [X] Updated `README.md`.
- [X] Kept the diff surgical.
- [X] `extensions/zentui/index.ts` remains orchestration-focused.
- [X] Used conventional commit-style PR title: `fix: preserve fixed editor spacers and custom UIs`.