### PR TITLE
feat: add composable ui styles and stabilize fixed editor

### DIFF
--- a/.github/ISSUE_TEMPLATE/rendering_issue.yml
+++ b/.github/ISSUE_TEMPLATE/rendering_issue.yml
@@ -72,7 +72,7 @@ body:
         - Previous user message styling
         - Runtime/git segment
         - Colors/theme mapping
-        - Polished (copy-friendly) editor style
+        - Opencode (copy-friendly) editor style
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/rendering_issue.yml
+++ b/.github/ISSUE_TEMPLATE/rendering_issue.yml
@@ -17,7 +17,7 @@ body:
           required: true
         - label: I am using a Nerd Font or verified whether the issue reproduces with one.
           required: true
-        - label: I checked whether copy-friendly mode changes the behavior, if relevant.
+        - label: I checked whether switching the affected component style or disabling custom styling changes the behavior, if relevant.
           required: false
 
   - type: input
@@ -72,7 +72,7 @@ body:
         - Previous user message styling
         - Runtime/git segment
         - Colors/theme mapping
-        - Copy-friendly mode
+        - Polished (copy-friendly) editor style
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/rendering_issue.yml
+++ b/.github/ISSUE_TEMPLATE/rendering_issue.yml
@@ -73,6 +73,7 @@ body:
         - Runtime/git segment
         - Colors/theme mapping
         - Opencode (copy-friendly) editor style
+        - Framed (copy-friendly) user-message style
         - Other
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,50 @@ jobs:
 
       - name: Dry-run pack
         run: npm run pack:check
+
+  fixed-editor-compatibility:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        pi-version: ["0.80.3", "0.82.1", "0.83.0"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Pin matching Pi package versions
+        env:
+          PI_VERSION: ${{ matrix.pi-version }}
+        run: |
+          npm pkg set "devDependencies.@earendil-works/pi-ai=$PI_VERSION"
+          npm pkg set "devDependencies.@earendil-works/pi-coding-agent=$PI_VERSION"
+          npm pkg set "devDependencies.@earendil-works/pi-tui=$PI_VERSION"
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Attest Pi package versions
+        env:
+          PI_VERSION: ${{ matrix.pi-version }}
+        run: |
+          npm ls --depth=0 @earendil-works/pi-ai @earendil-works/pi-coding-agent @earendil-works/pi-tui
+          node - <<'NODE'
+          for (const name of ["pi-ai", "pi-coding-agent", "pi-tui"]) {
+            const pkg = require(`./node_modules/@earendil-works/${name}/package.json`)
+            if (pkg.version !== process.env.PI_VERSION) throw new Error(`${pkg.name}: ${pkg.version}`)
+            console.log(pkg.name, pkg.version)
+          }
+          NODE
+
+      - name: Verify fixed editor
+        run: timeout 15m npm run test:fixed-editor
+        env:
+          RUN_FIXED_EDITOR_PTY: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,6 @@ jobs:
           NODE
 
       - name: Verify fixed editor
-        run: timeout 15m npm run test:fixed-editor
+        run: timeout --signal=TERM --kill-after=30s 15m npm run test:fixed-editor
         env:
           RUN_FIXED_EDITOR_PTY: "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ User config is created at:
 ~/.pi/agent/zentui.json
 ```
 
-Use `colors` for Starship-style color strings, hex/256-color values, or Pi theme tokens. `colorSources` controls whether Zentui maps colors through the Pi theme or renders terminal colors directly. `/zentui` changes editor and previous user-message sources together.
+Use `colors` for Starship-style color strings, hex/256-color values, or Pi theme tokens. Canonical color-source ownership is independent through `components.editor.colorSource`, `components.userMessages.colorSource`, `components.selectorBorders.colorSource`, and `components.footer.colorSource`. `/zentui` exposes separate controls for Editor, previous User messages, selector borders, and—while Starship is selected—the Footer; changing one does not change the others.
 
 ## Things to preserve
 

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Zentui brings two popular aesthetics to Pi:
 
 ### Editor (Opencode-inspired)
 
-- Selectable `polished` (default) and `minimalist` editor modes
+- Selectable `polished` (default) and `minimalist` editor styles
 - Bordered input box with configurable accent rail and border colors
-- Minimalist mode moves cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
+- Minimalist style moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
 - Model name and provider displayed inside the polished editor frame
 - Configurable model, provider, and thinking-level indicator colors
 - Prompt-box-style user messages matching the ZentUI input chrome
@@ -135,7 +135,7 @@ User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or
 The interactive `/zentui` menu is split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. Every listed control patches the shown JSON equivalent:
 
 1. **Appearance** — Starship/footer colors (`colorSources.starship`); editor + previous-message colors (`colorSources.editor` and `colorSources.userMessages`); separator (`separator`); icon mode (`icons.mode`).
-2. **Editor** — editor enabled (`features.editor`); editor mode (`editorMode`); focused minimalist path/context/visibility controls (`minimalist`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
+2. **Editor** — editor enabled (`features.editor`); editor style (`editorStyle`); settings for the active style (`editorStyles`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`). Minimalist-only rows appear only while that style is selected.
 3. **Footer** — status line enabled (`features.statusLine`); responsive footer (`responsiveFooter`); compact footer rows (`compactFooterMaxLines`); context style (`contextStyle`); path display (`pathDisplay.mode`); path depth (`pathDisplay.depth`).
 4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `modelInfo`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
 5. **Git** — Git branch visibility (`footerSegments.gitBranch`); branch length (`gitBranch.maxLength`); Git status visibility (`footerSegments.gitStatus`); Git counts visibility (`footerSegments.gitCounts`); Git commit visibility (`footerSegments.gitCommit`); commit-only-detached (`gitCommit.onlyDetached`); exact-match tag (`gitCommit.showTag`); Git metrics visibility (`footerSegments.gitMetrics`); hide zero metrics (`gitMetrics.onlyNonzero`); ignore submodules (`gitMetrics.ignoreSubmodules`).
@@ -178,14 +178,17 @@ Default config values — copy this and change any value you want:
 	"separator": "pipe",
 	"contextStyle": "text",
 	"editorModelLabel": "id",
-	"editorMode": "polished",
-	"minimalist": {
-		"pathDisplay": "compact",
-		"contextFormat": "percent",
-		"contextGauge": false,
-		"showTimer": true,
-		"showCost": true,
-		"showGit": true
+	"editorStyle": "polished",
+	"editorStyles": {
+		"minimalist": {
+			"pathDisplay": "compact",
+			"contextFormat": "percent",
+			"contextGauge": false,
+			"showSessionName": true,
+			"showTimer": true,
+			"showCost": true,
+			"showGit": true
+		}
 	},
 	"editorBorderColorMode": "static",
 	"contextThresholds": {
@@ -310,8 +313,8 @@ Default config values — copy this and change any value you want:
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Finite context percentages use one decimal place. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
 - `editorModelLabel`: controls the model shown in the editor frame, built-in model-info footer segment, and footer `$model` variable. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
-- `editorMode`: `polished` (default) keeps Zentui's accent-rail editor; `minimalist` uses the compact metadata frame described below. Cycle it from the `/zentui` **Editor** tab.
-- `minimalist`: focused minimalist-frame controls. `pathDisplay` is `compact` (cwd basename, default), `project` (repository name plus relative path when known), or `full` (home-contracted cwd). `contextFormat` is `percent` (default) or `percent-total`; `contextGauge` adds a compact gauge when space permits. `showTimer`, `showCost`, and `showGit` default to `true`.
+- `editorStyle`: `polished` (default) keeps Zentui's accent-rail editor; `minimalist` uses the compact metadata frame described below. Cycle it from the `/zentui` **Editor** tab. The tab shows concise settings for the selected style rather than adding a tab for each style.
+- `editorStyles.minimalist`: focused minimalist-frame controls. `pathDisplay` is `compact` (cwd basename, default), `project` (repository name plus relative path when known), or `full` (home-contracted cwd). `contextFormat` is `percent` (default) or `percent-total`; `contextGauge` adds a compact gauge when space permits. `showSessionName`, `showTimer`, `showCost`, and `showGit` default to `true`.
 - `editorBorderColorMode`: `static` (default) uses `colors.editorBorder`; `adaptive` follows Pi's current shell-mode and thinking-level editor border color. Cycle it from the `/zentui` **Editor** tab.
 - `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Appearance** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
@@ -337,13 +340,13 @@ Default config values — copy this and change any value you want:
 
 Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
 
-## Minimalist editor mode
+## Minimalist editor style
 
-Set `editorMode` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows Bash state and the current/completed turn duration at top left; cost, model, thinking level, and context usage at top right; Git branch/status at bottom left; and the configured path at bottom right. A blank interior row above and below the input adds symmetric breathing room. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
+Set `editorStyle` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows viewport counts, Bash state, the current/completed turn duration, and the explicit Pi session name at top left; cost, model, thinking level, and context usage at top right; viewport count plus Git branch/status at bottom left; and the configured path at bottom right. Unnamed sessions add no placeholder. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
 
-The `/zentui` **Editor** area exposes the focused `minimalist` subsection. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
+While `minimalist` is selected, the `/zentui` **Editor** area shows its focused controls without repeating the style name on every row. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Session name, timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
 
-When Zentui's editor and status line are both enabled, the separate footer rows are suppressed only while minimalist decoration succeeds. The footer stays visible for narrow or unsupported editor output so metadata is not lost. The configured status-line setting is preserved, so switching back to `polished` restores the footer. Minimalist mode does not remove Pi's header and does not add sticky positioning, mouse handling, clipboard behavior, or custom scrolling. The experimental fixed-editor option remains separate.
+When Zentui's editor and status line are both enabled, the separate footer rows are suppressed only while minimalist decoration succeeds. The footer stays visible for narrow or unsupported editor output so metadata is not lost. The configured status-line setting is preserved, so switching back to `polished` restores the footer. Minimalist style does not remove Pi's header and does not add sticky positioning, mouse handling, clipboard behavior, or custom scrolling. The experimental fixed-editor option remains separate.
 
 ## Editor Metadata Format
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ A Starship-inspired statusline and Opencode-style TUI for [Pi](https://pi.dev).
 
 ## What is this?
 
-Zentui brings two popular aesthetics to Pi:
+Zentui styles three major Pi surfaces independently:
 
-- **[Starship](https://starship.rs/) footer** — shows your current directory, git branch, git status indicators, and runtime/version detection in a compact, icon-rich format
-- **[Opencode](https://github.com/opencode-ai/opencode) editor** — clean bordered input box with accent rail, copy-friendly mode, and model/provider display inside the editor frame
+- **Editor** — selectable polished, low-rail polished, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
+- **User messages** — selectable framed, compact, and labeled transcript messages
+- **[Starship](https://starship.rs/) footer** — current directory, Git, runtime, context, tokens, cost, and other configurable segments
+
+Set any owning component's `enabled` field to `false` to use Pi's exact native surface. **Appearance** (selector borders and icons) and **Layout** (the fixed-editor experiment) remain supporting configuration domains.
 
 ## Features
 
@@ -30,14 +33,41 @@ Zentui brings two popular aesthetics to Pi:
 
 ### Editor (Opencode-inspired)
 
-- Selectable `polished` (default) and `minimalist` editor styles
-- Bordered input box with configurable accent rail and border colors
-- Minimalist style moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
-- Model name and provider displayed inside the polished editor frame
-- Configurable model, provider, and thinking-level indicator colors
-- Independently configurable framed user messages and Zentui selector borders
-- Editor and framed-message copy-friendly modes can be configured independently in `/zentui` or canonical JSON; `/zentui copy-friendly` remains an atomic compatibility recipe that updates both
+- `polished` (default) keeps an accent rail on every interior row
+- `polished-copy-friendly` (**Polished (copy-friendly)** in `/zentui`) preserves the low-rail rendering for clean terminal selection
+- `minimalist` moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
+- Model name and provider appear inside both polished editor variants
+- Configurable model, provider, thinking-level, accent, and border colors
 - **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of Zentui editor/footer enablement
+
+Editor previews:
+
+```text
+polished                 polished-copy-friendly     minimalist
+────────────────────     ────────────────────       ╭─ session ── model ╮
+│
+│ prompt                 › prompt                  │ prompt             │
+│
+│ metadata                metadata                 ╰─ git ───── path ──╯
+────────────────────     ────────────────────
+```
+
+### User messages
+
+- `framed` (default) preserves the full-width bordered prompt box
+- `compact` uses only an accent rail, with no border or padding rows
+- `labeled` uses a rounded box with the fixed label `User`
+- Disabling User-message styling delegates byte-for-byte to Pi's native renderer; native is not a style ID
+- No custom `plain` message style is provided
+
+```text
+framed                    compact              labeled
+────────────────────      │ Message            ╭─ User ───────────╮
+│                         │ Continued          │ Message          │
+│ Message                                      │ Continued        │
+│                                              ╰──────────────────╯
+────────────────────
+```
 
 ### Git Status Icons
 
@@ -136,14 +166,14 @@ The interactive `/zentui` menu is split into exactly eight component-oriented se
 
 1. **Appearance** — selector-border enablement, style, and colors; icon mode.
 2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
-3. **User messages** — framed-message enablement, style, colors, and copy-friendly behavior.
+3. **User messages** — message enablement, `framed | compact | labeled` style selection, and colors.
 4. **Layout** — fixed-editor enablement, mouse scrolling, and copy notices.
 5. **Footer** — footer enablement, style, colors, model label, responsive layout, separator, context style, and path display.
 6. **Segments** — visibility toggles for non-Git Starship segments.
 7. **Git** — Starship Git segment and probe controls.
 8. **Extensions** — Starship extension-status placement and color controls for active keys.
 
-Editor enablement changes only the editor; user messages and selector borders remain independently controlled. Color and model-label rows also update only their owning component. The polished-editor and framed-message copy-friendly rows are independent, while `/zentui copy-friendly` remains the sole atomic compatibility recipe and updates both values.
+Editor, User messages, and Footer each retain independent enablement and style configuration. Disabling a surface delegates to Pi instead of selecting a custom “native” style. Color and model-label rows update only their owning component.
 
 Settings for a component's selected style remain available while that component is disabled, allowing preconfiguration. Settings for inactive styles are hidden. Free-form values such as custom formats, polished metadata format, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
 
@@ -159,15 +189,6 @@ Useful slash-command shortcuts:
 /zentui messages disable
 /zentui messages toggle
 /zentui statusline toggle
-/zentui editor-copy-friendly enable
-/zentui editor-copy-friendly disable
-/zentui editor-copy-friendly toggle
-/zentui message-copy-friendly enable
-/zentui message-copy-friendly disable
-/zentui message-copy-friendly toggle
-/zentui copy-friendly enable
-/zentui copy-friendly disable
-/zentui copy-friendly toggle
 /zentui messages
 /zentui user-messages
 /zentui layout
@@ -196,7 +217,9 @@ Default config values — copy this and change any value you want:
 			"viewportIndicators": true,
 			"styles": {
 				"polished": {
-					"copyFriendly": false,
+					"metadataFormat": "$model  $provider(  $thinking)"
+				},
+				"polished-copy-friendly": {
 					"metadataFormat": "$model  $provider(  $thinking)"
 				},
 				"minimalist": {
@@ -219,9 +242,9 @@ Default config values — copy this and change any value you want:
 			"style": "framed",
 			"colorSource": "theme",
 			"styles": {
-				"framed": {
-					"copyFriendly": false
-				}
+				"framed": {},
+				"compact": {},
+				"labeled": {}
 			}
 		},
 		"selectorBorders": {
@@ -357,22 +380,22 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
-- `components.editor`: owns editor enablement, `polished | minimalist` style selection, color source, border mode, model label, viewport indicators, and both editor-style configurations.
-- `components.userMessages`: owns framed-message enablement, the fixed `framed` style, color source, and framed copy-friendly behavior.
+- `components.editor`: owns editor enablement, `polished | polished-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
+- `components.userMessages`: owns message enablement, `framed | compact | labeled` style selection, and color source.
 - `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
 - `components.footer`: owns footer enablement, the fixed `starship` style, footer color source, footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses).
 - `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/footer enablement.
 - Editor and footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
-- Polished-editor and framed-message `copyFriendly` values have separate menu controls and component-specific commands. `/zentui copy-friendly` remains an atomic compatibility recipe that writes both.
-- User messages currently support only `framed`, selector borders only `zentui`, and the footer only `starship`. Set the owning component's `enabled` to `false` for native/Pi fallback.
+- Selector borders support only `zentui`, and the Footer supports only `starship`. Set an owning component's `enabled` to `false` for exact native Pi fallback.
 - Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
+- Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are migration input only. Legacy message copy-friendly mode now migrates to disabled User-message styling, which delegates to Pi's native renderer. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; the raw released feature key remains preserved as user-owned migration data.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
-- `editorAccent` styles the active editor rail and framed user-message rail when their owning copy-friendly setting is disabled.
-- `editorPrompt` styles the copy-friendly editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
+- `editorAccent` styles Editor and User-message accent rails and the labeled message label.
+- `editorPrompt` styles the `polished-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
 - `editorBorder` styles previous user-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
-Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
+Tip: with `polished-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
 
 ## Minimalist editor style
 
@@ -384,7 +407,7 @@ Footer visibility is controlled only by `components.footer.enabled`. Minimalist 
 
 ## Editor Metadata Format
 
-Set `components.editor.styles.polished.metadataFormat` in `~/.pi/agent/zentui.json` to customize the left side of the polished editor metadata row:
+Set `metadataFormat` under either polished style in `~/.pi/agent/zentui.json` to customize that style's metadata row. The two variants retain independent values:
 
 ```json
 {
@@ -393,6 +416,9 @@ Set `components.editor.styles.polished.metadataFormat` in `~/.pi/agent/zentui.js
 			"styles": {
 				"polished": {
 					"metadataFormat": "$model_name ($model_id)( · $provider)( · $thinking)( · $session_name)"
+				},
+				"polished-copy-friendly": {
+					"metadataFormat": "$model( · $provider)"
 				}
 			}
 		}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Zentui brings two popular aesthetics to Pi:
 - Model name and provider displayed inside the polished editor frame
 - Configurable model, provider, and thinking-level indicator colors
 - Independently configurable framed user messages and Zentui selector borders
-- Editor and framed-message copy-friendly modes can be configured independently in canonical JSON; `/zentui copy-friendly` remains a compatibility recipe that updates both
+- Editor and framed-message copy-friendly modes can be configured independently in `/zentui` or canonical JSON; `/zentui copy-friendly` remains an atomic compatibility recipe that updates both
 - **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of Zentui editor/footer enablement
 
 ### Git Status Icons
@@ -132,18 +132,20 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu remains split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. These controls preserve their historical recipe behavior while saving canonical component snapshots:
+The interactive `/zentui` menu is split into exactly eight component-oriented sections, in this order. Use `Tab` and `Shift+Tab` to switch sections:
 
-1. **Appearance** — footer, editor/selector, and user-message color-source recipes; footer separator; icon mode.
-2. **Editor** — editor recipe, editor style/settings, border behavior, model-label recipe, copy-friendly recipe, viewport indicators, and fixed-layout controls. Minimalist-only rows appear only while that style is selected.
-3. **Footer** — footer enablement, responsive layout, compact rows, context style, and footer path display.
-4. **Segments** — visibility toggles for non-Git Starship segments.
-5. **Git** — Starship Git segment and probe controls.
-6. **Extensions** — Starship extension-status placement and color controls for active keys.
+1. **Appearance** — selector-border enablement, style, and colors; icon mode.
+2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
+3. **User messages** — framed-message enablement, style, colors, and copy-friendly behavior.
+4. **Layout** — fixed-editor enablement, mouse scrolling, and copy notices.
+5. **Footer** — footer enablement, style, colors, model label, responsive layout, separator, context style, and path display.
+6. **Segments** — visibility toggles for non-Git Starship segments.
+7. **Git** — Starship Git segment and probe controls.
+8. **Extensions** — Starship extension-status placement and color controls for active keys.
 
-The editor enable recipe still updates editor, framed-message, and selector enablement together; the editor color recipe still updates editor and selectors; copy-friendly and model-label recipes still update both historical destinations. Direct canonical JSON can configure each destination independently.
+Editor enablement changes only the editor; user messages and selector borders remain independently controlled. Color and model-label rows also update only their owning component. The polished-editor and framed-message copy-friendly rows are independent, while `/zentui copy-friendly` remains the sole atomic compatibility recipe and updates both values.
 
-Free-form values such as custom formats, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
+Settings for a component's selected style remain available while that component is disabled, allowing preconfiguration. Settings for inactive styles are hidden. Free-form values such as custom formats, polished metadata format, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
 
 Useful slash-command shortcuts:
 
@@ -153,10 +155,22 @@ Useful slash-command shortcuts:
 /zentui statusline enable
 /zentui statusline disable
 /zentui editor toggle
+/zentui messages enable
+/zentui messages disable
+/zentui messages toggle
 /zentui statusline toggle
+/zentui editor-copy-friendly enable
+/zentui editor-copy-friendly disable
+/zentui editor-copy-friendly toggle
+/zentui message-copy-friendly enable
+/zentui message-copy-friendly disable
+/zentui message-copy-friendly toggle
 /zentui copy-friendly enable
 /zentui copy-friendly disable
 /zentui copy-friendly toggle
+/zentui messages
+/zentui user-messages
+/zentui layout
 /zentui viewport-indicators enable
 /zentui viewport-indicators disable
 /zentui viewport-indicators toggle
@@ -348,8 +362,8 @@ Default config values — copy this and change any value you want:
 - `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
 - `components.footer`: owns footer enablement, the fixed `starship` style, footer color source, footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses).
 - `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/footer enablement.
-- Editor and footer `modelLabel` values are independent. The existing `/zentui` model-label control remains a compatibility recipe that writes both.
-- Polished-editor and framed-message `copyFriendly` values are independent. The existing `/zentui copy-friendly` control remains a compatibility recipe that writes both.
+- Editor and footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
+- Polished-editor and framed-message `copyFriendly` values have separate menu controls and component-specific commands. `/zentui copy-friendly` remains an atomic compatibility recipe that writes both.
 - User messages currently support only `framed`, selector borders only `zentui`, and the footer only `starship`. Set the owning component's `enabled` to `false` for native/Pi fallback.
 - Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
@@ -523,7 +537,7 @@ Or in `~/.pi/agent/zentui.json`:
 
 ### Mouse scroll (default on)
 
-Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable it from the `/zentui` **Editor** section or:
+Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable it from the `/zentui` **Layout** section or:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A Starship-inspired statusline and Opencode-style TUI for [Pi](https://pi.dev).
 
 Zentui styles three major Pi surfaces independently:
 
-- **Editor** — selectable polished, low-rail polished, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
+- **Editor** — selectable opencode, low-rail opencode, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
 - **User messages** — selectable framed, compact, and labeled transcript messages
 - **[Starship](https://starship.rs/) footer** — current directory, Git, runtime, context, tokens, cost, and other configurable segments
 
-Set any owning component's `enabled` field to `false` to use Pi's exact native surface. **Appearance** (selector borders and icons) and **Layout** (the fixed-editor experiment) remain supporting configuration domains.
+Editor, User messages, and selector borders use an `enabled` field. Footer uses one `style`: `native`, `starship`, or `hidden`. **Appearance** (selector borders and icons) and **Layout** (the fixed-editor experiment) remain supporting configuration domains.
 
 ## Features
 
@@ -33,17 +33,18 @@ Set any owning component's `enabled` field to `false` to use Pi's exact native s
 
 ### Editor (Opencode-inspired)
 
-- `polished` (default) keeps an accent rail on every interior row
-- `polished-copy-friendly` (**Polished (copy-friendly)** in `/zentui`) preserves the low-rail rendering for clean terminal selection
+- `opencode` (default) keeps an accent rail on every interior row
+- `opencode-copy-friendly` (**Opencode (copy-friendly)** in `/zentui`) preserves the low-rail rendering for clean terminal selection
 - `minimalist` moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
-- Model name and provider appear inside both polished editor variants
+- Model name and provider appear inside both Opencode editor variants
+- Opencode autocomplete rows retain Pi's original unframed trailing layout; Minimalist keeps autocomplete inside its rounded frame
 - Configurable model, provider, thinking-level, accent, and border colors
-- **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of Zentui editor/footer enablement
+- **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of selected editor and Footer modes
 
 Editor previews:
 
 ```text
-polished                 polished-copy-friendly     minimalist
+opencode                 opencode-copy-friendly     minimalist
 ────────────────────     ────────────────────       ╭─ session ── model ╮
 │
 │ prompt                 › prompt                  │ prompt             │
@@ -168,14 +169,14 @@ The interactive `/zentui` menu is split into exactly eight component-oriented se
 2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
 3. **User messages** — message enablement, `framed | compact | labeled` style selection, and colors.
 4. **Layout** — fixed-editor enablement, mouse scrolling, and copy notices.
-5. **Footer** — footer enablement, style, colors, model label, responsive layout, separator, context style, and path display.
+5. **Footer** — `Native | Starship | Hidden` style selection. Starship additionally shows colors, model label, responsive layout, separator, context style, and path display.
 6. **Segments** — visibility toggles for non-Git Starship segments.
 7. **Git** — Starship Git segment and probe controls.
 8. **Extensions** — Starship extension-status placement and color controls for active keys.
 
-Editor, User messages, and Footer each retain independent enablement and style configuration. Disabling a surface delegates to Pi instead of selecting a custom “native” style. Color and model-label rows update only their owning component.
+Editor and User messages retain independent enablement and style configuration. Footer's single style selects Pi's built-in Footer (`Native`), Zentui's Starship Footer, or an owned zero-row Footer (`Hidden`). Color and model-label rows update only their owning component.
 
-Settings for a component's selected style remain available while that component is disabled, allowing preconfiguration. Settings for inactive styles are hidden. Free-form values such as custom formats, polished metadata format, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
+Starship-specific Footer rows are shown only while Starship is selected. The **Segments**, **Git**, and **Extensions** sections remain available for preconfiguration under every Footer style. Free-form values such as custom formats, Opencode metadata format, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
 
 Useful slash-command shortcuts:
 
@@ -202,6 +203,8 @@ Useful slash-command shortcuts:
 /zentui format clear
 ```
 
+`footer`, `statusline`, `status`, and `status line` are aliases: enable selects Starship, disable selects Native, and toggle selects Native only from Starship (Native or Hidden toggle to Starship).
+
 Default config values — copy this and change any value you want:
 
 ```json
@@ -210,16 +213,16 @@ Default config values — copy this and change any value you want:
 	"components": {
 		"editor": {
 			"enabled": true,
-			"style": "polished",
+			"style": "opencode",
 			"colorSource": "theme",
 			"borderColorMode": "static",
 			"modelLabel": "id",
 			"viewportIndicators": true,
 			"styles": {
-				"polished": {
+				"opencode": {
 					"metadataFormat": "$model  $provider(  $thinking)"
 				},
-				"polished-copy-friendly": {
+				"opencode-copy-friendly": {
 					"metadataFormat": "$model  $provider(  $thinking)"
 				},
 				"minimalist": {
@@ -253,7 +256,6 @@ Default config values — copy this and change any value you want:
 			"colorSource": "theme"
 		},
 		"footer": {
-			"enabled": true,
 			"style": "starship",
 			"colorSource": "theme",
 			"modelLabel": "id",
@@ -380,22 +382,22 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
-- `components.editor`: owns editor enablement, `polished | polished-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
+- `components.editor`: owns editor enablement, `opencode | opencode-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
 - `components.userMessages`: owns message enablement, `framed | compact | labeled` style selection, and color source.
 - `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
-- `components.footer`: owns footer enablement, the fixed `starship` style, footer color source, footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses).
-- `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/footer enablement.
-- Editor and footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
-- Selector borders support only `zentui`, and the Footer supports only `starship`. Set an owning component's `enabled` to `false` for exact native Pi fallback.
-- Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
-- Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are migration input only. Legacy message copy-friendly mode now migrates to disabled User-message styling, which delegates to Pi's native renderer. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; the raw released feature key remains preserved as user-owned migration data.
+- `components.footer`: owns `native | starship | hidden` style selection, Footer color source, Footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses). Native restores Pi's built-in Footer; Hidden installs an empty component with zero rows.
+- `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/Footer style.
+- Editor and Footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
+- Selector borders support only `zentui`; set their owning `enabled` field to `false` for native Pi behavior.
+- Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. `components.footer.enabled` and `features.statusLine` migrate to Starship or Native when no valid Footer style is present; Hidden projects `features.statusLine: false`. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
+- `polished` and `polished-copy-friendly` remain read-only migration aliases for `opencode` and `opencode-copy-friendly`. Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are migration input only. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; raw released feature keys remain preserved as user-owned migration data.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles Editor and User-message accent rails and the labeled message label.
-- `editorPrompt` styles the `polished-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
+- `editorPrompt` styles the `opencode-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
 - `editorBorder` styles previous user-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
-Tip: with `polished-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
+Tip: with `opencode-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
 
 ## Minimalist editor style
 
@@ -403,21 +405,21 @@ Set `components.editor.style` to `minimalist` or select it from the `/zentui` **
 
 While `minimalist` is selected, the `/zentui` **Editor** area shows its focused controls without repeating the style name on every row. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Session name, timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
 
-Footer visibility is controlled only by `components.footer.enabled`. Minimalist editor decoration and the Starship footer may be shown together, including at narrow widths or after decoration fallback. Minimalist style does not remove Pi's header; the experimental fixed-editor layout remains separate.
+Footer visibility is controlled by `components.footer.style`: use `starship`, `native`, or `hidden`. Minimalist editor decoration and the Starship Footer may be shown together, including at narrow widths or after decoration fallback. Minimalist style does not remove Pi's header; the experimental fixed-editor layout remains separate.
 
 ## Editor Metadata Format
 
-Set `metadataFormat` under either polished style in `~/.pi/agent/zentui.json` to customize that style's metadata row. The two variants retain independent values:
+Set `metadataFormat` under either opencode style in `~/.pi/agent/zentui.json` to customize that style's metadata row. The two variants retain independent values:
 
 ```json
 {
 	"components": {
 		"editor": {
 			"styles": {
-				"polished": {
+				"opencode": {
 					"metadataFormat": "$model_name ($model_id)( · $provider)( · $thinking)( · $session_name)"
 				},
-				"polished-copy-friendly": {
+				"opencode-copy-friendly": {
 					"metadataFormat": "$model( · $provider)"
 				}
 			}
@@ -533,7 +535,7 @@ The released flat `footerFormat` and `footerSegments` keys remain accepted only 
 
 ## Fixed editor (experimental, opt-in)
 
-The fixed layout pins Pi's usable editor cluster at the bottom of the terminal while the transcript scrolls above. It can activate independently of Zentui editor/footer enablement; Pi compatibility inspection decides whether it is safe.
+The fixed layout pins Pi's usable editor cluster at the bottom of the terminal while the transcript scrolls above. It can activate independently of Zentui editor and Footer style; Pi compatibility inspection decides whether it is safe. Hidden contributes zero rows and no spacer. A live Footer style change tears down the compositor, replaces the Footer, and reprobes the new component; reprobe failure leaves ordinary rendering active.
 
 ### How to enable
 
@@ -583,6 +585,7 @@ Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable
 - **Incompatible with** `pi-powerline-footer`, `@tifan/pi-fixed-editor`, and `pi-sticky-input`. These packages patch the same Pi TUI internals; only one rendering owner can be active at a time.
 - **Alternate screen**: Uses the terminal's alternate screen buffer. Native scrollback history is not accessible while the fixed editor is active.
 - **Pi version fragility**: Patches internal TUI methods (`doRender`, `render`, `terminal.write`, `terminal.rows`) that may change across Pi versions. If the TUI layout is unsupported, Zentui falls back to normal rendering with a console warning.
+- Pi has no Footer getter or Footer-change event. Zentui observes normal third-party takeover through Pi's custom-component disposal callback and will not restore Native afterward. Direct internal mutation, a future Pi version that stops disposing replaced components, and automatic fixed-layout reprobe after third-party replacement cannot be detected.
 - If your terminal is stuck after a crash, run `reset` or restart the terminal.
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Zentui brings two popular aesthetics to Pi:
 - Minimalist style moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
 - Model name and provider displayed inside the polished editor frame
 - Configurable model, provider, and thinking-level indicator colors
-- Prompt-box-style user messages matching the ZentUI input chrome
-- Copy-friendly mode hides editor and previous-message rail glyphs so terminal selection copies less chrome
-- **Fixed editor** (experimental, opt-in): Pin the editor and footer at the bottom of the terminal while the transcript scrolls above
+- Independently configurable framed user messages and Zentui selector borders
+- Editor and framed-message copy-friendly modes can be configured independently in canonical JSON; `/zentui copy-friendly` remains a compatibility recipe that updates both
+- **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of Zentui editor/footer enablement
 
 ### Git Status Icons
 
@@ -132,14 +132,16 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu is split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. Every listed control patches the shown JSON equivalent:
+The interactive `/zentui` menu remains split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. These controls preserve their historical recipe behavior while saving canonical component snapshots:
 
-1. **Appearance** — Starship/footer colors (`colorSources.starship`); editor + previous-message colors (`colorSources.editor` and `colorSources.userMessages`); separator (`separator`); icon mode (`icons.mode`).
-2. **Editor** — editor enabled (`features.editor`); editor style (`editorStyle`); settings for the active style (`editorStyles`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`). Minimalist-only rows appear only while that style is selected.
-3. **Footer** — status line enabled (`features.statusLine`); responsive footer (`responsiveFooter`); compact footer rows (`compactFooterMaxLines`); context style (`contextStyle`); path display (`pathDisplay.mode`); path depth (`pathDisplay.depth`).
-4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `modelInfo`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
-5. **Git** — Git branch visibility (`footerSegments.gitBranch`); branch length (`gitBranch.maxLength`); Git status visibility (`footerSegments.gitStatus`); Git counts visibility (`footerSegments.gitCounts`); Git commit visibility (`footerSegments.gitCommit`); commit-only-detached (`gitCommit.onlyDetached`); exact-match tag (`gitCommit.showTag`); Git metrics visibility (`footerSegments.gitMetrics`); hide zero metrics (`gitMetrics.onlyNonzero`); ignore submodules (`gitMetrics.ignoreSubmodules`).
-6. **Extensions** — default placement (`extensionStatuses.defaultPlacement`) first, followed by placement (`extensionStatuses.placements[key]`) and color (`extensionStatuses.colorModes[key]`) controls for currently active status keys.
+1. **Appearance** — footer, editor/selector, and user-message color-source recipes; footer separator; icon mode.
+2. **Editor** — editor recipe, editor style/settings, border behavior, model-label recipe, copy-friendly recipe, viewport indicators, and fixed-layout controls. Minimalist-only rows appear only while that style is selected.
+3. **Footer** — footer enablement, responsive layout, compact rows, context style, and footer path display.
+4. **Segments** — visibility toggles for non-Git Starship segments.
+5. **Git** — Starship Git segment and probe controls.
+6. **Extensions** — Starship extension-status placement and color controls for active keys.
+
+The editor enable recipe still updates editor, framed-message, and selector enablement together; the editor color recipe still updates editor and selectors; copy-friendly and model-label recipes still update both historical destinations. Direct canonical JSON can configure each destination independently.
 
 Free-form values such as custom formats, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
 
@@ -170,37 +172,116 @@ Default config values — copy this and change any value you want:
 ```json
 {
 	"projectRefreshIntervalMs": 30000,
-	"footerFormat": "",
-	"responsiveFooter": true,
-	"compactFooterFormat": "$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens",
-	"compactFooterMaxLines": 2,
-	"editorMetadataFormat": "$model  $provider(  $thinking)",
-	"separator": "pipe",
-	"contextStyle": "text",
-	"editorModelLabel": "id",
-	"editorStyle": "polished",
-	"editorStyles": {
-		"minimalist": {
-			"pathDisplay": "compact",
-			"contextFormat": "percent",
-			"contextGauge": false,
-			"showSessionName": true,
-			"showTimer": true,
-			"showCost": true,
-			"showGit": true
+	"components": {
+		"editor": {
+			"enabled": true,
+			"style": "polished",
+			"colorSource": "theme",
+			"borderColorMode": "static",
+			"modelLabel": "id",
+			"viewportIndicators": true,
+			"styles": {
+				"polished": {
+					"copyFriendly": false,
+					"metadataFormat": "$model  $provider(  $thinking)"
+				},
+				"minimalist": {
+					"pathDisplay": "compact",
+					"contextFormat": "percent",
+					"contextGauge": false,
+					"showSessionName": true,
+					"showTimer": true,
+					"showCost": true,
+					"showGit": true,
+					"contextThresholds": {
+						"warning": 70,
+						"error": 90
+					}
+				}
+			}
+		},
+		"userMessages": {
+			"enabled": true,
+			"style": "framed",
+			"colorSource": "theme",
+			"styles": {
+				"framed": {
+					"copyFriendly": false
+				}
+			}
+		},
+		"selectorBorders": {
+			"enabled": true,
+			"style": "zentui",
+			"colorSource": "theme"
+		},
+		"footer": {
+			"enabled": true,
+			"style": "starship",
+			"colorSource": "theme",
+			"modelLabel": "id",
+			"styles": {
+				"starship": {
+					"format": "",
+					"responsive": true,
+					"compactFormat": "$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens",
+					"compactMaxLines": 2,
+					"separator": "pipe",
+					"contextStyle": "text",
+					"contextThresholds": {
+						"warning": 70,
+						"error": 90
+					},
+					"pathDisplay": {
+						"mode": "basename",
+						"depth": 0
+					},
+					"segments": {
+						"cwd": true,
+						"sessionName": true,
+						"gitBranch": true,
+						"gitStatus": true,
+						"gitCounts": false,
+						"runtime": true,
+						"modelInfo": false,
+						"context": true,
+						"tokens": true,
+						"cost": true,
+						"sessionDuration": false,
+						"username": false,
+						"time": false,
+						"os": false,
+						"packageVersion": false,
+						"gitCommit": false,
+						"gitMetrics": false
+					},
+					"gitBranch": {
+						"maxLength": "full"
+					},
+					"gitCommit": {
+						"hashLength": 7,
+						"onlyDetached": true,
+						"showTag": true
+					},
+					"gitMetrics": {
+						"onlyNonzero": true,
+						"ignoreSubmodules": false
+					},
+					"extensionStatuses": {
+						"defaultPlacement": "right",
+						"placements": {},
+						"colorModes": {}
+					}
+				}
+			}
 		}
 	},
-	"editorBorderColorMode": "static",
-	"contextThresholds": {
-		"warning": 70,
-		"error": 90
-	},
-	"pathDisplay": {
-		"mode": "basename",
-		"depth": 0
-	},
-	"gitBranch": {
-		"maxLength": "full"
+	"layout": {
+		"fixedEditor": {
+			"enabled": false,
+			"mouseScroll": true,
+			"copyNotice": true
+		}
 	},
 	"icons": {
 		"mode": "auto",
@@ -256,84 +337,23 @@ Default config values — copy this and change any value you want:
 		"editorThinkingMedium": "thinkingMedium",
 		"editorThinkingHigh": "thinkingHigh",
 		"editorThinkingXhigh": "thinkingXhigh"
-	},
-	"colorSources": {
-		"starship": "theme",
-		"editor": "theme",
-		"userMessages": "theme"
-	},
-	"features": {
-		"editor": true,
-		"statusLine": true,
-		"copyFriendly": false,
-		"viewportIndicators": true
-	},
-	"footerSegments": {
-		"cwd": true,
-		"sessionName": true,
-		"gitBranch": true,
-		"gitStatus": true,
-		"gitCounts": false,
-		"runtime": true,
-		"modelInfo": false,
-		"context": true,
-		"tokens": true,
-		"cost": true,
-		"sessionDuration": false,
-		"username": false,
-		"time": false,
-		"os": false,
-		"packageVersion": false,
-		"gitCommit": false,
-		"gitMetrics": false
-	},
-	"gitCommit": {
-		"hashLength": 7,
-		"onlyDetached": true,
-		"showTag": true
-	},
-	"gitMetrics": {
-		"onlyNonzero": true,
-		"ignoreSubmodules": false
-	},
-	"extensionStatuses": {
-		"defaultPlacement": "right",
-		"placements": {},
-		"colorModes": {}
-	},
-	"fixedEditor": {
-		"enabled": false,
-		"mouseScroll": true,
-		"copyNotice": true
 	}
 }
 ```
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
-- `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Finite context percentages use one decimal place. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
-- `editorModelLabel`: controls the model shown in the editor frame, built-in model-info footer segment, and footer `$model` variable. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
-- `editorStyle`: `polished` (default) keeps Zentui's accent-rail editor; `minimalist` uses the compact metadata frame described below. Cycle it from the `/zentui` **Editor** tab. The tab shows concise settings for the selected style rather than adding a tab for each style.
-- `editorStyles.minimalist`: focused minimalist-frame controls. `pathDisplay` is `compact` (cwd basename, default), `project` (repository name plus relative path when known), or `full` (home-contracted cwd). `contextFormat` is `percent` (default) or `percent-total`; `contextGauge` adds a compact gauge when space permits. `showSessionName`, `showTimer`, `showCost`, and `showGit` default to `true`.
-- `editorBorderColorMode`: `static` (default) uses `colors.editorBorder`; `adaptive` follows Pi's current shell-mode and thinking-level editor border color. Cycle it from the `/zentui` **Editor** tab.
-- `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
-- `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Appearance** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
-- `contextThresholds`: `{ warning, error }` percentages (default `70` / `90`) that select contextNormal / contextWarning / contextError colors.
-- `pathDisplay`: controls how the cwd/`$cwd` path is shown. `mode` is `basename` (default, last segment only) or `full` (path with home contracted to `~`). In `full` mode, `depth` keeps only the last N trailing directories (`0` = entire path after `~`, max `5`); when parents are dropped the path is prefixed with `…/` (Starship-style). The `/zentui` **Footer** tab cycles path mode and path depth (`0`–`5`; depth is ignored for basename). Example: `~/Projects/foo/bar` with `depth: 2` → `…/foo/bar`.
-- `gitBranch.maxLength`: visible width of the built-in branch name and `$git_branch` / `$branch`. The default `full` preserves the complete name; any positive integer uses that width including the trailing `…`. `/zentui` **Git** cycles `full`, `10`, `20`, `30`, `40`, and `50`; custom positive integers can be set in JSON.
-- `icons`: every shown icon key is configurable; omit any key to use the Zentui default. `icons.mode` is `auto` | `nerd` | `ascii` (default `auto`, same glyphs as nerd). ASCII mode swaps in plain fallbacks for statusline icons and runtime symbols — useful without a Nerd Font. Custom per-icon strings always win over mode defaults. Custom `icons.os` always wins; when left at the mode default, Zentui maps the OS icon by platform. `rail` sets the vertical glyph drawn as the left rail of the active editor frame and previous user messages when `copyFriendly` is disabled (default `│`; any single Unicode vertical or block glyph). `editorPrompt` controls an optional copy-friendly editor prompt glyph; the default is `""` so copy-friendly mode stays rail-free.
-- `colorSources`: `theme` maps styles through Pi theme tokens; `terminal` emits terminal colors. `/zentui` switches these sources; manual JSON controls specific style values.
-- `features`: `editor` enables Zentui's custom editor, selector borders, and previous-message chrome. `statusLine` enables Zentui's custom footer/status line. `copyFriendly` hides editor and previous-message rail glyphs so native terminal selection copies less chrome. `viewportIndicators` preserves Pi's native `↑ N more` / `↓ N more` wrapped-row counts in Zentui's editor borders (default `true`). All four can be changed from `/zentui` or direct slash-command arguments.
-- `footerSegments`: show or hide individual built-in footer segments (`cwd`, `sessionName`, `gitBranch`, `gitStatus`, `gitCounts`, `gitCommit`, `gitMetrics`, `runtime`, `modelInfo`, `packageVersion`, `sessionDuration`, `username`, `time`, `os`, `context`, `tokens`, `cost`). `modelInfo` is off by default and shows the selected model plus the provider unless the model label already contains it. Toggle non-Git segments from **Segments** and Git segments from **Git** in `/zentui`.
-- `footerFormat`: optional Starship-style template string that fully controls the footer layout. When set, it overrides `footerSegments`. See [Footer Format Template](#footer-format-template) below. The `/zentui` **Footer** tab configures responsive behavior, compact rows, context style, and path display mode/depth; **Appearance** configures separator and icon mode; **Git** configures branch length; set or clear custom formats with `/zentui format`.
-- `responsiveFooter`: enabled by default. Zentui keeps the current aligned one-row footer while every settings-resolved left/middle/right zone fits without layout truncation. Otherwise it tries two complete left-aligned rows, preferring `left` / `middle right` and then `left middle` / `right`. Only when neither split fits does it use `compactFooterFormat`. Set `false` to restore the legacy one-row fitting behavior. Selection uses measured terminal-cell width, not fixed device breakpoints.
-- `compactFooterFormat`: JSON-only template used by the compact stage. The default keeps cwd, session name, git branch/status, context, and abbreviated token/cache metrics. A top-level `$wrap` is an automatic wrap opportunity: one space on the same row or no space at a row break. `$wrap_sep` is the same kind of boundary but renders the styled ` | ` divider only when its adjacent chunks share a row. Nested uses of either boundary remain empty variables. `$fill` is ignored. A standalone `$extensions` chunk inserts active non-`off` extension statuses in left/middle/right placement order; embedded uses render empty. Custom `footerFormat` values use this built-in compact fallback unless this key is also customized.
-- `compactFooterMaxLines`: `1`, `2`, `3`, or `"unlimited"` (default `2`). Finite limits crop remaining chunks with exactly one trailing `…`. Compact cwd always uses basename mode; cwd/session/branch chunks target half the available row width before final ANSI-aware clamping. `/zentui` exposes the responsive toggle and row limit, while compact format editing remains JSON-only. Pi supplies footer width but no supported viewport-height budget, so `"unlimited"` is explicit.
-- `gitCommit`: Starship [`git_commit`](https://starship.rs/config/#git-commit)-style options for the `gitCommit` footer segment. `hashLength` (default `7`, clamped to `4`–`40`) controls the short-hash display length. `onlyDetached` (default `true`) shows the hash mainly on detached HEAD. `showTag` (default `true`) appends an exact-match tag (`git describe --tags --exact-match HEAD`). The tag probe piggybacks on the existing git refresh — it only runs when both the segment and `showTag` are on, and misses/failures degrade silently.
-- `gitMetrics`: Starship [`git_metrics`](https://starship.rs/config/#git-metrics)-style options for the `gitMetrics` footer segment. Uses `git diff HEAD --numstat` (staged + unstaged combined — the Starship “total dirty” view) to show aggregate `+added −deleted` line counts. `onlyNonzero` (default `true`) omits each zero component independently and hides the segment entirely at `0/0`. `ignoreSubmodules` (default `false`) adds `--ignore-submodules=all`. The numstat diff piggybacks on the existing git refresh and uses a hard 2s timeout; a metrics-only failure degrades silently without discarding fresh branch/status data. On very large monorepos the diff may lag or be omitted on timeout.
-- `extensionStatuses`: controls third-party statuses published by other Pi extensions through `ctx.ui.setStatus()`. `defaultPlacement` and each `placements` value can be `off`, `left`, `middle`, or `right`. The **Extensions** tab in `/zentui` lists only statuses that are currently active. `defaultPlacement` applies only when a status key has no entry in `placements`; keyed overrides always win.
+- `components.editor`: owns editor enablement, `polished | minimalist` style selection, color source, border mode, model label, viewport indicators, and both editor-style configurations.
+- `components.userMessages`: owns framed-message enablement, the fixed `framed` style, color source, and framed copy-friendly behavior.
+- `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
+- `components.footer`: owns footer enablement, the fixed `starship` style, footer color source, footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses).
+- `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/footer enablement.
+- Editor and footer `modelLabel` values are independent. The existing `/zentui` model-label control remains a compatibility recipe that writes both.
+- Polished-editor and framed-message `copyFriendly` values are independent. The existing `/zentui copy-friendly` control remains a compatibility recipe that writes both.
+- User messages currently support only `framed`, selector borders only `zentui`, and the footer only `starship`. Set the owning component's `enabled` to `false` for native/Pi fallback.
+- Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
-- `editorAccent` styles the active editor rail and previous user-message rail when `features.copyFriendly` is disabled.
+- `editorAccent` styles the active editor rail and framed user-message rail when their owning copy-friendly setting is disabled.
 - `editorPrompt` styles the copy-friendly editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
 - `editorBorder` styles previous user-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
@@ -342,19 +362,27 @@ Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.
 
 ## Minimalist editor style
 
-Set `editorStyle` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows viewport counts, Bash state, the current/completed turn duration, and the explicit Pi session name at top left; cost, model, thinking level, and context usage at top right; viewport count plus Git branch/status at bottom left; and the configured path at bottom right. Unnamed sessions add no placeholder. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
+Set `components.editor.style` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows viewport counts, Bash state, the current/completed turn duration, and the explicit Pi session name at top left; cost, model, thinking level, and context usage at top right; viewport count plus Git branch/status at bottom left; and the configured path at bottom right. Unnamed sessions add no placeholder. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
 
 While `minimalist` is selected, the `/zentui` **Editor** area shows its focused controls without repeating the style name on every row. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Session name, timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
 
-When Zentui's editor and status line are both enabled, the separate footer rows are suppressed only while minimalist decoration succeeds. The footer stays visible for narrow or unsupported editor output so metadata is not lost. The configured status-line setting is preserved, so switching back to `polished` restores the footer. Minimalist style does not remove Pi's header and does not add sticky positioning, mouse handling, clipboard behavior, or custom scrolling. The experimental fixed-editor option remains separate.
+Footer visibility is controlled only by `components.footer.enabled`. Minimalist editor decoration and the Starship footer may be shown together, including at narrow widths or after decoration fallback. Minimalist style does not remove Pi's header; the experimental fixed-editor layout remains separate.
 
 ## Editor Metadata Format
 
-Set `editorMetadataFormat` in `~/.pi/agent/zentui.json` to customize the left side of the editor metadata row:
+Set `components.editor.styles.polished.metadataFormat` in `~/.pi/agent/zentui.json` to customize the left side of the polished editor metadata row:
 
 ```json
 {
-	"editorMetadataFormat": "$model_name ($model_id)( · $provider)( · $thinking)( · $session_name)"
+	"components": {
+		"editor": {
+			"styles": {
+				"polished": {
+					"metadataFormat": "$model_name ($model_id)( · $provider)( · $thinking)( · $session_name)"
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -362,7 +390,7 @@ The syntax follows the relevant `footerFormat` conventions: `$variable` and `${v
 
 | Token           | Renders                                                                                       |
 | --------------- | --------------------------------------------------------------------------------------------- |
-| `$model`        | label selected by `editorModelLabel` (`id`, or name with ID fallback)                        |
+| `$model`        | label selected by `components.editor.modelLabel` (`id`, or name with ID fallback)            |
 | `$model_id`     | active Pi model ID                                                                            |
 | `$model_name`   | active Pi model display name; empty when no name is set                                       |
 | `$provider`     | provider label using Zentui's existing formatting                                             |
@@ -375,13 +403,21 @@ Missing, non-string, or empty values use the default `$model  $provider(  $think
 
 ## Footer Format Template
 
-For full control, set a Starship-style `footerFormat` template string. It supports `$variable` and `${variable}` tokens, a special `$fill` token that splits the line into left and right zones, and conditional groups `( ... )` that drop entirely when every nested variable is empty. When set, it overrides the built-in `footerSegments` layout; when empty or omitted, the segment layout above is used.
+For full control, set `components.footer.styles.starship.format` to a Starship-style template string. It supports `$variable` and `${variable}` tokens, a special `$fill` token that splits the line into left and right zones, and conditional groups `( ... )` that drop entirely when every nested variable is empty. When set, it overrides `components.footer.styles.starship.segments`; when empty or omitted, the segment layout above is used.
 
 A second `$fill` creates a **centered middle zone** — content between the two fills is true-centered (`floor((gap - middle) / 2)`), just like third-party statuses placed `middle`.
 
 ```json
 {
-	"footerFormat": "$os $username $cwd($sep$session_name)( on $git_branch)( $git_status)( via $runtime)$fill($context)($sep$tokens)($sep$cost)($sep$time)"
+	"components": {
+		"footer": {
+			"styles": {
+				"starship": {
+					"format": "$os $username $cwd($sep$session_name)( on $git_branch)( $git_status)( via $runtime)$fill($context)($sep$tokens)($sep$cost)($sep$time)"
+				}
+			}
+		}
+	}
 }
 ```
 
@@ -389,9 +425,19 @@ Center the branch between directory and cost:
 
 ```json
 {
-	"footerFormat": "$cwd $fill $git_branch $fill $cost"
+	"components": {
+		"footer": {
+			"styles": {
+				"starship": {
+					"format": "$cwd $fill $git_branch $fill $cost"
+				}
+			}
+		}
+	}
 }
 ```
+
+The released flat `footerFormat` and `footerSegments` keys remain accepted only as legacy migration inputs.
 
 ### Variables
 
@@ -408,7 +454,7 @@ Center the branch between directory and cost:
 | `$git_added`        |              | added line count (`+N`)                                             |
 | `$git_deleted`      |              | deleted line count (`−N`)                                           |
 | `$runtime`          |              | runtime icon + version                                              |
-| `$model`            |              | selected model label (`editorModelLabel`)                           |
+| `$model`            |              | selected model label (`components.footer.modelLabel`)                |
 | `$provider`         |              | formatted provider label                                            |
 | `$package`          |              | project package version, `is <glyph> <version>` (manifest-derived)  |
 | `$package_version`  |              | raw project package version (no icon)                               |
@@ -438,16 +484,16 @@ Center the branch between directory and cost:
 - Literal text (`on branch`, `using`, `\|`, spaces) is rendered verbatim — you control all spacing.
 - Each variable renders its core value only (no `on`/`via` prefixes); add those words as literal text.
 - Conditional groups: wrap optional pieces in parentheses, e.g. `$cwd( on $git_branch)($git_status)$fill($context)`. If every `$var` inside a group is empty, the whole group (including its literals) is dropped.
-- `$session_name` is available whenever `footerFormat` is set, independently of `footerSegments.sessionName`; use a conditional group such as `($sep$session_name)` so unnamed sessions leave no separator.
+- `$session_name` is available whenever `components.footer.styles.starship.format` is set, independently of `components.footer.styles.starship.segments.sessionName`; use a conditional group such as `($sep$session_name)` so unnamed sessions leave no separator.
 - The built-in wide footer appends cache totals to the token segment, `(sub)` to cost, and `(auto)` to context when available. Custom formats keep `$tokens`, `$cost`, and `$context` backward-compatible and include telemetry only through the atomic variables above.
-- `DEFAULT_COMPACT_FOOTER_FORMAT` omits model/provider and atomic telemetry. Add their variables explicitly to `compactFooterFormat` to opt in at narrow widths.
+- `DEFAULT_COMPACT_FOOTER_FORMAT` omits model/provider and atomic telemetry. Add their variables explicitly to `components.footer.styles.starship.compactFormat` to opt in at narrow widths. The flat `compactFooterFormat` key is a legacy migration input.
 - Auto-compaction settings refresh on the next normal footer synchronization event. Unsupported Pi capabilities or settings-read errors safely omit optional markers.
 - Unknown `$variables` render empty.
 - Set or clear at runtime: `/zentui format "<template>"` and `/zentui format clear`.
 
 ## Fixed editor (experimental, opt-in)
 
-The fixed editor pins the Zentui editor and footer at the bottom of the terminal while the transcript scrolls above. This enables composing follow-up messages while referencing earlier conversation history.
+The fixed layout pins Pi's usable editor cluster at the bottom of the terminal while the transcript scrolls above. It can activate independently of Zentui editor/footer enablement; Pi compatibility inspection decides whether it is safe.
 
 ### How to enable
 
@@ -459,8 +505,10 @@ Or in `~/.pi/agent/zentui.json`:
 
 ```json
 {
-	"fixedEditor": {
-		"enabled": true
+	"layout": {
+		"fixedEditor": {
+			"enabled": true
+		}
 	}
 }
 ```
@@ -475,13 +523,15 @@ Or in `~/.pi/agent/zentui.json`:
 
 ### Mouse scroll (default on)
 
-Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable it via `/zentui` Features or:
+Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable it from the `/zentui` **Editor** section or:
 
 ```json
 {
-	"fixedEditor": {
-		"enabled": true,
-		"mouseScroll": true
+	"layout": {
+		"fixedEditor": {
+			"enabled": true,
+			"mouseScroll": false
+		}
 	}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A Starship-inspired statusline and Opencode-style TUI for [Pi](https://pi.dev).
 Zentui styles three major Pi surfaces independently:
 
 - **Editor** — selectable opencode, low-rail opencode, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
-- **User messages** — selectable framed, compact, and labeled transcript messages
+- **User messages** — selectable framed, framed copy-friendly, compact, and labeled transcript messages
 - **[Starship](https://starship.rs/) footer** — current directory, Git, runtime, context, tokens, cost, and other configurable segments
 
 Editor, User messages, and selector borders use an `enabled` field. Footer uses one `style`: `native`, `starship`, or `hidden`. **Appearance** (selector borders and icons) and **Layout** (the fixed-editor experiment) remain supporting configuration domains.
@@ -55,19 +55,26 @@ opencode                 opencode-copy-friendly     minimalist
 
 ### User messages
 
-- `framed` (default) preserves the full-width bordered prompt box
+- `framed` (default) preserves the full-width bordered prompt box with an accent rail
+- `framed-copy-friendly` (**Framed (copy-friendly)** in `/zentui`) keeps the full-width horizontal borders and blank spacer rows while removing the copied accent rail and gutter
 - `compact` uses only an accent rail, with no border or padding rows
 - `labeled` uses a rounded box with the fixed label `User`
 - Disabling User-message styling delegates byte-for-byte to Pi's native renderer; native is not a style ID
 - No custom `plain` message style is provided
 
 ```text
-framed                    compact              labeled
-────────────────────      │ Message            ╭─ User ───────────╮
-│                         │ Continued          │ Message          │
-│ Message                                      │ Continued        │
-│                                              ╰──────────────────╯
-────────────────────
+framed                    framed-copy-friendly
+────────────────────      ────────────────────
+│
+│ Message                 Message
+│
+────────────────────      ────────────────────
+
+compact                    labeled
+│ Message                 ╭─ User ───────────╮
+│ Continued               │ Message          │
+                          │ Continued        │
+                          ╰──────────────────╯
 ```
 
 ### Git Status Icons
@@ -167,7 +174,7 @@ The interactive `/zentui` menu is split into exactly eight component-oriented se
 
 1. **Appearance** — selector-border enablement, style, and colors; icon mode.
 2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
-3. **User messages** — message enablement, `framed | compact | labeled` style selection, and colors.
+3. **User messages** — message enablement, `framed | framed-copy-friendly | compact | labeled` style selection (including **Framed (copy-friendly)**), and colors.
 4. **Layout** — fixed-editor enablement, mouse scrolling, and copy notices.
 5. **Footer** — `Native | Starship | Hidden` style selection. Starship additionally shows colors, model label, responsive layout, separator, context style, and path display.
 6. **Segments** — visibility toggles for non-Git Starship segments.
@@ -246,6 +253,7 @@ Default config values — copy this and change any value you want:
 			"colorSource": "theme",
 			"styles": {
 				"framed": {},
+				"framed-copy-friendly": {},
 				"compact": {},
 				"labeled": {}
 			}
@@ -383,18 +391,18 @@ Default config values — copy this and change any value you want:
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `components.editor`: owns editor enablement, `opencode | opencode-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
-- `components.userMessages`: owns message enablement, `framed | compact | labeled` style selection, and color source.
+- `components.userMessages`: owns message enablement, `framed | framed-copy-friendly | compact | labeled` style selection, and color source. `framed-copy-friendly` remains Zentui-rendered; disabling the component delegates to Pi's native renderer.
 - `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
 - `components.footer`: owns `native | starship | hidden` style selection, Footer color source, Footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses). Native restores Pi's built-in Footer; Hidden installs an empty component with zero rows.
 - `layout.fixedEditor`: owns fixed-layout enablement, mouse scrolling, and copy notices. Layout activation depends on Pi compatibility inspection, not on Zentui editor/Footer style.
 - Editor and Footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
 - Selector borders support only `zentui`; set their owning `enabled` field to `false` for native Pi behavior.
 - Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. `components.footer.enabled` and `features.statusLine` migrate to Starship or Native when no valid Footer style is present; Hidden projects `features.statusLine: false`. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
-- `polished` and `polished-copy-friendly` remain read-only migration aliases for `opencode` and `opencode-copy-friendly`. Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are migration input only. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; raw released feature keys remain preserved as user-owned migration data.
+- `polished` and `polished-copy-friendly` remain read-only migration aliases for `opencode` and `opencode-copy-friendly`. Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are read-only migration inputs: message copy-friendly `true` selects `framed-copy-friendly` rather than disabling custom rendering. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; raw released feature keys, unknown fields, and unknown style data remain preserved as user-owned migration data.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles Editor and User-message accent rails and the labeled message label.
 - `editorPrompt` styles the `opencode-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
-- `editorBorder` styles previous user-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
+- `editorBorder` styles the `framed` and `framed-copy-friendly` previous-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: with `opencode-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.

--- a/README.md
+++ b/README.md
@@ -413,6 +413,8 @@ Tip: with `opencode-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.
 
 Set `components.editor.style` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows viewport counts, Bash state, the current/completed turn duration, and the explicit Pi session name at top left; cost, model, thinking level, and context usage at top right; viewport count plus Git branch/status at bottom left; and the configured path at bottom right. Unnamed sessions add no placeholder. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
 
+The Minimalist editor is inspired by [pi-custom-input](https://github.com/VinhLe1410/pi-custom-input), with an independent implementation in Zentui.
+
 While `minimalist` is selected, the `/zentui` **Editor** area shows its focused controls without repeating the style name on every row. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Session name, timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
 
 Footer visibility is controlled by `components.footer.style`: use `starship`, `native`, or `hidden`. Minimalist editor decoration and the Starship Footer may be shown together, including at narrow widths or after decoration fallback. Minimalist style does not remove Pi's header; the experimental fixed-editor layout remains separate.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Editor, User messages, and selector borders use an `enabled` field. Footer uses 
 - Optional segments (off by default): selected model/provider, `user@host`, current time, OS icon, session duration, and the **project package version** (e.g. `package.json` → `0.6.0`) — distinct from the runtime segment, which shows the installed toolchain
 - Right side shows context usage, token counts, and cost
 - Built-in footer segments can be shown or hidden individually from `/zentui`
-- Fully custom Starship-style layout via a `footerFormat` template string — see [Footer Format Template](#footer-format-template)
+- Fully custom Starship-style layout via the `components.footer.styles.starship.format` template string — see [Footer Format Template](#footer-format-template)
 - Third-party Pi extension statuses from `ctx.ui.setStatus()` can be shown on the left,
   middle, or right side, or hidden per status key from `/zentui`
 
@@ -36,7 +36,7 @@ Editor, User messages, and selector borders use an `enabled` field. Footer uses 
 - `opencode` (default) keeps an accent rail on every interior row
 - `opencode-copy-friendly` (**Opencode (copy-friendly)** in `/zentui`) preserves the low-rail rendering for clean terminal selection
 - `minimalist` moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
-- Model name and provider appear inside both Opencode editor variants
+- The selected model label and provider appear inside both Opencode editor variants; the model ID is used by default, while `components.editor.modelLabel: "name"` uses the display name with ID fallback.
 - Opencode autocomplete rows retain Pi's original unframed trailing layout; Minimalist keeps autocomplete inside its rounded frame
 - Configurable model, provider, thinking-level, accent, and border colors
 - **Fixed editor** (experimental, opt-in): pin the editor cluster at the bottom of the terminal while the transcript scrolls above, independently of selected editor and Footer modes
@@ -56,7 +56,7 @@ opencode                 opencode-copy-friendly     minimalist
 ### User messages
 
 - `framed` (default) preserves the full-width bordered prompt box with an accent rail
-- `framed-copy-friendly` (**Framed (copy-friendly)** in `/zentui`) keeps the full-width horizontal borders and blank spacer rows while removing the copied accent rail and gutter
+- `framed-copy-friendly` (**Framed (copy-friendly)** in `/zentui`) keeps the full-width horizontal borders and blank spacer rows, removes the copied accent rail, and retains a one-cell leading gutter before body text.
 - `compact` uses only an accent rail, with no border or padding rows
 - `labeled` uses a rounded box with the fixed label `User`
 - Disabling User-message styling delegates byte-for-byte to Pi's native renderer; native is not a style ID
@@ -66,7 +66,7 @@ opencode                 opencode-copy-friendly     minimalist
 framed                    framed-copy-friendly
 ────────────────────      ────────────────────
 │
-│ Message                 Message
+│ Message                  Message
 │
 ────────────────────      ────────────────────
 
@@ -398,6 +398,8 @@ Default config values — copy this and change any value you want:
 - Editor and Footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
 - Selector borders support only `zentui`; set their owning `enabled` field to `false` for native Pi behavior.
 - Flat released keys such as `editorStyle`, `features`, `footerFormat`, and `fixedEditor` remain accepted as migration input. `components.footer.enabled` and `features.statusLine` migrate to Starship or Native when no valid Footer style is present; Hidden projects `features.statusLine: false`. Canonical `components` and `layout` paths are the primary JSON interface, and component saves materialize canonical snapshots.
+- Explicit unsupported future component style IDs are preserved unchanged on disk but fail open at runtime: Editor, User-message, and selector-border customization stay disabled, while Footer behavior is Native. Missing, empty, or malformed style values continue normal default and legacy migration behavior.
+- The flat properties returned by `mergeConfig`, `loadConfig`, and save helpers are deprecated compatibility output and will remain available until at least the next major release. This output deprecation is separate from accepted legacy flat JSON input.
 - `polished` and `polished-copy-friendly` remain read-only migration aliases for `opencode` and `opencode-copy-friendly`. Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are read-only migration inputs: message copy-friendly `true` selects `framed-copy-friendly` rather than disabling custom rendering. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; raw released feature keys, unknown fields, and unknown style data remain preserved as user-owned migration data.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
 - `editorAccent` styles Editor and User-message accent rails and the labeled message label.
@@ -436,7 +438,7 @@ Set `metadataFormat` under either opencode style in `~/.pi/agent/zentui.json` to
 }
 ```
 
-The syntax follows the relevant `footerFormat` conventions: `$variable` and `${variable}` references, literal text and spaces, and conditional groups `( ... )` that disappear when all variables inside are empty. Unknown variables and `$fill` render empty; `$fill` never creates an editor layout zone because the right side remains reserved for structural Vim status.
+The syntax follows the Footer Format Template conventions: `$variable` and `${variable}` references, literal text and spaces, and conditional groups `( ... )` that disappear when all variables inside are empty. Unknown variables and `$fill` render empty; `$fill` never creates an editor layout zone because the right side remains reserved for structural Vim status.
 
 | Token           | Renders                                                                                       |
 | --------------- | --------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Zentui brings two popular aesthetics to Pi:
 
 ### Editor (Opencode-inspired)
 
+- Selectable `polished` (default) and `minimalist` editor modes
 - Bordered input box with configurable accent rail and border colors
-- Model name and provider displayed inside the editor frame
+- Minimalist mode moves cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
+- Model name and provider displayed inside the polished editor frame
 - Configurable model, provider, and thinking-level indicator colors
 - Prompt-box-style user messages matching the ZentUI input chrome
 - Copy-friendly mode hides editor and previous-message rail glyphs so terminal selection copies less chrome
@@ -133,7 +135,7 @@ User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or
 The interactive `/zentui` menu is split into exactly six sections, in this order. Use `Tab` and `Shift+Tab` to switch sections. Every listed control patches the shown JSON equivalent:
 
 1. **Appearance** — Starship/footer colors (`colorSources.starship`); editor + previous-message colors (`colorSources.editor` and `colorSources.userMessages`); separator (`separator`); icon mode (`icons.mode`).
-2. **Editor** — editor enabled (`features.editor`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
+2. **Editor** — editor enabled (`features.editor`); editor mode (`editorMode`); focused minimalist path/context/visibility controls (`minimalist`); editor border color mode (`editorBorderColorMode`); editor model label (`editorModelLabel`); copy-friendly mode (`features.copyFriendly`); viewport indicators (`features.viewportIndicators`); fixed editor (`fixedEditor.enabled`); and, while fixed editor is enabled, mouse scroll (`fixedEditor.mouseScroll`) and copy notice (`fixedEditor.copyNotice`).
 3. **Footer** — status line enabled (`features.statusLine`); responsive footer (`responsiveFooter`); compact footer rows (`compactFooterMaxLines`); context style (`contextStyle`); path display (`pathDisplay.mode`); path depth (`pathDisplay.depth`).
 4. **Segments** — visibility toggles for every non-Git built-in segment under `footerSegments`: `cwd`, `sessionName`, `runtime`, `modelInfo`, `context`, `tokens`, `cost`, `sessionDuration`, `username`, `time`, `os`, and `packageVersion`.
 5. **Git** — Git branch visibility (`footerSegments.gitBranch`); branch length (`gitBranch.maxLength`); Git status visibility (`footerSegments.gitStatus`); Git counts visibility (`footerSegments.gitCounts`); Git commit visibility (`footerSegments.gitCommit`); commit-only-detached (`gitCommit.onlyDetached`); exact-match tag (`gitCommit.showTag`); Git metrics visibility (`footerSegments.gitMetrics`); hide zero metrics (`gitMetrics.onlyNonzero`); ignore submodules (`gitMetrics.ignoreSubmodules`).
@@ -176,6 +178,15 @@ Default config values — copy this and change any value you want:
 	"separator": "pipe",
 	"contextStyle": "text",
 	"editorModelLabel": "id",
+	"editorMode": "polished",
+	"minimalist": {
+		"pathDisplay": "compact",
+		"contextFormat": "percent",
+		"contextGauge": false,
+		"showTimer": true,
+		"showCost": true,
+		"showGit": true
+	},
 	"editorBorderColorMode": "static",
 	"contextThresholds": {
 		"warning": 70,
@@ -299,6 +310,8 @@ Default config values — copy this and change any value you want:
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `contextStyle`: `text` (default), `gauge`, or `text+gauge` for the context segment. Finite context percentages use one decimal place. Context usage refreshes during assistant streaming; token and cost totals remain canonical and finalize at turn boundaries.
 - `editorModelLabel`: controls the model shown in the editor frame, built-in model-info footer segment, and footer `$model` variable. `id` (default) shows the model id; `name` shows the model's display name (including custom `name` values set in `models.json`), falling back to the id when no name is set.
+- `editorMode`: `polished` (default) keeps Zentui's accent-rail editor; `minimalist` uses the compact metadata frame described below. Cycle it from the `/zentui` **Editor** tab.
+- `minimalist`: focused minimalist-frame controls. `pathDisplay` is `compact` (cwd basename, default), `project` (repository name plus relative path when known), or `full` (home-contracted cwd). `contextFormat` is `percent` (default) or `percent-total`; `contextGauge` adds a compact gauge when space permits. `showTimer`, `showCost`, and `showGit` default to `true`.
 - `editorBorderColorMode`: `static` (default) uses `colors.editorBorder`; `adaptive` follows Pi's current shell-mode and thinking-level editor border color. Cycle it from the `/zentui` **Editor** tab.
 - `editorMetadataFormat`: JSON-only template for the left side of the editor metadata row. Missing, non-string, or empty values restore the default `$model  $provider(  $thinking)` layout; non-empty strings, including whitespace-only strings, are preserved. See [Editor Metadata Format](#editor-metadata-format) below.
 - `separator`: controls the default footer layout and extension-status connectors: `pipe` (default, ` | `), `dot` (` · `), `chevron` (` › `), or `none` (one space). Cycle it from the `/zentui` **Appearance** tab. This selects the separator glyph; `colors.separator` controls its color. Custom `footerFormat` literals and `$sep` keep their existing behavior.
@@ -323,6 +336,14 @@ Default config values — copy this and change any value you want:
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: when using copy-friendly mode, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
+
+## Minimalist editor mode
+
+Set `editorMode` to `minimalist` or select it from the `/zentui` **Editor** tab. The rounded frame shows Bash state and the current/completed turn duration at top left; cost, model, thinking level, and context usage at top right; Git branch/status at bottom left; and the configured path at bottom right. A blank interior row above and below the input adds symmetric breathing room. Autocomplete stays inside the frame when Pi's existing editor output can be split safely. Unknown third-party editor layouts fail open without decoration.
+
+The `/zentui` **Editor** area exposes the focused `minimalist` subsection. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
+
+When Zentui's editor and status line are both enabled, the separate footer rows are suppressed only while minimalist decoration succeeds. The footer stays visible for narrow or unsupported editor output so metadata is not lost. The configured status-line setting is preserved, so switching back to `polished` restores the footer. Minimalist mode does not remove Pi's header and does not add sticky positioning, mouse handling, clipboard behavior, or custom scrolling. The experimental fixed-editor option remains separate.
 
 ## Editor Metadata Format
 
@@ -470,6 +491,10 @@ Mouse wheel scrolling is enabled by default when the fixed editor is on. Disable
 - **Alternate screen**: Uses the terminal's alternate screen buffer. Native scrollback history is not accessible while the fixed editor is active.
 - **Pi version fragility**: Patches internal TUI methods (`doRender`, `render`, `terminal.write`, `terminal.rows`) that may change across Pi versions. If the TUI layout is unsupported, Zentui falls back to normal rendering with a console warning.
 - If your terminal is stuck after a crash, run `reset` or restart the terminal.
+
+## Acknowledgments
+
+The minimalist frame's information hierarchy was inspired by [VinhLe1410/pi-custom-input](https://github.com/VinhLe1410/pi-custom-input) and is integrated with Zentui's existing editor, state, configuration, and compatibility layers.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -547,6 +547,8 @@ The released flat `footerFormat` and `footerSegments` keys remain accepted only 
 
 The fixed layout pins Pi's usable editor cluster at the bottom of the terminal while the transcript scrolls above. It can activate independently of Zentui editor and Footer style; Pi compatibility inspection decides whether it is safe. Hidden contributes zero rows and no spacer. A live Footer style change tears down the compositor, replaces the Footer, and reprobes the new component; reprobe failure leaves ordinary rendering active.
 
+At constrained heights, Zentui reserves one transcript row, keeps a complete Zentui editor frame and cursor, then prioritizes active autocomplete, Footer, below-editor widget, above-editor widget, and status. Editor content crops around the cursor; known autocomplete content crops around its selected item. Native and third-party editors are treated as opaque and are either pinned intact or rendered through Pi's normal layout. If the terminal later grows, fixed layout returns automatically without reinstalling the compositor.
+
 ### How to enable
 
 ```text
@@ -569,9 +571,15 @@ Or in `~/.pi/agent/zentui.json`:
 
 | Key | Action |
 | --- | ------ |
-| `PageUp` / `PageDown` | Scroll transcript one viewport up/down |
+| `PageUp` / `PageDown` | Scroll transcript one viewport up/down; consumed at either boundary while transcript scrolling exists |
 | `Ctrl+Shift+↑` / `Ctrl+Shift+↓` | Scroll transcript up/down (Kitty protocol variants supported) |
 | `Enter` | Jump to bottom (and submit message) |
+
+PageUp/PageDown propagate to Pi when there is no transcript scroll range, while normal-flow fallback is active, or while an overlay owns input.
+
+### Graceful cleanup
+
+Live disable restores the full scroll region, mouse modes, alternate-scroll behavior, autowrap, cursor visibility, and primary screen before Pi repaints its normal layout. Pi lifecycle shutdown (`/quit`, Ctrl+C, Ctrl+D, SIGHUP, and SIGTERM) performs the same reset without a late repaint into the caller's shell. Cleanup after `SIGKILL`, a fatal crash that prevents Pi's shutdown callback, terminal disconnect, or failure of both terminal writers cannot be guaranteed.
 
 ### Mouse scroll (default on)
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
 	"files": {
 		"includes": [
 			"**",

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -33,6 +33,17 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
+export type EditorMode = "polished" | "minimalist";
+export type MinimalistPathDisplayMode = "compact" | "project" | "full";
+export type MinimalistContextFormat = "percent" | "percent-total";
+export type MinimalistConfig = {
+	pathDisplay: MinimalistPathDisplayMode;
+	contextFormat: MinimalistContextFormat;
+	contextGauge: boolean;
+	showTimer: boolean;
+	showCost: boolean;
+	showGit: boolean;
+};
 export type EditorBorderColorMode = "static" | "adaptive";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
 
@@ -141,6 +152,8 @@ export type PolishedTuiConfig = {
 	separator: SeparatorStyle;
 	contextStyle: ContextStyle;
 	editorModelLabel: ModelLabelSource;
+	editorMode: EditorMode;
+	minimalist: MinimalistConfig;
 	editorBorderColorMode: EditorBorderColorMode;
 	contextThresholds: ContextThresholds;
 	pathDisplay: PathDisplayConfig;
@@ -249,6 +262,15 @@ export const defaultConfig: PolishedTuiConfig = {
 	separator: "pipe",
 	contextStyle: "text",
 	editorModelLabel: "id",
+	editorMode: "polished",
+	minimalist: {
+		pathDisplay: "compact",
+		contextFormat: "percent",
+		contextGauge: false,
+		showTimer: true,
+		showCost: true,
+		showGit: true,
+	},
 	editorBorderColorMode: "static",
 	contextThresholds: { warning: 70, error: 90 },
 	pathDisplay: { mode: "basename", depth: 0 },
@@ -359,6 +381,36 @@ function parseContextStyle(value: unknown): ContextStyle {
 function parseEditorModelLabel(value: unknown): ModelLabelSource {
 	if (value === "id" || value === "name") return value;
 	return defaultConfig.editorModelLabel;
+}
+
+function parseEditorMode(value: unknown): EditorMode {
+	if (value === "polished" || value === "minimalist") return value;
+	return defaultConfig.editorMode;
+}
+
+function normalizeMinimalistConfig(value: unknown): MinimalistConfig {
+	const record = isRecord(value) ? value : {};
+	const pathDisplay = record.pathDisplay;
+	return {
+		pathDisplay:
+			pathDisplay === "compact" || pathDisplay === "project" || pathDisplay === "full"
+				? pathDisplay
+				: defaultConfig.minimalist.pathDisplay,
+		contextFormat:
+			record.contextFormat === "percent" || record.contextFormat === "percent-total"
+				? record.contextFormat
+				: defaultConfig.minimalist.contextFormat,
+		contextGauge:
+			typeof record.contextGauge === "boolean"
+				? record.contextGauge
+				: defaultConfig.minimalist.contextGauge,
+		showTimer:
+			typeof record.showTimer === "boolean" ? record.showTimer : defaultConfig.minimalist.showTimer,
+		showCost:
+			typeof record.showCost === "boolean" ? record.showCost : defaultConfig.minimalist.showCost,
+		showGit:
+			typeof record.showGit === "boolean" ? record.showGit : defaultConfig.minimalist.showGit,
+	};
 }
 
 function parseEditorBorderColorMode(value: unknown): EditorBorderColorMode {
@@ -833,6 +885,8 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		separator: parseSeparatorStyle(config.separator),
 		contextStyle: parseContextStyle(config.contextStyle),
 		editorModelLabel: parseEditorModelLabel(config.editorModelLabel),
+		editorMode: parseEditorMode(config.editorMode),
+		minimalist: normalizeMinimalistConfig(config.minimalist),
 		editorBorderColorMode: parseEditorBorderColorMode(config.editorBorderColorMode),
 		contextThresholds: parseContextThresholds(config.contextThresholds),
 		pathDisplay: parsePathDisplay(config.pathDisplay),
@@ -1023,6 +1077,25 @@ export function saveEditorModelLabel(
 ): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
 		record.editorModelLabel = parseEditorModelLabel(value);
+	});
+}
+
+export function saveEditorMode(value: EditorMode, path = configPath): PolishedTuiConfig {
+	return mutateConfig(path, (record) => {
+		record.editorMode = parseEditorMode(value);
+	});
+}
+
+export function saveMinimalistPatch(
+	patch: Partial<MinimalistConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return mutateConfig(path, (record) => {
+		const existing = isRecord(record.minimalist)
+			? { ...(record.minimalist as Record<string, unknown>) }
+			: {};
+		const normalized = normalizeMinimalistConfig({ ...existing, ...patch });
+		record.minimalist = { ...existing, ...normalized };
 	});
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -33,10 +33,10 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
-export type EditorStyle = "polished" | "polished-copy-friendly" | "minimalist";
+export type EditorStyle = "opencode" | "opencode-copy-friendly" | "minimalist";
 export type UserMessageStyle = "framed" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
-export type FooterStyle = "starship";
+export type FooterStyle = "native" | "starship" | "hidden";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
 export type EditorBorderColorMode = "static" | "adaptive";
@@ -136,8 +136,8 @@ export type EditorComponentConfig = {
 	modelLabel: ModelLabelSource;
 	viewportIndicators: boolean;
 	styles: {
-		polished: PolishedEditorStyleConfig;
-		"polished-copy-friendly": PolishedCopyFriendlyEditorStyleConfig;
+		opencode: PolishedEditorStyleConfig;
+		"opencode-copy-friendly": PolishedCopyFriendlyEditorStyleConfig;
 		minimalist: MinimalistEditorStyleConfig;
 	};
 };
@@ -180,7 +180,6 @@ export type StarshipFooterStyleConfig = {
 };
 
 export type FooterComponentConfig = {
-	enabled: boolean;
 	style: FooterStyle;
 	colorSource: ColorSource;
 	modelLabel: ModelLabelSource;
@@ -405,14 +404,14 @@ const defaultStarshipStyle: StarshipFooterStyleConfig = {
 const defaultComponents: ComponentsConfig = {
 	editor: {
 		enabled: true,
-		style: "polished",
+		style: "opencode",
 		colorSource: "theme",
 		borderColorMode: "static",
 		modelLabel: "id",
 		viewportIndicators: true,
 		styles: {
-			polished: { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
-			"polished-copy-friendly": { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			opencode: { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			"opencode-copy-friendly": { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
 			minimalist: defaultMinimalistStyle,
 		},
 	},
@@ -424,7 +423,6 @@ const defaultComponents: ComponentsConfig = {
 	},
 	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 	footer: {
-		enabled: true,
 		style: "starship",
 		colorSource: "theme",
 		modelLabel: "id",
@@ -521,9 +519,11 @@ function parseEditorModelLabel(
 }
 
 function parseEditorStyle(value: unknown): EditorStyle {
-	if (value === "polished" || value === "polished-copy-friendly" || value === "minimalist") {
+	if (value === "opencode" || value === "opencode-copy-friendly" || value === "minimalist") {
 		return value;
 	}
+	if (value === "polished") return "opencode";
+	if (value === "polished-copy-friendly") return "opencode-copy-friendly";
 	return defaultConfig.editorStyle;
 }
 
@@ -916,8 +916,8 @@ function parseSelectorBorderStyle(value: unknown): SelectorBorderStyle {
 	return value === "zentui" ? value : "zentui";
 }
 
-function parseFooterStyle(value: unknown): FooterStyle {
-	return value === "starship" ? value : "starship";
+function parseFooterStyle(value: unknown): FooterStyle | undefined {
+	return value === "native" || value === "starship" || value === "hidden" ? value : undefined;
 }
 
 function parseNonEmptyString(value: unknown, fallback: string): string {
@@ -1019,16 +1019,33 @@ function resolveEditorStyle(
 	features: ConfigRecord,
 ): EditorStyle {
 	const rawStyle = editor.style;
-	if (rawStyle === "minimalist" || rawStyle === "polished-copy-friendly") return rawStyle;
+	if (
+		rawStyle === "opencode" ||
+		rawStyle === "opencode-copy-friendly" ||
+		rawStyle === "minimalist"
+	) {
+		return rawStyle;
+	}
+	if (rawStyle === "polished-copy-friendly") return "opencode-copy-friendly";
 	if (rawStyle === "polished") {
 		return hasOwn(polished, "copyFriendly") && legacyCopyFriendly(polished)
-			? "polished-copy-friendly"
-			: "polished";
+			? "opencode-copy-friendly"
+			: "opencode";
 	}
 	if (hasOwn(polished, "copyFriendly")) {
-		return legacyCopyFriendly(polished) ? "polished-copy-friendly" : "polished";
+		return legacyCopyFriendly(polished) ? "opencode-copy-friendly" : "opencode";
 	}
-	return legacyCopyFriendly(features) ? "polished-copy-friendly" : "polished";
+	return legacyCopyFriendly(features) ? "opencode-copy-friendly" : "opencode";
+}
+
+function resolveFooterStyle(footer: ConfigRecord, features: ConfigRecord): FooterStyle {
+	const explicit = parseFooterStyle(footer.style);
+	if (explicit) return explicit;
+	if (typeof footer.enabled === "boolean") return footer.enabled ? "starship" : "native";
+	if (typeof features.statusLine === "boolean") {
+		return features.statusLine ? "starship" : "native";
+	}
+	return defaultComponents.footer.style;
 }
 
 function resolveUserMessagesSelection(
@@ -1066,7 +1083,9 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const components = recordValue(config.components);
 	const editor = recordValue(components.editor);
 	const editorStyles = recordValue(editor.styles);
+	const opencode = recordValue(editorStyles.opencode);
 	const polished = recordValue(editorStyles.polished);
+	const opencodeCopyFriendly = recordValue(editorStyles["opencode-copy-friendly"]);
 	const polishedCopyFriendly = recordValue(editorStyles["polished-copy-friendly"]);
 	const minimalist = recordValue(editorStyles.minimalist);
 	const userMessages = recordValue(components.userMessages);
@@ -1090,13 +1109,14 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 		defaultStarshipStyle.contextThresholds,
 	);
 	const compactFormat = resolvedValue(starship, "compactFormat", config, "compactFooterFormat");
-	const metadataFormat = resolvedValue(polished, "metadataFormat", config, "editorMetadataFormat");
-	const lowRailMetadataFormat = resolvedValue(
-		polishedCopyFriendly,
-		"metadataFormat",
-		polished,
-		"metadataFormat",
-	);
+	const metadataFormat = hasOwn(opencode, "metadataFormat")
+		? opencode.metadataFormat
+		: resolvedValue(polished, "metadataFormat", config, "editorMetadataFormat");
+	const lowRailMetadataFormat = hasOwn(opencodeCopyFriendly, "metadataFormat")
+		? opencodeCopyFriendly.metadataFormat
+		: hasOwn(polishedCopyFriendly, "metadataFormat")
+			? polishedCopyFriendly.metadataFormat
+			: metadataFormat;
 	const userMessagesSelection = resolveUserMessagesSelection(userMessages, framed, features);
 
 	return {
@@ -1122,12 +1142,12 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 				defaultComponents.editor.viewportIndicators,
 			),
 			styles: {
-				polished: {
+				opencode: {
 					metadataFormat: parseNonEmptyString(metadataFormat, DEFAULT_EDITOR_METADATA_FORMAT),
 				},
-				"polished-copy-friendly": {
+				"opencode-copy-friendly": {
 					metadataFormat: parseNonEmptyString(
-						lowRailMetadataFormat ?? config.editorMetadataFormat,
+						lowRailMetadataFormat,
 						DEFAULT_EDITOR_METADATA_FORMAT,
 					),
 				},
@@ -1179,11 +1199,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 		},
 		footer: {
-			enabled: parseBoolean(
-				resolvedValue(footer, "enabled", features, "statusLine"),
-				defaultComponents.footer.enabled,
-			),
-			style: parseFooterStyle(resolvedValue(footer, "style")),
+			style: resolveFooterStyle(footer, features),
 			colorSource: parseColorSource(
 				resolvedValue(footer, "colorSource", colorSources, "starship"),
 				defaultComponents.footer.colorSource,
@@ -1246,7 +1262,7 @@ function compatibilityView(config: ZentuiConfig): PolishedTuiConfig {
 		extensionStatuses: starship.extensionStatuses,
 		editorStyle: config.components.editor.style,
 		editorStyles: { minimalist },
-		editorMetadataFormat: config.components.editor.styles.polished.metadataFormat,
+		editorMetadataFormat: config.components.editor.styles.opencode.metadataFormat,
 		editorBorderColorMode: config.components.editor.borderColorMode,
 		editorModelLabel: config.components.editor.modelLabel,
 		colorSources: {
@@ -1256,7 +1272,7 @@ function compatibilityView(config: ZentuiConfig): PolishedTuiConfig {
 		},
 		features: {
 			editor: config.components.editor.enabled,
-			statusLine: config.components.footer.enabled,
+			statusLine: config.components.footer.style === "starship",
 			viewportIndicators: config.components.editor.viewportIndicators,
 		},
 		fixedEditor: config.layout.fixedEditor,
@@ -1337,6 +1353,8 @@ function unknownSelectedStyleIds(record: ConfigRecord): PreservedStyleIds {
 	return {
 		editor:
 			typeof editorStyle === "string" &&
+			editorStyle !== "opencode" &&
+			editorStyle !== "opencode-copy-friendly" &&
 			editorStyle !== "polished" &&
 			editorStyle !== "polished-copy-friendly" &&
 			editorStyle !== "minimalist"
@@ -1353,7 +1371,13 @@ function unknownSelectedStyleIds(record: ConfigRecord): PreservedStyleIds {
 			typeof selectorBorderStyle === "string" && selectorBorderStyle !== "zentui"
 				? selectorBorderStyle
 				: undefined,
-		footer: typeof footerStyle === "string" && footerStyle !== "starship" ? footerStyle : undefined,
+		footer:
+			typeof footerStyle === "string" &&
+			footerStyle !== "native" &&
+			footerStyle !== "starship" &&
+			footerStyle !== "hidden"
+				? footerStyle
+				: undefined,
 	};
 }
 
@@ -1398,6 +1422,13 @@ function deleteLegacyEditorCopyFriendly(record: ConfigRecord): void {
 	if (!isRecord(styles)) return;
 	const polished = styles.polished;
 	if (isRecord(polished)) delete polished.copyFriendly;
+}
+
+function deleteLegacyFooterEnabled(record: ConfigRecord): void {
+	const components = record.components;
+	if (!isRecord(components)) return;
+	const footer = components.footer;
+	if (isRecord(footer)) delete footer.enabled;
 }
 
 function deleteLegacyMessageCopyFriendly(record: ConfigRecord): void {
@@ -1452,7 +1483,7 @@ export function savePolishedEditorStylePatch(
 	path = configPath,
 ): PolishedTuiConfig {
 	return saveComponentsMutation((components) => {
-		const style = components.editor.styles.polished;
+		const style = components.editor.styles.opencode;
 		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
 	}, path);
 }
@@ -1462,7 +1493,7 @@ export function savePolishedCopyFriendlyEditorStylePatch(
 	path = configPath,
 ): PolishedTuiConfig {
 	return saveComponentsMutation((components) => {
-		const style = components.editor.styles["polished-copy-friendly"];
+		const style = components.editor.styles["opencode-copy-friendly"];
 		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
 	}, path);
 }
@@ -1528,19 +1559,18 @@ export function saveSelectorBordersComponentPatch(
 }
 
 export function saveFooterComponentPatch(
-	patch: Partial<Pick<FooterComponentConfig, "enabled" | "style" | "colorSource" | "modelLabel">>,
+	patch: Partial<Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel">>,
 	path = configPath,
 ): PolishedTuiConfig {
 	return saveComponentsMutation(
 		(components) => {
 			const component = components.footer;
-			if (patch.enabled !== undefined) component.enabled = patch.enabled;
 			if (patch.style !== undefined) component.style = patch.style;
 			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
 			if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;
 		},
 		path,
-		undefined,
+		patch.style !== undefined ? deleteLegacyFooterEnabled : undefined,
 		patch.style !== undefined ? "footer" : undefined,
 	);
 }
@@ -1629,17 +1659,24 @@ export function saveUiFeaturesPatch(
 	path = configPath,
 ): PolishedTuiConfig {
 	const valid = validUiFeatureEntries(patch);
-	return saveComponentsMutation((components) => {
-		if (valid.editor !== undefined) {
-			components.editor.enabled = valid.editor;
-			components.userMessages.enabled = valid.editor;
-			components.selectorBorders.enabled = valid.editor;
-		}
-		if (valid.statusLine !== undefined) components.footer.enabled = valid.statusLine;
-		if (valid.viewportIndicators !== undefined) {
-			components.editor.viewportIndicators = valid.viewportIndicators;
-		}
-	}, path);
+	return saveComponentsMutation(
+		(components) => {
+			if (valid.editor !== undefined) {
+				components.editor.enabled = valid.editor;
+				components.userMessages.enabled = valid.editor;
+				components.selectorBorders.enabled = valid.editor;
+			}
+			if (valid.statusLine !== undefined) {
+				components.footer.style = valid.statusLine ? "starship" : "native";
+			}
+			if (valid.viewportIndicators !== undefined) {
+				components.editor.viewportIndicators = valid.viewportIndicators;
+			}
+		},
+		path,
+		valid.statusLine !== undefined ? deleteLegacyFooterEnabled : undefined,
+		valid.statusLine !== undefined ? "footer" : undefined,
+	);
 }
 
 export function saveFooterSegmentsPatch(

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -507,9 +507,12 @@ function parseContextStyle(value: unknown): ContextStyle {
 	return defaultConfig.contextStyle;
 }
 
-function parseEditorModelLabel(value: unknown): ModelLabelSource {
+function parseEditorModelLabel(
+	value: unknown,
+	fallback: ModelLabelSource = defaultComponents.editor.modelLabel,
+): ModelLabelSource {
 	if (value === "id" || value === "name") return value;
-	return defaultConfig.editorModelLabel;
+	return fallback;
 }
 
 function parseEditorStyle(value: unknown): EditorStyle {
@@ -530,8 +533,10 @@ function parseSeparatorStyle(value: unknown): SeparatorStyle {
 	return isSeparatorStyle(value) ? value : defaultConfig.separator;
 }
 
-function parseContextThresholds(value: unknown): ContextThresholds {
-	const defaults = defaultConfig.contextThresholds;
+function parseContextThresholds(
+	value: unknown,
+	defaults: ContextThresholds = defaultStarshipStyle.contextThresholds,
+): ContextThresholds {
 	if (!isRecord(value)) return { ...defaults };
 
 	const warningRaw = value.warning;
@@ -921,13 +926,20 @@ function parseNonEmptyString(value: unknown, fallback: string): string {
 	return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
-function resolveContextThresholds(canonical: unknown, legacy: unknown): ContextThresholds {
+function resolveContextThresholds(
+	canonical: unknown,
+	legacy: unknown,
+	defaults: ContextThresholds,
+): ContextThresholds {
 	const canonicalRecord = recordValue(canonical);
 	const legacyRecord = recordValue(legacy);
-	return parseContextThresholds({
-		warning: resolvedValue(canonicalRecord, "warning", legacyRecord),
-		error: resolvedValue(canonicalRecord, "error", legacyRecord),
-	});
+	return parseContextThresholds(
+		{
+			warning: resolvedValue(canonicalRecord, "warning", legacyRecord),
+			error: resolvedValue(canonicalRecord, "error", legacyRecord),
+		},
+		defaults,
+	);
 }
 
 function resolvePathDisplay(canonical: unknown, legacy: unknown): PathDisplayConfig {
@@ -1018,10 +1030,12 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const minimalistThresholds = resolveContextThresholds(
 		minimalist.contextThresholds,
 		config.contextThresholds,
+		defaultMinimalistStyle.contextThresholds,
 	);
 	const footerThresholds = resolveContextThresholds(
 		starship.contextThresholds,
 		config.contextThresholds,
+		defaultStarshipStyle.contextThresholds,
 	);
 	const compactFormat = resolvedValue(starship, "compactFormat", config, "compactFooterFormat");
 	const metadataFormat = resolvedValue(polished, "metadataFormat", config, "editorMetadataFormat");
@@ -1042,6 +1056,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 			modelLabel: parseEditorModelLabel(
 				resolvedValue(editor, "modelLabel", config, "editorModelLabel"),
+				defaultComponents.editor.modelLabel,
 			),
 			viewportIndicators: parseBoolean(
 				resolvedValue(editor, "viewportIndicators", features, "viewportIndicators"),
@@ -1120,6 +1135,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 			modelLabel: parseEditorModelLabel(
 				resolvedValue(footer, "modelLabel", config, "editorModelLabel"),
+				defaultComponents.footer.modelLabel,
 			),
 			styles: {
 				starship: {
@@ -1214,17 +1230,21 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 }
 
 export function getExtensionStatusPlacement(
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	key: string,
 ): ExtensionStatusPlacement {
-	return config.extensionStatuses.placements[key] ?? config.extensionStatuses.defaultPlacement;
+	const statuses = config.components.footer.styles.starship.extensionStatuses;
+	return statuses.placements[key] ?? statuses.defaultPlacement;
 }
 
 export function getExtensionStatusColorMode(
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	key: string,
 ): ExtensionStatusColorMode {
-	return config.extensionStatuses.colorModes[key] ?? DEFAULT_EXTENSION_STATUS_COLOR_MODE;
+	return (
+		config.components.footer.styles.starship.extensionStatuses.colorModes[key] ??
+		DEFAULT_EXTENSION_STATUS_COLOR_MODE
+	);
 }
 
 export function loadConfig(): PolishedTuiConfig {

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -33,16 +33,20 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
-export type EditorMode = "polished" | "minimalist";
+export type EditorStyle = "polished" | "minimalist";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
 export type MinimalistConfig = {
 	pathDisplay: MinimalistPathDisplayMode;
 	contextFormat: MinimalistContextFormat;
 	contextGauge: boolean;
+	showSessionName: boolean;
 	showTimer: boolean;
 	showCost: boolean;
 	showGit: boolean;
+};
+export type EditorStylesConfig = {
+	minimalist: MinimalistConfig;
 };
 export type EditorBorderColorMode = "static" | "adaptive";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
@@ -152,8 +156,8 @@ export type PolishedTuiConfig = {
 	separator: SeparatorStyle;
 	contextStyle: ContextStyle;
 	editorModelLabel: ModelLabelSource;
-	editorMode: EditorMode;
-	minimalist: MinimalistConfig;
+	editorStyle: EditorStyle;
+	editorStyles: EditorStylesConfig;
 	editorBorderColorMode: EditorBorderColorMode;
 	contextThresholds: ContextThresholds;
 	pathDisplay: PathDisplayConfig;
@@ -262,14 +266,17 @@ export const defaultConfig: PolishedTuiConfig = {
 	separator: "pipe",
 	contextStyle: "text",
 	editorModelLabel: "id",
-	editorMode: "polished",
-	minimalist: {
-		pathDisplay: "compact",
-		contextFormat: "percent",
-		contextGauge: false,
-		showTimer: true,
-		showCost: true,
-		showGit: true,
+	editorStyle: "polished",
+	editorStyles: {
+		minimalist: {
+			pathDisplay: "compact",
+			contextFormat: "percent",
+			contextGauge: false,
+			showSessionName: true,
+			showTimer: true,
+			showCost: true,
+			showGit: true,
+		},
 	},
 	editorBorderColorMode: "static",
 	contextThresholds: { warning: 70, error: 90 },
@@ -383,9 +390,9 @@ function parseEditorModelLabel(value: unknown): ModelLabelSource {
 	return defaultConfig.editorModelLabel;
 }
 
-function parseEditorMode(value: unknown): EditorMode {
+function parseEditorStyle(value: unknown): EditorStyle {
 	if (value === "polished" || value === "minimalist") return value;
-	return defaultConfig.editorMode;
+	return defaultConfig.editorStyle;
 }
 
 function normalizeMinimalistConfig(value: unknown): MinimalistConfig {
@@ -395,21 +402,31 @@ function normalizeMinimalistConfig(value: unknown): MinimalistConfig {
 		pathDisplay:
 			pathDisplay === "compact" || pathDisplay === "project" || pathDisplay === "full"
 				? pathDisplay
-				: defaultConfig.minimalist.pathDisplay,
+				: defaultConfig.editorStyles.minimalist.pathDisplay,
 		contextFormat:
 			record.contextFormat === "percent" || record.contextFormat === "percent-total"
 				? record.contextFormat
-				: defaultConfig.minimalist.contextFormat,
+				: defaultConfig.editorStyles.minimalist.contextFormat,
 		contextGauge:
 			typeof record.contextGauge === "boolean"
 				? record.contextGauge
-				: defaultConfig.minimalist.contextGauge,
+				: defaultConfig.editorStyles.minimalist.contextGauge,
+		showSessionName:
+			typeof record.showSessionName === "boolean"
+				? record.showSessionName
+				: defaultConfig.editorStyles.minimalist.showSessionName,
 		showTimer:
-			typeof record.showTimer === "boolean" ? record.showTimer : defaultConfig.minimalist.showTimer,
+			typeof record.showTimer === "boolean"
+				? record.showTimer
+				: defaultConfig.editorStyles.minimalist.showTimer,
 		showCost:
-			typeof record.showCost === "boolean" ? record.showCost : defaultConfig.minimalist.showCost,
+			typeof record.showCost === "boolean"
+				? record.showCost
+				: defaultConfig.editorStyles.minimalist.showCost,
 		showGit:
-			typeof record.showGit === "boolean" ? record.showGit : defaultConfig.minimalist.showGit,
+			typeof record.showGit === "boolean"
+				? record.showGit
+				: defaultConfig.editorStyles.minimalist.showGit,
 	};
 }
 
@@ -885,8 +902,12 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 		separator: parseSeparatorStyle(config.separator),
 		contextStyle: parseContextStyle(config.contextStyle),
 		editorModelLabel: parseEditorModelLabel(config.editorModelLabel),
-		editorMode: parseEditorMode(config.editorMode),
-		minimalist: normalizeMinimalistConfig(config.minimalist),
+		editorStyle: parseEditorStyle(config.editorStyle),
+		editorStyles: {
+			minimalist: normalizeMinimalistConfig(
+				isRecord(config.editorStyles) ? config.editorStyles.minimalist : undefined,
+			),
+		},
 		editorBorderColorMode: parseEditorBorderColorMode(config.editorBorderColorMode),
 		contextThresholds: parseContextThresholds(config.contextThresholds),
 		pathDisplay: parsePathDisplay(config.pathDisplay),
@@ -1080,9 +1101,9 @@ export function saveEditorModelLabel(
 	});
 }
 
-export function saveEditorMode(value: EditorMode, path = configPath): PolishedTuiConfig {
+export function saveEditorStyle(value: EditorStyle, path = configPath): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
-		record.editorMode = parseEditorMode(value);
+		record.editorStyle = parseEditorStyle(value);
 	});
 }
 
@@ -1091,11 +1112,15 @@ export function saveMinimalistPatch(
 	path = configPath,
 ): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.minimalist)
-			? { ...(record.minimalist as Record<string, unknown>) }
+		const editorStyles = isRecord(record.editorStyles)
+			? { ...(record.editorStyles as Record<string, unknown>) }
+			: {};
+		const existing = isRecord(editorStyles.minimalist)
+			? { ...(editorStyles.minimalist as Record<string, unknown>) }
 			: {};
 		const normalized = normalizeMinimalistConfig({ ...existing, ...patch });
-		record.minimalist = { ...existing, ...normalized };
+		editorStyles.minimalist = { ...existing, ...normalized };
+		record.editorStyles = editorStyles;
 	});
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -37,6 +37,7 @@ export type EditorStyle = "opencode" | "opencode-copy-friendly" | "minimalist";
 export type UserMessageStyle = "framed" | "framed-copy-friendly" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
 export type FooterStyle = "native" | "starship" | "hidden";
+export type ComponentStyleOwner = "editor" | "userMessages" | "selectorBorders" | "footer";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
 export type EditorBorderColorMode = "static" | "adaptive";
@@ -223,6 +224,7 @@ export type GitMetricsConfig = {
 	ignoreSubmodules: boolean;
 };
 
+const DEFAULT_EXTENSION_STATUS_PLACEMENT: ExtensionStatusPlacement = "right";
 const DEFAULT_EXTENSION_STATUS_COLOR_MODE: ExtensionStatusColorMode = "zentui";
 
 export type ExtensionStatusesConfig = {
@@ -1276,6 +1278,40 @@ function compatibilityView(config: ZentuiConfig): PolishedTuiConfig {
 	};
 }
 
+const unsupportedComponentStyles = new WeakMap<ZentuiConfig, ReadonlySet<ComponentStyleOwner>>();
+
+const knownComponentStyleIds: Record<ComponentStyleOwner, ReadonlySet<string>> = {
+	editor: new Set([
+		"opencode",
+		"opencode-copy-friendly",
+		"minimalist",
+		"polished",
+		"polished-copy-friendly",
+	]),
+	userMessages: new Set(["framed", "framed-copy-friendly", "compact", "labeled"]),
+	selectorBorders: new Set(["zentui"]),
+	footer: new Set(["native", "starship", "hidden"]),
+};
+
+function unsupportedSelectedStyleId(
+	record: ConfigRecord,
+	owner: ComponentStyleOwner,
+): string | undefined {
+	const component = recordValue(recordValue(record.components)[owner]);
+	if (!hasOwn(component, "style")) return undefined;
+	const style = component.style;
+	return typeof style === "string" && style.trim() && !knownComponentStyleIds[owner].has(style)
+		? style
+		: undefined;
+}
+
+export function hasUnsupportedComponentStyle(
+	config: ZentuiConfig,
+	owner: ComponentStyleOwner,
+): boolean {
+	return unsupportedComponentStyles.get(config)?.has(owner) ?? false;
+}
+
 export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const config = isRecord(parsed) ? parsed : {};
 	const iconsRecord = recordValue(config.icons);
@@ -1293,7 +1329,13 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 			fixedEditor: resolveFixedEditor(layout.fixedEditor, config.fixedEditor),
 		},
 	};
-	return compatibilityView(canonical);
+	const view = compatibilityView(canonical);
+	const unsupported = new Set<ComponentStyleOwner>();
+	for (const owner of ["editor", "userMessages", "selectorBorders", "footer"] as const) {
+		if (unsupportedSelectedStyleId(config, owner) !== undefined) unsupported.add(owner);
+	}
+	if (unsupported.size > 0) unsupportedComponentStyles.set(view, unsupported);
+	return view;
 }
 
 export function getExtensionStatusPlacement(
@@ -1301,17 +1343,25 @@ export function getExtensionStatusPlacement(
 	key: string,
 ): ExtensionStatusPlacement {
 	const statuses = config.components.footer.styles.starship.extensionStatuses;
-	return statuses.placements[key] ?? statuses.defaultPlacement;
+	if (Object.hasOwn(statuses.placements, key)) {
+		const placement = statuses.placements[key];
+		if (isExtensionStatusPlacement(placement)) return placement;
+	}
+	return isExtensionStatusPlacement(statuses.defaultPlacement)
+		? statuses.defaultPlacement
+		: DEFAULT_EXTENSION_STATUS_PLACEMENT;
 }
 
 export function getExtensionStatusColorMode(
 	config: ZentuiConfig,
 	key: string,
 ): ExtensionStatusColorMode {
-	return (
-		config.components.footer.styles.starship.extensionStatuses.colorModes[key] ??
-		DEFAULT_EXTENSION_STATUS_COLOR_MODE
-	);
+	const colorModes = config.components.footer.styles.starship.extensionStatuses.colorModes;
+	if (Object.hasOwn(colorModes, key)) {
+		const colorMode = colorModes[key];
+		if (isExtensionStatusColorMode(colorMode)) return colorMode;
+	}
+	return DEFAULT_EXTENSION_STATUS_COLOR_MODE;
 }
 
 export function loadConfig(): PolishedTuiConfig {
@@ -1337,45 +1387,14 @@ function overlayKnown(raw: unknown, known: unknown): unknown {
 	return output;
 }
 
-type ComponentStyleOwner = keyof ComponentsConfig;
-
 type PreservedStyleIds = Partial<Record<ComponentStyleOwner, string>>;
 
 function unknownSelectedStyleIds(record: ConfigRecord): PreservedStyleIds {
-	const components = recordValue(record.components);
-	const editorStyle = recordValue(components.editor).style;
-	const userMessageStyle = recordValue(components.userMessages).style;
-	const selectorBorderStyle = recordValue(components.selectorBorders).style;
-	const footerStyle = recordValue(components.footer).style;
 	return {
-		editor:
-			typeof editorStyle === "string" &&
-			editorStyle !== "opencode" &&
-			editorStyle !== "opencode-copy-friendly" &&
-			editorStyle !== "polished" &&
-			editorStyle !== "polished-copy-friendly" &&
-			editorStyle !== "minimalist"
-				? editorStyle
-				: undefined,
-		userMessages:
-			typeof userMessageStyle === "string" &&
-			userMessageStyle !== "framed" &&
-			userMessageStyle !== "framed-copy-friendly" &&
-			userMessageStyle !== "compact" &&
-			userMessageStyle !== "labeled"
-				? userMessageStyle
-				: undefined,
-		selectorBorders:
-			typeof selectorBorderStyle === "string" && selectorBorderStyle !== "zentui"
-				? selectorBorderStyle
-				: undefined,
-		footer:
-			typeof footerStyle === "string" &&
-			footerStyle !== "native" &&
-			footerStyle !== "starship" &&
-			footerStyle !== "hidden"
-				? footerStyle
-				: undefined,
+		editor: unsupportedSelectedStyleId(record, "editor"),
+		userMessages: unsupportedSelectedStyleId(record, "userMessages"),
+		selectorBorders: unsupportedSelectedStyleId(record, "selectorBorders"),
+		footer: unsupportedSelectedStyleId(record, "footer"),
 	};
 }
 

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -34,20 +34,11 @@ export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
 export type EditorStyle = "polished" | "minimalist";
+export type UserMessageStyle = "framed";
+export type SelectorBorderStyle = "zentui";
+export type FooterStyle = "starship";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
-export type MinimalistConfig = {
-	pathDisplay: MinimalistPathDisplayMode;
-	contextFormat: MinimalistContextFormat;
-	contextGauge: boolean;
-	showSessionName: boolean;
-	showTimer: boolean;
-	showCost: boolean;
-	showGit: boolean;
-};
-export type EditorStylesConfig = {
-	minimalist: MinimalistConfig;
-};
 export type EditorBorderColorMode = "static" | "adaptive";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
 
@@ -112,6 +103,98 @@ export type FixedEditorConfig = {
 	copyNotice: boolean;
 };
 
+export type PolishedEditorStyleConfig = {
+	copyFriendly: boolean;
+	metadataFormat: string;
+};
+
+export type MinimalistEditorStyleConfig = {
+	pathDisplay: MinimalistPathDisplayMode;
+	contextFormat: MinimalistContextFormat;
+	contextGauge: boolean;
+	showSessionName: boolean;
+	showTimer: boolean;
+	showCost: boolean;
+	showGit: boolean;
+	contextThresholds: ContextThresholds;
+};
+
+/** Temporary name retained for existing settings consumers. */
+export type MinimalistConfig = MinimalistEditorStyleConfig;
+
+export type EditorStylesConfig = {
+	minimalist: MinimalistEditorStyleConfig;
+};
+
+export type EditorComponentConfig = {
+	enabled: boolean;
+	style: EditorStyle;
+	colorSource: ColorSource;
+	borderColorMode: EditorBorderColorMode;
+	modelLabel: ModelLabelSource;
+	viewportIndicators: boolean;
+	styles: {
+		polished: PolishedEditorStyleConfig;
+		minimalist: MinimalistEditorStyleConfig;
+	};
+};
+
+export type FramedUserMessageStyleConfig = {
+	copyFriendly: boolean;
+};
+
+export type UserMessagesComponentConfig = {
+	enabled: boolean;
+	style: UserMessageStyle;
+	colorSource: ColorSource;
+	styles: {
+		framed: FramedUserMessageStyleConfig;
+	};
+};
+
+export type SelectorBordersComponentConfig = {
+	enabled: boolean;
+	style: SelectorBorderStyle;
+	colorSource: ColorSource;
+};
+
+export type StarshipFooterStyleConfig = {
+	format: string;
+	responsive: boolean;
+	compactFormat: string;
+	compactMaxLines: CompactFooterMaxLines;
+	separator: SeparatorStyle;
+	contextStyle: ContextStyle;
+	contextThresholds: ContextThresholds;
+	pathDisplay: PathDisplayConfig;
+	segments: FooterSegmentsConfig;
+	gitBranch: GitBranchConfig;
+	gitCommit: GitCommitConfig;
+	gitMetrics: GitMetricsConfig;
+	extensionStatuses: ExtensionStatusesConfig;
+};
+
+export type FooterComponentConfig = {
+	enabled: boolean;
+	style: FooterStyle;
+	colorSource: ColorSource;
+	modelLabel: ModelLabelSource;
+	styles: {
+		starship: StarshipFooterStyleConfig;
+	};
+};
+
+export type ComponentsConfig = {
+	editor: EditorComponentConfig;
+	userMessages: UserMessagesComponentConfig;
+	selectorBorders: SelectorBordersComponentConfig;
+	footer: FooterComponentConfig;
+};
+
+export type LayoutConfig = {
+	fixedEditor: FixedEditorConfig;
+};
+
 export type ExtensionStatusPlacement = "off" | "left" | "middle" | "right";
 export type ExtensionStatusColorMode = "zentui" | "original";
 
@@ -146,8 +229,53 @@ const DEFAULT_PROJECT_REFRESH_INTERVAL_MS = 30_000;
 const MIN_PROJECT_REFRESH_INTERVAL_MS = 5_000;
 export const DEFAULT_EDITOR_METADATA_FORMAT = "$model  $provider(  $thinking)";
 
-export type PolishedTuiConfig = {
+export type ZentuiConfig = {
 	projectRefreshIntervalMs: number;
+	icons: ResolvedIcons;
+	colors: PolishedTuiColors;
+	components: ComponentsConfig;
+	layout: LayoutConfig;
+};
+
+export type PolishedTuiColors = {
+	cwd: ColorSpec;
+	sessionName: ColorSpec;
+	gitBranch: ColorSpec;
+	gitStatus: ColorSpec;
+	contextNormal: ColorSpec;
+	contextWarning: ColorSpec;
+	contextError: ColorSpec;
+	tokens: ColorSpec;
+	cost: ColorSpec;
+	separator: ColorSpec;
+	runtimePrefix: ColorSpec;
+	extensionStatus: ColorSpec;
+	sessionDuration: ColorSpec;
+	packageVersion: ColorSpec;
+	gitCommit: ColorSpec;
+	gitMetricsAdded: ColorSpec;
+	gitMetricsDeleted: ColorSpec;
+	username: ColorSpec;
+	time: ColorSpec;
+	os: ColorSpec;
+	editorAccent?: ColorSpec;
+	editorPrompt?: ColorSpec;
+	editorBorder?: ColorSpec;
+	editorModel?: ColorSpec;
+	editorProvider?: ColorSpec;
+	editorThinking?: ColorSpec;
+	editorThinkingMinimal?: ColorSpec;
+	editorThinkingLow?: ColorSpec;
+	editorThinkingMedium?: ColorSpec;
+	editorThinkingHigh?: ColorSpec;
+	editorThinkingXhigh?: ColorSpec;
+};
+
+/**
+ * Canonical configuration plus a temporary flat compatibility projection used
+ * by production consumers while they migrate to `components` and `layout`.
+ */
+export type PolishedTuiConfig = ZentuiConfig & {
 	footerFormat: string;
 	responsiveFooter: boolean;
 	compactFooterFormat: string;
@@ -162,40 +290,6 @@ export type PolishedTuiConfig = {
 	contextThresholds: ContextThresholds;
 	pathDisplay: PathDisplayConfig;
 	gitBranch: GitBranchConfig;
-	icons: ResolvedIcons;
-	colors: {
-		cwd: ColorSpec;
-		sessionName: ColorSpec;
-		gitBranch: ColorSpec;
-		gitStatus: ColorSpec;
-		contextNormal: ColorSpec;
-		contextWarning: ColorSpec;
-		contextError: ColorSpec;
-		tokens: ColorSpec;
-		cost: ColorSpec;
-		separator: ColorSpec;
-		runtimePrefix: ColorSpec;
-		extensionStatus: ColorSpec;
-		sessionDuration: ColorSpec;
-		packageVersion: ColorSpec;
-		gitCommit: ColorSpec;
-		gitMetricsAdded: ColorSpec;
-		gitMetricsDeleted: ColorSpec;
-		username: ColorSpec;
-		time: ColorSpec;
-		os: ColorSpec;
-		editorAccent?: ColorSpec;
-		editorPrompt?: ColorSpec;
-		editorBorder?: ColorSpec;
-		editorModel?: ColorSpec;
-		editorProvider?: ColorSpec;
-		editorThinking?: ColorSpec;
-		editorThinkingMinimal?: ColorSpec;
-		editorThinkingLow?: ColorSpec;
-		editorThinkingMedium?: ColorSpec;
-		editorThinkingHigh?: ColorSpec;
-		editorThinkingXhigh?: ColorSpec;
-	};
 	colorSources: ColorSourcesConfig;
 	features: UiFeaturesConfig;
 	footerSegments: FooterSegmentsConfig;
@@ -256,36 +350,85 @@ export const FOOTER_FORMAT_ALIASES: Record<string, string> = {
 
 export const configPath = join(getAgentDir(), "zentui.json");
 
-export const defaultConfig: PolishedTuiConfig = {
-	projectRefreshIntervalMs: DEFAULT_PROJECT_REFRESH_INTERVAL_MS,
-	footerFormat: "",
-	responsiveFooter: true,
-	compactFooterFormat: DEFAULT_COMPACT_FOOTER_FORMAT,
-	compactFooterMaxLines: 2,
-	editorMetadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+const defaultFooterSegments: FooterSegmentsConfig = {
+	cwd: true,
+	sessionName: true,
+	gitBranch: true,
+	gitStatus: true,
+	gitCounts: false,
+	gitCommit: false,
+	gitMetrics: false,
+	runtime: true,
+	modelInfo: false,
+	context: true,
+	tokens: true,
+	cost: true,
+	sessionDuration: false,
+	username: false,
+	time: false,
+	os: false,
+	packageVersion: false,
+};
+
+const defaultMinimalistStyle: MinimalistEditorStyleConfig = {
+	pathDisplay: "compact",
+	contextFormat: "percent",
+	contextGauge: false,
+	showSessionName: true,
+	showTimer: true,
+	showCost: true,
+	showGit: true,
+	contextThresholds: { warning: 70, error: 90 },
+};
+
+const defaultStarshipStyle: StarshipFooterStyleConfig = {
+	format: "",
+	responsive: true,
+	compactFormat: DEFAULT_COMPACT_FOOTER_FORMAT,
+	compactMaxLines: 2,
 	separator: "pipe",
 	contextStyle: "text",
-	editorModelLabel: "id",
-	editorStyle: "polished",
-	editorStyles: {
-		minimalist: {
-			pathDisplay: "compact",
-			contextFormat: "percent",
-			contextGauge: false,
-			showSessionName: true,
-			showTimer: true,
-			showCost: true,
-			showGit: true,
-		},
-	},
-	editorBorderColorMode: "static",
 	contextThresholds: { warning: 70, error: 90 },
 	pathDisplay: { mode: "basename", depth: 0 },
+	segments: defaultFooterSegments,
 	gitBranch: { maxLength: "full" },
-	icons: {
-		mode: "auto",
-		...NERD_DEFAULT_ICONS,
+	gitCommit: { hashLength: 7, onlyDetached: true, showTag: true },
+	gitMetrics: { onlyNonzero: true, ignoreSubmodules: false },
+	extensionStatuses: { defaultPlacement: "right", placements: {}, colorModes: {} },
+};
+
+const defaultComponents: ComponentsConfig = {
+	editor: {
+		enabled: true,
+		style: "polished",
+		colorSource: "theme",
+		borderColorMode: "static",
+		modelLabel: "id",
+		viewportIndicators: true,
+		styles: {
+			polished: { copyFriendly: false, metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			minimalist: defaultMinimalistStyle,
+		},
 	},
+	userMessages: {
+		enabled: true,
+		style: "framed",
+		colorSource: "theme",
+		styles: { framed: { copyFriendly: false } },
+	},
+	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
+	footer: {
+		enabled: true,
+		style: "starship",
+		colorSource: "theme",
+		modelLabel: "id",
+		styles: { starship: defaultStarshipStyle },
+	},
+};
+
+export const defaultConfig: PolishedTuiConfig = {
+	projectRefreshIntervalMs: DEFAULT_PROJECT_REFRESH_INTERVAL_MS,
+	icons: { mode: "auto", ...NERD_DEFAULT_ICONS },
 	colors: {
 		cwd: "bold cyan",
 		sessionName: "bold green",
@@ -308,55 +451,34 @@ export const defaultConfig: PolishedTuiConfig = {
 		time: "bold yellow",
 		os: "bold white",
 	},
-	colorSources: {
-		starship: "theme",
-		editor: "theme",
-		userMessages: "theme",
-	},
+	components: defaultComponents,
+	layout: { fixedEditor: { enabled: false, mouseScroll: true, copyNotice: true } },
+	footerFormat: defaultStarshipStyle.format,
+	responsiveFooter: defaultStarshipStyle.responsive,
+	compactFooterFormat: defaultStarshipStyle.compactFormat,
+	compactFooterMaxLines: defaultStarshipStyle.compactMaxLines,
+	editorMetadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+	separator: defaultStarshipStyle.separator,
+	contextStyle: defaultStarshipStyle.contextStyle,
+	editorModelLabel: defaultComponents.editor.modelLabel,
+	editorStyle: defaultComponents.editor.style,
+	editorStyles: { minimalist: defaultMinimalistStyle },
+	editorBorderColorMode: defaultComponents.editor.borderColorMode,
+	contextThresholds: defaultStarshipStyle.contextThresholds,
+	pathDisplay: defaultStarshipStyle.pathDisplay,
+	gitBranch: defaultStarshipStyle.gitBranch,
+	colorSources: { starship: "theme", editor: "theme", userMessages: "theme" },
 	features: {
 		editor: true,
 		statusLine: true,
 		copyFriendly: false,
 		viewportIndicators: true,
 	},
-	footerSegments: {
-		cwd: true,
-		sessionName: true,
-		gitBranch: true,
-		gitStatus: true,
-		gitCounts: false,
-		runtime: true,
-		modelInfo: false,
-		context: true,
-		tokens: true,
-		cost: true,
-		sessionDuration: false,
-		username: false,
-		time: false,
-		os: false,
-		packageVersion: false,
-		gitCommit: false,
-		gitMetrics: false,
-	},
-	gitCommit: {
-		hashLength: 7,
-		onlyDetached: true,
-		showTag: true,
-	},
-	gitMetrics: {
-		onlyNonzero: true,
-		ignoreSubmodules: false,
-	},
-	extensionStatuses: {
-		defaultPlacement: "right",
-		placements: {},
-		colorModes: {},
-	},
-	fixedEditor: {
-		enabled: false,
-		mouseScroll: true,
-		copyNotice: true,
-	},
+	footerSegments: defaultFooterSegments,
+	gitCommit: defaultStarshipStyle.gitCommit,
+	gitMetrics: defaultStarshipStyle.gitMetrics,
+	extensionStatuses: defaultStarshipStyle.extensionStatuses,
+	fixedEditor: { enabled: false, mouseScroll: true, copyNotice: true },
 };
 
 type ConfigRecord = Record<string, unknown>;
@@ -393,41 +515,6 @@ function parseEditorModelLabel(value: unknown): ModelLabelSource {
 function parseEditorStyle(value: unknown): EditorStyle {
 	if (value === "polished" || value === "minimalist") return value;
 	return defaultConfig.editorStyle;
-}
-
-function normalizeMinimalistConfig(value: unknown): MinimalistConfig {
-	const record = isRecord(value) ? value : {};
-	const pathDisplay = record.pathDisplay;
-	return {
-		pathDisplay:
-			pathDisplay === "compact" || pathDisplay === "project" || pathDisplay === "full"
-				? pathDisplay
-				: defaultConfig.editorStyles.minimalist.pathDisplay,
-		contextFormat:
-			record.contextFormat === "percent" || record.contextFormat === "percent-total"
-				? record.contextFormat
-				: defaultConfig.editorStyles.minimalist.contextFormat,
-		contextGauge:
-			typeof record.contextGauge === "boolean"
-				? record.contextGauge
-				: defaultConfig.editorStyles.minimalist.contextGauge,
-		showSessionName:
-			typeof record.showSessionName === "boolean"
-				? record.showSessionName
-				: defaultConfig.editorStyles.minimalist.showSessionName,
-		showTimer:
-			typeof record.showTimer === "boolean"
-				? record.showTimer
-				: defaultConfig.editorStyles.minimalist.showTimer,
-		showCost:
-			typeof record.showCost === "boolean"
-				? record.showCost
-				: defaultConfig.editorStyles.minimalist.showCost,
-		showGit:
-			typeof record.showGit === "boolean"
-				? record.showGit
-				: defaultConfig.editorStyles.minimalist.showGit,
-	};
 }
 
 function parseEditorBorderColorMode(value: unknown): EditorBorderColorMode {
@@ -505,27 +592,6 @@ function colorValue(record: Record<string, unknown>, key: string): string | unde
 	return value !== undefined && isSupportedColorSpec(value) ? value : undefined;
 }
 
-function colorSourceValue(
-	record: Record<string, unknown>,
-	key: keyof ColorSourcesConfig,
-): ColorSource {
-	const value = record[key];
-	return value === "terminal" || value === "theme" ? value : defaultConfig.colorSources[key];
-}
-
-function booleanValue(record: Record<string, unknown>, key: keyof UiFeaturesConfig): boolean {
-	const value = record[key];
-	return typeof value === "boolean" ? value : defaultConfig.features[key];
-}
-
-function footerSegmentValue(
-	record: Record<string, unknown>,
-	key: keyof FooterSegmentsConfig,
-): boolean {
-	const value = record[key];
-	return typeof value === "boolean" ? value : defaultConfig.footerSegments[key];
-}
-
 function definedColors(
 	colors: Partial<Record<keyof PolishedTuiConfig["colors"], string | undefined>>,
 ): Partial<PolishedTuiConfig["colors"]> {
@@ -579,45 +645,6 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		editorThinkingHigh: colorValue(record, "editorThinkingHigh"),
 		editorThinkingXhigh: colorValue(record, "editorThinkingXhigh"),
 	});
-}
-
-function normalizeColorSources(record: Record<string, unknown>): ColorSourcesConfig {
-	return {
-		starship: colorSourceValue(record, "starship"),
-		editor: colorSourceValue(record, "editor"),
-		userMessages: colorSourceValue(record, "userMessages"),
-	};
-}
-
-function normalizeUiFeatures(record: Record<string, unknown>): UiFeaturesConfig {
-	return {
-		editor: booleanValue(record, "editor"),
-		statusLine: booleanValue(record, "statusLine"),
-		copyFriendly: booleanValue(record, "copyFriendly"),
-		viewportIndicators: booleanValue(record, "viewportIndicators"),
-	};
-}
-
-function normalizeFooterSegments(record: Record<string, unknown>): FooterSegmentsConfig {
-	return {
-		cwd: footerSegmentValue(record, "cwd"),
-		sessionName: footerSegmentValue(record, "sessionName"),
-		gitBranch: footerSegmentValue(record, "gitBranch"),
-		gitStatus: footerSegmentValue(record, "gitStatus"),
-		gitCounts: footerSegmentValue(record, "gitCounts"),
-		runtime: footerSegmentValue(record, "runtime"),
-		modelInfo: footerSegmentValue(record, "modelInfo"),
-		context: footerSegmentValue(record, "context"),
-		tokens: footerSegmentValue(record, "tokens"),
-		cost: footerSegmentValue(record, "cost"),
-		sessionDuration: footerSegmentValue(record, "sessionDuration"),
-		username: footerSegmentValue(record, "username"),
-		time: footerSegmentValue(record, "time"),
-		os: footerSegmentValue(record, "os"),
-		packageVersion: footerSegmentValue(record, "packageVersion"),
-		gitCommit: footerSegmentValue(record, "gitCommit"),
-		gitMetrics: footerSegmentValue(record, "gitMetrics"),
-	};
 }
 
 /** Clamp hashLength to Git's valid abbreviation range [4, 40]. */
@@ -844,91 +871,346 @@ function mutateConfig(path: string, mutate: (record: ConfigRecord) => void): Pol
 	return mergeConfig(state.record);
 }
 
-export function ensureConfigExists(): void {
+export function ensureConfigExists(_path = configPath): void {
 	// Intentionally left as a no-op. Zentui config is user-owned and
 	// compatibility-sensitive: runtime defaults come from `mergeConfig({})`, and
 	// the extension should not persist opinionated defaults unless the user
 	// explicitly changes a setting.
 }
 
-export function mergeConfig(parsed: unknown): PolishedTuiConfig {
-	const config = isRecord(parsed) ? parsed : {};
-	const iconsRecord = isRecord(config.icons) ? (config.icons as Record<string, unknown>) : {};
-	const iconMode = normalizeIconMode(iconsRecord.mode);
-	const iconOverrides = normalizeIconOverrides(iconsRecord);
-	const colors = isRecord(config.colors)
-		? normalizeColors(config.colors as Record<string, unknown>)
-		: {};
-	const colorSources = isRecord(config.colorSources)
-		? normalizeColorSources(config.colorSources as Record<string, unknown>)
-		: defaultConfig.colorSources;
-	const features = isRecord(config.features)
-		? normalizeUiFeatures(config.features as Record<string, unknown>)
-		: defaultConfig.features;
-	const footerSegments = isRecord(config.footerSegments)
-		? normalizeFooterSegments(config.footerSegments as Record<string, unknown>)
-		: defaultConfig.footerSegments;
-	const extensionStatuses = isRecord(config.extensionStatuses)
-		? normalizeExtensionStatuses(config.extensionStatuses as Record<string, unknown>)
-		: defaultConfig.extensionStatuses;
-	const gitCommit = isRecord(config.gitCommit)
-		? normalizeGitCommitConfig(config.gitCommit as Record<string, unknown>)
-		: defaultConfig.gitCommit;
-	const gitMetrics = isRecord(config.gitMetrics)
-		? normalizeGitMetricsConfig(config.gitMetrics as Record<string, unknown>)
-		: defaultConfig.gitMetrics;
-	const gitBranch = parseGitBranchConfig(config.gitBranch);
-	const fixedEditor = isRecord(config.fixedEditor)
-		? normalizeFixedEditorConfig(config.fixedEditor as Record<string, unknown>)
-		: defaultConfig.fixedEditor;
-	const editorMetadataFormat = stringValue(config, "editorMetadataFormat");
-	const compactFooterFormat = stringValue(config, "compactFooterFormat");
+function hasOwn(record: ConfigRecord, key: string): boolean {
+	return Object.hasOwn(record, key);
+}
+
+function recordValue(value: unknown): ConfigRecord {
+	return isRecord(value) ? value : {};
+}
+
+function resolvedValue(
+	canonical: ConfigRecord,
+	canonicalKey: string,
+	legacy?: ConfigRecord,
+	legacyKey = canonicalKey,
+): unknown {
+	if (hasOwn(canonical, canonicalKey)) return canonical[canonicalKey];
+	if (legacy && hasOwn(legacy, legacyKey)) return legacy[legacyKey];
+	return undefined;
+}
+
+function parseBoolean(value: unknown, fallback: boolean): boolean {
+	return typeof value === "boolean" ? value : fallback;
+}
+
+function parseColorSource(value: unknown, fallback: ColorSource): ColorSource {
+	return value === "theme" || value === "terminal" ? value : fallback;
+}
+
+function parseUserMessageStyle(value: unknown): UserMessageStyle {
+	return value === "framed" ? value : "framed";
+}
+
+function parseSelectorBorderStyle(value: unknown): SelectorBorderStyle {
+	return value === "zentui" ? value : "zentui";
+}
+
+function parseFooterStyle(value: unknown): FooterStyle {
+	return value === "starship" ? value : "starship";
+}
+
+function parseNonEmptyString(value: unknown, fallback: string): string {
+	return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function resolveContextThresholds(canonical: unknown, legacy: unknown): ContextThresholds {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return parseContextThresholds({
+		warning: resolvedValue(canonicalRecord, "warning", legacyRecord),
+		error: resolvedValue(canonicalRecord, "error", legacyRecord),
+	});
+}
+
+function resolvePathDisplay(canonical: unknown, legacy: unknown): PathDisplayConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return parsePathDisplay({
+		mode: resolvedValue(canonicalRecord, "mode", legacyRecord),
+		depth: resolvedValue(canonicalRecord, "depth", legacyRecord),
+	});
+}
+
+function resolveGitBranch(canonical: unknown, legacy: unknown): GitBranchConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return parseGitBranchConfig({
+		maxLength: resolvedValue(canonicalRecord, "maxLength", legacyRecord),
+	});
+}
+
+function resolveGitCommit(canonical: unknown, legacy: unknown): GitCommitConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return normalizeGitCommitConfig({
+		hashLength: resolvedValue(canonicalRecord, "hashLength", legacyRecord),
+		onlyDetached: resolvedValue(canonicalRecord, "onlyDetached", legacyRecord),
+		showTag: resolvedValue(canonicalRecord, "showTag", legacyRecord),
+	});
+}
+
+function resolveGitMetrics(canonical: unknown, legacy: unknown): GitMetricsConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return normalizeGitMetricsConfig({
+		onlyNonzero: resolvedValue(canonicalRecord, "onlyNonzero", legacyRecord),
+		ignoreSubmodules: resolvedValue(canonicalRecord, "ignoreSubmodules", legacyRecord),
+	});
+}
+
+function resolveExtensionStatuses(canonical: unknown, legacy: unknown): ExtensionStatusesConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return normalizeExtensionStatuses({
+		defaultPlacement: resolvedValue(canonicalRecord, "defaultPlacement", legacyRecord),
+		placements: resolvedValue(canonicalRecord, "placements", legacyRecord),
+		colorModes: resolvedValue(canonicalRecord, "colorModes", legacyRecord),
+	});
+}
+
+const FOOTER_SEGMENT_KEYS = Object.keys(defaultFooterSegments) as Array<keyof FooterSegmentsConfig>;
+
+function resolveFooterSegments(canonical: unknown, legacy: unknown): FooterSegmentsConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return Object.fromEntries(
+		FOOTER_SEGMENT_KEYS.map((key) => [
+			key,
+			parseBoolean(resolvedValue(canonicalRecord, key, legacyRecord), defaultFooterSegments[key]),
+		]),
+	) as FooterSegmentsConfig;
+}
+
+function resolveFixedEditor(canonical: unknown, legacy: unknown): FixedEditorConfig {
+	const canonicalRecord = recordValue(canonical);
+	const legacyRecord = recordValue(legacy);
+	return normalizeFixedEditorConfig({
+		enabled: resolvedValue(canonicalRecord, "enabled", legacyRecord),
+		mouseScroll: resolvedValue(canonicalRecord, "mouseScroll", legacyRecord),
+		copyNotice: resolvedValue(canonicalRecord, "copyNotice", legacyRecord),
+	});
+}
+
+function resolveComponents(config: ConfigRecord): ComponentsConfig {
+	const components = recordValue(config.components);
+	const editor = recordValue(components.editor);
+	const editorStyles = recordValue(editor.styles);
+	const polished = recordValue(editorStyles.polished);
+	const minimalist = recordValue(editorStyles.minimalist);
+	const userMessages = recordValue(components.userMessages);
+	const userMessageStyles = recordValue(userMessages.styles);
+	const framed = recordValue(userMessageStyles.framed);
+	const selectorBorders = recordValue(components.selectorBorders);
+	const footer = recordValue(components.footer);
+	const footerStyles = recordValue(footer.styles);
+	const starship = recordValue(footerStyles.starship);
+	const features = recordValue(config.features);
+	const colorSources = recordValue(config.colorSources);
+
+	const minimalistThresholds = resolveContextThresholds(
+		minimalist.contextThresholds,
+		config.contextThresholds,
+	);
+	const footerThresholds = resolveContextThresholds(
+		starship.contextThresholds,
+		config.contextThresholds,
+	);
+	const compactFormat = resolvedValue(starship, "compactFormat", config, "compactFooterFormat");
+	const metadataFormat = resolvedValue(polished, "metadataFormat", config, "editorMetadataFormat");
+
 	return {
-		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
-		footerFormat: stringValue(config, "footerFormat") ?? "",
-		responsiveFooter:
-			typeof config.responsiveFooter === "boolean"
-				? config.responsiveFooter
-				: defaultConfig.responsiveFooter,
-		compactFooterFormat:
-			compactFooterFormat && compactFooterFormat.length > 0
-				? compactFooterFormat
-				: DEFAULT_COMPACT_FOOTER_FORMAT,
-		compactFooterMaxLines: parseCompactFooterMaxLines(config.compactFooterMaxLines),
-		editorMetadataFormat:
-			editorMetadataFormat && editorMetadataFormat.length > 0
-				? editorMetadataFormat
-				: DEFAULT_EDITOR_METADATA_FORMAT,
-		separator: parseSeparatorStyle(config.separator),
-		contextStyle: parseContextStyle(config.contextStyle),
-		editorModelLabel: parseEditorModelLabel(config.editorModelLabel),
-		editorStyle: parseEditorStyle(config.editorStyle),
-		editorStyles: {
-			minimalist: normalizeMinimalistConfig(
-				isRecord(config.editorStyles) ? config.editorStyles.minimalist : undefined,
+		editor: {
+			enabled: parseBoolean(
+				resolvedValue(editor, "enabled", features, "editor"),
+				defaultComponents.editor.enabled,
+			),
+			style: parseEditorStyle(resolvedValue(editor, "style")),
+			colorSource: parseColorSource(
+				resolvedValue(editor, "colorSource", colorSources, "editor"),
+				defaultComponents.editor.colorSource,
+			),
+			borderColorMode: parseEditorBorderColorMode(
+				resolvedValue(editor, "borderColorMode", config, "editorBorderColorMode"),
+			),
+			modelLabel: parseEditorModelLabel(
+				resolvedValue(editor, "modelLabel", config, "editorModelLabel"),
+			),
+			viewportIndicators: parseBoolean(
+				resolvedValue(editor, "viewportIndicators", features, "viewportIndicators"),
+				defaultComponents.editor.viewportIndicators,
+			),
+			styles: {
+				polished: {
+					copyFriendly: parseBoolean(
+						resolvedValue(polished, "copyFriendly", features, "copyFriendly"),
+						defaultComponents.editor.styles.polished.copyFriendly,
+					),
+					metadataFormat: parseNonEmptyString(metadataFormat, DEFAULT_EDITOR_METADATA_FORMAT),
+				},
+				minimalist: {
+					pathDisplay:
+						minimalist.pathDisplay === "compact" ||
+						minimalist.pathDisplay === "project" ||
+						minimalist.pathDisplay === "full"
+							? minimalist.pathDisplay
+							: defaultMinimalistStyle.pathDisplay,
+					contextFormat:
+						minimalist.contextFormat === "percent" || minimalist.contextFormat === "percent-total"
+							? minimalist.contextFormat
+							: defaultMinimalistStyle.contextFormat,
+					contextGauge: parseBoolean(minimalist.contextGauge, defaultMinimalistStyle.contextGauge),
+					showSessionName: parseBoolean(
+						minimalist.showSessionName,
+						defaultMinimalistStyle.showSessionName,
+					),
+					showTimer: parseBoolean(minimalist.showTimer, defaultMinimalistStyle.showTimer),
+					showCost: parseBoolean(minimalist.showCost, defaultMinimalistStyle.showCost),
+					showGit: parseBoolean(minimalist.showGit, defaultMinimalistStyle.showGit),
+					contextThresholds: minimalistThresholds,
+				},
+			},
+		},
+		userMessages: {
+			enabled: parseBoolean(
+				resolvedValue(userMessages, "enabled", features, "editor"),
+				defaultComponents.userMessages.enabled,
+			),
+			style: parseUserMessageStyle(resolvedValue(userMessages, "style")),
+			colorSource: parseColorSource(
+				resolvedValue(userMessages, "colorSource", colorSources, "userMessages"),
+				defaultComponents.userMessages.colorSource,
+			),
+			styles: {
+				framed: {
+					copyFriendly: parseBoolean(
+						resolvedValue(framed, "copyFriendly", features, "copyFriendly"),
+						defaultComponents.userMessages.styles.framed.copyFriendly,
+					),
+				},
+			},
+		},
+		selectorBorders: {
+			enabled: parseBoolean(
+				resolvedValue(selectorBorders, "enabled", features, "editor"),
+				defaultComponents.selectorBorders.enabled,
+			),
+			style: parseSelectorBorderStyle(resolvedValue(selectorBorders, "style")),
+			colorSource: parseColorSource(
+				resolvedValue(selectorBorders, "colorSource", colorSources, "editor"),
+				defaultComponents.selectorBorders.colorSource,
 			),
 		},
-		editorBorderColorMode: parseEditorBorderColorMode(config.editorBorderColorMode),
-		contextThresholds: parseContextThresholds(config.contextThresholds),
-		pathDisplay: parsePathDisplay(config.pathDisplay),
-		gitBranch,
-		icons: resolveConfiguredIcons(iconMode, iconOverrides),
-		colors: {
-			...defaultConfig.colors,
-			...colors,
+		footer: {
+			enabled: parseBoolean(
+				resolvedValue(footer, "enabled", features, "statusLine"),
+				defaultComponents.footer.enabled,
+			),
+			style: parseFooterStyle(resolvedValue(footer, "style")),
+			colorSource: parseColorSource(
+				resolvedValue(footer, "colorSource", colorSources, "starship"),
+				defaultComponents.footer.colorSource,
+			),
+			modelLabel: parseEditorModelLabel(
+				resolvedValue(footer, "modelLabel", config, "editorModelLabel"),
+			),
+			styles: {
+				starship: {
+					format:
+						typeof resolvedValue(starship, "format", config, "footerFormat") === "string"
+							? (resolvedValue(starship, "format", config, "footerFormat") as string)
+							: defaultStarshipStyle.format,
+					responsive: parseBoolean(
+						resolvedValue(starship, "responsive", config, "responsiveFooter"),
+						defaultStarshipStyle.responsive,
+					),
+					compactFormat: parseNonEmptyString(compactFormat, defaultStarshipStyle.compactFormat),
+					compactMaxLines: parseCompactFooterMaxLines(
+						resolvedValue(starship, "compactMaxLines", config, "compactFooterMaxLines"),
+					),
+					separator: parseSeparatorStyle(resolvedValue(starship, "separator", config, "separator")),
+					contextStyle: parseContextStyle(
+						resolvedValue(starship, "contextStyle", config, "contextStyle"),
+					),
+					contextThresholds: footerThresholds,
+					pathDisplay: resolvePathDisplay(starship.pathDisplay, config.pathDisplay),
+					segments: resolveFooterSegments(starship.segments, config.footerSegments),
+					gitBranch: resolveGitBranch(starship.gitBranch, config.gitBranch),
+					gitCommit: resolveGitCommit(starship.gitCommit, config.gitCommit),
+					gitMetrics: resolveGitMetrics(starship.gitMetrics, config.gitMetrics),
+					extensionStatuses: resolveExtensionStatuses(
+						starship.extensionStatuses,
+						config.extensionStatuses,
+					),
+				},
+			},
 		},
-		colorSources: { ...colorSources },
-		features: { ...features },
-		footerSegments: { ...footerSegments },
-		gitCommit,
-		gitMetrics,
-		extensionStatuses: {
-			defaultPlacement: extensionStatuses.defaultPlacement,
-			placements: { ...extensionStatuses.placements },
-			colorModes: { ...extensionStatuses.colorModes },
-		},
-		fixedEditor,
 	};
+}
+
+function compatibilityView(config: ZentuiConfig): PolishedTuiConfig {
+	const starship = config.components.footer.styles.starship;
+	const minimalist = config.components.editor.styles.minimalist;
+	return {
+		...config,
+		footerFormat: starship.format,
+		responsiveFooter: starship.responsive,
+		compactFooterFormat: starship.compactFormat,
+		compactFooterMaxLines: starship.compactMaxLines,
+		separator: starship.separator,
+		contextStyle: starship.contextStyle,
+		contextThresholds: starship.contextThresholds,
+		pathDisplay: starship.pathDisplay,
+		gitBranch: starship.gitBranch,
+		footerSegments: starship.segments,
+		gitCommit: starship.gitCommit,
+		gitMetrics: starship.gitMetrics,
+		extensionStatuses: starship.extensionStatuses,
+		editorStyle: config.components.editor.style,
+		editorStyles: { minimalist },
+		editorMetadataFormat: config.components.editor.styles.polished.metadataFormat,
+		editorBorderColorMode: config.components.editor.borderColorMode,
+		editorModelLabel: config.components.editor.modelLabel,
+		colorSources: {
+			starship: config.components.footer.colorSource,
+			editor: config.components.editor.colorSource,
+			userMessages: config.components.userMessages.colorSource,
+		},
+		features: {
+			editor: config.components.editor.enabled,
+			statusLine: config.components.footer.enabled,
+			copyFriendly: config.components.editor.styles.polished.copyFriendly,
+			viewportIndicators: config.components.editor.viewportIndicators,
+		},
+		fixedEditor: config.layout.fixedEditor,
+	};
+}
+
+export function mergeConfig(parsed: unknown): PolishedTuiConfig {
+	const config = isRecord(parsed) ? parsed : {};
+	const iconsRecord = recordValue(config.icons);
+	const colorsRecord = recordValue(config.colors);
+	const layout = recordValue(config.layout);
+	const canonical: ZentuiConfig = {
+		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
+		icons: resolveConfiguredIcons(
+			normalizeIconMode(iconsRecord.mode),
+			normalizeIconOverrides(iconsRecord),
+		),
+		colors: { ...defaultConfig.colors, ...normalizeColors(colorsRecord) },
+		components: resolveComponents(config),
+		layout: {
+			fixedEditor: resolveFixedEditor(layout.fixedEditor, config.fixedEditor),
+		},
+	};
+	return compatibilityView(canonical);
 }
 
 export function getExtensionStatusPlacement(
@@ -954,55 +1236,264 @@ export function loadConfig(): PolishedTuiConfig {
 	}
 }
 
+function overlayKnown(raw: unknown, known: unknown): unknown {
+	if (!isRecord(known)) return known;
+	const output: ConfigRecord = isRecord(raw) ? { ...raw } : {};
+	for (const [key, value] of Object.entries(known)) {
+		Object.defineProperty(output, key, {
+			value: overlayKnown(output[key], value),
+			enumerable: true,
+			configurable: true,
+			writable: true,
+		});
+	}
+	return output;
+}
+
+function saveComponentsMutation(
+	update: (components: ComponentsConfig) => void,
+	path: string,
+): PolishedTuiConfig {
+	return mutateConfig(path, (record) => {
+		const components = mergeConfig(record).components;
+		update(components);
+		const normalized = resolveComponents({ components });
+		record.components = overlayKnown(record.components, normalized);
+	});
+}
+
+function applyEditorComponentPatch(
+	component: EditorComponentConfig,
+	patch: Partial<
+		Pick<
+			EditorComponentConfig,
+			"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+		>
+	>,
+): void {
+	if (patch.enabled !== undefined) component.enabled = patch.enabled;
+	if (patch.style !== undefined) component.style = patch.style;
+	if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+	if (patch.borderColorMode !== undefined) component.borderColorMode = patch.borderColorMode;
+	if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;
+	if (patch.viewportIndicators !== undefined) {
+		component.viewportIndicators = patch.viewportIndicators;
+	}
+}
+
+export function saveEditorComponentPatch(
+	patch: Partial<
+		Pick<
+			EditorComponentConfig,
+			"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+		>
+	>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation(
+		(components) => applyEditorComponentPatch(components.editor, patch),
+		path,
+	);
+}
+
+export function savePolishedEditorStylePatch(
+	patch: Partial<PolishedEditorStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const style = components.editor.styles.polished;
+		if (patch.copyFriendly !== undefined) style.copyFriendly = patch.copyFriendly;
+		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
+	}, path);
+}
+
+function applyMinimalistStylePatch(
+	style: MinimalistEditorStyleConfig,
+	patch: Partial<MinimalistEditorStyleConfig>,
+): void {
+	if (patch.pathDisplay !== undefined) style.pathDisplay = patch.pathDisplay;
+	if (patch.contextFormat !== undefined) style.contextFormat = patch.contextFormat;
+	if (patch.contextGauge !== undefined) style.contextGauge = patch.contextGauge;
+	if (patch.showSessionName !== undefined) style.showSessionName = patch.showSessionName;
+	if (patch.showTimer !== undefined) style.showTimer = patch.showTimer;
+	if (patch.showCost !== undefined) style.showCost = patch.showCost;
+	if (patch.showGit !== undefined) style.showGit = patch.showGit;
+	if (patch.contextThresholds !== undefined) {
+		style.contextThresholds = { ...style.contextThresholds, ...patch.contextThresholds };
+	}
+}
+
+export function saveMinimalistEditorStylePatch(
+	patch: Partial<MinimalistEditorStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation(
+		(components) => applyMinimalistStylePatch(components.editor.styles.minimalist, patch),
+		path,
+	);
+}
+
+export function saveUserMessagesComponentPatch(
+	patch: Partial<Pick<UserMessagesComponentConfig, "enabled" | "style" | "colorSource">>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const component = components.userMessages;
+		if (patch.enabled !== undefined) component.enabled = patch.enabled;
+		if (patch.style !== undefined) component.style = patch.style;
+		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+	}, path);
+}
+
+export function saveFramedUserMessagesStylePatch(
+	patch: Partial<FramedUserMessageStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		if (patch.copyFriendly !== undefined) {
+			components.userMessages.styles.framed.copyFriendly = patch.copyFriendly;
+		}
+	}, path);
+}
+
+export function saveSelectorBordersComponentPatch(
+	patch: Partial<SelectorBordersComponentConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const component = components.selectorBorders;
+		if (patch.enabled !== undefined) component.enabled = patch.enabled;
+		if (patch.style !== undefined) component.style = patch.style;
+		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+	}, path);
+}
+
+export function saveFooterComponentPatch(
+	patch: Partial<Pick<FooterComponentConfig, "enabled" | "style" | "colorSource" | "modelLabel">>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const component = components.footer;
+		if (patch.enabled !== undefined) component.enabled = patch.enabled;
+		if (patch.style !== undefined) component.style = patch.style;
+		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+		if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;
+	}, path);
+}
+
+function applyStarshipStylePatch(
+	style: StarshipFooterStyleConfig,
+	patch: Partial<StarshipFooterStyleConfig>,
+): void {
+	if (patch.format !== undefined) style.format = patch.format;
+	if (patch.responsive !== undefined) style.responsive = patch.responsive;
+	if (patch.compactFormat !== undefined) style.compactFormat = patch.compactFormat;
+	if (patch.compactMaxLines !== undefined) style.compactMaxLines = patch.compactMaxLines;
+	if (patch.separator !== undefined) style.separator = patch.separator;
+	if (patch.contextStyle !== undefined) style.contextStyle = patch.contextStyle;
+	if (patch.contextThresholds !== undefined) {
+		style.contextThresholds = { ...style.contextThresholds, ...patch.contextThresholds };
+	}
+	if (patch.pathDisplay !== undefined) {
+		style.pathDisplay = { ...style.pathDisplay, ...patch.pathDisplay };
+	}
+	if (patch.segments !== undefined) style.segments = { ...style.segments, ...patch.segments };
+	if (patch.gitBranch !== undefined) style.gitBranch = { ...style.gitBranch, ...patch.gitBranch };
+	if (patch.gitCommit !== undefined) style.gitCommit = { ...style.gitCommit, ...patch.gitCommit };
+	if (patch.gitMetrics !== undefined)
+		style.gitMetrics = { ...style.gitMetrics, ...patch.gitMetrics };
+	if (patch.extensionStatuses !== undefined) {
+		style.extensionStatuses = {
+			...style.extensionStatuses,
+			...patch.extensionStatuses,
+			placements: {
+				...style.extensionStatuses.placements,
+				...patch.extensionStatuses.placements,
+			},
+			colorModes: {
+				...style.extensionStatuses.colorModes,
+				...patch.extensionStatuses.colorModes,
+			},
+		};
+	}
+}
+
+export function saveStarshipFooterStylePatch(
+	patch: Partial<StarshipFooterStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation(
+		(components) => applyStarshipStylePatch(components.footer.styles.starship, patch),
+		path,
+	);
+}
+
+export function saveLayoutFixedEditorPatch(
+	patch: Partial<FixedEditorConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return mutateConfig(path, (record) => {
+		const fixedEditor = mergeConfig(record).layout.fixedEditor;
+		if (patch.enabled !== undefined) fixedEditor.enabled = patch.enabled;
+		if (patch.mouseScroll !== undefined) fixedEditor.mouseScroll = patch.mouseScroll;
+		if (patch.copyNotice !== undefined) fixedEditor.copyNotice = patch.copyNotice;
+		const normalized = normalizeFixedEditorConfig(fixedEditor as unknown as ConfigRecord);
+		const layout = recordValue(record.layout);
+		record.layout = overlayKnown(layout, { fixedEditor: normalized });
+	});
+}
+
 export function saveColorSourcesPatch(
 	patch: Partial<ColorSourcesConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.colorSources)
-			? { ...(record.colorSources as Record<string, unknown>) }
-			: {};
-		record.colorSources = {
-			...existing,
-			...validColorSourceEntries(patch),
-		};
-	});
+	const valid = validColorSourceEntries(patch);
+	return saveComponentsMutation((components) => {
+		if (valid.starship !== undefined) components.footer.colorSource = valid.starship;
+		if (valid.editor !== undefined) {
+			components.editor.colorSource = valid.editor;
+			components.selectorBorders.colorSource = valid.editor;
+		}
+		if (valid.userMessages !== undefined) {
+			components.userMessages.colorSource = valid.userMessages;
+		}
+	}, path);
 }
 
 export function saveUiFeaturesPatch(
 	patch: Partial<UiFeaturesConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.features)
-			? { ...(record.features as Record<string, unknown>) }
-			: {};
-		record.features = {
-			...existing,
-			...validUiFeatureEntries(patch),
-		};
-	});
+	const valid = validUiFeatureEntries(patch);
+	return saveComponentsMutation((components) => {
+		if (valid.editor !== undefined) {
+			components.editor.enabled = valid.editor;
+			components.userMessages.enabled = valid.editor;
+			components.selectorBorders.enabled = valid.editor;
+		}
+		if (valid.statusLine !== undefined) components.footer.enabled = valid.statusLine;
+		if (valid.viewportIndicators !== undefined) {
+			components.editor.viewportIndicators = valid.viewportIndicators;
+		}
+		if (valid.copyFriendly !== undefined) {
+			components.editor.styles.polished.copyFriendly = valid.copyFriendly;
+			components.userMessages.styles.framed.copyFriendly = valid.copyFriendly;
+		}
+	}, path);
 }
 
 export function saveFooterSegmentsPatch(
 	patch: Partial<FooterSegmentsConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.footerSegments)
-			? { ...(record.footerSegments as Record<string, unknown>) }
-			: {};
-		record.footerSegments = {
-			...existing,
-			...validFooterSegmentEntries(patch),
-		};
-	});
+	return saveStarshipFooterStylePatch(
+		{ segments: validFooterSegmentEntries(patch) as FooterSegmentsConfig },
+		path,
+	);
 }
 
 export function saveFooterFormatPatch(value: string, path = configPath): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.footerFormat = typeof value === "string" ? value : "";
-	});
+	return saveStarshipFooterStylePatch({ format: typeof value === "string" ? value : "" }, path);
 }
 
 export function saveResponsiveFooterPatch(
@@ -1011,173 +1502,146 @@ export function saveResponsiveFooterPatch(
 	>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		if (typeof patch.responsiveFooter === "boolean") {
-			record.responsiveFooter = patch.responsiveFooter;
-		}
-		if (typeof patch.compactFooterFormat === "string") {
-			record.compactFooterFormat = patch.compactFooterFormat;
-		}
-		if (patch.compactFooterMaxLines !== undefined) {
-			record.compactFooterMaxLines = parseCompactFooterMaxLines(patch.compactFooterMaxLines);
-		}
-	});
+	const canonical: Partial<StarshipFooterStyleConfig> = {};
+	if (typeof patch.responsiveFooter === "boolean") canonical.responsive = patch.responsiveFooter;
+	if (typeof patch.compactFooterFormat === "string")
+		canonical.compactFormat = patch.compactFooterFormat;
+	if (patch.compactFooterMaxLines !== undefined) {
+		canonical.compactMaxLines = parseCompactFooterMaxLines(patch.compactFooterMaxLines);
+	}
+	return saveStarshipFooterStylePatch(canonical, path);
 }
 
 export function saveIconsModePatch(mode: IconMode, path = configPath): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.icons) ? { ...(record.icons as Record<string, unknown>) } : {};
-		record.icons = {
-			...existing,
-			mode: normalizeIconMode(mode),
-		};
+		const existing = isRecord(record.icons) ? { ...record.icons } : {};
+		record.icons = { ...existing, mode: normalizeIconMode(mode) };
 	});
 }
 
 export function saveContextStylePatch(style: ContextStyle, path = configPath): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.contextStyle = parseContextStyle(style);
-	});
+	return saveStarshipFooterStylePatch({ contextStyle: parseContextStyle(style) }, path);
 }
 
 export function saveSeparatorPatch(
 	separator: SeparatorStyle,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.separator = parseSeparatorStyle(separator);
-	});
+	return saveStarshipFooterStylePatch({ separator: parseSeparatorStyle(separator) }, path);
 }
 
 export function saveContextThresholdsPatch(
 	thresholds: Partial<ContextThresholds>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.contextThresholds)
-			? { ...(record.contextThresholds as Record<string, unknown>) }
-			: {};
-		record.contextThresholds = {
-			...existing,
+	if (typeof thresholds.warning === "bigint" || typeof thresholds.error === "bigint") {
+		throw new TypeError("Context thresholds must be JSON-serializable numbers");
+	}
+	return saveComponentsMutation((components) => {
+		components.editor.styles.minimalist.contextThresholds = {
+			...components.editor.styles.minimalist.contextThresholds,
 			...thresholds,
 		};
-	});
+		components.footer.styles.starship.contextThresholds = {
+			...components.footer.styles.starship.contextThresholds,
+			...thresholds,
+		};
+	}, path);
 }
 
 export function savePathDisplayPatch(
 	patch: Partial<PathDisplayConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.pathDisplay)
-			? { ...(record.pathDisplay as Record<string, unknown>) }
-			: {};
-		if (patch.mode !== undefined) existing.mode = patch.mode;
-		if (patch.depth !== undefined) existing.depth = patch.depth;
-		record.pathDisplay = existing;
-	});
+	return saveComponentsMutation((components) => {
+		components.footer.styles.starship.pathDisplay = {
+			...components.footer.styles.starship.pathDisplay,
+			...patch,
+		};
+	}, path);
 }
 
 export function saveGitBranchPatch(
 	patch: Partial<GitBranchConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.gitBranch)
-			? { ...(record.gitBranch as Record<string, unknown>) }
-			: {};
-		if (patch.maxLength !== undefined)
-			existing.maxLength = normalizeGitBranchMaxLength(patch.maxLength);
-		record.gitBranch = existing;
-	});
+	return saveComponentsMutation((components) => {
+		components.footer.styles.starship.gitBranch = {
+			...components.footer.styles.starship.gitBranch,
+			...patch,
+		};
+	}, path);
 }
 
 export function saveEditorModelLabel(
 	value: ModelLabelSource,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.editorModelLabel = parseEditorModelLabel(value);
-	});
+	return saveComponentsMutation((components) => {
+		const normalized = parseEditorModelLabel(value);
+		components.editor.modelLabel = normalized;
+		components.footer.modelLabel = normalized;
+	}, path);
 }
 
 export function saveEditorStyle(value: EditorStyle, path = configPath): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.editorStyle = parseEditorStyle(value);
-	});
+	return saveEditorComponentPatch({ style: parseEditorStyle(value) }, path);
 }
 
 export function saveMinimalistPatch(
 	patch: Partial<MinimalistConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const editorStyles = isRecord(record.editorStyles)
-			? { ...(record.editorStyles as Record<string, unknown>) }
-			: {};
-		const existing = isRecord(editorStyles.minimalist)
-			? { ...(editorStyles.minimalist as Record<string, unknown>) }
-			: {};
-		const normalized = normalizeMinimalistConfig({ ...existing, ...patch });
-		editorStyles.minimalist = { ...existing, ...normalized };
-		record.editorStyles = editorStyles;
-	});
+	return saveMinimalistEditorStylePatch(patch, path);
 }
 
 export function saveEditorBorderColorMode(
 	value: EditorBorderColorMode,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		record.editorBorderColorMode = parseEditorBorderColorMode(value);
-	});
+	return saveEditorComponentPatch({ borderColorMode: parseEditorBorderColorMode(value) }, path);
 }
 
 export function saveGitCommitPatch(
 	patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.gitCommit)
-			? { ...(record.gitCommit as Record<string, unknown>) }
-			: {};
-		if (typeof patch.onlyDetached === "boolean") existing.onlyDetached = patch.onlyDetached;
-		if (typeof patch.showTag === "boolean") existing.showTag = patch.showTag;
-		record.gitCommit = existing;
-	});
+	const valid: Partial<GitCommitConfig> = {};
+	if (typeof patch.onlyDetached === "boolean") valid.onlyDetached = patch.onlyDetached;
+	if (typeof patch.showTag === "boolean") valid.showTag = patch.showTag;
+	return saveComponentsMutation((components) => {
+		components.footer.styles.starship.gitCommit = {
+			...components.footer.styles.starship.gitCommit,
+			...valid,
+		};
+	}, path);
 }
 
 export function saveGitMetricsPatch(
 	patch: Partial<GitMetricsConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.gitMetrics)
-			? { ...(record.gitMetrics as Record<string, unknown>) }
-			: {};
-		if (typeof patch.onlyNonzero === "boolean") existing.onlyNonzero = patch.onlyNonzero;
-		if (typeof patch.ignoreSubmodules === "boolean") {
-			existing.ignoreSubmodules = patch.ignoreSubmodules;
-		}
-		record.gitMetrics = existing;
-	});
+	const valid: Partial<GitMetricsConfig> = {};
+	if (typeof patch.onlyNonzero === "boolean") valid.onlyNonzero = patch.onlyNonzero;
+	if (typeof patch.ignoreSubmodules === "boolean") valid.ignoreSubmodules = patch.ignoreSubmodules;
+	return saveComponentsMutation((components) => {
+		components.footer.styles.starship.gitMetrics = {
+			...components.footer.styles.starship.gitMetrics,
+			...valid,
+		};
+	}, path);
 }
 
 export function saveExtensionStatusDefaultPlacement(
 	placement: ExtensionStatusPlacement,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.extensionStatuses)
-			? { ...(record.extensionStatuses as Record<string, unknown>) }
-			: {};
-		record.extensionStatuses = {
-			...existing,
-			defaultPlacement: isExtensionStatusPlacement(placement)
+	return saveComponentsMutation((components) => {
+		components.footer.styles.starship.extensionStatuses.defaultPlacement =
+			isExtensionStatusPlacement(placement)
 				? placement
-				: defaultConfig.extensionStatuses.defaultPlacement,
-		};
-	});
+				: defaultConfig.extensionStatuses.defaultPlacement;
+	}, path);
 }
 
 export function saveExtensionStatusPlacement(
@@ -1185,26 +1649,14 @@ export function saveExtensionStatusPlacement(
 	placement: ExtensionStatusPlacement,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existingExtensionStatuses = isRecord(record.extensionStatuses)
-			? { ...(record.extensionStatuses as Record<string, unknown>) }
-			: {};
-		const existingPlacements = isRecord(existingExtensionStatuses.placements)
-			? { ...(existingExtensionStatuses.placements as Record<string, unknown>) }
-			: {};
-
-		Object.defineProperty(existingPlacements, key, {
+	return saveComponentsMutation((components) => {
+		Object.defineProperty(components.footer.styles.starship.extensionStatuses.placements, key, {
 			value: placement,
 			enumerable: true,
 			configurable: true,
 			writable: true,
 		});
-
-		record.extensionStatuses = {
-			...existingExtensionStatuses,
-			placements: existingPlacements,
-		};
-	});
+	}, path);
 }
 
 export function saveExtensionStatusColorMode(
@@ -1212,41 +1664,19 @@ export function saveExtensionStatusColorMode(
 	colorMode: ExtensionStatusColorMode,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existingExtensionStatuses = isRecord(record.extensionStatuses)
-			? { ...(record.extensionStatuses as Record<string, unknown>) }
-			: {};
-		const existingColorModes = isRecord(existingExtensionStatuses.colorModes)
-			? { ...(existingExtensionStatuses.colorModes as Record<string, unknown>) }
-			: {};
-
-		Object.defineProperty(existingColorModes, key, {
+	return saveComponentsMutation((components) => {
+		Object.defineProperty(components.footer.styles.starship.extensionStatuses.colorModes, key, {
 			value: colorMode,
 			enumerable: true,
 			configurable: true,
 			writable: true,
 		});
-
-		record.extensionStatuses = {
-			...existingExtensionStatuses,
-			colorModes: existingColorModes,
-		};
-	});
+	}, path);
 }
 
 export function saveFixedEditorPatch(
 	patch: Partial<FixedEditorConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return mutateConfig(path, (record) => {
-		const existing = isRecord(record.fixedEditor)
-			? { ...(record.fixedEditor as Record<string, unknown>) }
-			: {};
-		record.fixedEditor = {
-			...existing,
-			...(patch.enabled !== undefined ? { enabled: patch.enabled } : {}),
-			...(patch.mouseScroll !== undefined ? { mouseScroll: patch.mouseScroll } : {}),
-			...(patch.copyNotice !== undefined ? { copyNotice: patch.copyNotice } : {}),
-		};
-	});
+	return saveLayoutFixedEditorPatch(patch, path);
 }

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -33,8 +33,8 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
-export type EditorStyle = "polished" | "minimalist";
-export type UserMessageStyle = "framed";
+export type EditorStyle = "polished" | "polished-copy-friendly" | "minimalist";
+export type UserMessageStyle = "framed" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
 export type FooterStyle = "starship";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
@@ -73,7 +73,6 @@ export type ColorSourcesConfig = {
 export type UiFeaturesConfig = {
 	editor: boolean;
 	statusLine: boolean;
-	copyFriendly: boolean;
 	viewportIndicators: boolean;
 };
 
@@ -104,7 +103,10 @@ export type FixedEditorConfig = {
 };
 
 export type PolishedEditorStyleConfig = {
-	copyFriendly: boolean;
+	metadataFormat: string;
+};
+
+export type PolishedCopyFriendlyEditorStyleConfig = {
 	metadataFormat: string;
 };
 
@@ -135,13 +137,14 @@ export type EditorComponentConfig = {
 	viewportIndicators: boolean;
 	styles: {
 		polished: PolishedEditorStyleConfig;
+		"polished-copy-friendly": PolishedCopyFriendlyEditorStyleConfig;
 		minimalist: MinimalistEditorStyleConfig;
 	};
 };
 
-export type FramedUserMessageStyleConfig = {
-	copyFriendly: boolean;
-};
+export type FramedUserMessageStyleConfig = Record<string, never>;
+export type CompactUserMessageStyleConfig = Record<string, never>;
+export type LabeledUserMessageStyleConfig = Record<string, never>;
 
 export type UserMessagesComponentConfig = {
 	enabled: boolean;
@@ -149,6 +152,8 @@ export type UserMessagesComponentConfig = {
 	colorSource: ColorSource;
 	styles: {
 		framed: FramedUserMessageStyleConfig;
+		compact: CompactUserMessageStyleConfig;
+		labeled: LabeledUserMessageStyleConfig;
 	};
 };
 
@@ -406,7 +411,8 @@ const defaultComponents: ComponentsConfig = {
 		modelLabel: "id",
 		viewportIndicators: true,
 		styles: {
-			polished: { copyFriendly: false, metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			polished: { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			"polished-copy-friendly": { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
 			minimalist: defaultMinimalistStyle,
 		},
 	},
@@ -414,7 +420,7 @@ const defaultComponents: ComponentsConfig = {
 		enabled: true,
 		style: "framed",
 		colorSource: "theme",
-		styles: { framed: { copyFriendly: false } },
+		styles: { framed: {}, compact: {}, labeled: {} },
 	},
 	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 	footer: {
@@ -471,7 +477,6 @@ export const defaultConfig: PolishedTuiConfig = {
 	features: {
 		editor: true,
 		statusLine: true,
-		copyFriendly: false,
 		viewportIndicators: true,
 	},
 	footerSegments: defaultFooterSegments,
@@ -516,7 +521,9 @@ function parseEditorModelLabel(
 }
 
 function parseEditorStyle(value: unknown): EditorStyle {
-	if (value === "polished" || value === "minimalist") return value;
+	if (value === "polished" || value === "polished-copy-friendly" || value === "minimalist") {
+		return value;
+	}
 	return defaultConfig.editorStyle;
 }
 
@@ -740,12 +747,7 @@ function isColorSourceKey(value: string): value is keyof ColorSourcesConfig {
 }
 
 function isUiFeatureKey(value: string): value is keyof UiFeaturesConfig {
-	return (
-		value === "editor" ||
-		value === "statusLine" ||
-		value === "copyFriendly" ||
-		value === "viewportIndicators"
-	);
+	return value === "editor" || value === "statusLine" || value === "viewportIndicators";
 }
 
 function isFooterSegmentKey(value: string): value is keyof FooterSegmentsConfig {
@@ -910,10 +912,6 @@ function parseColorSource(value: unknown, fallback: ColorSource): ColorSource {
 	return value === "theme" || value === "terminal" ? value : fallback;
 }
 
-function parseUserMessageStyle(value: unknown): UserMessageStyle {
-	return value === "framed" ? value : "framed";
-}
-
 function parseSelectorBorderStyle(value: unknown): SelectorBorderStyle {
 	return value === "zentui" ? value : "zentui";
 }
@@ -1011,11 +1009,65 @@ function resolveFixedEditor(canonical: unknown, legacy: unknown): FixedEditorCon
 	});
 }
 
+function legacyCopyFriendly(record: ConfigRecord): boolean {
+	return record.copyFriendly === true;
+}
+
+function resolveEditorStyle(
+	editor: ConfigRecord,
+	polished: ConfigRecord,
+	features: ConfigRecord,
+): EditorStyle {
+	const rawStyle = editor.style;
+	if (rawStyle === "minimalist" || rawStyle === "polished-copy-friendly") return rawStyle;
+	if (rawStyle === "polished") {
+		return hasOwn(polished, "copyFriendly") && legacyCopyFriendly(polished)
+			? "polished-copy-friendly"
+			: "polished";
+	}
+	if (hasOwn(polished, "copyFriendly")) {
+		return legacyCopyFriendly(polished) ? "polished-copy-friendly" : "polished";
+	}
+	return legacyCopyFriendly(features) ? "polished-copy-friendly" : "polished";
+}
+
+function resolveUserMessagesSelection(
+	userMessages: ConfigRecord,
+	framed: ConfigRecord,
+	features: ConfigRecord,
+): Pick<UserMessagesComponentConfig, "enabled" | "style"> {
+	const normalEnabled = parseBoolean(
+		resolvedValue(userMessages, "enabled", features, "editor"),
+		defaultComponents.userMessages.enabled,
+	);
+	const rawStyle = userMessages.style;
+	if (rawStyle === "compact" || rawStyle === "labeled") {
+		return { style: rawStyle, enabled: normalEnabled };
+	}
+	if (rawStyle === "framed") {
+		return {
+			style: "framed",
+			enabled: hasOwn(framed, "copyFriendly") && legacyCopyFriendly(framed) ? false : normalEnabled,
+		};
+	}
+	if (hasOwn(framed, "copyFriendly")) {
+		return {
+			style: "framed",
+			enabled: legacyCopyFriendly(framed) ? false : normalEnabled,
+		};
+	}
+	return {
+		style: "framed",
+		enabled: legacyCopyFriendly(features) ? false : normalEnabled,
+	};
+}
+
 function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const components = recordValue(config.components);
 	const editor = recordValue(components.editor);
 	const editorStyles = recordValue(editor.styles);
 	const polished = recordValue(editorStyles.polished);
+	const polishedCopyFriendly = recordValue(editorStyles["polished-copy-friendly"]);
 	const minimalist = recordValue(editorStyles.minimalist);
 	const userMessages = recordValue(components.userMessages);
 	const userMessageStyles = recordValue(userMessages.styles);
@@ -1039,6 +1091,13 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	);
 	const compactFormat = resolvedValue(starship, "compactFormat", config, "compactFooterFormat");
 	const metadataFormat = resolvedValue(polished, "metadataFormat", config, "editorMetadataFormat");
+	const lowRailMetadataFormat = resolvedValue(
+		polishedCopyFriendly,
+		"metadataFormat",
+		polished,
+		"metadataFormat",
+	);
+	const userMessagesSelection = resolveUserMessagesSelection(userMessages, framed, features);
 
 	return {
 		editor: {
@@ -1046,7 +1105,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 				resolvedValue(editor, "enabled", features, "editor"),
 				defaultComponents.editor.enabled,
 			),
-			style: parseEditorStyle(resolvedValue(editor, "style")),
+			style: resolveEditorStyle(editor, polished, features),
 			colorSource: parseColorSource(
 				resolvedValue(editor, "colorSource", colorSources, "editor"),
 				defaultComponents.editor.colorSource,
@@ -1064,11 +1123,13 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 			styles: {
 				polished: {
-					copyFriendly: parseBoolean(
-						resolvedValue(polished, "copyFriendly", features, "copyFriendly"),
-						defaultComponents.editor.styles.polished.copyFriendly,
-					),
 					metadataFormat: parseNonEmptyString(metadataFormat, DEFAULT_EDITOR_METADATA_FORMAT),
+				},
+				"polished-copy-friendly": {
+					metadataFormat: parseNonEmptyString(
+						lowRailMetadataFormat ?? config.editorMetadataFormat,
+						DEFAULT_EDITOR_METADATA_FORMAT,
+					),
 				},
 				minimalist: {
 					pathDisplay:
@@ -1094,22 +1155,16 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			},
 		},
 		userMessages: {
-			enabled: parseBoolean(
-				resolvedValue(userMessages, "enabled", features, "editor"),
-				defaultComponents.userMessages.enabled,
-			),
-			style: parseUserMessageStyle(resolvedValue(userMessages, "style")),
+			enabled: userMessagesSelection.enabled,
+			style: userMessagesSelection.style,
 			colorSource: parseColorSource(
 				resolvedValue(userMessages, "colorSource", colorSources, "userMessages"),
 				defaultComponents.userMessages.colorSource,
 			),
 			styles: {
-				framed: {
-					copyFriendly: parseBoolean(
-						resolvedValue(framed, "copyFriendly", features, "copyFriendly"),
-						defaultComponents.userMessages.styles.framed.copyFriendly,
-					),
-				},
+				framed: {},
+				compact: {},
+				labeled: {},
 			},
 		},
 		selectorBorders: {
@@ -1202,7 +1257,6 @@ function compatibilityView(config: ZentuiConfig): PolishedTuiConfig {
 		features: {
 			editor: config.components.editor.enabled,
 			statusLine: config.components.footer.enabled,
-			copyFriendly: config.components.editor.styles.polished.copyFriendly,
 			viewportIndicators: config.components.editor.viewportIndicators,
 		},
 		fixedEditor: config.layout.fixedEditor,
@@ -1270,16 +1324,91 @@ function overlayKnown(raw: unknown, known: unknown): unknown {
 	return output;
 }
 
+type ComponentStyleOwner = keyof ComponentsConfig;
+
+type PreservedStyleIds = Partial<Record<ComponentStyleOwner, string>>;
+
+function unknownSelectedStyleIds(record: ConfigRecord): PreservedStyleIds {
+	const components = recordValue(record.components);
+	const editorStyle = recordValue(components.editor).style;
+	const userMessageStyle = recordValue(components.userMessages).style;
+	const selectorBorderStyle = recordValue(components.selectorBorders).style;
+	const footerStyle = recordValue(components.footer).style;
+	return {
+		editor:
+			typeof editorStyle === "string" &&
+			editorStyle !== "polished" &&
+			editorStyle !== "polished-copy-friendly" &&
+			editorStyle !== "minimalist"
+				? editorStyle
+				: undefined,
+		userMessages:
+			typeof userMessageStyle === "string" &&
+			userMessageStyle !== "framed" &&
+			userMessageStyle !== "compact" &&
+			userMessageStyle !== "labeled"
+				? userMessageStyle
+				: undefined,
+		selectorBorders:
+			typeof selectorBorderStyle === "string" && selectorBorderStyle !== "zentui"
+				? selectorBorderStyle
+				: undefined,
+		footer: typeof footerStyle === "string" && footerStyle !== "starship" ? footerStyle : undefined,
+	};
+}
+
+function restoreUnknownSelectedStyleIds(
+	record: ConfigRecord,
+	preserved: PreservedStyleIds,
+	replacedStyle?: ComponentStyleOwner,
+): void {
+	const components = recordValue(record.components);
+	for (const [owner, style] of Object.entries(preserved) as [ComponentStyleOwner, string][]) {
+		if (style === undefined || owner === replacedStyle) continue;
+		const component = recordValue(components[owner]);
+		component.style = style;
+		components[owner] = component;
+	}
+	record.components = components;
+}
+
 function saveComponentsMutation(
 	update: (components: ComponentsConfig) => void,
 	path: string,
+	cleanupRaw?: (record: ConfigRecord) => void,
+	replacedStyle?: ComponentStyleOwner,
 ): PolishedTuiConfig {
 	return mutateConfig(path, (record) => {
+		const preservedStyles = unknownSelectedStyleIds(record);
 		const components = mergeConfig(record).components;
 		update(components);
 		const normalized = resolveComponents({ components });
 		record.components = overlayKnown(record.components, normalized);
+		restoreUnknownSelectedStyleIds(record, preservedStyles, replacedStyle);
+		cleanupRaw?.(record);
 	});
+}
+
+function deleteLegacyEditorCopyFriendly(record: ConfigRecord): void {
+	const components = record.components;
+	if (!isRecord(components)) return;
+	const editor = components.editor;
+	if (!isRecord(editor)) return;
+	const styles = editor.styles;
+	if (!isRecord(styles)) return;
+	const polished = styles.polished;
+	if (isRecord(polished)) delete polished.copyFriendly;
+}
+
+function deleteLegacyMessageCopyFriendly(record: ConfigRecord): void {
+	const components = record.components;
+	if (!isRecord(components)) return;
+	const userMessages = components.userMessages;
+	if (!isRecord(userMessages)) return;
+	const styles = userMessages.styles;
+	if (!isRecord(styles)) return;
+	const framed = styles.framed;
+	if (isRecord(framed)) delete framed.copyFriendly;
 }
 
 function applyEditorComponentPatch(
@@ -1313,6 +1442,8 @@ export function saveEditorComponentPatch(
 	return saveComponentsMutation(
 		(components) => applyEditorComponentPatch(components.editor, patch),
 		path,
+		patch.style !== undefined ? deleteLegacyEditorCopyFriendly : undefined,
+		patch.style !== undefined ? "editor" : undefined,
 	);
 }
 
@@ -1322,7 +1453,16 @@ export function savePolishedEditorStylePatch(
 ): PolishedTuiConfig {
 	return saveComponentsMutation((components) => {
 		const style = components.editor.styles.polished;
-		if (patch.copyFriendly !== undefined) style.copyFriendly = patch.copyFriendly;
+		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
+	}, path);
+}
+
+export function savePolishedCopyFriendlyEditorStylePatch(
+	patch: Partial<PolishedCopyFriendlyEditorStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const style = components.editor.styles["polished-copy-friendly"];
 		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
 	}, path);
 }
@@ -1357,48 +1497,52 @@ export function saveUserMessagesComponentPatch(
 	patch: Partial<Pick<UserMessagesComponentConfig, "enabled" | "style" | "colorSource">>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return saveComponentsMutation((components) => {
-		const component = components.userMessages;
-		if (patch.enabled !== undefined) component.enabled = patch.enabled;
-		if (patch.style !== undefined) component.style = patch.style;
-		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
-	}, path);
-}
-
-export function saveFramedUserMessagesStylePatch(
-	patch: Partial<FramedUserMessageStyleConfig>,
-	path = configPath,
-): PolishedTuiConfig {
-	return saveComponentsMutation((components) => {
-		if (patch.copyFriendly !== undefined) {
-			components.userMessages.styles.framed.copyFriendly = patch.copyFriendly;
-		}
-	}, path);
+	return saveComponentsMutation(
+		(components) => {
+			const component = components.userMessages;
+			if (patch.enabled !== undefined) component.enabled = patch.enabled;
+			if (patch.style !== undefined) component.style = patch.style;
+			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+		},
+		path,
+		patch.style !== undefined ? deleteLegacyMessageCopyFriendly : undefined,
+		patch.style !== undefined ? "userMessages" : undefined,
+	);
 }
 
 export function saveSelectorBordersComponentPatch(
 	patch: Partial<SelectorBordersComponentConfig>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return saveComponentsMutation((components) => {
-		const component = components.selectorBorders;
-		if (patch.enabled !== undefined) component.enabled = patch.enabled;
-		if (patch.style !== undefined) component.style = patch.style;
-		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
-	}, path);
+	return saveComponentsMutation(
+		(components) => {
+			const component = components.selectorBorders;
+			if (patch.enabled !== undefined) component.enabled = patch.enabled;
+			if (patch.style !== undefined) component.style = patch.style;
+			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+		},
+		path,
+		undefined,
+		patch.style !== undefined ? "selectorBorders" : undefined,
+	);
 }
 
 export function saveFooterComponentPatch(
 	patch: Partial<Pick<FooterComponentConfig, "enabled" | "style" | "colorSource" | "modelLabel">>,
 	path = configPath,
 ): PolishedTuiConfig {
-	return saveComponentsMutation((components) => {
-		const component = components.footer;
-		if (patch.enabled !== undefined) component.enabled = patch.enabled;
-		if (patch.style !== undefined) component.style = patch.style;
-		if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
-		if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;
-	}, path);
+	return saveComponentsMutation(
+		(components) => {
+			const component = components.footer;
+			if (patch.enabled !== undefined) component.enabled = patch.enabled;
+			if (patch.style !== undefined) component.style = patch.style;
+			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+			if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;
+		},
+		path,
+		undefined,
+		patch.style !== undefined ? "footer" : undefined,
+	);
 }
 
 function applyStarshipStylePatch(
@@ -1494,10 +1638,6 @@ export function saveUiFeaturesPatch(
 		if (valid.statusLine !== undefined) components.footer.enabled = valid.statusLine;
 		if (valid.viewportIndicators !== undefined) {
 			components.editor.viewportIndicators = valid.viewportIndicators;
-		}
-		if (valid.copyFriendly !== undefined) {
-			components.editor.styles.polished.copyFriendly = valid.copyFriendly;
-			components.userMessages.styles.framed.copyFriendly = valid.copyFriendly;
 		}
 	}, path);
 }

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -34,7 +34,7 @@ export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
 export type EditorStyle = "opencode" | "opencode-copy-friendly" | "minimalist";
-export type UserMessageStyle = "framed" | "compact" | "labeled";
+export type UserMessageStyle = "framed" | "framed-copy-friendly" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
 export type FooterStyle = "native" | "starship" | "hidden";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
@@ -143,6 +143,7 @@ export type EditorComponentConfig = {
 };
 
 export type FramedUserMessageStyleConfig = Record<string, never>;
+export type FramedCopyFriendlyUserMessageStyleConfig = Record<string, never>;
 export type CompactUserMessageStyleConfig = Record<string, never>;
 export type LabeledUserMessageStyleConfig = Record<string, never>;
 
@@ -152,6 +153,7 @@ export type UserMessagesComponentConfig = {
 	colorSource: ColorSource;
 	styles: {
 		framed: FramedUserMessageStyleConfig;
+		"framed-copy-friendly": FramedCopyFriendlyUserMessageStyleConfig;
 		compact: CompactUserMessageStyleConfig;
 		labeled: LabeledUserMessageStyleConfig;
 	};
@@ -419,7 +421,7 @@ const defaultComponents: ComponentsConfig = {
 		enabled: true,
 		style: "framed",
 		colorSource: "theme",
-		styles: { framed: {}, compact: {}, labeled: {} },
+		styles: { framed: {}, "framed-copy-friendly": {}, compact: {}, labeled: {} },
 	},
 	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 	footer: {
@@ -1058,24 +1060,18 @@ function resolveUserMessagesSelection(
 		defaultComponents.userMessages.enabled,
 	);
 	const rawStyle = userMessages.style;
-	if (rawStyle === "compact" || rawStyle === "labeled") {
+	if (rawStyle === "compact" || rawStyle === "labeled" || rawStyle === "framed-copy-friendly") {
 		return { style: rawStyle, enabled: normalEnabled };
 	}
-	if (rawStyle === "framed") {
+	if (rawStyle === "framed" || hasOwn(framed, "copyFriendly")) {
 		return {
-			style: "framed",
-			enabled: hasOwn(framed, "copyFriendly") && legacyCopyFriendly(framed) ? false : normalEnabled,
-		};
-	}
-	if (hasOwn(framed, "copyFriendly")) {
-		return {
-			style: "framed",
-			enabled: legacyCopyFriendly(framed) ? false : normalEnabled,
+			style: legacyCopyFriendly(framed) ? "framed-copy-friendly" : "framed",
+			enabled: normalEnabled,
 		};
 	}
 	return {
-		style: "framed",
-		enabled: legacyCopyFriendly(features) ? false : normalEnabled,
+		style: legacyCopyFriendly(features) ? "framed-copy-friendly" : "framed",
+		enabled: normalEnabled,
 	};
 }
 
@@ -1183,6 +1179,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 			styles: {
 				framed: {},
+				"framed-copy-friendly": {},
 				compact: {},
 				labeled: {},
 			},
@@ -1363,6 +1360,7 @@ function unknownSelectedStyleIds(record: ConfigRecord): PreservedStyleIds {
 		userMessages:
 			typeof userMessageStyle === "string" &&
 			userMessageStyle !== "framed" &&
+			userMessageStyle !== "framed-copy-friendly" &&
 			userMessageStyle !== "compact" &&
 			userMessageStyle !== "labeled"
 				? userMessageStyle

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import type { PolishedTuiConfig } from "./config";
+import type { ZentuiConfig } from "./config";
 import { type FormatToken, parseFooterFormat } from "./footer-format";
 import { EDITOR_ACCENT_FALLBACK, renderStyleForSourceOrFallback, safeThemeFg } from "./style";
 
@@ -120,7 +120,7 @@ export function sanitizeEditorMetadataText(value: string): string {
 	return sanitized;
 }
 
-function editorThinkingStyle(config: PolishedTuiConfig, level: string): string | undefined {
+function editorThinkingStyle(config: ZentuiConfig, level: string): string | undefined {
 	switch (level.toLowerCase()) {
 		case "minimal":
 			return config.colors.editorThinkingMinimal ?? config.colors.editorThinking;
@@ -141,9 +141,9 @@ function renderVariable(
 	name: string,
 	values: EditorMetadataValues,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): { plain: string; styled: string } {
-	const colorSource = config.colorSources.editor;
+	const colorSource = config.components.editor.colorSource;
 	const thinking = values.thinking.toLowerCase() === "off" ? "" : values.thinking;
 	const raw =
 		name === "model"
@@ -208,7 +208,7 @@ function renderTokens(
 	tokens: FormatToken[],
 	values: EditorMetadataValues,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): RenderedTokens {
 	let styled = "";
 	let hasDynamic = false;
@@ -248,7 +248,7 @@ export function renderEditorMetadataFormat(
 	format: string,
 	values: EditorMetadataValues,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): string {
 	return renderTokens(
 		parseFooterFormat(sanitizeEditorMetadataText(format)),

--- a/extensions/zentui/extension-status.ts
+++ b/extensions/zentui/extension-status.ts
@@ -1,9 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
-import type {
-	ExtensionStatusColorMode,
-	ExtensionStatusPlacement,
-	PolishedTuiConfig,
-} from "./config";
+import type { ExtensionStatusColorMode, ExtensionStatusPlacement, ZentuiConfig } from "./config";
 import { getExtensionStatusColorMode, getExtensionStatusPlacement } from "./config";
 
 export type ExtensionStatusSegment = {
@@ -59,7 +55,7 @@ export function sanitizeExtensionStatusOriginalText(value: string): string {
 
 export function collectExtensionStatusSegments(
 	statuses: ReadonlyMap<string, string>,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): ExtensionStatusSegmentsByPlacement {
 	const segments: ExtensionStatusSegmentsByPlacement = {
 		left: [],

--- a/extensions/zentui/extension-status.ts
+++ b/extensions/zentui/extension-status.ts
@@ -1,6 +1,10 @@
 import { stripVTControlCharacters } from "node:util";
 import type { ExtensionStatusColorMode, ExtensionStatusPlacement, ZentuiConfig } from "./config";
-import { getExtensionStatusColorMode, getExtensionStatusPlacement } from "./config";
+import {
+	getExtensionStatusColorMode,
+	getExtensionStatusPlacement,
+	isExtensionStatusPlacement,
+} from "./config";
 
 export type ExtensionStatusSegment = {
 	key: string;
@@ -65,7 +69,8 @@ export function collectExtensionStatusSegments(
 
 	for (const [key, value] of statuses.entries()) {
 		const placement = getExtensionStatusPlacement(config, key);
-		if (placement === "off") continue;
+		if (placement === "off" || !isExtensionStatusPlacement(placement)) continue;
+		if (placement !== "left" && placement !== "middle" && placement !== "right") continue;
 
 		const colorMode = getExtensionStatusColorMode(config, key);
 		const text =

--- a/extensions/zentui/fixed-editor/cluster.ts
+++ b/extensions/zentui/fixed-editor/cluster.ts
@@ -1,89 +1,79 @@
-/**
- * Cluster rendering for the fixed editor.
- *
- * Pi-specific cluster discovery and validation live in pi-compat.ts. This module
- * only renders the already-verified pinned components.
- *
- * @internal
- */
+/** Fixed-editor source collection and planned cluster materialization. @internal */
 
 import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-
+import { readFixedEditorLayout } from "./editor-layout";
+import { planFixedLayout, takeTail } from "./layout";
 import type { PiFixedCluster, PiRenderableCapability } from "./pi-compat";
 import type { ClusterRender } from "./types";
 
 export type FixedCluster = PiFixedCluster;
 
-function renderComponent(component: PiRenderableCapability | null, width: number): string[] {
+function renderComponent(
+	component: PiRenderableCapability | null,
+	width: number,
+	trim = true,
+): string[] {
 	if (!component) return [];
 	const lines = component.render.call(component.target, width);
-	// Strip only trailing blank lines — internal blank lines (e.g. low-rail
-	// polished padding) must be preserved.
+	if (!trim) return [...lines];
 	let end = lines.length;
-	while (end > 0 && visibleWidth(lines[end - 1]) === 0) end--;
-	return lines.slice(0, Math.max(end, 1));
+	while (end > 0 && visibleWidth(lines[end - 1] ?? "") === 0) end--;
+	return lines.slice(0, Math.max(end, lines.length > 0 ? 1 : 0));
 }
 
-/**
- * Cap editor lines to `maxLines`, keeping the cursor row visible.
- * If the cursor marker is found, the window centers on it; otherwise
- * the last `maxLines` are kept.
- */
-export function capEditorLines(lines: string[], maxLines: number): string[] {
-	if (maxLines <= 0) return [];
-	if (lines.length <= maxLines) return lines;
-
-	const cursorRow = lines.findIndex((line) => line.includes(CURSOR_MARKER));
-	if (cursorRow !== -1) {
-		const start = Math.max(0, Math.min(cursorRow - maxLines + 1, lines.length - maxLines));
-		return lines.slice(start, start + maxLines);
-	}
-	return lines.slice(lines.length - maxLines);
-}
-
-function sanitizeLines(lines: string[], width: number): string[] {
+function sanitizeLines(lines: readonly string[], width: number): string[] {
 	return lines.map((line) =>
 		visibleWidth(line) > width ? truncateToWidth(line, width, "", true) : line,
 	);
 }
 
-/**
- * Render the full cluster (status + widgets + editor + footer) and extract
- * the cursor position from the CURSOR_MARKER.
- */
+export function collectClusterSource(cluster: FixedCluster, width: number) {
+	const w = Math.max(1, Math.floor(width));
+	const status = sanitizeLines(renderComponent(cluster.status, w), w);
+	const above = sanitizeLines(renderComponent(cluster.aboveWidget, w), w);
+	const editor = sanitizeLines(renderComponent(cluster.editor, w, false), w);
+	const below = sanitizeLines(renderComponent(cluster.belowWidget, w), w);
+	const footer = sanitizeLines(renderComponent(cluster.footer, w), w);
+	const metadata = readFixedEditorLayout(cluster.editorChild, editor, w);
+	return { width: w, status, above, editor, below, footer, metadata };
+}
+
 export function renderCluster(
 	cluster: FixedCluster,
 	width: number,
-	maxHeight: number,
+	rawRows: number,
 ): ClusterRender {
-	const w = Math.max(1, width);
-	const maxRows = Math.max(1, maxHeight - 1);
+	const normalizedRows = Math.max(0, Math.floor(Number.isFinite(rawRows) ? rawRows : 0));
+	if (normalizedRows === 0)
+		return {
+			mode: "no-terminal-rows",
+			lines: [],
+			cursor: null,
+			plan: { mode: "no-terminal-rows", pendingDesiredMode: "fixed" },
+		};
+	const source = collectClusterSource(cluster, width);
+	const plan = planFixedLayout({
+		rawRows: normalizedRows,
+		editorRows: source.editor,
+		metadata: source.metadata,
+		statusRows: source.status,
+		aboveRows: source.above,
+		belowRows: source.below,
+		footerRows: source.footer,
+	});
+	if (plan.mode !== "fixed") return { mode: "normal-flow", lines: [], cursor: null, plan };
 
-	const statusLines = sanitizeLines(renderComponent(cluster.status, w), w);
-	const aboveLines = sanitizeLines(renderComponent(cluster.aboveWidget, w), w);
-	const editorSource = sanitizeLines(renderComponent(cluster.editor, w), w);
-	const belowLines = sanitizeLines(renderComponent(cluster.belowWidget, w), w);
-	const footerLines = sanitizeLines(renderComponent(cluster.footer, w), w);
-
-	const editorLines = capEditorLines(editorSource, maxRows);
-	let remaining = maxRows - editorLines.length;
-
-	const footer = footerLines.slice(-remaining);
-	remaining -= footer.length;
-
-	const below = belowLines.slice(-remaining);
-	remaining -= below.length;
-
-	const above = aboveLines.slice(-remaining);
-	remaining -= above.length;
-
-	const status = statusLines.slice(-remaining);
-
-	let allLines = [...status, ...above, ...editorLines, ...below, ...footer];
-
-	// Strip leading blank lines (e.g. empty status line above the editor border).
+	const selectedRows = new Set([...plan.selectedEditorRows, ...plan.selectedAutocompleteRows]);
+	const editor = source.editor.filter((_line, index) => selectedRows.has(index));
+	let allLines = [
+		...takeTail(source.status, plan.statusBudget),
+		...takeTail(source.above, plan.aboveBudget),
+		...editor,
+		...takeTail(source.below, plan.belowBudget),
+		...takeTail(source.footer, plan.footerBudget),
+	];
 	let start = 0;
-	while (start < allLines.length - 1 && visibleWidth(allLines[start]) === 0) start++;
+	while (start < allLines.length - 1 && visibleWidth(allLines[start] ?? "") === 0) start++;
 	allLines = allLines.slice(start);
 
 	let cursor: { row: number; col: number } | null = null;
@@ -93,6 +83,5 @@ export function renderCluster(
 		cursor ??= { row, col: visibleWidth(line.slice(0, markerIndex)) };
 		return line.slice(0, markerIndex) + line.slice(markerIndex + CURSOR_MARKER.length);
 	});
-
-	return { lines: cleaned, cursor };
+	return { mode: "fixed", lines: cleaned, cursor, plan };
 }

--- a/extensions/zentui/fixed-editor/cluster.ts
+++ b/extensions/zentui/fixed-editor/cluster.ts
@@ -17,8 +17,8 @@ export type FixedCluster = PiFixedCluster;
 function renderComponent(component: PiRenderableCapability | null, width: number): string[] {
 	if (!component) return [];
 	const lines = component.render.call(component.target, width);
-	// Strip only trailing blank lines — internal blank lines (e.g. editor
-	// padding in copy-friendly mode) must be preserved.
+	// Strip only trailing blank lines — internal blank lines (e.g. low-rail
+	// polished padding) must be preserved.
 	let end = lines.length;
 	while (end > 0 && visibleWidth(lines[end - 1]) === 0) end--;
 	return lines.slice(0, Math.max(end, 1));

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -1,19 +1,7 @@
-/**
- * TerminalSplitCompositor — pins editor/footer at the bottom of the terminal
- * while the transcript scrolls above, using terminal scroll regions + alt screen.
- *
- * This patches Pi's internal TUI methods. It is inherently fragile across Pi
- * versions. All patches include capability checks and silent fallback.
- *
- * Adapted from @tifan/pi-fixed-editor (MIT) by Tifan Dwi Avianto, which was
- * itself adapted from pi-powerline-footer (MIT) by Nico Bailon.
- *
- * @internal
- */
+/** Experimental fixed-editor terminal compositor. @internal */
 
 import { copyToClipboard } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-
 import { renderCluster } from "./cluster";
 import { clampScrollOffset, parseKeyboardScroll, parseMouseEvent } from "./input";
 import type {
@@ -23,304 +11,239 @@ import type {
 } from "./pi-compat";
 import { highlightSelection, SelectionState } from "./selection";
 import {
+	CANONICAL_TERMINAL_RESET,
 	CLEAR_LINE,
 	cursorTo,
 	DISABLE_ALT_SCROLL,
 	DISABLE_AUTOWRAP,
 	DISABLE_MOUSE,
-	ENABLE_ALT_SCROLL,
 	ENABLE_AUTOWRAP,
 	ENABLE_MOUSE_SGR,
 	ENTER_ALT_SCREEN,
-	EXIT_ALT_SCREEN,
-	emergencyTerminalReset,
 	HIDE_CURSOR,
 	RESET_SCROLL_REGION,
 	SHOW_CURSOR,
 	SYNC_BEGIN,
 	SYNC_END,
 	setScrollRegion,
+	transitionPrelude,
 } from "./terminal-modes";
-import type { ClusterRender, CompositorConfig } from "./types";
+import type { ClusterRender, CompositorConfig, DisposalReason } from "./types";
 
 function replaceMethod(
 	capability: PiMethodCapability,
 	method: (...args: unknown[]) => unknown,
 ): void {
-	const descriptor = capability.ownDescriptor;
 	Object.defineProperty(capability.target, capability.key, {
-		...(descriptor ?? { configurable: true, enumerable: false, writable: true }),
+		...(capability.ownDescriptor ?? { configurable: true, enumerable: false, writable: true }),
 		value: method,
 	});
 }
 
 function restoreMethod(capability: PiMethodCapability): void {
-	if (capability.ownDescriptor) {
+	if (capability.ownDescriptor)
 		Object.defineProperty(capability.target, capability.key, capability.ownDescriptor);
-	} else {
-		Reflect.deleteProperty(capability.target, capability.key);
-	}
+	else Reflect.deleteProperty(capability.target, capability.key);
 }
 
-function hideRenderable(capability: PiRenderableCapability | null): void {
+function replaceRenderable(
+	capability: PiRenderableCapability | null,
+	render: (width: number) => string[],
+): void {
 	if (!capability) return;
 	Object.defineProperty(capability.target, "render", {
 		...(capability.ownDescriptor ?? { configurable: true, enumerable: false, writable: true }),
-		value: () => [],
+		value: render,
 	});
 }
 
 function restoreRenderable(capability: PiRenderableCapability | null): void {
 	if (!capability) return;
-	if (capability.ownDescriptor) {
+	if (capability.ownDescriptor)
 		Object.defineProperty(capability.target, "render", capability.ownDescriptor);
-	} else {
-		Reflect.deleteProperty(capability.target, "render");
-	}
+	else Reflect.deleteProperty(capability.target, "render");
 }
 
 function sanitizeLine(line: string, width: number): string {
 	return visibleWidth(line) > width ? truncateToWidth(line, width, "", true) : line;
 }
 
+type PhysicalMode = "not-entered" | "fixed" | "normal-flow";
+type RenderPhase = "idle" | "fixed-root" | "normal-flow";
+
 export class TerminalSplitCompositor {
-	private readonly capabilities: PiFixedEditorCapabilities;
-	private readonly getConfig: () => CompositorConfig;
 	private inputListener:
 		| ((data: string) => { consume?: boolean; data?: string } | undefined)
 		| null = null;
 	private inputListenerDisposer: (() => void) | null = null;
-	private emergencyCleanup: (() => void) | null = null;
-
 	private installed = false;
 	private disposed = false;
+	private disposing = false;
 	private terminalModesEntered = false;
 	private writing = false;
-	private renderingCluster = false;
 	private checkingOverlay = false;
-
+	private planningCluster = false;
+	private renderPhase: RenderPhase = "idle";
+	private transactionMode: "fixed" | "normal-flow" | null = null;
+	private activeMode: PhysicalMode = "not-entered";
+	private transitionTarget: "fixed" | "normal-flow" | null = null;
+	private transitionGuard = false;
+	private completingTransition = false;
+	private pendingDesiredMode: "fixed" | "normal-flow" | null = null;
 	private scrollOffset = 0;
 	private maxScrollOffset = 0;
 	private lastRootLineCount = 0;
-
-	/** Root lines from last renderScrollableRoot — used for selection text extraction. */
 	private rootLines: string[] = [];
-	/** Absolute start index of visible window in rootLines. */
 	private visibleRootStart = 0;
-	/** Height of the scrollable region in last render. */
 	private visibleScrollableRows = 0;
-
-	/** Selection state for app-level drag-to-select. */
 	private readonly selection = new SelectionState();
-	/** Timer for right-click context menu mouse reporting pause. */
 	private mouseResumeTimer: ReturnType<typeof setTimeout> | null = null;
 	private cursorVisible = true;
-
-	private readonly onCopy: (() => void) | null;
-	private readonly onDismissNotice: (() => void) | null;
-
 	private cachedClusterRender: { width: number; rows: number; render: ClusterRender } | null = null;
+	private readonly onCopy: ((text: string) => void) | null;
+	private readonly onDismissNotice: (() => void) | null;
+	private readonly fallbackWrite: (data: string) => unknown;
 
 	constructor(
-		capabilities: PiFixedEditorCapabilities,
-		getConfig: () => CompositorConfig,
-		onCopy?: () => void,
+		private readonly capabilities: PiFixedEditorCapabilities,
+		private readonly getConfig: () => CompositorConfig,
+		onCopy?: (text: string) => void,
 		onDismissNotice?: () => void,
+		fallbackWrite: (data: string) => unknown = (data) => process.stdout.write(data),
 	) {
-		this.capabilities = capabilities;
-		this.getConfig = getConfig;
 		this.onCopy = onCopy ?? null;
 		this.onDismissNotice = onDismissNotice ?? null;
+		this.fallbackWrite = fallbackWrite;
 	}
 
 	install(): boolean {
 		if (this.installed) return true;
 		if (this.disposed) return false;
-		const cluster = this.capabilities.cluster;
 		try {
-			for (const component of [
-				cluster.status,
-				cluster.aboveWidget,
-				cluster.editor,
-				cluster.belowWidget,
-				cluster.footer,
-			]) {
-				hideRenderable(component);
+			for (const component of this.components()) {
+				if (!component) continue;
+				const captured = component;
+				replaceRenderable(captured, (width) =>
+					this.renderPhase === "normal-flow" ? captured.render.call(captured.target, width) : [],
+				);
 			}
 			Object.defineProperty(this.capabilities.terminal, "rows", {
 				configurable: true,
 				get: () => this.getScrollableRows(),
 			});
-			replaceMethod(this.capabilities.renderMethod, (width) =>
-				this.renderScrollableRoot(Number(width)),
-			);
-			replaceMethod(this.capabilities.doRenderMethod, () => {
-				this.cachedClusterRender = null;
-				try {
-					this.callOriginalDoRender();
-					this.requestRepaint();
-				} catch {
-					// If doRender throws, the original write already happened.
-				}
-			});
+			replaceMethod(this.capabilities.renderMethod, (width) => this.renderRoot(Number(width)));
+			replaceMethod(this.capabilities.doRenderMethod, () => this.doRender());
 			replaceMethod(this.capabilities.writeMethod, (data) => this.write(String(data)));
-
 			this.inputListener = (data) => this.handleInput(data);
-			const inputListenerDisposer = this.capabilities.addInputListener(this.inputListener);
-			if (typeof inputListenerDisposer !== "function") {
-				throw new TypeError("Invalid input listener disposer");
-			}
-			this.inputListenerDisposer = inputListenerDisposer as () => void;
-			this.emergencyCleanup = () => {
-				if (!this.disposed) this.restoreForExit();
-			};
-			process.once("exit", this.emergencyCleanup);
-
-			this.terminalModesEntered = true;
-			this.callOriginalWrite(
-				SYNC_BEGIN +
-					ENTER_ALT_SCREEN +
-					DISABLE_ALT_SCROLL +
-					(this.getConfig().mouseScroll ? ENABLE_MOUSE_SGR : DISABLE_MOUSE) +
-					SYNC_END,
-			);
+			const disposer = this.capabilities.addInputListener(this.inputListener);
+			if (typeof disposer !== "function") throw new TypeError("Invalid input listener disposer");
+			this.inputListenerDisposer = disposer as () => void;
 			this.installed = true;
+			if (this.getRawRows() > 0) this.beginTransition("fixed", "shutdown");
+			else this.pendingDesiredMode = "fixed";
+			return true;
 		} catch {
 			this.rollbackInstallation();
 			return false;
 		}
-		try {
-			this.capabilities.requestRender?.(true);
-		} catch {}
-		return true;
 	}
 
-	dispose(): void {
-		if (this.disposed) return;
-		this.disposed = true;
-		if (!this.installed) return;
-		this.clearInputListener();
-		if (this.mouseResumeTimer) {
-			clearTimeout(this.mouseResumeTimer);
-			this.mouseResumeTimer = null;
-		}
-		if (this.emergencyCleanup) {
-			process.removeListener("exit", this.emergencyCleanup);
-			this.emergencyCleanup = null;
-		}
-		this.restorePatchedCapabilities();
-		this.restoreForExit();
-		this.terminalModesEntered = false;
-		this.installed = false;
+	dispose(reason: DisposalReason): void {
+		if (this.disposed || this.disposing) return;
+		this.disposing = true;
+		let firstFailure: unknown;
+		const attempt = (operation: () => void) => {
+			try {
+				operation();
+			} catch (error) {
+				firstFailure ??= error;
+			}
+		};
 		try {
-			this.capabilities.requestRender?.(true);
-		} catch {}
+			const resumeTimer = this.mouseResumeTimer;
+			this.mouseResumeTimer = null;
+			if (resumeTimer) attempt(() => clearTimeout(resumeTimer));
+			const listener = this.inputListener;
+			const disposer = this.inputListenerDisposer;
+			this.inputListener = null;
+			this.inputListenerDisposer = null;
+			if (disposer) attempt(disposer);
+			if (listener) attempt(() => this.capabilities.removeInputListener(listener));
+
+			for (const component of this.components()) attempt(() => restoreRenderable(component));
+			attempt(() => restoreMethod(this.capabilities.writeMethod));
+			attempt(() => restoreMethod(this.capabilities.doRenderMethod));
+			attempt(() => restoreMethod(this.capabilities.renderMethod));
+			attempt(() => {
+				if (this.capabilities.rowsOwnDescriptor)
+					Object.defineProperty(
+						this.capabilities.terminal,
+						"rows",
+						this.capabilities.rowsOwnDescriptor,
+					);
+				else Reflect.deleteProperty(this.capabilities.terminal, "rows");
+			});
+
+			if (this.terminalModesEntered) {
+				let primaryFailed = false;
+				try {
+					this.callOriginalWrite(CANONICAL_TERMINAL_RESET);
+				} catch (error) {
+					firstFailure ??= error;
+					primaryFailed = true;
+				}
+				if (primaryFailed)
+					attempt(() => {
+						this.fallbackWrite(CANONICAL_TERMINAL_RESET);
+					});
+			}
+			if (reason === "live" && this.installed)
+				attempt(() => this.capabilities.requestForceRender());
+		} finally {
+			this.installed = false;
+			this.terminalModesEntered = false;
+			this.transitionTarget = null;
+			this.transitionGuard = false;
+			this.transactionMode = null;
+			this.activeMode = "not-entered";
+			this.disposed = true;
+			this.disposing = false;
+		}
+		if (reason === "live" && firstFailure) throw firstFailure;
 	}
 
 	private rollbackInstallation(): void {
-		this.clearInputListener();
-		if (this.emergencyCleanup) {
-			process.removeListener("exit", this.emergencyCleanup);
-			this.emergencyCleanup = null;
-		}
-		this.restorePatchedCapabilities();
-		if (this.terminalModesEntered) this.restoreForExit();
-		this.terminalModesEntered = false;
-		this.installed = false;
+		try {
+			this.dispose("shutdown");
+		} catch {}
 	}
 
-	private clearInputListener(): void {
-		const listener = this.inputListener;
-		const disposer = this.inputListenerDisposer;
-		this.inputListener = null;
-		this.inputListenerDisposer = null;
-		let disposed = false;
-		if (disposer) {
-			try {
-				disposer();
-				disposed = true;
-			} catch {}
-		}
-		if (!disposed && listener) {
-			try {
-				this.capabilities.removeInputListener(listener);
-			} catch {}
-		}
-	}
-
-	private restorePatchedCapabilities(): void {
-		restoreMethod(this.capabilities.writeMethod);
-		restoreMethod(this.capabilities.doRenderMethod);
-		restoreMethod(this.capabilities.renderMethod);
-		for (const component of [
-			this.capabilities.cluster.status,
-			this.capabilities.cluster.aboveWidget,
-			this.capabilities.cluster.editor,
-			this.capabilities.cluster.belowWidget,
-			this.capabilities.cluster.footer,
-		]) {
-			restoreRenderable(component);
-		}
-		if (this.capabilities.rowsOwnDescriptor) {
-			Object.defineProperty(
-				this.capabilities.terminal,
-				"rows",
-				this.capabilities.rowsOwnDescriptor,
-			);
-		} else {
-			Reflect.deleteProperty(this.capabilities.terminal, "rows");
-		}
+	private components(): (PiRenderableCapability | null)[] {
+		const cluster = this.capabilities.cluster;
+		return [
+			cluster.status,
+			cluster.aboveWidget,
+			cluster.editor,
+			cluster.belowWidget,
+			cluster.footer,
+		];
 	}
 
 	private callOriginalWrite(data: string): void {
 		Reflect.apply(this.capabilities.writeMethod.method, this.capabilities.terminal, [data]);
 	}
-
 	private callOriginalDoRender(): void {
 		Reflect.apply(this.capabilities.doRenderMethod.method, this.capabilities.tui, []);
 	}
-
 	private callOriginalRender(width: number): string[] {
 		return Reflect.apply(this.capabilities.renderMethod.method, this.capabilities.tui, [
 			width,
 		]) as string[];
 	}
-
 	private getRawRows(): number {
-		return Math.max(2, this.capabilities.readRawRows());
+		const value = this.capabilities.readRawRows();
+		return Math.max(0, Math.floor(Number.isFinite(value) ? value : 0));
 	}
-
-	private getClusterRender(width: number, rawRows: number): ClusterRender {
-		if (this.cachedClusterRender?.width === width && this.cachedClusterRender?.rows === rawRows) {
-			return this.cachedClusterRender.render;
-		}
-		const wasRendering = this.renderingCluster;
-		this.renderingCluster = true;
-		try {
-			const render = renderCluster(this.capabilities.cluster, width, rawRows);
-			this.cachedClusterRender = { width, rows: rawRows, render };
-			return render;
-		} finally {
-			this.renderingCluster = wasRendering;
-		}
-	}
-
-	private getScrollableRows(): number {
-		if (
-			this.disposed ||
-			this.writing ||
-			this.renderingCluster ||
-			this.checkingOverlay ||
-			this.hasVisibleOverlay()
-		) {
-			return this.getRawRows();
-		}
-		const rawRows = this.getRawRows();
-		const width = Math.max(1, this.capabilities.getColumns() || 80);
-		const cluster = this.getClusterRender(width, rawRows);
-		return Math.max(1, rawRows - cluster.lines.length);
-	}
-
 	private hasVisibleOverlay(): boolean {
 		if (this.checkingOverlay) return false;
 		this.checkingOverlay = true;
@@ -330,276 +253,385 @@ export class TerminalSplitCompositor {
 			this.checkingOverlay = false;
 		}
 	}
+	private getClusterRender(width: number, rows: number): ClusterRender {
+		if (this.cachedClusterRender?.width === width && this.cachedClusterRender.rows === rows)
+			return this.cachedClusterRender.render;
+		const previous = this.planningCluster;
+		this.planningCluster = true;
+		try {
+			const render = renderCluster(this.capabilities.cluster, width, rows);
+			this.cachedClusterRender = { width, rows, render };
+			return render;
+		} finally {
+			this.planningCluster = previous;
+		}
+	}
+	private desiredMode(width: number, rows: number): "fixed" | "normal-flow" {
+		if (this.hasVisibleOverlay()) return "normal-flow";
+		return this.getClusterRender(width, rows).mode === "fixed" ? "fixed" : "normal-flow";
+	}
+	private getScrollableRows(): number {
+		const rows = this.getRawRows();
+		if (
+			rows === 0 ||
+			this.disposed ||
+			this.writing ||
+			this.planningCluster ||
+			this.renderPhase === "normal-flow" ||
+			this.transactionMode === "normal-flow" ||
+			this.transitionTarget === "normal-flow" ||
+			this.hasVisibleOverlay() ||
+			(this.activeMode === "normal-flow" &&
+				this.transactionMode !== "fixed" &&
+				this.transitionTarget !== "fixed")
+		)
+			return rows;
+		const width = Math.max(1, this.capabilities.getColumns() || 80);
+		const cluster = this.getClusterRender(width, rows);
+		return cluster.mode === "fixed"
+			? Math.max(
+					1,
+					cluster.plan?.mode === "fixed"
+						? cluster.plan.transcriptRows
+						: rows - cluster.lines.length,
+				)
+			: rows;
+	}
 
-	private renderScrollableRoot(width: number): string[] {
+	private clearPhysicalTransitionState(): void {
+		this.selection.clear();
+		this.cachedClusterRender = null;
+		this.rootLines = [];
+		this.visibleRootStart = 0;
+		this.visibleScrollableRows = 0;
+		this.cursorVisible = true;
+	}
+
+	private beginTransition(
+		target: "fixed" | "normal-flow",
+		failureReason: DisposalReason = "live",
+	): void {
+		if (this.transitionGuard) return;
+		this.transitionTarget = target;
+		this.transitionGuard = true;
+		this.clearPhysicalTransitionState();
+		try {
+			if (!this.terminalModesEntered) {
+				// Ownership begins before the first byte: a partial write still requires reset recovery.
+				this.terminalModesEntered = true;
+				this.callOriginalWrite(SYNC_BEGIN + ENTER_ALT_SCREEN + DISABLE_ALT_SCROLL + SYNC_END);
+			}
+			this.callOriginalWrite(transitionPrelude(target));
+			this.capabilities.requestForceRender();
+		} catch (error) {
+			this.transitionGuard = false;
+			this.transitionTarget = null;
+			try {
+				this.dispose(failureReason);
+			} catch {}
+			throw error;
+		}
+	}
+
+	private doRender(): void {
+		if (this.disposed) {
+			this.callOriginalDoRender();
+			return;
+		}
+		const rows = this.getRawRows();
+		if (rows === 0) {
+			this.pendingDesiredMode = this.hasVisibleOverlay() ? "normal-flow" : "fixed";
+			return;
+		}
+		if (this.pendingDesiredMode) this.pendingDesiredMode = null;
+		this.cachedClusterRender = null;
+		const width = Math.max(1, this.capabilities.getColumns() || 80);
+		const desired = this.desiredMode(width, rows);
+		if (!this.transitionTarget && this.activeMode !== desired) {
+			this.beginTransition(desired);
+			return;
+		}
+		this.completingTransition = Boolean(this.transitionTarget);
+		try {
+			let target = this.transitionTarget ?? desired;
+			if (this.transitionTarget && target !== desired) {
+				// The materialized layout is authoritative: metadata/height may change while
+				// the forced transition render is queued.
+				target = desired;
+				this.transitionTarget = desired;
+				this.clearPhysicalTransitionState();
+				this.callOriginalWrite(transitionPrelude(desired));
+			}
+			this.transactionMode = target;
+			this.callOriginalDoRender();
+			if (target === "fixed") this.requestRepaint();
+			if (this.transitionTarget) this.activeMode = target;
+		} catch (error) {
+			if (this.transitionTarget) {
+				try {
+					this.dispose("live");
+				} catch {}
+			} else throw error;
+		} finally {
+			this.transactionMode = null;
+			this.completingTransition = false;
+			this.transitionTarget = null;
+			this.transitionGuard = false;
+		}
+	}
+
+	private withPhase<T>(phase: RenderPhase, operation: () => T): T {
+		const previous = this.renderPhase;
+		this.renderPhase = phase;
+		try {
+			return operation();
+		} finally {
+			this.renderPhase = previous;
+		}
+	}
+	private renderRoot(width: number): string[] {
 		if (this.disposed) return this.callOriginalRender(width);
-
-		if (this.hasVisibleOverlay()) return this.callOriginalRender(width);
-
-		const rawRows = this.getRawRows();
-		const cluster = this.getClusterRender(Math.max(1, width), rawRows);
-		const scrollableRows = Math.max(1, rawRows - cluster.lines.length);
-
+		if (this.hasVisibleOverlay())
+			return this.withPhase("normal-flow", () => this.callOriginalRender(width));
+		const rows = this.getRawRows();
+		const target =
+			this.transactionMode ??
+			this.transitionTarget ??
+			(rows > 0 ? this.desiredMode(Math.max(1, width), rows) : "normal-flow");
+		if (target === "normal-flow")
+			return this.withPhase("normal-flow", () => this.callOriginalRender(width));
+		return this.withPhase("fixed-root", () => this.renderScrollableRoot(width));
+	}
+	private renderScrollableRoot(width: number): string[] {
+		const rows = this.getRawRows();
+		const cluster = this.getClusterRender(Math.max(1, width), rows);
+		if (cluster.mode !== "fixed")
+			return this.withPhase("normal-flow", () => this.callOriginalRender(width));
+		const scrollableRows = Math.max(
+			1,
+			cluster.plan?.mode === "fixed" ? cluster.plan.transcriptRows : rows - cluster.lines.length,
+		);
 		const lines = this.callOriginalRender(Math.max(1, width));
-
-		// Adjust scroll offset when new content arrives while scrolled up.
 		if (
 			this.scrollOffset > 0 &&
 			this.lastRootLineCount > 0 &&
 			lines.length > this.lastRootLineCount
-		) {
+		)
 			this.scrollOffset += lines.length - this.lastRootLineCount;
-		}
 		this.lastRootLineCount = lines.length;
 		this.maxScrollOffset = Math.max(0, lines.length - scrollableRows);
 		this.scrollOffset = clampScrollOffset(this.scrollOffset, this.maxScrollOffset);
-
 		const start = Math.max(0, lines.length - scrollableRows - this.scrollOffset);
 		const visible = lines.slice(start, start + scrollableRows);
 		while (visible.length < scrollableRows) visible.push("");
-
-		// Store for selection mapping and text extraction.
 		this.rootLines = lines;
 		this.visibleRootStart = start;
 		this.visibleScrollableRows = scrollableRows;
-
-		// Apply selection highlight to visible lines.
-		return visible.map((line, i) => highlightSelection(line, start + i, this.selection));
+		return visible.map((line, index) => highlightSelection(line, start + index, this.selection));
 	}
 
 	private handleInput(data: string): { consume?: boolean; data?: string } | undefined {
-		if (this.disposed || this.hasVisibleOverlay()) return undefined;
+		if (
+			this.disposed ||
+			this.transitionGuard ||
+			this.hasVisibleOverlay() ||
+			this.activeMode === "normal-flow"
+		)
+			return undefined;
 		this.onDismissNotice?.();
-
-		const mouseScroll = this.getConfig().mouseScroll;
-		if (mouseScroll) {
-			const mouseEv = parseMouseEvent(data);
-			if (mouseEv) {
-				this.handleMouseEvent(mouseEv);
+		if (this.getConfig().mouseScroll) {
+			const event = parseMouseEvent(data);
+			if (event) {
+				this.handleMouseEvent(event);
 				return { consume: true };
 			}
 		}
-
 		const keyboard = parseKeyboardScroll(data);
 		if (!keyboard) return undefined;
-
 		if (keyboard.action === "jumpBottom") {
 			this.scrollOffset = 0;
 			this.selection.clear();
-			this.capabilities.requestRender?.();
-			return undefined; // Let Enter propagate to the editor.
+			this.capabilities.requestNormalRender();
+			return undefined;
 		}
-
-		const rawRows = this.getRawRows();
-		const scrollableRows = Math.max(
-			1,
-			rawRows - this.getClusterRender(this.capabilities.getColumns() || 80, rawRows).lines.length,
-		);
-
-		if (keyboard.action === "pageUp") {
+		if (keyboard.action === "pageUp" || keyboard.action === "pageDown") {
+			if (this.maxScrollOffset <= 0) return undefined;
 			const before = this.scrollOffset;
+			const amount = Math.max(1, this.visibleScrollableRows);
 			this.selection.clear();
-			this.scrollBy(scrollableRows);
-			return this.scrollOffset !== before ? { consume: true } : undefined;
+			this.scrollBy(keyboard.action === "pageUp" ? amount : -amount);
+			if (before === this.scrollOffset) return { consume: true };
+			return { consume: true };
 		}
-		if (keyboard.action === "pageDown") {
-			const before = this.scrollOffset;
-			this.selection.clear();
-			this.scrollBy(-scrollableRows);
-			return this.scrollOffset !== before ? { consume: true } : undefined;
-		}
-
 		return { consume: true };
 	}
 
-	private handleMouseEvent(ev: { button: string; action: string; col: number; row: number }): void {
-		// Wheel scroll.
-		if (ev.button === "wheel-up" && ev.action === "press") {
+	private handleMouseEvent(event: {
+		button: string;
+		action: string;
+		col: number;
+		row: number;
+	}): void {
+		if (event.button === "wheel-up" && event.action === "press") {
 			this.selection.clear();
 			this.scrollBy(3);
 			return;
 		}
-		if (ev.button === "wheel-down" && ev.action === "press") {
+		if (event.button === "wheel-down" && event.action === "press") {
 			this.selection.clear();
 			this.scrollBy(-3);
 			return;
 		}
-
-		// Right-click: pause mouse reporting for native context menu.
-		if (ev.button === "right" && ev.action === "press") {
-			const selectedText = this.selection.active
-				? this.selection.getSelectedText(this.rootLines)
-				: "";
-			if (selectedText) {
-				void copyToClipboard(selectedText);
-			}
+		if (event.button === "right" && event.action === "press") {
+			const text = this.selection.active ? this.selection.getSelectedText(this.rootLines) : "";
+			if (text) void copyToClipboard(text);
 			this.selection.clear();
 			this.pauseMouseReporting();
-			this.capabilities.requestRender?.();
+			this.capabilities.requestNormalRender();
 			return;
 		}
-
-		// Only left button is used for drag-select.
-		if (ev.button !== "left") return;
-
-		// Ignore clicks in the cluster region (below scrollable area).
-		if (ev.row > this.visibleScrollableRows) return;
-
-		// Map screen row to transcript line index.
-		const lineIndex = this.visibleRootStart + ev.row - 1;
-		const col = Math.max(0, ev.col - 1);
-
-		if (ev.action === "press") {
-			this.selection.start(lineIndex, col);
-			this.capabilities.requestRender?.();
+		if (event.button !== "left") return;
+		if (
+			event.action === "release" &&
+			this.selection.isDragging &&
+			event.row > this.visibleScrollableRows
+		) {
+			this.selection.clear();
+			this.capabilities.requestNormalRender();
 			return;
 		}
-		if (ev.action === "drag" && this.selection.isDragging) {
-			this.selection.extend(lineIndex, col + 1);
-			this.capabilities.requestRender?.();
-			return;
-		}
-		if (ev.action === "release" && this.selection.isDragging) {
-			this.selection.extend(lineIndex, col + 1);
+		if (event.row > this.visibleScrollableRows) return;
+		const line = this.visibleRootStart + event.row - 1;
+		const col = Math.max(0, event.col - 1);
+		if (event.action === "press") {
+			this.selection.start(line, col);
+			this.capabilities.requestNormalRender();
+		} else if (event.action === "drag" && this.selection.isDragging) {
+			this.selection.extend(line, col + 1);
+			this.capabilities.requestNormalRender();
+		} else if (event.action === "release" && this.selection.isDragging) {
+			this.selection.extend(line, col + 1);
 			this.selection.setDragging(false);
 			const text = this.selection.getSelectedText(this.rootLines);
 			this.selection.clear();
-			this.capabilities.requestRender?.();
+			this.capabilities.requestNormalRender();
 			if (text) {
 				void copyToClipboard(text);
-				if (this.getConfig().copyNotice) this.onCopy?.();
+				if (this.getConfig().copyNotice) this.onCopy?.(text);
 			}
-			return;
 		}
 	}
-
-	/** Temporarily disable mouse reporting so the terminal's native context menu works. */
 	private pauseMouseReporting(): void {
 		if (this.mouseResumeTimer) clearTimeout(this.mouseResumeTimer);
 		this.callOriginalWrite(SYNC_BEGIN + DISABLE_MOUSE + SYNC_END);
 		this.mouseResumeTimer = setTimeout(() => {
 			this.mouseResumeTimer = null;
-			if (!this.disposed) {
+			if (
+				!this.disposed &&
+				this.installed &&
+				!this.transitionGuard &&
+				this.activeMode === "fixed" &&
+				this.transactionMode !== "normal-flow" &&
+				!this.hasVisibleOverlay() &&
+				this.getConfig().mouseScroll
+			)
 				this.callOriginalWrite(SYNC_BEGIN + ENABLE_MOUSE_SGR + SYNC_END);
-			}
 		}, 1200);
-		if (typeof this.mouseResumeTimer === "object" && "unref" in this.mouseResumeTimer) {
+		if (typeof this.mouseResumeTimer === "object" && "unref" in this.mouseResumeTimer)
 			(this.mouseResumeTimer as { unref: () => void }).unref();
-		}
 	}
-
 	private scrollBy(delta: number): void {
 		const next = clampScrollOffset(this.scrollOffset + delta, this.maxScrollOffset);
 		if (next === this.scrollOffset) return;
 		this.scrollOffset = next;
-		this.capabilities.requestRender?.();
+		this.capabilities.requestNormalRender();
 	}
-
-	private paintCluster(cluster: ClusterRender, rawRows: number, width: number): string {
+	private paintCluster(cluster: ClusterRender, rows: number, width: number): string {
 		if (cluster.lines.length === 0) return "";
-		const startRow = Math.max(1, rawRows - cluster.lines.length + 1);
-		let buf = RESET_SCROLL_REGION;
-		for (let i = 0; i < cluster.lines.length; i++) {
-			buf += cursorTo(startRow + i, 1) + CLEAR_LINE + sanitizeLine(cluster.lines[i] ?? "", width);
-		}
+		const startRow = Math.max(1, rows - cluster.lines.length + 1);
+		let buffer = RESET_SCROLL_REGION;
+		for (let index = 0; index < cluster.lines.length; index++)
+			buffer +=
+				cursorTo(startRow + index, 1) +
+				CLEAR_LINE +
+				sanitizeLine(cluster.lines[index] ?? "", width);
 		if (cluster.cursor) {
-			buf += cursorTo(startRow + cluster.cursor.row, Math.max(1, cluster.cursor.col + 1));
+			buffer += cursorTo(startRow + cluster.cursor.row, Math.max(1, cluster.cursor.col + 1));
 			if (!this.cursorVisible) {
-				buf += SHOW_CURSOR;
+				buffer += SHOW_CURSOR;
 				this.cursorVisible = true;
 			}
 		} else if (this.cursorVisible) {
-			buf += HIDE_CURSOR;
+			buffer += HIDE_CURSOR;
 			this.cursorVisible = false;
 		}
-		return buf;
+		return buffer;
 	}
-
-	/**
-	 * Restore the cursor to the row Pi's differential renderer expects.
-	 *
-	 * `setScrollRegion` (DECSTBM) homes the cursor to row 1, col 1, but Pi's
-	 * `doRender` emits *relative* cursor moves (CUU/CUD/`\r`) computed from
-	 * its tracked `hardwareCursorRow`. Without repositioning, a sparse
-	 * differential update (e.g. one selection-highlighted line) is written
-	 * at the wrong row because the relative move departs from (1,1)
-	 * instead of the tracked row.
-	 */
 	private syncTuiCursor(scrollBottom: number): string {
-		const { hardwareCursorRow, previousViewportTop: viewportTop } =
-			this.capabilities.getCursorBookkeeping();
-		const row = Math.max(1, Math.min(scrollBottom, hardwareCursorRow - viewportTop + 1));
-		return cursorTo(row, 1);
+		const { hardwareCursorRow, previousViewportTop } = this.capabilities.getCursorBookkeeping();
+		return cursorTo(
+			Math.max(1, Math.min(scrollBottom, hardwareCursorRow - previousViewportTop + 1)),
+			1,
+		);
 	}
-
 	private requestRepaint(): void {
-		if (this.disposed || this.hasVisibleOverlay()) return;
-		const rawRows = this.getRawRows();
+		if (this.disposed || this.transactionMode === "normal-flow" || this.hasVisibleOverlay()) return;
+		const rows = this.getRawRows();
+		if (rows === 0) return;
 		const width = Math.max(1, this.capabilities.getColumns() || 80);
-		const cluster = this.getClusterRender(width, rawRows);
-		if (cluster.lines.length === 0) return;
+		const cluster = this.getClusterRender(width, rows);
+		if (cluster.mode !== "fixed" || cluster.lines.length === 0) return;
 		this.callOriginalWrite(
 			SYNC_BEGIN +
 				DISABLE_AUTOWRAP +
-				this.paintCluster(cluster, rawRows, width) +
+				this.paintCluster(cluster, rows, width) +
 				ENABLE_AUTOWRAP +
 				(this.getConfig().mouseScroll ? ENABLE_MOUSE_SGR : DISABLE_MOUSE) +
+				DISABLE_ALT_SCROLL +
 				SYNC_END,
 		);
 	}
-
 	private write(data: string): void {
-		if (this.disposed || this.writing || this.hasVisibleOverlay()) {
+		if (this.disposed || this.writing) {
+			this.callOriginalWrite(data);
+			return;
+		}
+		if (this.transitionGuard && !this.completingTransition) return;
+		const mode =
+			this.transactionMode ??
+			this.transitionTarget ??
+			(this.activeMode === "fixed" ? "fixed" : "normal-flow");
+		if (mode === "normal-flow" || this.hasVisibleOverlay()) {
 			this.callOriginalWrite(data);
 			return;
 		}
 		this.writing = true;
 		try {
-			const rawRows = this.getRawRows();
+			const rows = this.getRawRows();
+			if (rows === 0) return;
 			const width = Math.max(1, this.capabilities.getColumns() || 80);
-			const cluster = this.getClusterRender(width, rawRows);
-			const reservedRows = cluster.lines.length;
-			if (reservedRows === 0 || rawRows <= 2) {
+			const cluster = this.getClusterRender(width, rows);
+			if (cluster.mode !== "fixed" || cluster.lines.length === 0) {
 				this.callOriginalWrite(data);
 				return;
 			}
-			const scrollBottom = Math.max(1, rawRows - reservedRows);
+			const scrollBottom = Math.max(1, rows - cluster.lines.length);
 			this.callOriginalWrite(
 				SYNC_BEGIN +
 					DISABLE_AUTOWRAP +
 					setScrollRegion(1, scrollBottom) +
 					this.syncTuiCursor(scrollBottom) +
 					data +
-					this.paintCluster(cluster, rawRows, width) +
+					this.paintCluster(cluster, rows, width) +
 					ENABLE_AUTOWRAP +
 					(this.getConfig().mouseScroll ? ENABLE_MOUSE_SGR : DISABLE_MOUSE) +
+					DISABLE_ALT_SCROLL +
 					SYNC_END,
 			);
 		} finally {
 			this.writing = false;
 		}
 	}
-
-	private restoreTerminalState(): void {
-		this.callOriginalWrite(
-			SYNC_BEGIN +
-				RESET_SCROLL_REGION +
-				DISABLE_MOUSE +
-				ENABLE_ALT_SCROLL +
-				EXIT_ALT_SCREEN +
-				SHOW_CURSOR +
-				SYNC_END,
-		);
-	}
-
-	private restoreForExit(): void {
-		try {
-			this.restoreTerminalState();
-		} catch {
-			// Process-exit cleanup cannot report errors and must not throw.
-		}
-	}
 }
 
-/** Export for the emergency reset test. */
-export { emergencyTerminalReset };
+export { CANONICAL_TERMINAL_RESET as emergencyTerminalReset };

--- a/extensions/zentui/fixed-editor/compositor.ts
+++ b/extensions/zentui/fixed-editor/compositor.ts
@@ -46,6 +46,16 @@ function restoreMethod(capability: PiMethodCapability): void {
 	else Reflect.deleteProperty(capability.target, capability.key);
 }
 
+function restoreOwnedMethod(
+	capability: PiMethodCapability,
+	wrapper: ((...args: unknown[]) => unknown) | null,
+): void {
+	if (!wrapper) return;
+	const descriptor = Object.getOwnPropertyDescriptor(capability.target, capability.key);
+	if (!descriptor || !("value" in descriptor) || descriptor.value !== wrapper) return;
+	restoreMethod(capability);
+}
+
 function replaceRenderable(
 	capability: PiRenderableCapability | null,
 	render: (width: number) => string[],
@@ -98,6 +108,9 @@ export class TerminalSplitCompositor {
 	private visibleScrollableRows = 0;
 	private readonly selection = new SelectionState();
 	private mouseResumeTimer: ReturnType<typeof setTimeout> | null = null;
+	private drainInputWrapper: ((...args: unknown[]) => unknown) | null = null;
+	private stopWrapper: ((...args: unknown[]) => unknown) | null = null;
+	private preparingTerminalCleanup = false;
 	private cursorVisible = true;
 	private cachedClusterRender: { width: number; rows: number; render: ClusterRender } | null = null;
 	private readonly onCopy: ((text: string) => void) | null;
@@ -120,6 +133,7 @@ export class TerminalSplitCompositor {
 		if (this.installed) return true;
 		if (this.disposed) return false;
 		try {
+			this.installTerminalCleanupWrappers();
 			for (const component of this.components()) {
 				if (!component) continue;
 				const captured = component;
@@ -171,6 +185,10 @@ export class TerminalSplitCompositor {
 			if (listener) attempt(() => this.capabilities.removeInputListener(listener));
 
 			for (const component of this.components()) attempt(() => restoreRenderable(component));
+			attempt(() => restoreOwnedMethod(this.capabilities.stopMethod, this.stopWrapper));
+			attempt(() => restoreOwnedMethod(this.capabilities.drainInputMethod, this.drainInputWrapper));
+			this.stopWrapper = null;
+			this.drainInputWrapper = null;
 			attempt(() => restoreMethod(this.capabilities.writeMethod));
 			attempt(() => restoreMethod(this.capabilities.doRenderMethod));
 			attempt(() => restoreMethod(this.capabilities.renderMethod));
@@ -216,6 +234,66 @@ export class TerminalSplitCompositor {
 		try {
 			this.dispose("shutdown");
 		} catch {}
+	}
+
+	private installTerminalCleanupWrappers(): void {
+		const compositor = this;
+		const drainCapability = this.capabilities.drainInputMethod;
+		const stopCapability = this.capabilities.stopMethod;
+		const drainWrapper = function (this: unknown, ...args: unknown[]): unknown {
+			try {
+				compositor.prepareForPiTerminalCleanup();
+			} catch {}
+			return Reflect.apply(drainCapability.method, this, args);
+		};
+		const stopWrapper = function (this: unknown, ...args: unknown[]): unknown {
+			try {
+				compositor.prepareForPiTerminalCleanup();
+			} catch {}
+			return Reflect.apply(stopCapability.method, this, args);
+		};
+		this.drainInputWrapper = drainWrapper;
+		this.stopWrapper = stopWrapper;
+		replaceMethod(drainCapability, drainWrapper);
+		replaceMethod(stopCapability, stopWrapper);
+	}
+
+	private prepareForPiTerminalCleanup(): void {
+		if (this.preparingTerminalCleanup) return;
+		this.preparingTerminalCleanup = true;
+		try {
+			const resumeTimer = this.mouseResumeTimer;
+			this.mouseResumeTimer = null;
+			if (resumeTimer) {
+				try {
+					clearTimeout(resumeTimer);
+				} catch {}
+			}
+			this.clearPhysicalTransitionState();
+			if (!this.terminalModesEntered) return;
+			let resetWritten = false;
+			try {
+				this.callOriginalWrite(CANONICAL_TERMINAL_RESET);
+				resetWritten = true;
+			} catch {
+				try {
+					this.fallbackWrite(CANONICAL_TERMINAL_RESET);
+					resetWritten = true;
+				} catch {}
+			}
+			if (!resetWritten) return;
+			this.terminalModesEntered = false;
+			this.transitionTarget = null;
+			this.transitionGuard = false;
+			this.completingTransition = false;
+			this.transactionMode = null;
+			this.activeMode = "not-entered";
+			this.pendingDesiredMode = "fixed";
+			this.renderPhase = "idle";
+			this.writing = false;
+		} finally {
+			this.preparingTerminalCleanup = false;
+		}
 	}
 
 	private components(): (PiRenderableCapability | null)[] {

--- a/extensions/zentui/fixed-editor/editor-layout.ts
+++ b/extensions/zentui/fixed-editor/editor-layout.ts
@@ -1,0 +1,227 @@
+/** Private semantic row metadata for Zentui-owned editor frames. @internal */
+
+export const FIXED_EDITOR_LAYOUT = Symbol("pi-zentui.fixed-editor-layout");
+
+export type AbsoluteOutputRange = { start: number; end: number };
+export type BorderPair = { top: number; bottom: number };
+export type ItemToOutputRow = { itemIndex: number; outputRow: number };
+
+export type FixedEditorLayoutMetadata = {
+	width: number;
+	renderedRowCount: number;
+	editor: {
+		rows: readonly AbsoluteOutputRange[];
+		frame: readonly AbsoluteOutputRange[];
+		content: readonly AbsoluteOutputRange[];
+		structuralRows: readonly number[];
+		cursorRow: number;
+		borderPairs: readonly BorderPair[];
+	};
+	autocomplete?: {
+		rows: AbsoluteOutputRange;
+		structuralRows: readonly number[];
+		closureRows: readonly number[];
+		borderPairs: readonly BorderPair[];
+		selection:
+			| {
+					known: true;
+					selectedIndex: number;
+					visibleWindow: { start: number; end: number };
+					itemToOutputRows: readonly ItemToOutputRow[];
+					selectedRow: number;
+			  }
+			| { known: false };
+	};
+};
+
+export type FixedEditorLayoutProvider = {
+	[FIXED_EDITOR_LAYOUT](
+		renderedRows: readonly string[],
+		width: number,
+	): FixedEditorLayoutMetadata | undefined;
+};
+
+function integer(value: unknown): value is number {
+	return typeof value === "number" && Number.isFinite(value) && Number.isInteger(value);
+}
+
+function range(value: AbsoluteOutputRange, count: number): boolean {
+	return (
+		integer(value.start) &&
+		integer(value.end) &&
+		value.start >= 0 &&
+		value.start < value.end &&
+		value.end <= count
+	);
+}
+
+function orderedRanges(values: readonly AbsoluteOutputRange[], count: number): boolean {
+	return (
+		values.length > 0 &&
+		values.every((value, index) => {
+			const previous = values[index - 1];
+			return (
+				range(value, count) &&
+				(index === 0 || (previous !== undefined && previous.end <= value.start))
+			);
+		})
+	);
+}
+
+function expand(values: readonly AbsoluteOutputRange[]): number[] {
+	return values.flatMap(({ start, end }) =>
+		Array.from({ length: end - start }, (_, index) => start + index),
+	);
+}
+
+function uniqueRows(values: readonly number[], count: number): boolean {
+	return (
+		values.every((value) => integer(value) && value >= 0 && value < count) &&
+		new Set(values).size === values.length
+	);
+}
+
+function pairsValid(values: readonly BorderPair[], allowed: Set<number>): boolean {
+	let previousBottom = -1;
+	for (const { top, bottom } of values) {
+		if (
+			!integer(top) ||
+			!integer(bottom) ||
+			top >= bottom ||
+			top <= previousBottom ||
+			!allowed.has(top) ||
+			!allowed.has(bottom)
+		)
+			return false;
+		previousBottom = bottom;
+	}
+	return true;
+}
+
+function subset(values: readonly number[], allowed: Set<number>): boolean {
+	return values.every((value) => allowed.has(value));
+}
+
+function clone(metadata: FixedEditorLayoutMetadata): FixedEditorLayoutMetadata {
+	return structuredClone(metadata);
+}
+
+export function validateFixedEditorLayout(
+	metadata: FixedEditorLayoutMetadata | undefined,
+	renderedRows: readonly string[],
+	width: number,
+): FixedEditorLayoutMetadata | undefined {
+	if (
+		!metadata ||
+		!integer(width) ||
+		metadata.width !== width ||
+		metadata.renderedRowCount !== renderedRows.length
+	)
+		return undefined;
+	const count = renderedRows.length;
+	const editor = metadata.editor;
+	if (
+		!orderedRanges(editor.rows, count) ||
+		!orderedRanges(editor.frame, count) ||
+		!orderedRanges(editor.content, count)
+	)
+		return undefined;
+	const editorRows = expand(editor.rows);
+	const editorSet = new Set(editorRows);
+	if (
+		!uniqueRows(editorRows, count) ||
+		!uniqueRows(editor.structuralRows, count) ||
+		!subset(editor.structuralRows, editorSet) ||
+		!editorSet.has(editor.cursorRow)
+	)
+		return undefined;
+	if (
+		!expand(editor.frame).every((row) => editorSet.has(row)) ||
+		!expand(editor.content).every((row) => editorSet.has(row)) ||
+		!pairsValid(editor.borderPairs, editorSet)
+	)
+		return undefined;
+
+	const autocomplete = metadata.autocomplete;
+	const autocompleteRows = autocomplete ? expand([autocomplete.rows]) : [];
+	const autoSet = new Set(autocompleteRows);
+	const partition = [...editorRows, ...autocompleteRows].sort((a, b) => a - b);
+	if (partition.length !== count || partition.some((row, index) => row !== index)) return undefined;
+	if (autocomplete) {
+		if (
+			!range(autocomplete.rows, count) ||
+			!uniqueRows(autocomplete.structuralRows, count) ||
+			!uniqueRows(autocomplete.closureRows, count)
+		)
+			return undefined;
+		if (
+			!subset(autocomplete.structuralRows, autoSet) ||
+			!subset(autocomplete.closureRows, autoSet) ||
+			!pairsValid(autocomplete.borderPairs, autoSet)
+		)
+			return undefined;
+		const forbidden = new Set([
+			...autocomplete.structuralRows,
+			...autocomplete.closureRows,
+			...autocomplete.borderPairs.flatMap(({ top, bottom }) => [top, bottom]),
+		]);
+		if (autocomplete.selection.known) {
+			const selection = autocomplete.selection;
+			if (
+				!integer(selection.selectedIndex) ||
+				!range(selection.visibleWindow, Number.MAX_SAFE_INTEGER) ||
+				selection.selectedIndex < selection.visibleWindow.start ||
+				selection.selectedIndex >= selection.visibleWindow.end
+			)
+				return undefined;
+			const expected = selection.visibleWindow.end - selection.visibleWindow.start;
+			if (selection.itemToOutputRows.length !== expected) return undefined;
+			const items = new Set<number>();
+			const rows = new Set<number>();
+			for (const mapping of selection.itemToOutputRows) {
+				if (
+					!integer(mapping.itemIndex) ||
+					mapping.itemIndex < selection.visibleWindow.start ||
+					mapping.itemIndex >= selection.visibleWindow.end ||
+					!autoSet.has(mapping.outputRow) ||
+					forbidden.has(mapping.outputRow) ||
+					items.has(mapping.itemIndex) ||
+					rows.has(mapping.outputRow)
+				)
+					return undefined;
+				items.add(mapping.itemIndex);
+				rows.add(mapping.outputRow);
+			}
+			const selected = selection.itemToOutputRows.find(
+				({ itemIndex }) => itemIndex === selection.selectedIndex,
+			);
+			if (
+				!selected ||
+				selection.selectedRow !== selected.outputRow ||
+				forbidden.has(selection.selectedRow)
+			)
+				return undefined;
+		}
+	}
+	return clone(metadata);
+}
+
+export function readFixedEditorLayout(
+	value: unknown,
+	renderedRows: readonly string[],
+	width: number,
+): FixedEditorLayoutMetadata | undefined {
+	if ((typeof value !== "object" && typeof value !== "function") || value === null)
+		return undefined;
+	try {
+		const provider = Reflect.get(value, FIXED_EDITOR_LAYOUT);
+		if (typeof provider !== "function") return undefined;
+		return validateFixedEditorLayout(
+			Reflect.apply(provider, value, [renderedRows, width]),
+			renderedRows,
+			width,
+		);
+	} catch {
+		return undefined;
+	}
+}

--- a/extensions/zentui/fixed-editor/index.ts
+++ b/extensions/zentui/fixed-editor/index.ts
@@ -11,7 +11,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { type Component, type TUI, visibleWidth } from "@earendil-works/pi-tui";
 
-import type { PolishedTuiConfig } from "../config";
+import type { ZentuiConfig } from "../config";
 import type { SessionLifecycle } from "../session-lifecycle";
 import { renderStyleForSourceOrFallback } from "../style";
 import { TerminalSplitCompositor } from "./compositor";
@@ -60,20 +60,20 @@ class CopyNoticeComponent implements Component {
 	invalidate(): void {}
 }
 
-function showCopyNotice(ctx: ExtensionContext, getConfig: () => PolishedTuiConfig): void {
+function showCopyNotice(ctx: ExtensionContext, getConfig: () => ZentuiConfig): void {
 	if (!ctx.hasUI || typeof ctx.ui.setWidget !== "function") return;
 	const config = getConfig();
 	ctx.ui.setWidget(COPY_NOTICE_KEY, (_tui, theme) => {
 		const text = renderStyleForSourceOrFallback(
 			theme,
-			config.colorSources.editor,
+			config.components.editor.colorSource,
 			undefined,
 			{ terminal: "yellow", theme: "warning" },
 			"Copied to clipboard",
 		);
 		const border = renderStyleForSourceOrFallback(
 			theme,
-			config.colorSources.editor,
+			config.components.editor.colorSource,
 			config.colors.editorBorder,
 			{ terminal: "yellow", theme: "border" },
 			"",
@@ -121,15 +121,11 @@ function warnUnsupported(ctx: ExtensionContext): void {
 	);
 }
 
-function installFromProbe(
-	ctx: ExtensionContext,
-	tui: TUI,
-	getConfig: () => PolishedTuiConfig,
-): void {
+function installFromProbe(ctx: ExtensionContext, tui: TUI, getConfig: () => ZentuiConfig): void {
 	if (compositor) return;
 	try {
 		const config = getConfig();
-		if (!config.fixedEditor?.enabled) return;
+		if (!config.layout.fixedEditor.enabled) return;
 
 		const capabilities = inspectPiTui(tui);
 		if (!capabilities) {
@@ -140,9 +136,9 @@ function installFromProbe(
 		const next = new TerminalSplitCompositor(
 			capabilities,
 			() => ({
-				enabled: getConfig().fixedEditor?.enabled ?? false,
-				mouseScroll: getConfig().fixedEditor?.mouseScroll ?? false,
-				copyNotice: getConfig().fixedEditor?.copyNotice ?? true,
+				enabled: getConfig().layout.fixedEditor.enabled,
+				mouseScroll: getConfig().layout.fixedEditor.mouseScroll,
+				copyNotice: getConfig().layout.fixedEditor.copyNotice,
 			}),
 			ctx.hasUI ? () => showCopyNotice(ctx, getConfig) : undefined,
 			ctx.hasUI ? () => clearCopyNotice(ctx) : undefined,
@@ -168,7 +164,7 @@ const WIDGET_KEY = "zentui-fixed-editor-probe";
  */
 export function installFixedEditorProbe(
 	ctx: ExtensionContext,
-	getConfig: () => PolishedTuiConfig,
+	getConfig: () => ZentuiConfig,
 	lifecycle: SessionLifecycle,
 ): void {
 	if (!lifecycle.isCurrent() || !ctx.hasUI) return;
@@ -200,14 +196,26 @@ export function installFixedEditorProbe(
 export function disposeFixedEditor(ctx?: ExtensionContext): void {
 	cancelProbeInstall?.();
 	cancelProbeInstall = null;
-	compositor?.dispose();
+	const activeCompositor = compositor;
 	compositor = null;
-	if (copyNoticeTimer) {
-		clearTimeout(copyNoticeTimer);
+	let failure: unknown;
+	try {
+		activeCompositor?.dispose();
+	} catch (error) {
+		failure = error;
+	} finally {
+		if (copyNoticeTimer) clearTimeout(copyNoticeTimer);
 		copyNoticeTimer = null;
+		storedCtx = null;
 	}
-	storedCtx = null;
-	if (ctx) clearCopyNotice(ctx);
+	if (ctx) {
+		try {
+			clearCopyNotice(ctx);
+		} catch (error) {
+			failure ??= error;
+		}
+	}
+	if (failure) throw failure;
 }
 
 /**

--- a/extensions/zentui/fixed-editor/index.ts
+++ b/extensions/zentui/fixed-editor/index.ts
@@ -16,6 +16,7 @@ import type { SessionLifecycle } from "../session-lifecycle";
 import { renderStyleForSourceOrFallback } from "../style";
 import { TerminalSplitCompositor } from "./compositor";
 import { inspectPiTui } from "./pi-compat";
+import type { DisposalReason } from "./types";
 
 let compositor: TerminalSplitCompositor | null = null;
 let didWarnUnsupported = false;
@@ -193,14 +194,14 @@ export function installFixedEditorProbe(
  * Dispose the compositor if active.
  * Call from session_shutdown and cleanupUi.
  */
-export function disposeFixedEditor(ctx?: ExtensionContext): void {
+export function disposeFixedEditor(reason: DisposalReason, ctx?: ExtensionContext): void {
 	cancelProbeInstall?.();
 	cancelProbeInstall = null;
 	const activeCompositor = compositor;
 	compositor = null;
 	let failure: unknown;
 	try {
-		activeCompositor?.dispose();
+		activeCompositor?.dispose(reason);
 	} catch (error) {
 		failure = error;
 	} finally {

--- a/extensions/zentui/fixed-editor/layout.ts
+++ b/extensions/zentui/fixed-editor/layout.ts
@@ -1,0 +1,144 @@
+import type { FixedEditorLayoutMetadata } from "./editor-layout";
+import type { FixedLayoutPlan } from "./types";
+
+export function takeTail<T>(rows: readonly T[], budget: number): T[] {
+	const count = Math.max(0, Math.floor(budget));
+	if (count <= 0) return [];
+	return rows.slice(Math.max(0, rows.length - count));
+}
+
+export function cropAround<T>(rows: readonly T[], anchor: number, budget: number): T[] {
+	const count = Math.max(0, Math.floor(budget));
+	if (count <= 0 || rows.length === 0) return [];
+	if (rows.length <= count) return [...rows];
+	const at = Math.max(0, Math.min(rows.length - 1, Math.floor(anchor)));
+	const start = Math.max(0, Math.min(at - Math.floor((count - 1) / 2), rows.length - count));
+	return rows.slice(start, start + count);
+}
+
+function expand(ranges: readonly { start: number; end: number }[]): number[] {
+	return ranges.flatMap(({ start, end }) =>
+		Array.from({ length: end - start }, (_, index) => start + index),
+	);
+}
+
+function sorted(values: Iterable<number>): number[] {
+	return [...new Set(values)].sort((a, b) => a - b);
+}
+
+export type FixedLayoutInput = {
+	rawRows: number;
+	desiredMode?: "fixed" | "normal-flow";
+	editorRows: readonly string[];
+	metadata?: FixedEditorLayoutMetadata;
+	statusRows?: readonly string[];
+	aboveRows?: readonly string[];
+	belowRows?: readonly string[];
+	footerRows?: readonly string[];
+};
+
+export function planFixedLayout(input: FixedLayoutInput): FixedLayoutPlan {
+	const rawRows = Math.max(0, Math.floor(Number.isFinite(input.rawRows) ? input.rawRows : 0));
+	const desired = input.desiredMode ?? "fixed";
+	if (rawRows === 0) return { mode: "no-terminal-rows", pendingDesiredMode: desired };
+	const available = Math.max(0, rawRows - 1);
+	if (desired === "normal-flow") {
+		return {
+			mode: "normal-flow",
+			reason: input.metadata ? "editor-minimum-does-not-fit" : "opaque-editor-does-not-fit",
+		};
+	}
+
+	let editorRows: number[];
+	let autocompleteRows: number[] = [];
+	let used = 0;
+	if (!input.metadata) {
+		if (input.editorRows.length > available)
+			return { mode: "normal-flow", reason: "opaque-editor-does-not-fit" };
+		editorRows = input.editorRows.map((_, index) => index);
+		used = editorRows.length;
+	} else {
+		const metadata = input.metadata;
+		const editorMinimum = sorted([
+			...metadata.editor.structuralRows,
+			...metadata.editor.borderPairs.flatMap(({ top, bottom }) => [top, bottom]),
+			metadata.editor.cursorRow,
+		]);
+		if (editorMinimum.length > available)
+			return { mode: "normal-flow", reason: "editor-minimum-does-not-fit" };
+		editorRows = editorMinimum;
+		used = editorRows.length;
+		const autocomplete = metadata.autocomplete;
+		if (autocomplete) {
+			const allAutoRows = Array.from(
+				{ length: autocomplete.rows.end - autocomplete.rows.start },
+				(_, index) => autocomplete.rows.start + index,
+			);
+			if (autocomplete.selection.known) {
+				const minimum = sorted([
+					...autocomplete.structuralRows,
+					...autocomplete.closureRows,
+					...autocomplete.borderPairs.flatMap(({ top, bottom }) => [top, bottom]),
+					autocomplete.selection.selectedRow,
+				]);
+				if (used + minimum.length <= available) {
+					const remaining = available - used - minimum.length;
+					const itemRows = autocomplete.selection.itemToOutputRows.map(
+						({ outputRow }) => outputRow,
+					);
+					const selectedOffset = Math.max(0, itemRows.indexOf(autocomplete.selection.selectedRow));
+					const extras = cropAround(
+						itemRows,
+						selectedOffset,
+						Math.min(itemRows.length, remaining + 1),
+					);
+					autocompleteRows = sorted([...minimum, ...extras]);
+					used += autocompleteRows.length;
+				}
+			} else if (used + allAutoRows.length <= available) {
+				autocompleteRows = allAutoRows;
+				used += autocompleteRows.length;
+			}
+		}
+	}
+
+	const allocate = (rows: readonly string[] | undefined): number => {
+		const count = Math.min(rows?.length ?? 0, Math.max(0, available - used));
+		used += count;
+		return count;
+	};
+	const footerBudget = allocate(input.footerRows);
+	const belowBudget = allocate(input.belowRows);
+	const aboveBudget = allocate(input.aboveRows);
+	const statusBudget = allocate(input.statusRows);
+
+	if (input.metadata && used < available) {
+		const selected = new Set(editorRows);
+		const cursorRow = input.metadata.editor.cursorRow;
+		const candidates = expand(input.metadata.editor.rows)
+			.filter((row) => !selected.has(row))
+			.sort((a, b) => Math.abs(a - cursorRow) - Math.abs(b - cursorRow) || a - b);
+		for (const row of candidates.slice(0, available - used)) selected.add(row);
+		editorRows = sorted(selected);
+	}
+
+	return {
+		mode: "fixed",
+		transcriptRows: Math.max(
+			1,
+			rawRows -
+				(editorRows.length +
+					autocompleteRows.length +
+					statusBudget +
+					aboveBudget +
+					belowBudget +
+					footerBudget),
+		),
+		selectedEditorRows: editorRows,
+		selectedAutocompleteRows: autocompleteRows,
+		statusBudget,
+		aboveBudget,
+		belowBudget,
+		footerBudget,
+	};
+}

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -16,6 +16,7 @@ export type PiFixedCluster = {
 	status: PiRenderableCapability | null;
 	aboveWidget: PiRenderableCapability | null;
 	editor: PiRenderableCapability;
+	editorChild?: unknown;
 	belowWidget: PiRenderableCapability | null;
 	footer: PiRenderableCapability | null;
 };
@@ -38,7 +39,9 @@ export type PiFixedEditorCapabilities = {
 	removeInputListener: (
 		listener: (data: string) => { consume?: boolean; data?: string } | undefined,
 	) => void;
-	requestRender?: (force?: boolean) => void;
+	requestRender: (force?: boolean) => void;
+	requestNormalRender: () => void;
+	requestForceRender: () => void;
 };
 
 function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
@@ -123,7 +126,8 @@ export function findEditorContainerIndex(
 
 function clusterCapability(children: unknown[], editorIndex: number): PiFixedCluster | undefined {
 	const editor = renderable(children[editorIndex]);
-	if (!editor) return undefined;
+	const editorChild = containerChildren(children[editorIndex])?.find(isEditorLike);
+	if (!editor || !editorChild) return undefined;
 	const optional = (index: number): PiRenderableCapability | null | undefined => {
 		if (index < 0 || index >= children.length) return null;
 		return renderable(children[index]);
@@ -140,7 +144,7 @@ function clusterCapability(children: unknown[], editorIndex: number): PiFixedClu
 	) {
 		return undefined;
 	}
-	return { status, aboveWidget, editor, belowWidget, footer };
+	return { status, aboveWidget, editor, editorChild, belowWidget, footer };
 }
 
 function readRowsValue(
@@ -224,6 +228,8 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 	}
 
 	const requestRenderValue = Reflect.get(value, "requestRender");
+	if (typeof requestRenderValue !== "function") return undefined;
+	const requestRender = (force?: boolean) => Reflect.apply(requestRenderValue, value, [force]);
 	return {
 		tui: value,
 		terminal: terminalValue,
@@ -280,10 +286,9 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 		removeInputListener: (listener) => {
 			Reflect.apply(removeInputListenerValue, value, [listener]);
 		},
-		requestRender:
-			typeof requestRenderValue === "function"
-				? (force) => Reflect.apply(requestRenderValue, value, [force])
-				: undefined,
+		requestRender,
+		requestNormalRender: () => requestRender(),
+		requestForceRender: () => requestRender(true),
 	};
 }
 

--- a/extensions/zentui/fixed-editor/pi-compat.ts
+++ b/extensions/zentui/fixed-editor/pi-compat.ts
@@ -1,7 +1,7 @@
 /** Verified private Pi TUI capabilities required by the experimental fixed editor. @internal */
 export type PiMethodCapability = {
 	target: Record<PropertyKey, unknown>;
-	key: "render" | "doRender" | "write";
+	key: "render" | "doRender" | "write" | "drainInput" | "stop";
 	method: (...args: unknown[]) => unknown;
 	ownDescriptor: PropertyDescriptor | undefined;
 };
@@ -28,6 +28,8 @@ export type PiFixedEditorCapabilities = {
 	renderMethod: PiMethodCapability;
 	doRenderMethod: PiMethodCapability;
 	writeMethod: PiMethodCapability;
+	drainInputMethod: PiMethodCapability;
+	stopMethod: PiMethodCapability;
 	rowsOwnDescriptor: PropertyDescriptor | undefined;
 	readRawRows: () => number;
 	getColumns: () => number;
@@ -181,7 +183,10 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 	const renderMethod = writableMethod(value, "render");
 	const doRenderMethod = writableMethod(value, "doRender");
 	const writeMethod = writableMethod(terminalValue, "write");
-	if (!renderMethod || !doRenderMethod || !writeMethod) return undefined;
+	const drainInputMethod = writableMethod(terminalValue, "drainInput");
+	const stopMethod = writableMethod(terminalValue, "stop");
+	if (!renderMethod || !doRenderMethod || !writeMethod || !drainInputMethod || !stopMethod)
+		return undefined;
 
 	const addInputListenerValue = Reflect.get(value, "addInputListener");
 	const removeInputListenerValue = Reflect.get(value, "removeInputListener");
@@ -237,6 +242,8 @@ function inspectPiTuiUnsafe(value: unknown): PiFixedEditorCapabilities | undefin
 		renderMethod,
 		doRenderMethod,
 		writeMethod,
+		drainInputMethod,
+		stopMethod,
 		rowsOwnDescriptor,
 		readRawRows: rowsReader(terminalValue, rowsDescriptor, initialRows),
 		getColumns: () => {

--- a/extensions/zentui/fixed-editor/terminal-modes.ts
+++ b/extensions/zentui/fixed-editor/terminal-modes.ts
@@ -42,6 +42,12 @@ export const SHOW_CURSOR = "\x1b[?25h";
 /** Clear entire line. */
 export const CLEAR_LINE = "\x1b[2K";
 
+/** Clear the current viewport without erasing scrollback. */
+export const CLEAR_DISPLAY = "\x1b[2J";
+
+/** Move the cursor home. */
+export const HOME_CURSOR = "\x1b[H";
+
 /** Disable auto-wrap (DECAWM off). */
 export const DISABLE_AUTOWRAP = "\x1b[?7l";
 
@@ -58,18 +64,32 @@ export function cursorTo(row: number, col: number): string {
 	return `\x1b[${row};${col}H`;
 }
 
-/**
- * Emit all sequences needed to restore the terminal to a safe state.
- * Call on dispose and process.exit to avoid leaving the terminal broken.
- */
-export function emergencyTerminalReset(): string {
+/** Canonical idempotent reset for every terminal mode owned by Zentui. */
+export const CANONICAL_TERMINAL_RESET =
+	SYNC_BEGIN +
+	RESET_SCROLL_REGION +
+	DISABLE_MOUSE +
+	DISABLE_ALT_SCROLL +
+	ENABLE_AUTOWRAP +
+	SHOW_CURSOR +
+	EXIT_ALT_SCREEN +
+	SYNC_END;
+
+/** Clear-and-normalize prelude for a physical layout transition. */
+export function transitionPrelude(target: "fixed" | "normal-flow"): string {
 	return (
 		SYNC_BEGIN +
 		RESET_SCROLL_REGION +
+		ENABLE_AUTOWRAP +
 		DISABLE_MOUSE +
-		ENABLE_ALT_SCROLL +
-		EXIT_ALT_SCREEN +
+		(target === "fixed" ? DISABLE_ALT_SCROLL : ENABLE_ALT_SCROLL) +
 		SHOW_CURSOR +
+		HOME_CURSOR +
+		CLEAR_DISPLAY +
 		SYNC_END
 	);
+}
+
+export function emergencyTerminalReset(): string {
+	return CANONICAL_TERMINAL_RESET;
 }

--- a/extensions/zentui/fixed-editor/types.ts
+++ b/extensions/zentui/fixed-editor/types.ts
@@ -30,8 +30,29 @@ export type CompositorConfig = {
 	copyNotice: boolean;
 };
 
+export type DisposalReason = "live" | "shutdown";
+
+export type FixedLayoutPlan =
+	| {
+			mode: "fixed";
+			transcriptRows: number;
+			selectedEditorRows: readonly number[];
+			selectedAutocompleteRows: readonly number[];
+			statusBudget: number;
+			aboveBudget: number;
+			belowBudget: number;
+			footerBudget: number;
+	  }
+	| {
+			mode: "normal-flow";
+			reason: "editor-minimum-does-not-fit" | "opaque-editor-does-not-fit";
+	  }
+	| { mode: "no-terminal-rows"; pendingDesiredMode: "fixed" | "normal-flow" };
+
 /** Result of rendering the pinned cluster. */
 export type ClusterRender = {
+	mode: "fixed" | "normal-flow" | "no-terminal-rows";
 	lines: string[];
 	cursor: { row: number; col: number } | null;
+	plan?: FixedLayoutPlan;
 };

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -186,6 +186,7 @@ export function installFooter(
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
 		getLiveContext?: () => LiveContextOverride | undefined;
+		onDispose?: () => void;
 	},
 ): void {
 	ctx.ui.setFooter((tui, theme, footerData) => {
@@ -201,6 +202,7 @@ export function installFooter(
 				unsubscribeBranch();
 				hooks.setRequestRender(undefined);
 				hooks.setExtensionStatusesGetter?.(undefined);
+				hooks.onDispose?.();
 			},
 			invalidate() {},
 			render(width: number): string[] {
@@ -800,4 +802,14 @@ export function installFooter(
 			},
 		};
 	});
+}
+
+export function installHiddenFooter(ctx: ExtensionContext, onDispose?: () => void): void {
+	ctx.ui.setFooter(() => ({
+		dispose: onDispose,
+		invalidate() {},
+		render(): string[] {
+			return [];
+		},
+	}));
 }

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -2,6 +2,7 @@ import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { SeparatorStyle, ZentuiConfig } from "./config";
 import { FOOTER_FORMAT_ALIASES } from "./config";
+import { sanitizeEditorMetadataText } from "./editor-metadata-format";
 import {
 	collectExtensionStatusSegments,
 	type ExtensionStatusSegment,
@@ -226,6 +227,35 @@ export function installFooter(
 				);
 				const colorSource = config.components.footer.colorSource;
 				const iconMode = config.icons.mode;
+				const formattedCwd = sanitizeEditorMetadataText(
+					formatCwdLabel(ctx.cwd, config.icons.cwd, {
+						mode: config.components.footer.styles.starship.pathDisplay.mode,
+						depth: config.components.footer.styles.starship.pathDisplay.depth,
+					}),
+				);
+				const branch = sanitizeEditorMetadataText(state.branch ?? "") || undefined;
+				const gitStateLabel = sanitizeEditorMetadataText(state.gitStateLabel ?? "");
+				const commit = state.commit
+					? {
+							...state.commit,
+							oid: state.commit.oid ? sanitizeEditorMetadataText(state.commit.oid) || null : null,
+							tag: state.commit.tag ? sanitizeEditorMetadataText(state.commit.tag) || null : null,
+						}
+					: undefined;
+				const runtime = state.runtime
+					? {
+							...state.runtime,
+							name: sanitizeEditorMetadataText(state.runtime.name),
+							symbol: sanitizeEditorMetadataText(state.runtime.symbol),
+							version: sanitizeEditorMetadataText(state.runtime.version ?? ""),
+						}
+					: undefined;
+				const packageVersion = state.packageVersion
+					? {
+							...state.packageVersion,
+							version: sanitizeEditorMetadataText(state.packageVersion.version),
+						}
+					: undefined;
 				const separator = renderStyleForSource(
 					theme,
 					colorSource,
@@ -233,15 +263,7 @@ export function installFooter(
 					separatorText[config.components.footer.styles.starship.separator],
 				);
 				const innerWidth = Math.max(1, width - 2);
-				const cwdLabel = renderStyleForSource(
-					theme,
-					colorSource,
-					config.colors.cwd,
-					formatCwdLabel(ctx.cwd, config.icons.cwd, {
-						mode: config.components.footer.styles.starship.pathDisplay.mode,
-						depth: config.components.footer.styles.starship.pathDisplay.depth,
-					}),
-				);
+				const cwdLabel = renderStyleForSource(theme, colorSource, config.colors.cwd, formattedCwd);
 				const needsSessionName =
 					(config.components.footer.styles.starship.format
 						? wideReferences.has("session_name")
@@ -254,7 +276,6 @@ export function installFooter(
 					? renderStyleForSource(theme, colorSource, config.colors.sessionName, sessionName)
 					: "";
 				const builtInSessionNameLabel = sessionNameLabel ? `in ${sessionNameLabel}` : "";
-				const branch = state.branch;
 				const branchText = branch
 					? formatGitBranchText(
 							branch,
@@ -333,7 +354,6 @@ export function installFooter(
 				})();
 				const statusBlock =
 					allStatus || aheadBehind ? gitStatusColor(`[${allStatus}${aheadBehind}]`) : "";
-				const gitStateLabel = state.gitStateLabel ?? "";
 				const gitStateBlock = gitStateLabel ? gitStatusColor(gitStateLabel) : "";
 				const renderVariable = (name: string): string => {
 					const canonical = FOOTER_FORMAT_ALIASES[name] ?? name;
@@ -353,14 +373,10 @@ export function installFooter(
 						case "git_state":
 							return gitStateBlock;
 						case "runtime": {
-							if (!state.runtime) return "";
-							const symbol = resolveRuntimeSymbol(
-								state.runtime.name,
-								state.runtime.symbol,
-								iconMode,
-							);
-							const label = state.runtime.version ? `${symbol} ${state.runtime.version}` : symbol;
-							return renderStyleForSource(theme, colorSource, state.runtime.style, label);
+							if (!runtime) return "";
+							const symbol = resolveRuntimeSymbol(runtime.name, runtime.symbol, iconMode);
+							const label = runtime.version ? `${symbol} ${runtime.version}` : symbol;
+							return renderStyleForSource(theme, colorSource, runtime.style, label);
 						}
 						case "model":
 							return sanitizeExtensionStatusText(footerModelLabel);
@@ -418,19 +434,19 @@ export function installFooter(
 						case "package":
 							return formatPackageVersionSegment(
 								theme,
-								state.packageVersion,
+								packageVersion,
 								colorSource,
 								iconMode,
 								config.icons.package,
 								config.colors.packageVersion,
 							);
 						case "package_version":
-							return state.packageVersion?.version
+							return packageVersion?.version
 								? renderStyleForSource(
 										theme,
 										colorSource,
 										config.colors.packageVersion,
-										state.packageVersion.version,
+										packageVersion.version,
 									)
 								: "";
 						case "sep":
@@ -438,19 +454,14 @@ export function installFooter(
 						case "git_commit":
 							return formatGitCommitSegment(
 								theme,
-								state.commit,
+								commit,
 								config.components.footer.styles.starship.gitCommit,
 								colorSource,
 								config.colors.gitCommit,
 							);
 						case "git_tag":
-							return config.components.footer.styles.starship.gitCommit.showTag && state.commit?.tag
-								? renderStyleForSource(
-										theme,
-										colorSource,
-										config.colors.gitCommit,
-										state.commit.tag,
-									)
+							return config.components.footer.styles.starship.gitCommit.showTag && commit?.tag
+								? renderStyleForSource(theme, colorSource, config.colors.gitCommit, commit.tag)
 								: "";
 						case "git_metrics":
 							return formatGitMetricsSegment(
@@ -487,18 +498,18 @@ export function installFooter(
 				if (config.components.footer.styles.starship.segments.gitBranch) {
 					if (branchText) {
 						branchParts.push("on", gitIcon, gitColor(branchText));
-					} else if (state.commit?.detached) {
+					} else if (commit?.detached) {
 						// `HEAD` uses git-branch style; `(hash)` uses git-commit style
 						// (bold green) per Starship `git_commit` format.
 						branchParts.push("on", gitIcon, gitColor("HEAD"));
-						if (config.components.footer.styles.starship.segments.gitCommit && state.commit.oid) {
-							const shortHash = state.commit.oid.slice(
+						if (config.components.footer.styles.starship.segments.gitCommit && commit.oid) {
+							const shortHash = commit.oid.slice(
 								0,
 								config.components.footer.styles.starship.gitCommit.hashLength,
 							);
 							const tag =
-								config.components.footer.styles.starship.gitCommit.showTag && state.commit.tag
-									? state.commit.tag
+								config.components.footer.styles.starship.gitCommit.showTag && commit.tag
+									? commit.tag
 									: "";
 							const inner = [shortHash, tag].filter(Boolean).join(" ");
 							branchParts.push(
@@ -519,18 +530,12 @@ export function installFooter(
 					.filter(Boolean)
 					.join(" ");
 				const runtimeLabel = config.components.footer.styles.starship.segments.runtime
-					? formatRuntimeSegment(
-							theme,
-							state.runtime,
-							config.colors.runtimePrefix,
-							colorSource,
-							iconMode,
-						)
+					? formatRuntimeSegment(theme, runtime, config.colors.runtimePrefix, colorSource, iconMode)
 					: "";
 				const packageVersionLabel = config.components.footer.styles.starship.segments.packageVersion
 					? formatPackageVersionSegment(
 							theme,
-							state.packageVersion,
+							packageVersion,
 							colorSource,
 							iconMode,
 							config.icons.package,
@@ -540,12 +545,12 @@ export function installFooter(
 				// Skip standalone gitCommit when hash is already folded into the
 				// branch display on detached HEAD.
 				const hashFoldedIntoBranch =
-					state.commit?.detached && config.components.footer.styles.starship.segments.gitBranch;
+					commit?.detached && config.components.footer.styles.starship.segments.gitBranch;
 				const gitCommitLabel =
 					config.components.footer.styles.starship.segments.gitCommit && !hashFoldedIntoBranch
 						? formatGitCommitSegment(
 								theme,
-								state.commit,
+								commit,
 								config.components.footer.styles.starship.gitCommit,
 								colorSource,
 								config.colors.gitCommit,
@@ -731,7 +736,9 @@ export function installFooter(
 						theme,
 						colorSource,
 						config.colors.cwd,
-						formatCwdLabel(ctx.cwd, config.icons.cwd, { mode: "basename", depth: 0 }),
+						sanitizeEditorMetadataText(
+							formatCwdLabel(ctx.cwd, config.icons.cwd, { mode: "basename", depth: 0 }),
+						),
 					),
 					chunkBudget,
 					"…",

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -1,6 +1,6 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { PolishedTuiConfig, SeparatorStyle } from "./config";
+import type { SeparatorStyle, ZentuiConfig } from "./config";
 import { FOOTER_FORMAT_ALIASES } from "./config";
 import {
 	collectExtensionStatusSegments,
@@ -37,7 +37,7 @@ import {
 } from "./format";
 import { resolveRuntimeSymbol } from "./icons";
 import type { LiveContextOverride } from "./live-context";
-import type { FooterState } from "./state";
+import { type FooterState, modelLabelFor } from "./state";
 import { renderStyleForSource } from "./style";
 
 const separatorText: Record<SeparatorStyle, string> = {
@@ -180,13 +180,12 @@ function composeFooterContent(
 export function installFooter(
 	ctx: ExtensionContext,
 	state: FooterState,
-	getConfig: () => PolishedTuiConfig,
+	getConfig: () => ZentuiConfig,
 	hooks: {
 		setRequestRender: (fn: (() => void) | undefined) => void;
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
 		getLiveContext?: () => LiveContextOverride | undefined;
-		suppressVisibleOutput?: () => boolean;
 	},
 ): void {
 	ctx.ui.setFooter((tui, theme, footerData) => {
@@ -205,12 +204,15 @@ export function installFooter(
 			},
 			invalidate() {},
 			render(width: number): string[] {
-				if (hooks.suppressVisibleOutput?.()) return [];
 				if (width <= 0) return [""];
 				const config = getConfig();
-				const wideFormatTokens = config.footerFormat ? parseFooterFormat(config.footerFormat) : [];
-				const compactFormatTokens = config.responsiveFooter
-					? parseFooterFormat(config.compactFooterFormat)
+				const footer = config.components.footer;
+				const footerModelLabel = modelLabelFor(state, footer.modelLabel);
+				const wideFormatTokens = config.components.footer.styles.starship.format
+					? parseFooterFormat(config.components.footer.styles.starship.format)
+					: [];
+				const compactFormatTokens = config.components.footer.styles.starship.responsive
+					? parseFooterFormat(config.components.footer.styles.starship.compactFormat)
 					: [];
 				const wideReferences = collectFooterFormatReferences(
 					wideFormatTokens,
@@ -220,13 +222,13 @@ export function installFooter(
 					compactFormatTokens,
 					FOOTER_FORMAT_ALIASES,
 				);
-				const colorSource = config.colorSources.starship;
+				const colorSource = config.components.footer.colorSource;
 				const iconMode = config.icons.mode;
 				const separator = renderStyleForSource(
 					theme,
 					colorSource,
 					config.colors.separator,
-					separatorText[config.separator],
+					separatorText[config.components.footer.styles.starship.separator],
 				);
 				const innerWidth = Math.max(1, width - 2);
 				const cwdLabel = renderStyleForSource(
@@ -234,14 +236,15 @@ export function installFooter(
 					colorSource,
 					config.colors.cwd,
 					formatCwdLabel(ctx.cwd, config.icons.cwd, {
-						mode: config.pathDisplay.mode,
-						depth: config.pathDisplay.depth,
+						mode: config.components.footer.styles.starship.pathDisplay.mode,
+						depth: config.components.footer.styles.starship.pathDisplay.depth,
 					}),
 				);
 				const needsSessionName =
-					(config.footerFormat
+					(config.components.footer.styles.starship.format
 						? wideReferences.has("session_name")
-						: config.footerSegments.sessionName) || compactReferences.has("session_name");
+						: config.components.footer.styles.starship.segments.sessionName) ||
+					compactReferences.has("session_name");
 				const sessionName = needsSessionName
 					? sanitizeExtensionStatusText(ctx.sessionManager.getSessionName() ?? "")
 					: "";
@@ -251,7 +254,10 @@ export function installFooter(
 				const builtInSessionNameLabel = sessionNameLabel ? `in ${sessionNameLabel}` : "";
 				const branch = state.branch;
 				const branchText = branch
-					? formatGitBranchText(branch, config.gitBranch.maxLength)
+					? formatGitBranchText(
+							branch,
+							config.components.footer.styles.starship.gitBranch.maxLength,
+						)
 					: undefined;
 				const contextUsage = ctx.getContextUsage();
 				const liveContext = hooks.getLiveContext?.();
@@ -264,10 +270,13 @@ export function installFooter(
 				const contextLabel = buildContextDisplayLabel({
 					percent: contextPercent,
 					contextWindow,
-					style: config.contextStyle,
+					style: config.components.footer.styles.starship.contextStyle,
 					asciiGauge: iconMode === "ascii",
 				});
-				const tier = contextColorTier(contextPercent, config.contextThresholds);
+				const tier = contextColorTier(
+					contextPercent,
+					config.components.footer.styles.starship.contextThresholds,
+				);
 				const contextColor =
 					tier === "error"
 						? config.colors.contextError
@@ -291,7 +300,7 @@ export function installFooter(
 				const gitStatusColor = (text: string) =>
 					renderStyleForSource(theme, colorSource, config.colors.gitStatus, text);
 				const gitIcon = config.icons.git ? gitColor(config.icons.git) : "";
-				const gitCounts = config.footerSegments.gitCounts;
+				const gitCounts = config.components.footer.styles.starship.segments.gitCounts;
 				const stashLabel =
 					state.stashed > 0
 						? gitCounts
@@ -352,7 +361,7 @@ export function installFooter(
 							return renderStyleForSource(theme, colorSource, state.runtime.style, label);
 						}
 						case "model":
-							return sanitizeExtensionStatusText(state.modelLabel);
+							return sanitizeExtensionStatusText(footerModelLabel);
 						case "provider":
 							return sanitizeExtensionStatusText(state.providerLabel);
 						case "session_duration":
@@ -428,12 +437,12 @@ export function installFooter(
 							return formatGitCommitSegment(
 								theme,
 								state.commit,
-								config.gitCommit,
+								config.components.footer.styles.starship.gitCommit,
 								colorSource,
 								config.colors.gitCommit,
 							);
 						case "git_tag":
-							return config.gitCommit.showTag && state.commit?.tag
+							return config.components.footer.styles.starship.gitCommit.showTag && state.commit?.tag
 								? renderStyleForSource(
 										theme,
 										colorSource,
@@ -445,7 +454,7 @@ export function installFooter(
 							return formatGitMetricsSegment(
 								theme,
 								state.metrics,
-								config.gitMetrics,
+								config.components.footer.styles.starship.gitMetrics,
 								colorSource,
 								config.colors.gitMetricsAdded,
 								config.colors.gitMetricsDeleted,
@@ -473,16 +482,22 @@ export function installFooter(
 					}
 				};
 				const branchParts: string[] = [];
-				if (config.footerSegments.gitBranch) {
+				if (config.components.footer.styles.starship.segments.gitBranch) {
 					if (branchText) {
 						branchParts.push("on", gitIcon, gitColor(branchText));
 					} else if (state.commit?.detached) {
 						// `HEAD` uses git-branch style; `(hash)` uses git-commit style
 						// (bold green) per Starship `git_commit` format.
 						branchParts.push("on", gitIcon, gitColor("HEAD"));
-						if (config.footerSegments.gitCommit && state.commit.oid) {
-							const shortHash = state.commit.oid.slice(0, config.gitCommit.hashLength);
-							const tag = config.gitCommit.showTag && state.commit.tag ? state.commit.tag : "";
+						if (config.components.footer.styles.starship.segments.gitCommit && state.commit.oid) {
+							const shortHash = state.commit.oid.slice(
+								0,
+								config.components.footer.styles.starship.gitCommit.hashLength,
+							);
+							const tag =
+								config.components.footer.styles.starship.gitCommit.showTag && state.commit.tag
+									? state.commit.tag
+									: "";
 							const inner = [shortHash, tag].filter(Boolean).join(" ");
 							branchParts.push(
 								renderStyleForSource(theme, colorSource, config.colors.gitCommit, `(${inner})`),
@@ -490,13 +505,18 @@ export function installFooter(
 						}
 					}
 				}
-				const gitStatusParts = config.footerSegments.gitStatus && statusBlock ? [statusBlock] : [];
-				const showGitState = config.footerSegments.gitBranch || config.footerSegments.gitStatus;
+				const gitStatusParts =
+					config.components.footer.styles.starship.segments.gitStatus && statusBlock
+						? [statusBlock]
+						: [];
+				const showGitState =
+					config.components.footer.styles.starship.segments.gitBranch ||
+					config.components.footer.styles.starship.segments.gitStatus;
 				const gitStateParts = showGitState && gitStateBlock ? [gitStateBlock] : [];
 				const branchLabel = [...branchParts, ...gitStatusParts, ...gitStateParts]
 					.filter(Boolean)
 					.join(" ");
-				const runtimeLabel = config.footerSegments.runtime
+				const runtimeLabel = config.components.footer.styles.starship.segments.runtime
 					? formatRuntimeSegment(
 							theme,
 							state.runtime,
@@ -505,7 +525,7 @@ export function installFooter(
 							iconMode,
 						)
 					: "";
-				const packageVersionLabel = config.footerSegments.packageVersion
+				const packageVersionLabel = config.components.footer.styles.starship.segments.packageVersion
 					? formatPackageVersionSegment(
 							theme,
 							state.packageVersion,
@@ -517,22 +537,23 @@ export function installFooter(
 					: "";
 				// Skip standalone gitCommit when hash is already folded into the
 				// branch display on detached HEAD.
-				const hashFoldedIntoBranch = state.commit?.detached && config.footerSegments.gitBranch;
+				const hashFoldedIntoBranch =
+					state.commit?.detached && config.components.footer.styles.starship.segments.gitBranch;
 				const gitCommitLabel =
-					config.footerSegments.gitCommit && !hashFoldedIntoBranch
+					config.components.footer.styles.starship.segments.gitCommit && !hashFoldedIntoBranch
 						? formatGitCommitSegment(
 								theme,
 								state.commit,
-								config.gitCommit,
+								config.components.footer.styles.starship.gitCommit,
 								colorSource,
 								config.colors.gitCommit,
 							)
 						: "";
-				const gitMetricsLabel = config.footerSegments.gitMetrics
+				const gitMetricsLabel = config.components.footer.styles.starship.segments.gitMetrics
 					? formatGitMetricsSegment(
 							theme,
 							state.metrics,
-							config.gitMetrics,
+							config.components.footer.styles.starship.gitMetrics,
 							colorSource,
 							config.colors.gitMetricsAdded,
 							config.colors.gitMetricsDeleted,
@@ -540,7 +561,11 @@ export function installFooter(
 					: "";
 
 				const sessionDurationSegment = (() => {
-					if (!config.footerSegments.sessionDuration || !state.sessionStartEpoch) return "";
+					if (
+						!config.components.footer.styles.starship.segments.sessionDuration ||
+						!state.sessionStartEpoch
+					)
+						return "";
 					const timeLabel = buildSessionDurationLabel(state.sessionStartEpoch);
 					const prefix = renderStyleForSource(theme, colorSource, "", "up for");
 					const time = renderStyleForSource(
@@ -551,7 +576,7 @@ export function installFooter(
 					);
 					return `${prefix} ${time}`;
 				})();
-				const usernameSegment = config.footerSegments.username
+				const usernameSegment = config.components.footer.styles.starship.segments.username
 					? renderStyleForSource(
 							theme,
 							colorSource,
@@ -559,7 +584,7 @@ export function installFooter(
 							formatUsernameHostLabel(config.icons.username),
 						)
 					: "";
-				const osSegment = config.footerSegments.os
+				const osSegment = config.components.footer.styles.starship.segments.os
 					? renderStyleForSource(
 							theme,
 							colorSource,
@@ -570,8 +595,10 @@ export function installFooter(
 				const left = [
 					osSegment,
 					usernameSegment,
-					config.footerSegments.cwd ? cwdLabel : "",
-					config.footerSegments.sessionName ? builtInSessionNameLabel : "",
+					config.components.footer.styles.starship.segments.cwd ? cwdLabel : "",
+					config.components.footer.styles.starship.segments.sessionName
+						? builtInSessionNameLabel
+						: "",
 					branchLabel,
 					gitCommitLabel,
 					gitMetricsLabel,
@@ -582,13 +609,13 @@ export function installFooter(
 					.filter(Boolean)
 					.join(" ");
 
-				const modelInfoSegment = config.footerSegments.modelInfo
+				const modelInfoSegment = config.components.footer.styles.starship.segments.modelInfo
 					? composeModelInfoLabel(
-							sanitizeExtensionStatusText(state.modelLabel),
+							sanitizeExtensionStatusText(footerModelLabel),
 							sanitizeExtensionStatusText(state.providerLabel),
 						)
 					: "";
-				const timeSegment = config.footerSegments.time
+				const timeSegment = config.components.footer.styles.starship.segments.time
 					? renderStyleForSource(
 							theme,
 							colorSource,
@@ -617,9 +644,9 @@ export function installFooter(
 					.join(" ");
 				const right = [
 					modelInfoSegment,
-					config.footerSegments.context ? builtInContextLabel : "",
-					config.footerSegments.tokens ? builtInTokenLabel : "",
-					config.footerSegments.cost ? builtInCostLabel : "",
+					config.components.footer.styles.starship.segments.context ? builtInContextLabel : "",
+					config.components.footer.styles.starship.segments.tokens ? builtInTokenLabel : "",
+					config.components.footer.styles.starship.segments.cost ? builtInCostLabel : "",
 					timeSegment,
 				]
 					.filter(Boolean)
@@ -628,7 +655,7 @@ export function installFooter(
 				let contentLeft = left;
 				let contentMiddle = "";
 				let contentRight = right;
-				if (config.footerFormat) {
+				if (config.components.footer.styles.starship.format) {
 					const {
 						left: fmtLeft,
 						middle: fmtMiddle,
@@ -669,7 +696,8 @@ export function installFooter(
 						return truncateToWidth(framed, width, "");
 					});
 
-				if (!config.responsiveFooter) return frameRows([renderLegacyContent()]);
+				if (!config.components.footer.styles.starship.responsive)
+					return frameRows([renderLegacyContent()]);
 
 				const fullZones = {
 					left: appendStatusArea(
@@ -765,7 +793,7 @@ export function installFooter(
 					packCompactChunks(
 						compactChunks,
 						innerWidth,
-						config.compactFooterMaxLines,
+						config.components.footer.styles.starship.compactMaxLines,
 						renderVariable("sep"),
 					),
 				);

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -186,6 +186,7 @@ export function installFooter(
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
 		getLiveContext?: () => LiveContextOverride | undefined;
+		suppressVisibleOutput?: () => boolean;
 	},
 ): void {
 	ctx.ui.setFooter((tui, theme, footerData) => {
@@ -204,6 +205,7 @@ export function installFooter(
 			},
 			invalidate() {},
 			render(width: number): string[] {
+				if (hooks.suppressVisibleOutput?.()) return [];
 				if (width <= 0) return [""];
 				const config = getConfig();
 				const wideFormatTokens = config.footerFormat ? parseFooterFormat(config.footerFormat) : [];

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -49,6 +49,7 @@ import {
 	saveSeparatorPatch,
 	saveUiFeaturesPatch,
 	type UiFeaturesConfig,
+	type ZentuiConfig,
 } from "./config";
 import {
 	type EditorTransferFailureReason,
@@ -73,16 +74,17 @@ import {
 } from "./project-refresh";
 import { applyProjectRefreshToState } from "./project-state";
 import { readRuntimeInfo } from "./runtime";
-import { installSelectorBorderStyle } from "./selector-border";
+import { installSelectorBorderStyle, removeSelectorBorderStyle } from "./selector-border";
 import { SessionLifecycle } from "./session-lifecycle";
 import { registerZentuiSettingsCommand } from "./settings-command";
-import { createInitialState, type FooterState, syncState } from "./state";
+import { createInitialState, type FooterState, modelLabelFor, syncState } from "./state";
 import { resolveFooterTelemetry } from "./telemetry";
 import { PolishedEditor, WrappedPolishedEditor } from "./ui";
-import { installUserMessageStyle } from "./user-message";
+import { installUserMessageStyle, removeUserMessageStyle } from "./user-message";
 
 const ZENTUI_EDITOR_FACTORY = Symbol.for("pi-zentui.editor-factory");
 const ZENTUI_EDITOR_BASE_FACTORY = Symbol.for("pi-zentui.editor-base-factory");
+const ZENTUI_FOOTER_OWNER = Symbol.for("pi-zentui.footer-owner");
 
 type EditorFactory = NonNullable<Parameters<ExtensionContext["ui"]["setEditorComponent"]>[0]>;
 
@@ -125,20 +127,21 @@ function getZentuiEditorBaseFactory(factory: EditorFactory | undefined): EditorF
 	return (factory as ZentuiEditorFactory | undefined)?.[ZENTUI_EDITOR_BASE_FACTORY];
 }
 
-export function activeFooterReferences(config: PolishedTuiConfig): Set<string> {
-	const references = config.footerFormat
-		? collectFooterFormatReferences(parseFooterFormat(config.footerFormat), FOOTER_FORMAT_ALIASES)
+export function activeFooterReferences(config: ZentuiConfig): Set<string> {
+	const starship = config.components.footer.styles.starship;
+	const references = starship.format
+		? collectFooterFormatReferences(parseFooterFormat(starship.format), FOOTER_FORMAT_ALIASES)
 		: new Set<string>([
-				...(config.footerSegments.sessionName ? ["session_name"] : []),
-				...(config.footerSegments.gitCommit ? ["git_commit"] : []),
-				...(config.footerSegments.gitMetrics ? ["git_metrics"] : []),
-				...(config.footerSegments.packageVersion ? ["package"] : []),
-				...(config.footerSegments.sessionDuration ? ["session_duration"] : []),
-				...(config.footerSegments.time ? ["time"] : []),
+				...(starship.segments.sessionName ? ["session_name"] : []),
+				...(starship.segments.gitCommit ? ["git_commit"] : []),
+				...(starship.segments.gitMetrics ? ["git_metrics"] : []),
+				...(starship.segments.packageVersion ? ["package"] : []),
+				...(starship.segments.sessionDuration ? ["session_duration"] : []),
+				...(starship.segments.time ? ["time"] : []),
 			]);
-	if (config.responsiveFooter) {
+	if (starship.responsive) {
 		for (const name of collectFooterFormatReferences(
-			parseFooterFormat(config.compactFooterFormat),
+			parseFooterFormat(starship.compactFormat),
 			FOOTER_FORMAT_ALIASES,
 		)) {
 			references.add(name);
@@ -176,13 +179,16 @@ export default function (pi: ExtensionAPI) {
 	let requestEditorRender: (() => void) | undefined;
 	let getActiveExtensionStatuses: () => ReadonlyMap<string, string> = () => new Map();
 	let stopRefreshInterval: StopProjectRefreshInterval = () => {};
-	let cleanupPrototypePatches: () => void = () => {};
+	let cleanupUserMessageStyle: () => void = () => {};
+	let userMessageStyleInstalled = false;
+	let cleanupSelectorBorderStyle: () => void = () => {};
+	let selectorBorderStyleInstalled = false;
 	let footerInstalled = false;
+	let footerReconciled = false;
 	let editorInstalled = false;
 	let editorInstallMode: EditorInstallMode = "none";
 	let installedEditorFactory: EditorFactory | undefined;
 	let wrappedEditorFactory: EditorFactory | undefined;
-	let prototypePatchesInstalled = false;
 	let stopSessionTimer: () => void = () => {};
 	let stopAgentTimer: () => void = () => {};
 	let agentTimerRunning = false;
@@ -194,6 +200,7 @@ export default function (pi: ExtensionAPI) {
 	let agentDurationMs: number | undefined;
 	let minimalistProjectRoot: string | undefined;
 	let projectRefreshActive = false;
+	let fixedLayoutEnabled = false;
 	let activeTuiContext: ExtensionContext | undefined;
 
 	const ownsInstalledEditorFactory = () => {
@@ -235,20 +242,19 @@ export default function (pi: ExtensionAPI) {
 	const getThinkingLevel = () =>
 		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
-		syncState(
-			state,
-			ctx,
-			currentConfig.icons.cacheHit,
-			currentConfig.editorModelLabel,
-			resolveFooterTelemetry(ctx),
-		);
+		syncState(state, ctx, currentConfig.icons.cacheHit, resolveFooterTelemetry(ctx));
+	const installedFooterReferences = () =>
+		footerInstalled && currentConfig.components.footer.enabled
+			? activeFooterReferences(currentConfig)
+			: new Set<string>();
 
 	type ProjectRefreshTarget = { cwd: string; generation: number };
 	const refreshProjectState = async ({ cwd, generation }: ProjectRefreshTarget) => {
 		if (!sessionLifecycle.isCurrent(generation)) return;
-		const gitCommitConfig = currentConfig.gitCommit;
-		const gitMetricsConfig = currentConfig.gitMetrics;
-		const references = activeFooterReferences(currentConfig);
+		const starship = currentConfig.components.footer.styles.starship;
+		const gitCommitConfig = starship.gitCommit;
+		const gitMetricsConfig = starship.gitMetrics;
+		const references = installedFooterReferences();
 		const wantExactTag =
 			(references.has("git_commit") && gitCommitConfig.showTag) || references.has("git_tag");
 		const wantMetrics =
@@ -285,11 +291,17 @@ export default function (pi: ExtensionAPI) {
 		projectRefreshScheduler.schedule({ cwd, generation }, options);
 	};
 
-	const needsProjectRefresh = () =>
-		footerInstalled ||
-		(currentConfig.features.editor &&
-			currentConfig.editorStyle === "minimalist" &&
-			ownsInstalledEditorFactory());
+	const minimalistProjectRequired = () => {
+		const editor = currentConfig.components.editor;
+		const minimalist = editor.styles.minimalist;
+		return (
+			ownsInstalledEditorFactory() &&
+			editor.style === "minimalist" &&
+			(minimalist.showGit || minimalist.pathDisplay === "project")
+		);
+	};
+
+	const needsProjectRefresh = () => footerInstalled || minimalistProjectRequired();
 
 	const stopProjectRefresh = () => {
 		stopRefreshInterval();
@@ -332,14 +344,14 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	const reconcileSessionTimer = () => {
-		const references = activeFooterReferences(currentConfig);
+		const references = installedFooterReferences();
 		const needsTime = references.has("time");
 		const needsDuration = references.has("session_duration");
 		const nextRequirements = needsTime || needsDuration ? `${needsTime}:${needsDuration}` : "";
 		if (
 			!sessionLifecycle.isCurrent() ||
 			!footerInstalled ||
-			!currentConfig.features.statusLine ||
+			!currentConfig.components.footer.enabled ||
 			!nextRequirements
 		) {
 			stopSessionTimer();
@@ -378,7 +390,8 @@ export default function (pi: ExtensionAPI) {
 			agentStartedAt !== undefined &&
 			minimalistDecorationActive &&
 			ownsInstalledEditorFactory() &&
-			currentConfig.editorStyles.minimalist.showTimer;
+			currentConfig.components.editor.style === "minimalist" &&
+			currentConfig.components.editor.styles.minimalist.showTimer;
 		if (!needed) {
 			stopAgentTimer();
 			return;
@@ -405,7 +418,6 @@ export default function (pi: ExtensionAPI) {
 		if (minimalistDecorationActive === next) return;
 		minimalistDecorationActive = next;
 		reconcileAgentTimer();
-		requestFooterRender?.();
 	};
 
 	const startAgentTurn = () => {
@@ -448,34 +460,84 @@ export default function (pi: ExtensionAPI) {
 		if (needsProjectRefresh()) scheduleProjectRefresh(ctx, { force: true });
 	};
 
-	const installPrototypePatches = (): boolean => {
-		if (prototypePatchesInstalled) return true;
-		let cleanupSelectorBorderStyle: (() => void) | undefined;
+	const installUserMessages = () => {
+		if (userMessageStyleInstalled) return;
+		let cleanup: (() => void) | undefined;
 		try {
-			cleanupSelectorBorderStyle = installSelectorBorderStyle(getActiveTheme, getCurrentConfig);
-			const cleanupUserMessageStyle = installUserMessageStyle(getActiveTheme, getCurrentConfig);
-			cleanupPrototypePatches = () => {
-				cleanupSelectorBorderStyle?.();
-				cleanupUserMessageStyle();
-			};
-			prototypePatchesInstalled = true;
-			return true;
+			cleanup = installUserMessageStyle(getActiveTheme, getCurrentConfig);
+			cleanupUserMessageStyle = cleanup;
+			userMessageStyleInstalled = true;
 		} catch {
 			try {
-				cleanupSelectorBorderStyle?.();
+				cleanup?.();
 			} catch {
-				// Best effort: each installer is locally transactional as well.
+				// Best effort: the installer is locally transactional.
 			}
-			cleanupPrototypePatches = () => {};
-			prototypePatchesInstalled = false;
-			return false;
+			cleanupUserMessageStyle = () => {};
+			userMessageStyleInstalled = false;
 		}
 	};
 
-	const uninstallPrototypePatches = () => {
-		cleanupPrototypePatches();
-		cleanupPrototypePatches = () => {};
-		prototypePatchesInstalled = false;
+	const uninstallUserMessages = () => {
+		try {
+			cleanupUserMessageStyle();
+		} catch {
+			// Best effort cleanup.
+		} finally {
+			try {
+				removeUserMessageStyle();
+			} catch {
+				// Best effort cleanup of a stale registration from an earlier reload.
+			}
+			cleanupUserMessageStyle = () => {};
+			userMessageStyleInstalled = false;
+		}
+	};
+
+	const reconcileUserMessages = () => {
+		const messages = currentConfig.components.userMessages;
+		if (messages.enabled && messages.style === "framed") installUserMessages();
+		else uninstallUserMessages();
+	};
+
+	const installSelectorBorders = () => {
+		if (selectorBorderStyleInstalled) return;
+		let cleanup: (() => void) | undefined;
+		try {
+			cleanup = installSelectorBorderStyle(getActiveTheme, getCurrentConfig);
+			cleanupSelectorBorderStyle = cleanup;
+			selectorBorderStyleInstalled = true;
+		} catch {
+			try {
+				cleanup?.();
+			} catch {
+				// Best effort: the installer is locally transactional.
+			}
+			cleanupSelectorBorderStyle = () => {};
+			selectorBorderStyleInstalled = false;
+		}
+	};
+
+	const uninstallSelectorBorders = () => {
+		try {
+			cleanupSelectorBorderStyle();
+		} catch {
+			// Best effort cleanup.
+		} finally {
+			try {
+				removeSelectorBorderStyle();
+			} catch {
+				// Best effort cleanup of stale registrations from an earlier reload.
+			}
+			cleanupSelectorBorderStyle = () => {};
+			selectorBorderStyleInstalled = false;
+		}
+	};
+
+	const reconcileSelectorBorders = () => {
+		const selectors = currentConfig.components.selectorBorders;
+		if (selectors.enabled && selectors.style === "zentui") installSelectorBorders();
+		else uninstallSelectorBorders();
 	};
 
 	const clearEditorOwnership = () => {
@@ -511,7 +573,6 @@ export default function (pi: ExtensionAPI) {
 		if (observed.factory && isZentuiEditorFactory(observed.factory)) {
 			trackZentuiEditorFactory(observed.factory);
 		} else {
-			uninstallPrototypePatches();
 			clearEditorOwnership();
 			reconcileProjectRefresh(ctx);
 		}
@@ -529,7 +590,7 @@ export default function (pi: ExtensionAPI) {
 				sessionTheme,
 				getCurrentConfig,
 				() => ({
-					modelLabel: state.modelLabel,
+					modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
 					modelId: state.modelId,
 					modelName: state.modelName,
 					providerLabel: state.providerLabel,
@@ -544,7 +605,7 @@ export default function (pi: ExtensionAPI) {
 					ahead: state.ahead,
 					behind: state.behind,
 					costLabel: state.costLabel,
-					modelLabel: state.modelLabel,
+					modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
 					thinkingLevel: getThinkingLevel(),
 					contextPercent: getContextPercent(ctx),
 					contextWindow: getContextWindow(ctx),
@@ -571,7 +632,7 @@ export default function (pi: ExtensionAPI) {
 				sessionTheme,
 				getCurrentConfig,
 				() => ({
-					modelLabel: state.modelLabel,
+					modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
 					modelId: state.modelId,
 					modelName: state.modelName,
 					providerLabel: state.providerLabel,
@@ -586,7 +647,7 @@ export default function (pi: ExtensionAPI) {
 					ahead: state.ahead,
 					behind: state.behind,
 					costLabel: state.costLabel,
-					modelLabel: state.modelLabel,
+					modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
 					thinkingLevel: getThinkingLevel(),
 					contextPercent: getContextPercent(ctx),
 					contextWindow: getContextWindow(ctx),
@@ -626,16 +687,6 @@ export default function (pi: ExtensionAPI) {
 			: makeEditorFactory(ctx);
 		const replacement = replaceEditor(ctx, nextFactory);
 		if (!replacement.ok) return replacement;
-		if (!installPrototypePatches()) {
-			const rollback = replaceEditor(ctx, currentFactory);
-			reconcileObservedEditorOwnership(ctx);
-			return {
-				ok: false,
-				reason: rollback.ok
-					? "editor chrome patch installation failed; the previous factory was reapplied, but editor instance identity is not guaranteed"
-					: "editor chrome patch installation failed and the previous factory could not be restored; reload Pi before editing",
-			};
-		}
 
 		trackZentuiEditorFactory(nextFactory);
 		return { ok: true };
@@ -652,7 +703,6 @@ export default function (pi: ExtensionAPI) {
 		}
 		const currentFactory = observed.factory;
 		if (!currentFactory || !isZentuiEditorFactory(currentFactory)) {
-			uninstallPrototypePatches();
 			clearEditorOwnership();
 			return { ok: true };
 		}
@@ -666,62 +716,140 @@ export default function (pi: ExtensionAPI) {
 		);
 		if (!replacement.ok) return replacement;
 
-		uninstallPrototypePatches();
 		clearEditorOwnership();
 		return { ok: true };
 	};
 
+	const ownsStatusLine = (ctx: ExtensionContext) =>
+		Boolean((ctx.ui as unknown as Record<PropertyKey, unknown>)[ZENTUI_FOOTER_OWNER]);
+
+	const setStatusLineOwnership = (ctx: ExtensionContext, owned: boolean) => {
+		const ui = ctx.ui as unknown as Record<PropertyKey, unknown>;
+		try {
+			if (owned) ui[ZENTUI_FOOTER_OWNER] = true;
+			else delete ui[ZENTUI_FOOTER_OWNER];
+		} catch {
+			// Local bookkeeping still preserves ordinary-session cleanup.
+		}
+	};
+
 	const installStatusLine = (ctx: ExtensionContext) => {
 		if (footerInstalled) return;
-		installFooter(ctx, state, getCurrentConfig, {
-			setRequestRender: (fn) => {
-				requestFooterRender = fn;
-			},
-			scheduleProjectRefresh,
-			setExtensionStatusesGetter(fn) {
-				getActiveExtensionStatuses = fn ?? (() => new Map());
-			},
-			getLiveContext: () => liveContext.get(),
-			suppressVisibleOutput: () => minimalistDecorationActive && ownsInstalledEditorFactory(),
-		});
-		footerInstalled = true;
-		reconcileProjectRefresh(ctx, true);
-		refresh();
-		reconcileSessionTimer();
+		try {
+			installFooter(ctx, state, getCurrentConfig, {
+				setRequestRender: (fn) => {
+					requestFooterRender = fn;
+				},
+				scheduleProjectRefresh,
+				setExtensionStatusesGetter(fn) {
+					getActiveExtensionStatuses = fn ?? (() => new Map());
+				},
+				getLiveContext: () => liveContext.get(),
+			});
+			footerInstalled = true;
+			setStatusLineOwnership(ctx, true);
+			refresh();
+			reconcileSessionTimer();
+		} catch {
+			try {
+				ctx.ui.setFooter(undefined);
+			} catch {
+				// Best effort: Pi remains responsible for its native footer fallback.
+			}
+			footerInstalled = false;
+			setStatusLineOwnership(ctx, false);
+			requestFooterRender = undefined;
+			getActiveExtensionStatuses = () => new Map();
+			stopSessionTimer();
+		}
 	};
 
 	const uninstallStatusLine = (ctx: ExtensionContext) => {
 		stopSessionTimer();
-		ctx.ui.setFooter(undefined);
+		if (footerInstalled || ownsStatusLine(ctx)) {
+			try {
+				ctx.ui.setFooter(undefined);
+			} catch {
+				// Best effort cleanup must not prevent other surfaces from reconciling.
+			}
+		}
 		footerInstalled = false;
+		setStatusLineOwnership(ctx, false);
 		requestFooterRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
-		reconcileProjectRefresh(ctx);
+	};
+
+	const reconcileFooter = (ctx: ExtensionContext) => {
+		const footer = currentConfig.components.footer;
+		if (footer.enabled && footer.style === "starship") installStatusLine(ctx);
+		else if (footerInstalled || !footerReconciled) uninstallStatusLine(ctx);
+		footerReconciled = true;
+	};
+
+	const cleanupFixedLayout = (ctx: ExtensionContext) => {
+		try {
+			disposeFixedEditor(ctx);
+		} catch {
+			// Best effort ordinary-layout fallback.
+		}
+		try {
+			removeFixedEditorProbe(ctx);
+		} catch {
+			// Probe cleanup is independent from compositor disposal.
+		}
+		fixedLayoutEnabled = false;
+	};
+
+	const reconcileFixedLayout = (ctx: ExtensionContext) => {
+		const enabled = currentConfig.layout.fixedEditor.enabled;
+		if (enabled === fixedLayoutEnabled) return;
+		if (!enabled) {
+			cleanupFixedLayout(ctx);
+			return;
+		}
+		try {
+			installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
+			fixedLayoutEnabled = true;
+		} catch {
+			cleanupFixedLayout(ctx);
+		}
+	};
+
+	const reconcileEditor = (ctx: ExtensionContext): EditorChangeResult | undefined => {
+		try {
+			if (currentConfig.components.editor.enabled) {
+				const currentFactory = ctx.ui.getEditorComponent();
+				const editorMissingOrReplaced = !editorInstalled || !isZentuiEditorFactory(currentFactory);
+				if (editorMissingOrReplaced) return installEditor(ctx);
+			} else {
+				const currentFactory = ctx.ui.getEditorComponent();
+				if (editorInstalled || isZentuiEditorFactory(currentFactory)) return uninstallEditor(ctx);
+			}
+		} catch {
+			return {
+				ok: false,
+				reason: "the editor could not be reconciled safely; reload Pi to apply this change",
+			};
+		}
 	};
 
 	const applyConfiguredUi = (ctx: ExtensionContext): ApplyUiResult => {
 		const result: ApplyUiResult = { editorBlocked: false };
 		if (!isTuiContext(ctx)) return result;
 		activeTheme = ctx.ui.theme;
-		let editorChange: EditorChangeResult | undefined;
-		if (currentConfig.features.editor) {
-			const currentFactory = ctx.ui.getEditorComponent();
-			const editorMissingOrReplaced = !editorInstalled || !isZentuiEditorFactory(currentFactory);
-			if (editorMissingOrReplaced) editorChange = installEditor(ctx);
-		} else if (editorInstalled || prototypePatchesInstalled) {
-			editorChange = uninstallEditor(ctx);
-		}
+
+		const editorChange = reconcileEditor(ctx);
 		if (editorChange && !editorChange.ok) {
 			result.editorBlocked = true;
 			result.editorReason = editorChange.reason;
 		}
-
-		if (currentConfig.features.statusLine) {
-			installStatusLine(ctx);
-		} else if (footerInstalled) {
-			uninstallStatusLine(ctx);
-		}
+		reconcileUserMessages();
+		reconcileSelectorBorders();
+		reconcileFooter(ctx);
+		reconcileFixedLayout(ctx);
 		reconcileProjectRefresh(ctx);
+		reconcileSessionTimer();
+		reconcileAgentTimer();
 		return result;
 	};
 
@@ -729,30 +857,35 @@ export default function (pi: ExtensionAPI) {
 		if (!isTuiContext(ctx)) return;
 		activeTuiContext = ctx;
 		activeTheme = ctx.ui.theme;
-		uninstallPrototypePatches();
-		footerInstalled = false;
-		editorInstalled = false;
-		minimalistDecorationActive = false;
-		requestEditorRender = undefined;
-		installedEditorFactory = undefined;
 		ensureConfigExists();
 		currentConfig = loadConfig();
 		syncFooterState(ctx);
 		stopProjectRefresh();
-		applyConfiguredUi(ctx);
-		if (currentConfig.fixedEditor?.enabled) {
-			installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
+
+		cleanupFixedLayout(ctx);
+		uninstallUserMessages();
+		uninstallSelectorBorders();
+		uninstallStatusLine(ctx);
+		if (currentConfig.components.editor.enabled) clearEditorOwnership();
+		else {
+			try {
+				uninstallEditor(ctx);
+			} catch {
+				// Reconciliation below retries observable stale ownership.
+			}
 		}
+
+		footerReconciled = false;
+		applyConfiguredUi(ctx);
 		refresh();
 	};
 
 	const scheduleEditorReconciliation = (ctx: ExtensionContext) => {
 		sessionLifecycle.defer(() => {
-			if (!isTuiContext(ctx) || !currentConfig.features.editor) return;
+			if (!isTuiContext(ctx) || !currentConfig.components.editor.enabled) return;
 			const observed = observeEditorFactory(ctx);
 			if (!observed.known || observed.factory === installedEditorFactory) return;
 			if (!observed.factory || !isZentuiEditorFactory(observed.factory)) {
-				uninstallPrototypePatches();
 				clearEditorOwnership();
 				reconcileProjectRefresh(ctx);
 				refresh();
@@ -766,17 +899,25 @@ export default function (pi: ExtensionAPI) {
 	const cleanupUi = (ctx?: ExtensionContext) => {
 		if (!ctx || !sessionLifecycle.isCurrent()) return;
 		sessionLifecycle.shutdown();
-		try {
-			disposeFixedEditor(ctx);
-			if (isTuiContext(ctx)) removeFixedEditorProbe(ctx);
-			stopSessionTimer();
-			resetAgentTimer();
-			stopProjectRefresh();
-			requestFooterRender = undefined;
-			requestEditorRender = undefined;
-			getActiveExtensionStatuses = () => new Map();
-			if (isTuiContext(ctx)) {
-				ctx.ui.setFooter(undefined);
+		stopSessionTimer();
+		resetAgentTimer();
+		stopProjectRefresh();
+
+		if (isTuiContext(ctx)) cleanupFixedLayout(ctx);
+		else {
+			try {
+				disposeFixedEditor(ctx);
+			} catch {
+				// Continue cleaning independent surfaces.
+			} finally {
+				fixedLayoutEnabled = false;
+			}
+		}
+
+		let retainedEditorOwnership = false;
+		if (isTuiContext(ctx)) {
+			uninstallStatusLine(ctx);
+			try {
 				const before = observeEditorFactory(ctx);
 				if (before.known) {
 					const currentFactory = before.factory;
@@ -789,17 +930,26 @@ export default function (pi: ExtensionAPI) {
 									: undefined),
 						);
 					}
-					reconcileObservedEditorOwnership(ctx);
 				}
+				const after = observeEditorFactory(ctx);
+				if (after.known && after.factory && isZentuiEditorFactory(after.factory)) {
+					trackZentuiEditorFactory(after.factory);
+					retainedEditorOwnership = true;
+				}
+			} catch {
+				// Continue cleaning independent surfaces.
 			}
-			uninstallPrototypePatches();
-			footerInstalled = false;
-			activeTheme = undefined;
-		} finally {
-			activeTuiContext = undefined;
-			requestFooterRender = undefined;
-			requestEditorRender = undefined;
 		}
+		if (!retainedEditorOwnership) clearEditorOwnership();
+		uninstallUserMessages();
+		uninstallSelectorBorders();
+		footerInstalled = false;
+		footerReconciled = false;
+		requestFooterRender = undefined;
+		requestEditorRender = undefined;
+		getActiveExtensionStatuses = () => new Map();
+		activeTheme = undefined;
+		activeTuiContext = undefined;
 	};
 
 	const syncInteractiveState = (_event: unknown, ctx: ExtensionContext) => {
@@ -876,6 +1026,7 @@ export default function (pi: ExtensionAPI) {
 		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
 			currentConfig = saveMinimalistPatch(patch);
 			reconcileAgentTimer();
+			reconcileProjectRefresh(ctx);
 			if (needsProjectRefresh() && (patch.pathDisplay === "project" || patch.showGit === true)) {
 				scheduleProjectRefresh(ctx, { force: true });
 			}
@@ -913,11 +1064,7 @@ export default function (pi: ExtensionAPI) {
 		},
 		setFixedEditor(patch: Partial<FixedEditorConfig>, ctx: ExtensionContext) {
 			currentConfig = saveFixedEditorPatch(patch);
-			if (patch.enabled === true) {
-				installFixedEditorProbe(ctx, getCurrentConfig, sessionLifecycle);
-			} else if (patch.enabled === false) {
-				disposeFixedEditor(ctx);
-			}
+			reconcileFixedLayout(ctx);
 			refresh();
 		},
 		requestRender() {

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -17,7 +17,6 @@ import {
 	FOOTER_FORMAT_ALIASES,
 	type FooterComponentConfig,
 	type FooterSegmentsConfig,
-	type FramedUserMessageStyleConfig,
 	type GitBranchConfig,
 	type GitCommitConfig,
 	type GitMetricsConfig,
@@ -25,7 +24,6 @@ import {
 	loadConfig,
 	type MinimalistConfig,
 	type PathDisplayConfig,
-	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
@@ -34,14 +32,11 @@ import {
 	saveExtensionStatusDefaultPlacement,
 	saveExtensionStatusPlacement,
 	saveFooterComponentPatch,
-	saveFramedUserMessagesStylePatch,
 	saveIconsModePatch,
 	saveLayoutFixedEditorPatch,
 	saveMinimalistEditorStylePatch,
-	savePolishedEditorStylePatch,
 	saveSelectorBordersComponentPatch,
 	saveStarshipFooterStylePatch,
-	saveUiFeaturesPatch,
 	saveUserMessagesComponentPatch,
 	type UserMessagesComponentConfig,
 	type ZentuiConfig,
@@ -491,7 +486,7 @@ export default function (pi: ExtensionAPI) {
 
 	const reconcileUserMessages = () => {
 		const messages = currentConfig.components.userMessages;
-		if (messages.enabled && messages.style === "framed") installUserMessages();
+		if (messages.enabled) installUserMessages();
 		else uninstallUserMessages();
 	};
 
@@ -985,10 +980,6 @@ export default function (pi: ExtensionAPI) {
 				reason: result && !result.ok ? result.reason : undefined,
 			};
 		},
-		setPolishedEditorStyle(patch: Partial<PolishedEditorStyleConfig>, _ctx: ExtensionContext) {
-			currentConfig = savePolishedEditorStylePatch(patch);
-			refresh();
-		},
 		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
 			currentConfig = saveMinimalistEditorStylePatch(patch);
 			reconcileAgentTimer();
@@ -1000,14 +991,7 @@ export default function (pi: ExtensionAPI) {
 		},
 		setUserMessagesComponent(patch: Partial<UserMessagesComponentConfig>, _ctx: ExtensionContext) {
 			currentConfig = saveUserMessagesComponentPatch(patch);
-			if (patch.enabled !== undefined || patch.style !== undefined) reconcileUserMessages();
-			refresh();
-		},
-		setFramedUserMessagesStyle(
-			patch: Partial<FramedUserMessageStyleConfig>,
-			_ctx: ExtensionContext,
-		) {
-			currentConfig = saveFramedUserMessagesStylePatch(patch);
+			if (patch.enabled !== undefined) reconcileUserMessages();
 			refresh();
 		},
 		setSelectorBordersComponent(
@@ -1024,10 +1008,6 @@ export default function (pi: ExtensionAPI) {
 			if (patch.modelLabel !== undefined) syncFooterState(ctx);
 			reconcileProjectRefresh(ctx);
 			reconcileSessionTimer();
-			refresh();
-		},
-		setCopyFriendlyRecipe(enabled: boolean, _ctx: ExtensionContext) {
-			currentConfig = saveUiFeaturesPatch({ copyFriendly: enabled });
 			refresh();
 		},
 		setFooterSegments(patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) {

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -50,7 +50,7 @@ import {
 	installFixedEditorProbe,
 	removeFixedEditorProbe,
 } from "./fixed-editor";
-import { installFooter } from "./footer";
+import { installFooter, installHiddenFooter } from "./footer";
 import { collectFooterFormatReferences, parseFooterFormat } from "./footer-format";
 import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
@@ -91,6 +91,7 @@ type ApplyUiResult = {
 type EditorChangeResult = { ok: true } | { ok: false; reason: string };
 
 type EditorInstallMode = "none" | "standalone" | "wrapper";
+type InstalledFooterKind = "starship" | "hidden";
 
 function editorTransferFailureMessage(reason: EditorTransferFailureReason): string {
 	switch (reason) {
@@ -173,8 +174,8 @@ export default function (pi: ExtensionAPI) {
 	let userMessageStyleInstalled = false;
 	let cleanupSelectorBorderStyle: () => void = () => {};
 	let selectorBorderStyleInstalled = false;
-	let footerInstalled = false;
-	let footerReconciled = false;
+	let installedFooterKind: InstalledFooterKind | undefined;
+	let installedFooterToken: symbol | undefined;
 	let editorInstalled = false;
 	let editorInstallMode: EditorInstallMode = "none";
 	let installedEditorFactory: EditorFactory | undefined;
@@ -233,8 +234,14 @@ export default function (pi: ExtensionAPI) {
 		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
 		syncState(state, ctx, currentConfig.icons.cacheHit, resolveFooterTelemetry(ctx));
+	const ownsInstalledFooter = () =>
+		Boolean(
+			activeTuiContext &&
+				installedFooterToken &&
+				ctxFooterOwner(activeTuiContext) === installedFooterToken,
+		);
 	const installedFooterReferences = () =>
-		footerInstalled && currentConfig.components.footer.enabled
+		installedFooterKind === "starship" && ownsInstalledFooter()
 			? activeFooterReferences(currentConfig)
 			: new Set<string>();
 
@@ -291,7 +298,8 @@ export default function (pi: ExtensionAPI) {
 		);
 	};
 
-	const needsProjectRefresh = () => footerInstalled || minimalistProjectRequired();
+	const needsProjectRefresh = () =>
+		(installedFooterKind === "starship" && ownsInstalledFooter()) || minimalistProjectRequired();
 
 	const stopProjectRefresh = () => {
 		stopRefreshInterval();
@@ -340,8 +348,8 @@ export default function (pi: ExtensionAPI) {
 		const nextRequirements = needsTime || needsDuration ? `${needsTime}:${needsDuration}` : "";
 		if (
 			!sessionLifecycle.isCurrent() ||
-			!footerInstalled ||
-			!currentConfig.components.footer.enabled ||
+			installedFooterKind !== "starship" ||
+			!ownsInstalledFooter() ||
 			!nextRequirements
 		) {
 			stopSessionTimer();
@@ -710,21 +718,48 @@ export default function (pi: ExtensionAPI) {
 		return { ok: true };
 	};
 
-	const ownsStatusLine = (ctx: ExtensionContext) =>
-		Boolean((ctx.ui as unknown as Record<PropertyKey, unknown>)[ZENTUI_FOOTER_OWNER]);
+	const ctxFooterOwner = (ctx: ExtensionContext): unknown =>
+		(ctx.ui as unknown as Record<PropertyKey, unknown>)[ZENTUI_FOOTER_OWNER];
 
-	const setStatusLineOwnership = (ctx: ExtensionContext, owned: boolean) => {
+	const setStatusLineOwnership = (ctx: ExtensionContext, token: symbol | undefined) => {
 		const ui = ctx.ui as unknown as Record<PropertyKey, unknown>;
 		try {
-			if (owned) ui[ZENTUI_FOOTER_OWNER] = true;
+			if (token) ui[ZENTUI_FOOTER_OWNER] = token;
 			else delete ui[ZENTUI_FOOTER_OWNER];
 		} catch {
-			// Local bookkeeping still preserves ordinary-session cleanup.
+			// Failure to mark ownership intentionally prevents Native from restoring it.
 		}
 	};
 
+	const ownsStatusLine = (ctx: ExtensionContext) =>
+		installedFooterToken !== undefined && ctxFooterOwner(ctx) === installedFooterToken;
+
+	const clearFooterOwnership = (ctx: ExtensionContext, token: symbol) => {
+		if (installedFooterToken !== token) return;
+		installedFooterKind = undefined;
+		installedFooterToken = undefined;
+		if (ctxFooterOwner(ctx) === token) setStatusLineOwnership(ctx, undefined);
+		requestFooterRender = undefined;
+		getActiveExtensionStatuses = () => new Map();
+		stopSessionTimer();
+		if (sessionLifecycle.isCurrent()) reconcileProjectRefresh(ctx);
+	};
+
+	const resetFailedFooterInstallation = (ctx: ExtensionContext, token: symbol) => {
+		try {
+			ctx.ui.setFooter(undefined);
+		} catch {
+			// Best effort: Zentui initiated the failed replacement.
+		}
+		clearFooterOwnership(ctx, token);
+		requestFooterRender = undefined;
+		getActiveExtensionStatuses = () => new Map();
+		stopSessionTimer();
+	};
+
 	const installStatusLine = (ctx: ExtensionContext) => {
-		if (footerInstalled) return;
+		if (installedFooterKind === "starship" && ownsStatusLine(ctx)) return;
+		const token = Symbol("zentui-starship-footer");
 		try {
 			installFooter(ctx, state, getCurrentConfig, {
 				setRequestRender: (fn) => {
@@ -735,45 +770,59 @@ export default function (pi: ExtensionAPI) {
 					getActiveExtensionStatuses = fn ?? (() => new Map());
 				},
 				getLiveContext: () => liveContext.get(),
+				onDispose: () => clearFooterOwnership(ctx, token),
 			});
-			footerInstalled = true;
-			setStatusLineOwnership(ctx, true);
+			installedFooterKind = "starship";
+			installedFooterToken = token;
+			setStatusLineOwnership(ctx, token);
 			refresh();
 			reconcileSessionTimer();
 		} catch {
-			try {
-				ctx.ui.setFooter(undefined);
-			} catch {
-				// Best effort: Pi remains responsible for its native footer fallback.
-			}
-			footerInstalled = false;
-			setStatusLineOwnership(ctx, false);
+			resetFailedFooterInstallation(ctx, token);
+		}
+	};
+
+	const installHiddenStatusLine = (ctx: ExtensionContext) => {
+		if (installedFooterKind === "hidden" && ownsStatusLine(ctx)) return;
+		const token = Symbol("zentui-hidden-footer");
+		try {
+			installHiddenFooter(ctx, () => clearFooterOwnership(ctx, token));
+			installedFooterKind = "hidden";
+			installedFooterToken = token;
+			setStatusLineOwnership(ctx, token);
 			requestFooterRender = undefined;
 			getActiveExtensionStatuses = () => new Map();
 			stopSessionTimer();
+		} catch {
+			resetFailedFooterInstallation(ctx, token);
 		}
 	};
 
 	const uninstallStatusLine = (ctx: ExtensionContext) => {
 		stopSessionTimer();
-		if (footerInstalled || ownsStatusLine(ctx)) {
+		const ownedToken = ownsStatusLine(ctx) ? installedFooterToken : undefined;
+		if (ownedToken) {
 			try {
 				ctx.ui.setFooter(undefined);
 			} catch {
 				// Best effort cleanup must not prevent other surfaces from reconciling.
 			}
+			clearFooterOwnership(ctx, ownedToken);
 		}
-		footerInstalled = false;
-		setStatusLineOwnership(ctx, false);
-		requestFooterRender = undefined;
-		getActiveExtensionStatuses = () => new Map();
 	};
 
 	const reconcileFooter = (ctx: ExtensionContext) => {
-		const footer = currentConfig.components.footer;
-		if (footer.enabled && footer.style === "starship") installStatusLine(ctx);
-		else if (footerInstalled || !footerReconciled) uninstallStatusLine(ctx);
-		footerReconciled = true;
+		switch (currentConfig.components.footer.style) {
+			case "starship":
+				installStatusLine(ctx);
+				break;
+			case "hidden":
+				installHiddenStatusLine(ctx);
+				break;
+			case "native":
+				uninstallStatusLine(ctx);
+				break;
+		}
 	};
 
 	const cleanupFixedLayout = (ctx: ExtensionContext) => {
@@ -847,6 +896,8 @@ export default function (pi: ExtensionAPI) {
 		if (!isTuiContext(ctx)) return;
 		activeTuiContext = ctx;
 		activeTheme = ctx.ui.theme;
+		const staleFooterOwner = ctxFooterOwner(ctx);
+		if (typeof staleFooterOwner === "symbol") installedFooterToken = staleFooterOwner;
 		ensureConfigExists();
 		currentConfig = loadConfig();
 		syncFooterState(ctx);
@@ -865,7 +916,6 @@ export default function (pi: ExtensionAPI) {
 			}
 		}
 
-		footerReconciled = false;
 		applyConfiguredUi(ctx);
 		refresh();
 	};
@@ -933,8 +983,8 @@ export default function (pi: ExtensionAPI) {
 		if (!retainedEditorOwnership) clearEditorOwnership();
 		uninstallUserMessages();
 		uninstallSelectorBorders();
-		footerInstalled = false;
-		footerReconciled = false;
+		installedFooterKind = undefined;
+		installedFooterToken = undefined;
 		requestFooterRender = undefined;
 		requestEditorRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
@@ -1003,8 +1053,12 @@ export default function (pi: ExtensionAPI) {
 			refresh();
 		},
 		setFooterComponent(patch: Partial<FooterComponentConfig>, ctx: ExtensionContext) {
+			const previousStyle = currentConfig.components.footer.style;
 			currentConfig = saveFooterComponentPatch(patch);
-			if (patch.enabled !== undefined || patch.style !== undefined) reconcileFooter(ctx);
+			const styleChanged = currentConfig.components.footer.style !== previousStyle;
+			if (styleChanged && fixedLayoutEnabled) cleanupFixedLayout(ctx);
+			if (patch.style !== undefined) reconcileFooter(ctx);
+			if (styleChanged && currentConfig.layout.fixedEditor.enabled) reconcileFixedLayout(ctx);
 			if (patch.modelLabel !== undefined) syncFooterState(ctx);
 			reconcileProjectRefresh(ctx);
 			reconcileSessionTimer();

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -891,9 +891,9 @@ export default function (pi: ExtensionAPI) {
 		}
 	};
 
-	const cleanupFixedLayout = (ctx: ExtensionContext) => {
+	const cleanupFixedLayout = (ctx: ExtensionContext, reason: "live" | "shutdown" = "live") => {
 		try {
-			disposeFixedEditor(ctx);
+			disposeFixedEditor(reason, ctx);
 		} catch {
 			// Best effort ordinary-layout fallback.
 		}
@@ -1033,10 +1033,10 @@ export default function (pi: ExtensionAPI) {
 		resetAgentTimer();
 		stopProjectRefresh();
 
-		if (isTuiContext(ctx)) cleanupFixedLayout(ctx);
+		if (isTuiContext(ctx)) cleanupFixedLayout(ctx, "shutdown");
 		else {
 			try {
-				disposeFixedEditor(ctx);
+				disposeFixedEditor("shutdown", ctx);
 			} catch {
 				// Continue cleaning independent surfaces.
 			} finally {

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -11,7 +11,7 @@ import {
 	type ColorSourcesConfig,
 	type ContextStyle,
 	type EditorBorderColorMode,
-	type EditorMode,
+	type EditorStyle,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	ensureConfigExists,
@@ -31,8 +31,8 @@ import {
 	saveColorSourcesPatch,
 	saveContextStylePatch,
 	saveEditorBorderColorMode,
-	saveEditorMode,
 	saveEditorModelLabel,
+	saveEditorStyle,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
 	saveExtensionStatusPlacement,
@@ -288,7 +288,7 @@ export default function (pi: ExtensionAPI) {
 	const needsProjectRefresh = () =>
 		footerInstalled ||
 		(currentConfig.features.editor &&
-			currentConfig.editorMode === "minimalist" &&
+			currentConfig.editorStyle === "minimalist" &&
 			ownsInstalledEditorFactory());
 
 	const stopProjectRefresh = () => {
@@ -378,7 +378,7 @@ export default function (pi: ExtensionAPI) {
 			agentStartedAt !== undefined &&
 			minimalistDecorationActive &&
 			ownsInstalledEditorFactory() &&
-			currentConfig.minimalist.showTimer;
+			currentConfig.editorStyles.minimalist.showTimer;
 		if (!needed) {
 			stopAgentTimer();
 			return;
@@ -548,6 +548,7 @@ export default function (pi: ExtensionAPI) {
 					thinkingLevel: getThinkingLevel(),
 					contextPercent: getContextPercent(ctx),
 					contextWindow: getContextWindow(ctx),
+					sessionName: ctx.sessionManager.getSessionName() ?? "",
 					agentDurationMs: getAgentDurationMs(),
 					agentActive: agentStartedAt !== undefined,
 				}),
@@ -589,6 +590,7 @@ export default function (pi: ExtensionAPI) {
 					thinkingLevel: getThinkingLevel(),
 					contextPercent: getContextPercent(ctx),
 					contextWindow: getContextWindow(ctx),
+					sessionName: ctx.sessionManager.getSessionName() ?? "",
 					agentDurationMs: getAgentDurationMs(),
 					agentActive: agentStartedAt !== undefined,
 				}),
@@ -864,8 +866,8 @@ export default function (pi: ExtensionAPI) {
 			currentConfig = saveEditorModelLabel(value);
 			syncFooterState(ctx);
 		},
-		setEditorMode(value: EditorMode, ctx: ExtensionContext) {
-			currentConfig = saveEditorMode(value);
+		setEditorStyle(value: EditorStyle, ctx: ExtensionContext) {
+			currentConfig = saveEditorStyle(value);
 			if (value !== "minimalist") setMinimalistDecorationActive(false);
 			reconcileProjectRefresh(ctx);
 			reconcileAgentTimer();

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -20,6 +20,7 @@ import {
 	type GitBranchConfig,
 	type GitCommitConfig,
 	type GitMetricsConfig,
+	hasUnsupportedComponentStyle,
 	type IconMode,
 	loadConfig,
 	type MinimalistConfig,
@@ -58,6 +59,7 @@ import { LiveContextController } from "./live-context";
 import { readPackageVersionResult } from "./package-version";
 import {
 	createProjectRefreshScheduler,
+	type ProjectRefreshRun,
 	type ScheduleProjectRefreshOptions,
 	type StopProjectRefreshInterval,
 	startProjectRefreshInterval,
@@ -74,6 +76,7 @@ import { installUserMessageStyle, removeUserMessageStyle } from "./user-message"
 
 const ZENTUI_EDITOR_FACTORY = Symbol.for("pi-zentui.editor-factory");
 const ZENTUI_EDITOR_BASE_FACTORY = Symbol.for("pi-zentui.editor-base-factory");
+const ZENTUI_EDITOR_OWNER = Symbol.for("pi-zentui.editor-owner");
 const ZENTUI_FOOTER_OWNER = Symbol.for("pi-zentui.footer-owner");
 
 type EditorFactory = NonNullable<Parameters<ExtensionContext["ui"]["setEditorComponent"]>[0]>;
@@ -81,6 +84,7 @@ type EditorFactory = NonNullable<Parameters<ExtensionContext["ui"]["setEditorCom
 type ZentuiEditorFactory = EditorFactory & {
 	[ZENTUI_EDITOR_FACTORY]?: true;
 	[ZENTUI_EDITOR_BASE_FACTORY]?: EditorFactory;
+	[ZENTUI_EDITOR_OWNER]?: symbol;
 };
 
 type ApplyUiResult = {
@@ -124,6 +128,7 @@ export function activeFooterReferences(config: ZentuiConfig): Set<string> {
 		? collectFooterFormatReferences(parseFooterFormat(starship.format), FOOTER_FORMAT_ALIASES)
 		: new Set<string>([
 				...(starship.segments.sessionName ? ["session_name"] : []),
+				...(starship.segments.runtime ? ["runtime"] : []),
 				...(starship.segments.gitCommit ? ["git_commit"] : []),
 				...(starship.segments.gitMetrics ? ["git_metrics"] : []),
 				...(starship.segments.packageVersion ? ["package"] : []),
@@ -163,6 +168,7 @@ function isTuiContext(ctx: ExtensionContext): boolean {
 export default function (pi: ExtensionAPI) {
 	const state: FooterState = createInitialState(emptyGitStatus());
 	const sessionLifecycle = new SessionLifecycle();
+	const editorOwnerToken = Symbol("zentui-editor-owner");
 
 	let currentConfig: PolishedTuiConfig = loadConfig();
 	let activeTheme: Theme | undefined;
@@ -194,6 +200,22 @@ export default function (pi: ExtensionAPI) {
 	let fixedLayoutEnabled = false;
 	let activeTuiContext: ExtensionContext | undefined;
 
+	const isOwnedEditorFactory = (factory: EditorFactory | undefined) =>
+		(factory as ZentuiEditorFactory | undefined)?.[ZENTUI_EDITOR_OWNER] === editorOwnerToken;
+	const effectiveEditorEnabled = () =>
+		currentConfig.components.editor.enabled &&
+		!hasUnsupportedComponentStyle(currentConfig, "editor");
+	const effectiveUserMessagesEnabled = () =>
+		currentConfig.components.userMessages.enabled &&
+		!hasUnsupportedComponentStyle(currentConfig, "userMessages");
+	const effectiveSelectorBordersEnabled = () =>
+		currentConfig.components.selectorBorders.enabled &&
+		!hasUnsupportedComponentStyle(currentConfig, "selectorBorders");
+	const effectiveFooterStyle = () =>
+		hasUnsupportedComponentStyle(currentConfig, "footer")
+			? ("native" as const)
+			: currentConfig.components.footer.style;
+
 	const ownsInstalledEditorFactory = () => {
 		if (
 			!sessionLifecycle.isCurrent() ||
@@ -204,7 +226,10 @@ export default function (pi: ExtensionAPI) {
 			return false;
 		}
 		try {
-			return activeTuiContext.ui.getEditorComponent() === installedEditorFactory;
+			return (
+				isOwnedEditorFactory(installedEditorFactory) &&
+				activeTuiContext.ui.getEditorComponent() === installedEditorFactory
+			);
 		} catch {
 			return false;
 		}
@@ -246,8 +271,11 @@ export default function (pi: ExtensionAPI) {
 			: new Set<string>();
 
 	type ProjectRefreshTarget = { cwd: string; generation: number };
-	const refreshProjectState = async ({ cwd, generation }: ProjectRefreshTarget) => {
-		if (!sessionLifecycle.isCurrent(generation)) return;
+	const refreshProjectState = async (
+		{ cwd, generation }: ProjectRefreshTarget,
+		run: ProjectRefreshRun,
+	) => {
+		if (!run.isCurrent() || !sessionLifecycle.isCurrent(generation)) return;
 		const starship = currentConfig.components.footer.styles.starship;
 		const gitCommitConfig = starship.gitCommit;
 		const gitMetricsConfig = starship.gitMetrics;
@@ -257,16 +285,21 @@ export default function (pi: ExtensionAPI) {
 		const wantMetrics =
 			references.has("git_metrics") || references.has("git_added") || references.has("git_deleted");
 		const wantPackage = references.has("package") || references.has("package_version");
+		const wantRuntime = references.has("runtime");
 		const [git, runtime, packageVersion] = await Promise.all([
 			readGitStatus(cwd, {
 				readExactTag: wantExactTag,
 				readMetrics: wantMetrics,
 				ignoreSubmodules: gitMetricsConfig.ignoreSubmodules,
 			}),
-			readRuntimeInfo(cwd),
-			wantPackage ? readPackageVersionResult(cwd) : Promise.resolve(undefined),
+			wantRuntime
+				? readRuntimeInfo(cwd)
+				: Promise.resolve({ kind: "ok" as const, runtime: undefined }),
+			wantPackage
+				? readPackageVersionResult(cwd)
+				: Promise.resolve({ kind: "ok" as const, result: null }),
 		]);
-		if (!sessionLifecycle.isCurrent(generation)) return;
+		if (!run.isCurrent() || !sessionLifecycle.isCurrent(generation)) return;
 		minimalistProjectRoot = git.kind === "ok" ? findRepositoryRoot(cwd) : undefined;
 		lastProjectCwd = applyProjectRefreshToState(state, {
 			cwd,
@@ -292,6 +325,7 @@ export default function (pi: ExtensionAPI) {
 		const editor = currentConfig.components.editor;
 		const minimalist = editor.styles.minimalist;
 		return (
+			effectiveEditorEnabled() &&
 			ownsInstalledEditorFactory() &&
 			editor.style === "minimalist" &&
 			(minimalist.showGit || minimalist.pathDisplay === "project")
@@ -330,6 +364,7 @@ export default function (pi: ExtensionAPI) {
 			);
 			projectRefreshActive = true;
 		}
+		if (force && !activated) projectRefreshScheduler.invalidate();
 		if (force || activated) scheduleProjectRefresh(ctx, { force: true });
 	};
 
@@ -387,6 +422,7 @@ export default function (pi: ExtensionAPI) {
 			sessionLifecycle.isCurrent() &&
 			agentStartedAt !== undefined &&
 			minimalistDecorationActive &&
+			effectiveEditorEnabled() &&
 			ownsInstalledEditorFactory() &&
 			currentConfig.components.editor.style === "minimalist" &&
 			currentConfig.components.editor.styles.minimalist.showTimer;
@@ -455,7 +491,7 @@ export default function (pi: ExtensionAPI) {
 		currentConfig = nextConfig;
 		if (sameReferences(before, after)) return;
 		reconcileSessionTimer();
-		if (needsProjectRefresh()) scheduleProjectRefresh(ctx, { force: true });
+		reconcileProjectRefresh(ctx, true);
 	};
 
 	const installUserMessages = () => {
@@ -482,19 +518,13 @@ export default function (pi: ExtensionAPI) {
 		} catch {
 			// Best effort cleanup.
 		} finally {
-			try {
-				removeUserMessageStyle();
-			} catch {
-				// Best effort cleanup of a stale registration from an earlier reload.
-			}
 			cleanupUserMessageStyle = () => {};
 			userMessageStyleInstalled = false;
 		}
 	};
 
 	const reconcileUserMessages = () => {
-		const messages = currentConfig.components.userMessages;
-		if (messages.enabled) installUserMessages();
+		if (effectiveUserMessagesEnabled()) installUserMessages();
 		else uninstallUserMessages();
 	};
 
@@ -522,11 +552,6 @@ export default function (pi: ExtensionAPI) {
 		} catch {
 			// Best effort cleanup.
 		} finally {
-			try {
-				removeSelectorBorderStyle();
-			} catch {
-				// Best effort cleanup of stale registrations from an earlier reload.
-			}
 			cleanupSelectorBorderStyle = () => {};
 			selectorBorderStyleInstalled = false;
 		}
@@ -534,8 +559,9 @@ export default function (pi: ExtensionAPI) {
 
 	const reconcileSelectorBorders = () => {
 		const selectors = currentConfig.components.selectorBorders;
-		if (selectors.enabled && selectors.style === "zentui") installSelectorBorders();
-		else uninstallSelectorBorders();
+		if (effectiveSelectorBordersEnabled() && selectors.style === "zentui") {
+			installSelectorBorders();
+		} else uninstallSelectorBorders();
 	};
 
 	const clearEditorOwnership = () => {
@@ -547,12 +573,14 @@ export default function (pi: ExtensionAPI) {
 		editorInstalled = false;
 	};
 
-	const trackZentuiEditorFactory = (factory: EditorFactory) => {
+	const trackZentuiEditorFactory = (factory: EditorFactory): boolean => {
+		if (!isOwnedEditorFactory(factory)) return false;
 		const baseFactory = getZentuiEditorBaseFactory(factory);
 		wrappedEditorFactory = baseFactory;
 		installedEditorFactory = factory;
 		editorInstallMode = baseFactory ? "wrapper" : "standalone";
 		editorInstalled = true;
+		return true;
 	};
 
 	const observeEditorFactory = (
@@ -568,7 +596,7 @@ export default function (pi: ExtensionAPI) {
 	const reconcileObservedEditorOwnership = (ctx: ExtensionContext) => {
 		const observed = observeEditorFactory(ctx);
 		if (!observed.known) return observed;
-		if (observed.factory && isZentuiEditorFactory(observed.factory)) {
+		if (observed.factory && isOwnedEditorFactory(observed.factory)) {
 			trackZentuiEditorFactory(observed.factory);
 		} else {
 			clearEditorOwnership();
@@ -615,6 +643,7 @@ export default function (pi: ExtensionAPI) {
 			);
 		}) as ZentuiEditorFactory;
 		factory[ZENTUI_EDITOR_FACTORY] = true;
+		factory[ZENTUI_EDITOR_OWNER] = editorOwnerToken;
 		return factory;
 	};
 
@@ -657,6 +686,7 @@ export default function (pi: ExtensionAPI) {
 			);
 		}) as ZentuiEditorFactory;
 		factory[ZENTUI_EDITOR_FACTORY] = true;
+		factory[ZENTUI_EDITOR_OWNER] = editorOwnerToken;
 		factory[ZENTUI_EDITOR_BASE_FACTORY] = baseFactory;
 		return factory;
 	};
@@ -690,7 +720,10 @@ export default function (pi: ExtensionAPI) {
 		return { ok: true };
 	};
 
-	const uninstallEditor = (ctx: ExtensionContext): EditorChangeResult => {
+	const uninstallEditor = (
+		ctx: ExtensionContext,
+		options: { allowStaleZentui?: boolean } = {},
+	): EditorChangeResult => {
 		const observed = observeEditorFactory(ctx);
 		if (!observed.known) {
 			return {
@@ -701,6 +734,10 @@ export default function (pi: ExtensionAPI) {
 		}
 		const currentFactory = observed.factory;
 		if (!currentFactory || !isZentuiEditorFactory(currentFactory)) {
+			clearEditorOwnership();
+			return { ok: true };
+		}
+		if (!isOwnedEditorFactory(currentFactory) && !options.allowStaleZentui) {
 			clearEditorOwnership();
 			return { ok: true };
 		}
@@ -742,14 +779,38 @@ export default function (pi: ExtensionAPI) {
 		requestFooterRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
 		stopSessionTimer();
-		if (sessionLifecycle.isCurrent()) reconcileProjectRefresh(ctx);
+		if (sessionLifecycle.isCurrent()) reconcileProjectRefresh(ctx, true);
 	};
 
-	const resetFailedFooterInstallation = (ctx: ExtensionContext, token: symbol) => {
-		try {
-			ctx.ui.setFooter(undefined);
-		} catch {
-			// Best effort: Zentui initiated the failed replacement.
+	type FooterBookkeepingSnapshot = {
+		token: symbol | undefined;
+		requestRender: (() => void) | undefined;
+		getExtensionStatuses: () => ReadonlyMap<string, string>;
+	};
+
+	const snapshotFooterBookkeeping = (ctx: ExtensionContext): FooterBookkeepingSnapshot => ({
+		token: ownsStatusLine(ctx) ? installedFooterToken : undefined,
+		requestRender: requestFooterRender,
+		getExtensionStatuses: getActiveExtensionStatuses,
+	});
+
+	const resetFailedFooterInstallation = (
+		ctx: ExtensionContext,
+		token: symbol,
+		previous: FooterBookkeepingSnapshot,
+	) => {
+		// Pi has no transactional Footer replacement API. If a live replacement
+		// fails while retaining our predecessor, preserve that Footer's callbacks
+		// and timer. Otherwise clear only local bookkeeping; never issue a
+		// destructive setFooter(undefined) rollback.
+		if (
+			previous.token !== undefined &&
+			installedFooterToken === previous.token &&
+			ctxFooterOwner(ctx) === previous.token
+		) {
+			requestFooterRender = previous.requestRender;
+			getActiveExtensionStatuses = previous.getExtensionStatuses;
+			return;
 		}
 		clearFooterOwnership(ctx, token);
 		requestFooterRender = undefined;
@@ -760,6 +821,7 @@ export default function (pi: ExtensionAPI) {
 	const installStatusLine = (ctx: ExtensionContext) => {
 		if (installedFooterKind === "starship" && ownsStatusLine(ctx)) return;
 		const token = Symbol("zentui-starship-footer");
+		const previous = snapshotFooterBookkeeping(ctx);
 		try {
 			installFooter(ctx, state, getCurrentConfig, {
 				setRequestRender: (fn) => {
@@ -778,13 +840,14 @@ export default function (pi: ExtensionAPI) {
 			refresh();
 			reconcileSessionTimer();
 		} catch {
-			resetFailedFooterInstallation(ctx, token);
+			resetFailedFooterInstallation(ctx, token, previous);
 		}
 	};
 
 	const installHiddenStatusLine = (ctx: ExtensionContext) => {
 		if (installedFooterKind === "hidden" && ownsStatusLine(ctx)) return;
 		const token = Symbol("zentui-hidden-footer");
+		const previous = snapshotFooterBookkeeping(ctx);
 		try {
 			installHiddenFooter(ctx, () => clearFooterOwnership(ctx, token));
 			installedFooterKind = "hidden";
@@ -794,25 +857,28 @@ export default function (pi: ExtensionAPI) {
 			getActiveExtensionStatuses = () => new Map();
 			stopSessionTimer();
 		} catch {
-			resetFailedFooterInstallation(ctx, token);
+			resetFailedFooterInstallation(ctx, token, previous);
 		}
 	};
 
-	const uninstallStatusLine = (ctx: ExtensionContext) => {
-		stopSessionTimer();
+	const uninstallStatusLine = (
+		ctx: ExtensionContext,
+		options: { forceLocalCleanup?: boolean } = {},
+	) => {
 		const ownedToken = ownsStatusLine(ctx) ? installedFooterToken : undefined;
-		if (ownedToken) {
-			try {
-				ctx.ui.setFooter(undefined);
-			} catch {
-				// Best effort cleanup must not prevent other surfaces from reconciling.
-			}
-			clearFooterOwnership(ctx, ownedToken);
+		if (!ownedToken) return;
+		try {
+			ctx.ui.setFooter(undefined);
+		} catch {
+			// A live transition must preserve an owned Footer that Pi retained.
+			// Shutdown cannot keep local callbacks alive, so it clears bookkeeping.
+			if (!options.forceLocalCleanup) return;
 		}
+		clearFooterOwnership(ctx, ownedToken);
 	};
 
 	const reconcileFooter = (ctx: ExtensionContext) => {
-		switch (currentConfig.components.footer.style) {
+		switch (effectiveFooterStyle()) {
 			case "starship":
 				installStatusLine(ctx);
 				break;
@@ -854,15 +920,26 @@ export default function (pi: ExtensionAPI) {
 		}
 	};
 
-	const reconcileEditor = (ctx: ExtensionContext): EditorChangeResult | undefined => {
+	const reconcileEditor = (
+		ctx: ExtensionContext,
+		options: { allowStaleZentui?: boolean } = {},
+	): EditorChangeResult | undefined => {
 		try {
-			if (currentConfig.components.editor.enabled) {
+			if (effectiveEditorEnabled()) {
 				const currentFactory = ctx.ui.getEditorComponent();
-				const editorMissingOrReplaced = !editorInstalled || !isZentuiEditorFactory(currentFactory);
+				if (
+					isZentuiEditorFactory(currentFactory) &&
+					!isOwnedEditorFactory(currentFactory) &&
+					!options.allowStaleZentui
+				) {
+					clearEditorOwnership();
+					return;
+				}
+				const editorMissingOrReplaced = !editorInstalled || !isOwnedEditorFactory(currentFactory);
 				if (editorMissingOrReplaced) return installEditor(ctx);
 			} else {
 				const currentFactory = ctx.ui.getEditorComponent();
-				if (editorInstalled || isZentuiEditorFactory(currentFactory)) return uninstallEditor(ctx);
+				if (editorInstalled || isOwnedEditorFactory(currentFactory)) return uninstallEditor(ctx);
 			}
 		} catch {
 			return {
@@ -872,12 +949,15 @@ export default function (pi: ExtensionAPI) {
 		}
 	};
 
-	const applyConfiguredUi = (ctx: ExtensionContext): ApplyUiResult => {
+	const applyConfiguredUi = (
+		ctx: ExtensionContext,
+		options: { allowStaleZentui?: boolean } = {},
+	): ApplyUiResult => {
 		const result: ApplyUiResult = { editorBlocked: false };
 		if (!isTuiContext(ctx)) return result;
 		activeTheme = ctx.ui.theme;
 
-		const editorChange = reconcileEditor(ctx);
+		const editorChange = reconcileEditor(ctx, options);
 		if (editorChange && !editorChange.ok) {
 			result.editorBlocked = true;
 			result.editorReason = editorChange.reason;
@@ -906,26 +986,36 @@ export default function (pi: ExtensionAPI) {
 		cleanupFixedLayout(ctx);
 		uninstallUserMessages();
 		uninstallSelectorBorders();
+		try {
+			removeUserMessageStyle();
+		} catch {
+			// Startup alone may supersede a stale registration from an earlier reload.
+		}
+		try {
+			removeSelectorBorderStyle();
+		} catch {
+			// Startup alone may supersede a stale registration from an earlier reload.
+		}
 		uninstallStatusLine(ctx);
-		if (currentConfig.components.editor.enabled) clearEditorOwnership();
+		if (effectiveEditorEnabled()) clearEditorOwnership();
 		else {
 			try {
-				uninstallEditor(ctx);
+				uninstallEditor(ctx, { allowStaleZentui: true });
 			} catch {
 				// Reconciliation below retries observable stale ownership.
 			}
 		}
 
-		applyConfiguredUi(ctx);
+		applyConfiguredUi(ctx, { allowStaleZentui: true });
 		refresh();
 	};
 
 	const scheduleEditorReconciliation = (ctx: ExtensionContext) => {
 		sessionLifecycle.defer(() => {
-			if (!isTuiContext(ctx) || !currentConfig.components.editor.enabled) return;
+			if (!isTuiContext(ctx) || !effectiveEditorEnabled()) return;
 			const observed = observeEditorFactory(ctx);
 			if (!observed.known || observed.factory === installedEditorFactory) return;
-			if (!observed.factory || !isZentuiEditorFactory(observed.factory)) {
+			if (!observed.factory || !isOwnedEditorFactory(observed.factory)) {
 				clearEditorOwnership();
 				reconcileProjectRefresh(ctx);
 				refresh();
@@ -956,12 +1046,12 @@ export default function (pi: ExtensionAPI) {
 
 		let retainedEditorOwnership = false;
 		if (isTuiContext(ctx)) {
-			uninstallStatusLine(ctx);
+			uninstallStatusLine(ctx, { forceLocalCleanup: true });
 			try {
 				const before = observeEditorFactory(ctx);
 				if (before.known) {
 					const currentFactory = before.factory;
-					if (currentFactory && isZentuiEditorFactory(currentFactory)) {
+					if (currentFactory && isOwnedEditorFactory(currentFactory)) {
 						replaceEditor(
 							ctx,
 							getZentuiEditorBaseFactory(currentFactory) ??
@@ -972,7 +1062,7 @@ export default function (pi: ExtensionAPI) {
 					}
 				}
 				const after = observeEditorFactory(ctx);
-				if (after.known && after.factory && isZentuiEditorFactory(after.factory)) {
+				if (after.known && after.factory && isOwnedEditorFactory(after.factory)) {
 					trackZentuiEditorFactory(after.factory);
 					retainedEditorOwnership = true;
 				}
@@ -1017,7 +1107,9 @@ export default function (pi: ExtensionAPI) {
 		setEditorComponent(patch: Partial<EditorComponentConfig>, ctx: ExtensionContext) {
 			currentConfig = saveEditorComponentPatch(patch);
 			let result: EditorChangeResult | undefined;
-			if (patch.enabled !== undefined && isTuiContext(ctx)) result = reconcileEditor(ctx);
+			if ((patch.enabled !== undefined || patch.style !== undefined) && isTuiContext(ctx)) {
+				result = reconcileEditor(ctx);
+			}
 			if (patch.style !== undefined && patch.style !== "minimalist") {
 				setMinimalistDecorationActive(false);
 			}
@@ -1033,15 +1125,12 @@ export default function (pi: ExtensionAPI) {
 		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
 			currentConfig = saveMinimalistEditorStylePatch(patch);
 			reconcileAgentTimer();
-			reconcileProjectRefresh(ctx);
-			if (needsProjectRefresh() && (patch.pathDisplay === "project" || patch.showGit === true)) {
-				scheduleProjectRefresh(ctx, { force: true });
-			}
+			reconcileProjectRefresh(ctx, patch.pathDisplay !== undefined || patch.showGit !== undefined);
 			refresh();
 		},
 		setUserMessagesComponent(patch: Partial<UserMessagesComponentConfig>, _ctx: ExtensionContext) {
 			currentConfig = saveUserMessagesComponentPatch(patch);
-			if (patch.enabled !== undefined) reconcileUserMessages();
+			if (patch.enabled !== undefined || patch.style !== undefined) reconcileUserMessages();
 			refresh();
 		},
 		setSelectorBordersComponent(
@@ -1053,14 +1142,14 @@ export default function (pi: ExtensionAPI) {
 			refresh();
 		},
 		setFooterComponent(patch: Partial<FooterComponentConfig>, ctx: ExtensionContext) {
-			const previousStyle = currentConfig.components.footer.style;
+			const previousStyle = effectiveFooterStyle();
 			currentConfig = saveFooterComponentPatch(patch);
-			const styleChanged = currentConfig.components.footer.style !== previousStyle;
+			const styleChanged = effectiveFooterStyle() !== previousStyle;
 			if (styleChanged && fixedLayoutEnabled) cleanupFixedLayout(ctx);
 			if (patch.style !== undefined) reconcileFooter(ctx);
 			if (styleChanged && currentConfig.layout.fixedEditor.enabled) reconcileFixedLayout(ctx);
 			if (patch.modelLabel !== undefined) syncFooterState(ctx);
-			reconcileProjectRefresh(ctx);
+			reconcileProjectRefresh(ctx, styleChanged);
 			reconcileSessionTimer();
 			refresh();
 		},
@@ -1105,15 +1194,11 @@ export default function (pi: ExtensionAPI) {
 			ctx: ExtensionContext,
 		) {
 			currentConfig = saveStarshipFooterStylePatch({ gitCommit: patch as GitCommitConfig });
-			if (patch.showTag !== undefined && needsProjectRefresh()) {
-				scheduleProjectRefresh(ctx, { force: true });
-			}
+			if (patch.showTag !== undefined) reconcileProjectRefresh(ctx, true);
 		},
 		setGitMetrics(patch: Partial<GitMetricsConfig>, ctx: ExtensionContext) {
 			currentConfig = saveStarshipFooterStylePatch({ gitMetrics: patch as GitMetricsConfig });
-			if (patch.ignoreSubmodules !== undefined && needsProjectRefresh()) {
-				scheduleProjectRefresh(ctx, { force: true });
-			}
+			if (patch.ignoreSubmodules !== undefined) reconcileProjectRefresh(ctx, true);
 		},
 		getActiveExtensionStatuses() {
 			return getActiveExtensionStatuses();

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -9,6 +11,7 @@ import {
 	type ColorSourcesConfig,
 	type ContextStyle,
 	type EditorBorderColorMode,
+	type EditorMode,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	ensureConfigExists,
@@ -20,6 +23,7 @@ import {
 	type GitMetricsConfig,
 	type IconMode,
 	loadConfig,
+	type MinimalistConfig,
 	type ModelLabelSource,
 	type PathDisplayConfig,
 	type PolishedTuiConfig,
@@ -27,6 +31,7 @@ import {
 	saveColorSourcesPatch,
 	saveContextStylePatch,
 	saveEditorBorderColorMode,
+	saveEditorMode,
 	saveEditorModelLabel,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
@@ -38,6 +43,7 @@ import {
 	saveGitCommitPatch,
 	saveGitMetricsPatch,
 	saveIconsModePatch,
+	saveMinimalistPatch,
 	savePathDisplayPatch,
 	saveResponsiveFooterPatch,
 	saveSeparatorPatch,
@@ -141,6 +147,16 @@ export function activeFooterReferences(config: PolishedTuiConfig): Set<string> {
 	return references;
 }
 
+function findRepositoryRoot(cwd: string): string | undefined {
+	let current = resolve(cwd);
+	while (true) {
+		if (existsSync(join(current, ".git"))) return current;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
 function isTuiContext(ctx: ExtensionContext): boolean {
 	try {
 		const mode = (ctx as ExtensionContext & { mode?: string }).mode;
@@ -157,6 +173,7 @@ export default function (pi: ExtensionAPI) {
 	let currentConfig: PolishedTuiConfig = loadConfig();
 	let activeTheme: Theme | undefined;
 	let requestFooterRender: (() => void) | undefined;
+	let requestEditorRender: (() => void) | undefined;
 	let getActiveExtensionStatuses: () => ReadonlyMap<string, string> = () => new Map();
 	let stopRefreshInterval: StopProjectRefreshInterval = () => {};
 	let cleanupPrototypePatches: () => void = () => {};
@@ -167,16 +184,54 @@ export default function (pi: ExtensionAPI) {
 	let wrappedEditorFactory: EditorFactory | undefined;
 	let prototypePatchesInstalled = false;
 	let stopSessionTimer: () => void = () => {};
+	let stopAgentTimer: () => void = () => {};
+	let agentTimerRunning = false;
+	let minimalistDecorationActive = false;
 	let sessionTimerRequirements = "";
 	let lastDurationLabel = "";
 	let lastProjectCwd: string | undefined;
+	let agentStartedAt: number | undefined;
+	let agentDurationMs: number | undefined;
+	let minimalistProjectRoot: string | undefined;
+	let projectRefreshActive = false;
+	let activeTuiContext: ExtensionContext | undefined;
+
+	const ownsInstalledEditorFactory = () => {
+		if (
+			!sessionLifecycle.isCurrent() ||
+			!editorInstalled ||
+			!installedEditorFactory ||
+			!activeTuiContext
+		) {
+			return false;
+		}
+		try {
+			return activeTuiContext.ui.getEditorComponent() === installedEditorFactory;
+		} catch {
+			return false;
+		}
+	};
 
 	const refresh = () => {
-		if (sessionLifecycle.isCurrent()) requestFooterRender?.();
+		if (!sessionLifecycle.isCurrent()) return;
+		requestFooterRender?.();
+		requestEditorRender?.();
 	};
 	const liveContext = new LiveContextController(sessionLifecycle, refresh);
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
+	const getContextWindow = (ctx: ExtensionContext): number | undefined =>
+		ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow;
+	const getContextPercent = (ctx: ExtensionContext): number | undefined => {
+		const usage = ctx.getContextUsage();
+		const contextWindow = getContextWindow(ctx);
+		const live = liveContext.get();
+		return live && contextWindow && contextWindow > 0
+			? (live.tokens / contextWindow) * 100
+			: (usage?.percent ?? undefined);
+	};
+	const getAgentDurationMs = () =>
+		agentStartedAt === undefined ? agentDurationMs : Math.max(0, Date.now() - agentStartedAt);
 	const getThinkingLevel = () =>
 		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
@@ -209,6 +264,7 @@ export default function (pi: ExtensionAPI) {
 			wantPackage ? readPackageVersionResult(cwd) : Promise.resolve(undefined),
 		]);
 		if (!sessionLifecycle.isCurrent(generation)) return;
+		minimalistProjectRoot = git.kind === "ok" ? findRepositoryRoot(cwd) : undefined;
 		lastProjectCwd = applyProjectRefreshToState(state, {
 			cwd,
 			previousCwd: lastProjectCwd,
@@ -229,17 +285,50 @@ export default function (pi: ExtensionAPI) {
 		projectRefreshScheduler.schedule({ cwd, generation }, options);
 	};
 
-	const refreshInteractiveState = (ctx: ExtensionContext, project = false) => {
-		if (!sessionLifecycle.isCurrent() || !ctx.hasUI) return;
-		syncFooterState(ctx);
-		if (project && currentConfig.features.statusLine) scheduleProjectRefresh(ctx);
-		refresh();
-	};
+	const needsProjectRefresh = () =>
+		footerInstalled ||
+		(currentConfig.features.editor &&
+			currentConfig.editorMode === "minimalist" &&
+			ownsInstalledEditorFactory());
 
 	const stopProjectRefresh = () => {
 		stopRefreshInterval();
 		stopRefreshInterval = () => {};
 		projectRefreshScheduler.stop();
+		projectRefreshActive = false;
+	};
+
+	const reconcileProjectRefresh = (ctx: ExtensionContext, force = false) => {
+		if (!sessionLifecycle.isCurrent() || !needsProjectRefresh()) {
+			stopProjectRefresh();
+			return;
+		}
+		const activated = !projectRefreshActive;
+		if (activated) {
+			stopRefreshInterval = startProjectRefreshInterval(
+				currentConfig.projectRefreshIntervalMs,
+				() => {
+					if (editorInstalled && !ownsInstalledEditorFactory()) {
+						reconcileObservedEditorOwnership(ctx);
+					}
+					if (!needsProjectRefresh()) {
+						stopProjectRefresh();
+						return;
+					}
+					scheduleProjectRefresh(ctx);
+				},
+			);
+			projectRefreshActive = true;
+		}
+		if (force || activated) scheduleProjectRefresh(ctx, { force: true });
+	};
+
+	const refreshInteractiveState = (ctx: ExtensionContext, project = false) => {
+		if (!sessionLifecycle.isCurrent() || !ctx.hasUI) return;
+		if (editorInstalled && !ownsInstalledEditorFactory()) reconcileObservedEditorOwnership(ctx);
+		syncFooterState(ctx);
+		if (project && needsProjectRefresh()) scheduleProjectRefresh(ctx);
+		refresh();
 	};
 
 	const reconcileSessionTimer = () => {
@@ -283,6 +372,66 @@ export default function (pi: ExtensionAPI) {
 		};
 	};
 
+	const reconcileAgentTimer = () => {
+		const needed =
+			sessionLifecycle.isCurrent() &&
+			agentStartedAt !== undefined &&
+			minimalistDecorationActive &&
+			ownsInstalledEditorFactory() &&
+			currentConfig.minimalist.showTimer;
+		if (!needed) {
+			stopAgentTimer();
+			return;
+		}
+		if (agentTimerRunning) return;
+		const timer = setInterval(() => {
+			const ctx = activeTuiContext;
+			if (ctx && editorInstalled && !ownsInstalledEditorFactory()) {
+				reconcileObservedEditorOwnership(ctx);
+			}
+			reconcileAgentTimer();
+			if (agentTimerRunning) refresh();
+		}, 1000);
+		agentTimerRunning = true;
+		stopAgentTimer = () => {
+			clearInterval(timer);
+			agentTimerRunning = false;
+			stopAgentTimer = () => {};
+		};
+	};
+
+	const setMinimalistDecorationActive = (active: boolean) => {
+		const next = sessionLifecycle.isCurrent() && active && ownsInstalledEditorFactory();
+		if (minimalistDecorationActive === next) return;
+		minimalistDecorationActive = next;
+		reconcileAgentTimer();
+		requestFooterRender?.();
+	};
+
+	const startAgentTurn = () => {
+		stopAgentTimer();
+		agentStartedAt = Date.now();
+		agentDurationMs = 0;
+		reconcileAgentTimer();
+		refresh();
+	};
+
+	const finishAgentTurn = () => {
+		if (agentStartedAt !== undefined) {
+			agentDurationMs = Math.max(0, Date.now() - agentStartedAt);
+		}
+		agentStartedAt = undefined;
+		reconcileAgentTimer();
+		refresh();
+	};
+
+	const resetAgentTimer = () => {
+		stopAgentTimer();
+		agentTimerRunning = false;
+		agentStartedAt = undefined;
+		agentDurationMs = undefined;
+	};
+
 	const sameReferences = (left: Set<string>, right: Set<string>) =>
 		left.size === right.size && [...left].every((name) => right.has(name));
 
@@ -296,7 +445,7 @@ export default function (pi: ExtensionAPI) {
 		currentConfig = nextConfig;
 		if (sameReferences(before, after)) return;
 		reconcileSessionTimer();
-		if (footerInstalled) scheduleProjectRefresh(ctx, { force: true });
+		if (needsProjectRefresh()) scheduleProjectRefresh(ctx, { force: true });
 	};
 
 	const installPrototypePatches = (): boolean => {
@@ -330,6 +479,8 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	const clearEditorOwnership = () => {
+		setMinimalistDecorationActive(false);
+		requestEditorRender = undefined;
 		wrappedEditorFactory = undefined;
 		installedEditorFactory = undefined;
 		editorInstallMode = "none";
@@ -362,14 +513,16 @@ export default function (pi: ExtensionAPI) {
 		} else {
 			uninstallPrototypePatches();
 			clearEditorOwnership();
+			reconcileProjectRefresh(ctx);
 		}
 		return observed;
 	};
 
 	const makeEditorFactory = (ctx: ExtensionContext): ZentuiEditorFactory => {
 		const sessionTheme = ctx.ui.theme;
-		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
-			new PolishedEditor(
+		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => {
+			requestEditorRender = () => tui.requestRender();
+			return new PolishedEditor(
 				tui,
 				theme,
 				keybindings,
@@ -383,7 +536,24 @@ export default function (pi: ExtensionAPI) {
 					sessionName: ctx.sessionManager.getSessionName() ?? "",
 				}),
 				getThinkingLevel,
-			)) as ZentuiEditorFactory;
+				() => ({
+					cwd: ctx.cwd,
+					projectRoot: minimalistProjectRoot,
+					branch: state.branch,
+					dirty: state.dirty,
+					ahead: state.ahead,
+					behind: state.behind,
+					costLabel: state.costLabel,
+					modelLabel: state.modelLabel,
+					thinkingLevel: getThinkingLevel(),
+					contextPercent: getContextPercent(ctx),
+					contextWindow: getContextWindow(ctx),
+					agentDurationMs: getAgentDurationMs(),
+					agentActive: agentStartedAt !== undefined,
+				}),
+				setMinimalistDecorationActive,
+			);
+		}) as ZentuiEditorFactory;
 		factory[ZENTUI_EDITOR_FACTORY] = true;
 		return factory;
 	};
@@ -393,8 +563,9 @@ export default function (pi: ExtensionAPI) {
 		baseFactory: EditorFactory,
 	): ZentuiEditorFactory => {
 		const sessionTheme = ctx.ui.theme;
-		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) =>
-			new WrappedPolishedEditor(
+		const factory = ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => {
+			requestEditorRender = () => tui.requestRender();
+			return new WrappedPolishedEditor(
 				baseFactory(tui, theme, keybindings),
 				sessionTheme,
 				getCurrentConfig,
@@ -406,7 +577,24 @@ export default function (pi: ExtensionAPI) {
 					sessionName: ctx.sessionManager.getSessionName() ?? "",
 				}),
 				getThinkingLevel,
-			)) as ZentuiEditorFactory;
+				() => ({
+					cwd: ctx.cwd,
+					projectRoot: minimalistProjectRoot,
+					branch: state.branch,
+					dirty: state.dirty,
+					ahead: state.ahead,
+					behind: state.behind,
+					costLabel: state.costLabel,
+					modelLabel: state.modelLabel,
+					thinkingLevel: getThinkingLevel(),
+					contextPercent: getContextPercent(ctx),
+					contextWindow: getContextWindow(ctx),
+					agentDurationMs: getAgentDurationMs(),
+					agentActive: agentStartedAt !== undefined,
+				}),
+				setMinimalistDecorationActive,
+			);
+		}) as ZentuiEditorFactory;
 		factory[ZENTUI_EDITOR_FACTORY] = true;
 		factory[ZENTUI_EDITOR_BASE_FACTORY] = baseFactory;
 		return factory;
@@ -492,24 +680,21 @@ export default function (pi: ExtensionAPI) {
 				getActiveExtensionStatuses = fn ?? (() => new Map());
 			},
 			getLiveContext: () => liveContext.get(),
+			suppressVisibleOutput: () => minimalistDecorationActive && ownsInstalledEditorFactory(),
 		});
 		footerInstalled = true;
-		stopProjectRefresh();
-		stopRefreshInterval = startProjectRefreshInterval(currentConfig.projectRefreshIntervalMs, () =>
-			scheduleProjectRefresh(ctx),
-		);
-		scheduleProjectRefresh(ctx, { force: true });
+		reconcileProjectRefresh(ctx, true);
 		refresh();
 		reconcileSessionTimer();
 	};
 
 	const uninstallStatusLine = (ctx: ExtensionContext) => {
 		stopSessionTimer();
-		stopProjectRefresh();
 		ctx.ui.setFooter(undefined);
 		footerInstalled = false;
 		requestFooterRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
+		reconcileProjectRefresh(ctx);
 	};
 
 	const applyConfiguredUi = (ctx: ExtensionContext): ApplyUiResult => {
@@ -534,15 +719,19 @@ export default function (pi: ExtensionAPI) {
 		} else if (footerInstalled) {
 			uninstallStatusLine(ctx);
 		}
+		reconcileProjectRefresh(ctx);
 		return result;
 	};
 
 	const installUi = (ctx: ExtensionContext) => {
 		if (!isTuiContext(ctx)) return;
+		activeTuiContext = ctx;
 		activeTheme = ctx.ui.theme;
 		uninstallPrototypePatches();
 		footerInstalled = false;
 		editorInstalled = false;
+		minimalistDecorationActive = false;
+		requestEditorRender = undefined;
 		installedEditorFactory = undefined;
 		ensureConfigExists();
 		currentConfig = loadConfig();
@@ -563,6 +752,7 @@ export default function (pi: ExtensionAPI) {
 			if (!observed.factory || !isZentuiEditorFactory(observed.factory)) {
 				uninstallPrototypePatches();
 				clearEditorOwnership();
+				reconcileProjectRefresh(ctx);
 				refresh();
 				return;
 			}
@@ -578,8 +768,10 @@ export default function (pi: ExtensionAPI) {
 			disposeFixedEditor(ctx);
 			if (isTuiContext(ctx)) removeFixedEditorProbe(ctx);
 			stopSessionTimer();
+			resetAgentTimer();
 			stopProjectRefresh();
 			requestFooterRender = undefined;
+			requestEditorRender = undefined;
 			getActiveExtensionStatuses = () => new Map();
 			if (isTuiContext(ctx)) {
 				ctx.ui.setFooter(undefined);
@@ -602,7 +794,9 @@ export default function (pi: ExtensionAPI) {
 			footerInstalled = false;
 			activeTheme = undefined;
 		} finally {
+			activeTuiContext = undefined;
 			requestFooterRender = undefined;
+			requestEditorRender = undefined;
 		}
 	};
 
@@ -618,7 +812,9 @@ export default function (pi: ExtensionAPI) {
 		liveContext.clear();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
+		resetAgentTimer();
 		lastProjectCwd = undefined;
+		minimalistProjectRoot = undefined;
 		installUi(ctx);
 		scheduleEditorReconciliation(ctx);
 	});
@@ -668,6 +864,21 @@ export default function (pi: ExtensionAPI) {
 			currentConfig = saveEditorModelLabel(value);
 			syncFooterState(ctx);
 		},
+		setEditorMode(value: EditorMode, ctx: ExtensionContext) {
+			currentConfig = saveEditorMode(value);
+			if (value !== "minimalist") setMinimalistDecorationActive(false);
+			reconcileProjectRefresh(ctx);
+			reconcileAgentTimer();
+			refresh();
+		},
+		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
+			currentConfig = saveMinimalistPatch(patch);
+			reconcileAgentTimer();
+			if (needsProjectRefresh() && (patch.pathDisplay === "project" || patch.showGit === true)) {
+				scheduleProjectRefresh(ctx, { force: true });
+			}
+			refresh();
+		},
 		setEditorBorderColorMode(value: EditorBorderColorMode) {
 			currentConfig = saveEditorBorderColorMode(value);
 		},
@@ -676,13 +887,13 @@ export default function (pi: ExtensionAPI) {
 			ctx: ExtensionContext,
 		) {
 			currentConfig = saveGitCommitPatch(patch);
-			if (patch.showTag !== undefined && footerInstalled) {
+			if (patch.showTag !== undefined && needsProjectRefresh()) {
 				scheduleProjectRefresh(ctx, { force: true });
 			}
 		},
 		setGitMetrics(patch: Partial<GitMetricsConfig>, ctx: ExtensionContext) {
 			currentConfig = saveGitMetricsPatch(patch);
-			if (patch.ignoreSubmodules !== undefined && footerInstalled) {
+			if (patch.ignoreSubmodules !== undefined && needsProjectRefresh()) {
 				scheduleProjectRefresh(ctx, { force: true });
 			}
 		},
@@ -724,10 +935,12 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("agent_start", (event, ctx) => {
 		liveContext.clear();
+		startAgentTurn();
 		syncInteractiveState(event, ctx);
 	});
 	pi.on("agent_end", (event, ctx) => {
 		liveContext.clear();
+		finishAgentTurn();
 		// Reconcile once more after Pi has persisted the assistant message.
 		syncInteractiveAndProjectStateWithUsage(event, ctx);
 	});

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -8,47 +8,42 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import {
-	type ColorSourcesConfig,
 	type ContextStyle,
-	type EditorBorderColorMode,
-	type EditorStyle,
+	type EditorComponentConfig,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	ensureConfigExists,
 	type FixedEditorConfig,
 	FOOTER_FORMAT_ALIASES,
+	type FooterComponentConfig,
 	type FooterSegmentsConfig,
+	type FramedUserMessageStyleConfig,
 	type GitBranchConfig,
 	type GitCommitConfig,
 	type GitMetricsConfig,
 	type IconMode,
 	loadConfig,
 	type MinimalistConfig,
-	type ModelLabelSource,
 	type PathDisplayConfig,
+	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
+	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
-	saveColorSourcesPatch,
-	saveContextStylePatch,
-	saveEditorBorderColorMode,
-	saveEditorModelLabel,
-	saveEditorStyle,
+	saveEditorComponentPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
 	saveExtensionStatusPlacement,
-	saveFixedEditorPatch,
-	saveFooterFormatPatch,
-	saveFooterSegmentsPatch,
-	saveGitBranchPatch,
-	saveGitCommitPatch,
-	saveGitMetricsPatch,
+	saveFooterComponentPatch,
+	saveFramedUserMessagesStylePatch,
 	saveIconsModePatch,
-	saveMinimalistPatch,
-	savePathDisplayPatch,
-	saveResponsiveFooterPatch,
-	saveSeparatorPatch,
+	saveLayoutFixedEditorPatch,
+	saveMinimalistEditorStylePatch,
+	savePolishedEditorStylePatch,
+	saveSelectorBordersComponentPatch,
+	saveStarshipFooterStylePatch,
 	saveUiFeaturesPatch,
-	type UiFeaturesConfig,
+	saveUserMessagesComponentPatch,
+	type UserMessagesComponentConfig,
 	type ZentuiConfig,
 } from "./config";
 import {
@@ -974,57 +969,28 @@ export default function (pi: ExtensionAPI) {
 	registerZentuiSettingsCommand(pi, {
 		sessionLifecycle,
 		getConfig: getCurrentConfig,
-		setColorSources(patch: Partial<ColorSourcesConfig>) {
-			currentConfig = saveColorSourcesPatch(patch);
-		},
-		setUiFeatures(patch: Partial<UiFeaturesConfig>, ctx: ExtensionContext) {
-			currentConfig = saveUiFeaturesPatch(patch);
-			const result = applyConfiguredUi(ctx);
-			return {
-				applied: !(patch.editor !== undefined && result.editorBlocked),
-				reason: result.editorBlocked ? result.editorReason : undefined,
-			};
-		},
-		setFooterSegments(patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) {
-			applyFooterDependencyConfigChange(ctx, () => saveFooterSegmentsPatch(patch));
-		},
-		setFooterFormat(value: string, ctx: ExtensionContext) {
-			applyFooterDependencyConfigChange(ctx, () => saveFooterFormatPatch(value));
-		},
-		setResponsiveFooter(
-			patch: Partial<Pick<PolishedTuiConfig, "responsiveFooter" | "compactFooterMaxLines">>,
-			ctx: ExtensionContext,
-		) {
-			applyFooterDependencyConfigChange(ctx, () => saveResponsiveFooterPatch(patch));
-		},
-		setIconMode(mode: IconMode) {
-			currentConfig = saveIconsModePatch(mode);
-		},
-		setContextStyle(style: ContextStyle) {
-			currentConfig = saveContextStylePatch(style);
-		},
-		setSeparator(separator: SeparatorStyle) {
-			currentConfig = saveSeparatorPatch(separator);
-		},
-		setPathDisplay(patch: Partial<PathDisplayConfig>) {
-			currentConfig = savePathDisplayPatch(patch);
-		},
-		setGitBranch(patch: Partial<GitBranchConfig>) {
-			currentConfig = saveGitBranchPatch(patch);
-		},
-		setEditorModelLabel(value: ModelLabelSource, ctx: ExtensionContext) {
-			currentConfig = saveEditorModelLabel(value);
-			syncFooterState(ctx);
-		},
-		setEditorStyle(value: EditorStyle, ctx: ExtensionContext) {
-			currentConfig = saveEditorStyle(value);
-			if (value !== "minimalist") setMinimalistDecorationActive(false);
+		setEditorComponent(patch: Partial<EditorComponentConfig>, ctx: ExtensionContext) {
+			currentConfig = saveEditorComponentPatch(patch);
+			let result: EditorChangeResult | undefined;
+			if (patch.enabled !== undefined && isTuiContext(ctx)) result = reconcileEditor(ctx);
+			if (patch.style !== undefined && patch.style !== "minimalist") {
+				setMinimalistDecorationActive(false);
+			}
+			if (patch.modelLabel !== undefined) syncFooterState(ctx);
 			reconcileProjectRefresh(ctx);
 			reconcileAgentTimer();
 			refresh();
+			return {
+				applied: !result || result.ok,
+				reason: result && !result.ok ? result.reason : undefined,
+			};
+		},
+		setPolishedEditorStyle(patch: Partial<PolishedEditorStyleConfig>, _ctx: ExtensionContext) {
+			currentConfig = savePolishedEditorStylePatch(patch);
+			refresh();
 		},
 		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
-			currentConfig = saveMinimalistPatch(patch);
+			currentConfig = saveMinimalistEditorStylePatch(patch);
 			reconcileAgentTimer();
 			reconcileProjectRefresh(ctx);
 			if (needsProjectRefresh() && (patch.pathDisplay === "project" || patch.showGit === true)) {
@@ -1032,20 +998,85 @@ export default function (pi: ExtensionAPI) {
 			}
 			refresh();
 		},
-		setEditorBorderColorMode(value: EditorBorderColorMode) {
-			currentConfig = saveEditorBorderColorMode(value);
+		setUserMessagesComponent(patch: Partial<UserMessagesComponentConfig>, _ctx: ExtensionContext) {
+			currentConfig = saveUserMessagesComponentPatch(patch);
+			if (patch.enabled !== undefined || patch.style !== undefined) reconcileUserMessages();
+			refresh();
+		},
+		setFramedUserMessagesStyle(
+			patch: Partial<FramedUserMessageStyleConfig>,
+			_ctx: ExtensionContext,
+		) {
+			currentConfig = saveFramedUserMessagesStylePatch(patch);
+			refresh();
+		},
+		setSelectorBordersComponent(
+			patch: Partial<SelectorBordersComponentConfig>,
+			_ctx: ExtensionContext,
+		) {
+			currentConfig = saveSelectorBordersComponentPatch(patch);
+			if (patch.enabled !== undefined || patch.style !== undefined) reconcileSelectorBorders();
+			refresh();
+		},
+		setFooterComponent(patch: Partial<FooterComponentConfig>, ctx: ExtensionContext) {
+			currentConfig = saveFooterComponentPatch(patch);
+			if (patch.enabled !== undefined || patch.style !== undefined) reconcileFooter(ctx);
+			if (patch.modelLabel !== undefined) syncFooterState(ctx);
+			reconcileProjectRefresh(ctx);
+			reconcileSessionTimer();
+			refresh();
+		},
+		setCopyFriendlyRecipe(enabled: boolean, _ctx: ExtensionContext) {
+			currentConfig = saveUiFeaturesPatch({ copyFriendly: enabled });
+			refresh();
+		},
+		setFooterSegments(patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) {
+			applyFooterDependencyConfigChange(ctx, () =>
+				saveStarshipFooterStylePatch({ segments: patch as FooterSegmentsConfig }),
+			);
+		},
+		setFooterFormat(value: string, ctx: ExtensionContext) {
+			applyFooterDependencyConfigChange(ctx, () => saveStarshipFooterStylePatch({ format: value }));
+		},
+		setResponsiveFooter(
+			patch: Partial<Pick<PolishedTuiConfig, "responsiveFooter" | "compactFooterMaxLines">>,
+			ctx: ExtensionContext,
+		) {
+			applyFooterDependencyConfigChange(ctx, () =>
+				saveStarshipFooterStylePatch({
+					...(patch.responsiveFooter === undefined ? {} : { responsive: patch.responsiveFooter }),
+					...(patch.compactFooterMaxLines === undefined
+						? {}
+						: { compactMaxLines: patch.compactFooterMaxLines }),
+				}),
+			);
+		},
+		setIconMode(mode: IconMode) {
+			currentConfig = saveIconsModePatch(mode);
+		},
+		setContextStyle(style: ContextStyle) {
+			currentConfig = saveStarshipFooterStylePatch({ contextStyle: style });
+		},
+		setSeparator(separator: SeparatorStyle) {
+			currentConfig = saveStarshipFooterStylePatch({ separator });
+		},
+		setPathDisplay(patch: Partial<PathDisplayConfig>) {
+			currentConfig = saveStarshipFooterStylePatch({ pathDisplay: patch as PathDisplayConfig });
+		},
+		setGitBranch(patch: Partial<GitBranchConfig>) {
+			currentConfig = saveStarshipFooterStylePatch({ gitBranch: patch as GitBranchConfig });
 		},
 		setGitCommit(
 			patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,
 			ctx: ExtensionContext,
 		) {
-			currentConfig = saveGitCommitPatch(patch);
+			currentConfig = saveStarshipFooterStylePatch({ gitCommit: patch as GitCommitConfig });
 			if (patch.showTag !== undefined && needsProjectRefresh()) {
 				scheduleProjectRefresh(ctx, { force: true });
 			}
 		},
 		setGitMetrics(patch: Partial<GitMetricsConfig>, ctx: ExtensionContext) {
-			currentConfig = saveGitMetricsPatch(patch);
+			currentConfig = saveStarshipFooterStylePatch({ gitMetrics: patch as GitMetricsConfig });
 			if (patch.ignoreSubmodules !== undefined && needsProjectRefresh()) {
 				scheduleProjectRefresh(ctx, { force: true });
 			}
@@ -1063,7 +1094,7 @@ export default function (pi: ExtensionAPI) {
 			currentConfig = saveExtensionStatusColorMode(key, colorMode);
 		},
 		setFixedEditor(patch: Partial<FixedEditorConfig>, ctx: ExtensionContext) {
-			currentConfig = saveFixedEditorPatch(patch);
+			currentConfig = saveLayoutFixedEditorPatch(patch);
 			reconcileFixedLayout(ctx);
 			refresh();
 		},

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -24,6 +24,7 @@ export type MinimalistEditorMetadata = {
 	thinkingLevel?: string;
 	contextPercent?: number;
 	contextWindow?: number;
+	sessionName?: string;
 	agentDurationMs?: number;
 	agentActive?: boolean;
 };
@@ -88,6 +89,7 @@ function renderTopLeft(
 	metadata: MinimalistEditorMetadata,
 	uiTheme: Theme,
 	config: PolishedTuiConfig,
+	includeSessionName = true,
 ): string {
 	const source = config.colorSources.editor;
 	const trimmed = inputText.trimStart();
@@ -100,7 +102,7 @@ function renderTopLeft(
 				: safeThemeFg(uiTheme, "bashMode", "$"),
 		);
 	}
-	if (config.minimalist.showTimer && metadata.agentDurationMs !== undefined) {
+	if (config.editorStyles.minimalist.showTimer && metadata.agentDurationMs !== undefined) {
 		const duration = formatElapsedDuration(metadata.agentDurationMs);
 		parts.push(
 			metadata.agentActive
@@ -114,6 +116,12 @@ function renderTopLeft(
 				: safeThemeFg(uiTheme, "muted", duration),
 		);
 	}
+	const sessionName = includeSessionName
+		? sanitizeEditorMetadataText(metadata.sessionName ?? "")
+		: "";
+	if (config.editorStyles.minimalist.showSessionName && sessionName) {
+		parts.push(renderStyleForSource(uiTheme, source, config.colors.sessionName, sessionName));
+	}
 	return joinStyled(parts, safeThemeFg(uiTheme, "muted", " · "));
 }
 
@@ -125,7 +133,7 @@ function renderTopRight(
 ): string {
 	const source = config.colorSources.editor;
 	const parts: string[] = [];
-	const cost = config.minimalist.showCost
+	const cost = config.editorStyles.minimalist.showCost
 		? sanitizeEditorMetadataText(metadata.costLabel ?? "")
 		: "";
 	if (cost) {
@@ -165,7 +173,7 @@ function renderTopRight(
 					? config.colors.contextWarning
 					: config.colors.contextNormal;
 		const total =
-			config.minimalist.contextFormat === "percent-total" &&
+			config.editorStyles.minimalist.contextFormat === "percent-total" &&
 			metadata.contextWindow !== undefined &&
 			Number.isFinite(metadata.contextWindow) &&
 			metadata.contextWindow > 0
@@ -173,7 +181,7 @@ function renderTopRight(
 				: "";
 		const text = `${percent}%${total}`;
 		let context = renderStyleForSource(uiTheme, source, style, text);
-		if (config.minimalist.contextGauge) {
+		if (config.editorStyles.minimalist.contextGauge) {
 			for (const gaugeWidth of [5, 3]) {
 				const gauge = `[${buildContextGauge(percent, gaugeWidth, config.icons.mode === "ascii")}] ${text}`;
 				const styledGauge = renderStyleForSource(uiTheme, source, style, gauge);
@@ -194,7 +202,7 @@ function renderBottomLeft(
 	uiTheme: Theme,
 	config: PolishedTuiConfig,
 ): string {
-	if (!config.minimalist.showGit) return "";
+	if (!config.editorStyles.minimalist.showGit) return "";
 	const source = config.colorSources.editor;
 	const branch = sanitizeEditorMetadataText(metadata.branch ?? "");
 	const parts = branch
@@ -214,8 +222,9 @@ function renderBottomLeft(
 
 function minimalistCwdLabel(metadata: MinimalistEditorMetadata, config: PolishedTuiConfig): string {
 	const full = () => formatCwdLabel(metadata.cwd, "", { mode: "full", depth: 0 });
-	if (config.minimalist.pathDisplay === "full") return full();
-	if (config.minimalist.pathDisplay === "compact") return basename(metadata.cwd) || metadata.cwd;
+	if (config.editorStyles.minimalist.pathDisplay === "full") return full();
+	if (config.editorStyles.minimalist.pathDisplay === "compact")
+		return basename(metadata.cwd) || metadata.cwd;
 	if (!metadata.projectRoot) return full();
 
 	const pathFromRoot = relative(metadata.projectRoot, metadata.cwd);
@@ -240,7 +249,7 @@ function renderBottomRight(
 function renderLabeledBorder(options: {
 	width: number;
 	left: string;
-	leftFallback?: string;
+	leftFallbacks?: string[];
 	right: string;
 	leftCorner: string;
 	rightCorner: string;
@@ -273,10 +282,12 @@ function renderLabeledBorder(options: {
 		right = rightBudget > 0 ? truncateToWidth(right, rightBudget, "…") : "";
 		return leftBudget < leftNatural;
 	};
-	if (fitLabels() && options.leftFallback !== undefined) {
-		left = options.leftFallback;
+	let leftTruncated = fitLabels();
+	for (const fallback of options.leftFallbacks ?? []) {
+		if (!leftTruncated) break;
+		left = fallback;
 		right = options.right;
-		fitLabels();
+		leftTruncated = fitLabels();
 	}
 	const partWidth = (label: string) => (label ? visibleWidth(label) + 3 : 1);
 	let leftWidth = partWidth(left);
@@ -338,13 +349,18 @@ export function renderMinimalistFrame({
 		return safeThemeFg(uiTheme, "muted", `${direction === "above" ? "↑" : "↓"} ${count} more`);
 	};
 	const topMetadata = renderTopLeft(inputText, metadata, uiTheme, config);
+	const topOperational = renderTopLeft(inputText, metadata, uiTheme, config, false);
 	const topViewport = viewportLabel("above", viewport?.above);
 	const topLeft = joinStyled([topViewport, topMetadata], separator);
 	const topRightBudget = Math.max(0, width - 8 - visibleWidth(topLeft));
+	const topFallbacks = [
+		joinStyled([topViewport, topOperational], separator),
+		topOperational,
+	].filter((value, index, values) => value !== topLeft && values.indexOf(value) === index);
 	const top = renderLabeledBorder({
 		width,
 		left: topLeft,
-		leftFallback: topViewport ? topMetadata : undefined,
+		leftFallbacks: topFallbacks,
 		right: renderTopRight(metadata, uiTheme, config, topRightBudget),
 		leftCorner: "╭",
 		rightCorner: "╮",
@@ -355,7 +371,7 @@ export function renderMinimalistFrame({
 	const bottom = renderLabeledBorder({
 		width,
 		left: joinStyled([bottomViewport, bottomMetadata], separator),
-		leftFallback: bottomViewport ? bottomMetadata : undefined,
+		leftFallbacks: bottomViewport ? [bottomMetadata] : undefined,
 		right: renderBottomRight(metadata, uiTheme, config),
 		leftCorner: "╰",
 		rightCorner: "╯",

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -32,6 +32,10 @@ export type MinimalistFrameOptions = {
 	width: number;
 	editorLines: string[];
 	autocompleteLines?: string[];
+	viewport?: {
+		above?: string;
+		below?: string;
+	};
 	inputText: string;
 	metadata: MinimalistEditorMetadata;
 	uiTheme: Theme;
@@ -236,6 +240,7 @@ function renderBottomRight(
 function renderLabeledBorder(options: {
 	width: number;
 	left: string;
+	leftFallback?: string;
 	right: string;
 	leftCorner: string;
 	rightCorner: string;
@@ -249,7 +254,7 @@ function renderLabeledBorder(options: {
 		const budget = Math.max(0, innerWidth - overhead);
 		const leftNatural = visibleWidth(left);
 		const rightNatural = visibleWidth(right);
-		if (leftNatural + rightNatural <= budget) return;
+		if (leftNatural + rightNatural <= budget) return false;
 
 		let leftBudget = left ? budget : 0;
 		let rightBudget = right ? budget : 0;
@@ -266,8 +271,13 @@ function renderLabeledBorder(options: {
 		}
 		left = leftBudget > 0 ? truncateToWidth(left, leftBudget, "…") : "";
 		right = rightBudget > 0 ? truncateToWidth(right, rightBudget, "…") : "";
+		return leftBudget < leftNatural;
 	};
-	fitLabels();
+	if (fitLabels() && options.leftFallback !== undefined) {
+		left = options.leftFallback;
+		right = options.right;
+		fitLabels();
+	}
 	const partWidth = (label: string) => (label ? visibleWidth(label) + 3 : 1);
 	let leftWidth = partWidth(left);
 	let rightWidth = partWidth(right);
@@ -294,6 +304,7 @@ export function renderMinimalistFrame({
 	width,
 	editorLines,
 	autocompleteLines = [],
+	viewport,
 	inputText,
 	metadata,
 	uiTheme,
@@ -321,19 +332,30 @@ export function renderMinimalistFrame({
 			return renderStaticBorder(text);
 		}
 	};
-	const topLeft = renderTopLeft(inputText, metadata, uiTheme, config);
+	const separator = safeThemeFg(uiTheme, "muted", " · ");
+	const viewportLabel = (direction: "above" | "below", count: string | undefined) => {
+		if (!count || !/^[1-9]\d*$/.test(count)) return "";
+		return safeThemeFg(uiTheme, "muted", `${direction === "above" ? "↑" : "↓"} ${count} more`);
+	};
+	const topMetadata = renderTopLeft(inputText, metadata, uiTheme, config);
+	const topViewport = viewportLabel("above", viewport?.above);
+	const topLeft = joinStyled([topViewport, topMetadata], separator);
 	const topRightBudget = Math.max(0, width - 8 - visibleWidth(topLeft));
 	const top = renderLabeledBorder({
 		width,
 		left: topLeft,
+		leftFallback: topViewport ? topMetadata : undefined,
 		right: renderTopRight(metadata, uiTheme, config, topRightBudget),
 		leftCorner: "╭",
 		rightCorner: "╮",
 		renderBorder,
 	});
+	const bottomMetadata = renderBottomLeft(metadata, uiTheme, config);
+	const bottomViewport = viewportLabel("below", viewport?.below);
 	const bottom = renderLabeledBorder({
 		width,
-		left: renderBottomLeft(metadata, uiTheme, config),
+		left: joinStyled([bottomViewport, bottomMetadata], separator),
+		leftFallback: bottomViewport ? bottomMetadata : undefined,
 		right: renderBottomRight(metadata, uiTheme, config),
 		leftCorner: "╰",
 		rightCorner: "╯",

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -339,7 +339,7 @@ export function renderMinimalistFrame({
 		rightCorner: "╯",
 		renderBorder,
 	});
-	const content = ["", ...editorLines, ""].map(
+	const content = editorLines.map(
 		(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
 	);
 	const autocomplete = autocompleteLines.length

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -1,0 +1,354 @@
+import { basename, isAbsolute, relative, sep } from "node:path";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { PolishedTuiConfig } from "./config";
+import { sanitizeEditorMetadataText } from "./editor-metadata-format";
+import { buildContextGauge, contextColorTier, formatCount, formatCwdLabel } from "./format";
+import {
+	EDITOR_ACCENT_FALLBACK,
+	EDITOR_BORDER_FALLBACK,
+	renderStyleForSource,
+	renderStyleForSourceOrFallback,
+	safeThemeFg,
+} from "./style";
+
+export type MinimalistEditorMetadata = {
+	cwd: string;
+	projectRoot?: string;
+	branch?: string;
+	dirty?: boolean;
+	ahead?: number;
+	behind?: number;
+	costLabel?: string;
+	modelLabel?: string;
+	thinkingLevel?: string;
+	contextPercent?: number;
+	contextWindow?: number;
+	agentDurationMs?: number;
+	agentActive?: boolean;
+};
+
+export type MinimalistFrameOptions = {
+	width: number;
+	editorLines: string[];
+	autocompleteLines?: string[];
+	inputText: string;
+	metadata: MinimalistEditorMetadata;
+	uiTheme: Theme;
+	config: PolishedTuiConfig;
+	borderColor?: (text: string) => string;
+};
+
+export function formatElapsedDuration(durationMs: number): string {
+	const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
+function fillLine(content: string, width: number): string {
+	const truncated = truncateToWidth(content, Math.max(0, width), "");
+	return `${truncated}${" ".repeat(Math.max(0, width - visibleWidth(truncated)))}`;
+}
+
+function clampLines(lines: string[], width: number): string[] {
+	return lines.map((line) => truncateToWidth(line, Math.max(0, width), ""));
+}
+
+function joinStyled(parts: string[], separator: string): string {
+	return parts.filter(Boolean).join(separator);
+}
+
+function thinkingStyle(config: PolishedTuiConfig, level: string): string | undefined {
+	switch (level.toLowerCase()) {
+		case "minimal":
+			return config.colors.editorThinkingMinimal ?? config.colors.editorThinking;
+		case "low":
+			return config.colors.editorThinkingLow ?? config.colors.editorThinking;
+		case "medium":
+			return config.colors.editorThinkingMedium ?? config.colors.editorThinking;
+		case "high":
+			return config.colors.editorThinkingHigh ?? config.colors.editorThinking;
+		case "xhigh":
+			return config.colors.editorThinkingXhigh ?? config.colors.editorThinking;
+		default:
+			return config.colors.editorThinking;
+	}
+}
+
+function renderTopLeft(
+	inputText: string,
+	metadata: MinimalistEditorMetadata,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): string {
+	const source = config.colorSources.editor;
+	const trimmed = inputText.trimStart();
+	const bashMode = trimmed.startsWith("!!") ? "no-context" : trimmed.startsWith("!") ? "shell" : "";
+	const parts: string[] = [];
+	if (bashMode) {
+		parts.push(
+			bashMode === "no-context"
+				? safeThemeFg(uiTheme, "muted", "$")
+				: safeThemeFg(uiTheme, "bashMode", "$"),
+		);
+	}
+	if (config.minimalist.showTimer && metadata.agentDurationMs !== undefined) {
+		const duration = formatElapsedDuration(metadata.agentDurationMs);
+		parts.push(
+			metadata.agentActive
+				? renderStyleForSourceOrFallback(
+						uiTheme,
+						source,
+						config.colors.sessionDuration,
+						EDITOR_ACCENT_FALLBACK,
+						duration,
+					)
+				: safeThemeFg(uiTheme, "muted", duration),
+		);
+	}
+	return joinStyled(parts, safeThemeFg(uiTheme, "muted", " · "));
+}
+
+function renderTopRight(
+	metadata: MinimalistEditorMetadata,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+	availableWidth: number,
+): string {
+	const source = config.colorSources.editor;
+	const parts: string[] = [];
+	const cost = config.minimalist.showCost
+		? sanitizeEditorMetadataText(metadata.costLabel ?? "")
+		: "";
+	if (cost) {
+		parts.push(renderStyleForSource(uiTheme, source, config.colors.cost, cost));
+	}
+	const model = sanitizeEditorMetadataText(metadata.modelLabel ?? "");
+	if (model) {
+		parts.push(
+			renderStyleForSourceOrFallback(
+				uiTheme,
+				source,
+				config.colors.editorModel,
+				EDITOR_ACCENT_FALLBACK,
+				model,
+			),
+		);
+	}
+	const thinking = sanitizeEditorMetadataText(metadata.thinkingLevel ?? "");
+	if (thinking && thinking.toLowerCase() !== "off") {
+		parts.push(
+			renderStyleForSourceOrFallback(
+				uiTheme,
+				source,
+				thinkingStyle(config, thinking),
+				"muted",
+				thinking,
+			),
+		);
+	}
+	if (metadata.contextPercent !== undefined && Number.isFinite(metadata.contextPercent)) {
+		const percent = Math.round(Math.max(0, Math.min(999, metadata.contextPercent)));
+		const tier = contextColorTier(percent, config.contextThresholds);
+		const style =
+			tier === "error"
+				? config.colors.contextError
+				: tier === "warning"
+					? config.colors.contextWarning
+					: config.colors.contextNormal;
+		const total =
+			config.minimalist.contextFormat === "percent-total" &&
+			metadata.contextWindow !== undefined &&
+			Number.isFinite(metadata.contextWindow) &&
+			metadata.contextWindow > 0
+				? `/${formatCount(metadata.contextWindow)}`
+				: "";
+		const text = `${percent}%${total}`;
+		let context = renderStyleForSource(uiTheme, source, style, text);
+		if (config.minimalist.contextGauge) {
+			for (const gaugeWidth of [5, 3]) {
+				const gauge = `[${buildContextGauge(percent, gaugeWidth, config.icons.mode === "ascii")}] ${text}`;
+				const styledGauge = renderStyleForSource(uiTheme, source, style, gauge);
+				const candidate = joinStyled([...parts, styledGauge], safeThemeFg(uiTheme, "muted", " – "));
+				if (visibleWidth(candidate) <= availableWidth) {
+					context = styledGauge;
+					break;
+				}
+			}
+		}
+		parts.push(context);
+	}
+	return joinStyled(parts, safeThemeFg(uiTheme, "muted", " – "));
+}
+
+function renderBottomLeft(
+	metadata: MinimalistEditorMetadata,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): string {
+	if (!config.minimalist.showGit) return "";
+	const source = config.colorSources.editor;
+	const branch = sanitizeEditorMetadataText(metadata.branch ?? "");
+	const parts = branch
+		? [renderStyleForSource(uiTheme, source, config.colors.gitBranch, branch)]
+		: [];
+	if (metadata.dirty) {
+		parts.push(renderStyleForSource(uiTheme, source, config.colors.gitStatus, "*"));
+	}
+	if ((metadata.ahead ?? 0) > 0) {
+		parts.push(safeThemeFg(uiTheme, "success", `↑${metadata.ahead}`));
+	}
+	if ((metadata.behind ?? 0) > 0) {
+		parts.push(safeThemeFg(uiTheme, "error", `↓${metadata.behind}`));
+	}
+	return parts.join(" ");
+}
+
+function minimalistCwdLabel(metadata: MinimalistEditorMetadata, config: PolishedTuiConfig): string {
+	const full = () => formatCwdLabel(metadata.cwd, "", { mode: "full", depth: 0 });
+	if (config.minimalist.pathDisplay === "full") return full();
+	if (config.minimalist.pathDisplay === "compact") return basename(metadata.cwd) || metadata.cwd;
+	if (!metadata.projectRoot) return full();
+
+	const pathFromRoot = relative(metadata.projectRoot, metadata.cwd);
+	if (pathFromRoot === ".." || pathFromRoot.startsWith(`..${sep}`) || isAbsolute(pathFromRoot)) {
+		return full();
+	}
+	const project = basename(metadata.projectRoot) || metadata.projectRoot;
+	return pathFromRoot ? `${project}/${pathFromRoot}` : project;
+}
+
+function renderBottomRight(
+	metadata: MinimalistEditorMetadata,
+	uiTheme: Theme,
+	config: PolishedTuiConfig,
+): string {
+	const cwd = sanitizeEditorMetadataText(minimalistCwdLabel(metadata, config));
+	return cwd
+		? renderStyleForSource(uiTheme, config.colorSources.editor, config.colors.cwd, cwd)
+		: "";
+}
+
+function renderLabeledBorder(options: {
+	width: number;
+	left: string;
+	right: string;
+	leftCorner: string;
+	rightCorner: string;
+	renderBorder: (text: string) => string;
+}): string {
+	const innerWidth = Math.max(0, options.width - 2);
+	let left = options.left;
+	let right = options.right;
+	const fitLabels = () => {
+		const overhead = (left ? 3 : 1) + (right ? 3 : 1);
+		const budget = Math.max(0, innerWidth - overhead);
+		const leftNatural = visibleWidth(left);
+		const rightNatural = visibleWidth(right);
+		if (leftNatural + rightNatural <= budget) return;
+
+		let leftBudget = left ? budget : 0;
+		let rightBudget = right ? budget : 0;
+		if (left && right) {
+			leftBudget = Math.ceil(budget / 2);
+			rightBudget = budget - leftBudget;
+			if (leftNatural < leftBudget) {
+				leftBudget = leftNatural;
+				rightBudget = budget - leftBudget;
+			} else if (rightNatural < rightBudget) {
+				rightBudget = rightNatural;
+				leftBudget = budget - rightBudget;
+			}
+		}
+		left = leftBudget > 0 ? truncateToWidth(left, leftBudget, "…") : "";
+		right = rightBudget > 0 ? truncateToWidth(right, rightBudget, "…") : "";
+	};
+	fitLabels();
+	const partWidth = (label: string) => (label ? visibleWidth(label) + 3 : 1);
+	let leftWidth = partWidth(left);
+	let rightWidth = partWidth(right);
+	if (leftWidth + rightWidth > innerWidth) {
+		left = "";
+		right = "";
+		leftWidth = 1;
+		rightWidth = 1;
+	}
+
+	const fillWidth = Math.max(0, innerWidth - leftWidth - rightWidth);
+	const leftPart = left
+		? `${options.renderBorder("─ ")}${left}${options.renderBorder(" ")}`
+		: options.renderBorder("─");
+	const rightPart = right
+		? `${options.renderBorder(" ")}${right}${options.renderBorder(" ─")}`
+		: options.renderBorder("─");
+	return `${options.renderBorder(options.leftCorner)}${leftPart}${options.renderBorder(
+		"─".repeat(fillWidth),
+	)}${rightPart}${options.renderBorder(options.rightCorner)}`;
+}
+
+export function renderMinimalistFrame({
+	width,
+	editorLines,
+	autocompleteLines = [],
+	inputText,
+	metadata,
+	uiTheme,
+	config,
+	borderColor,
+}: MinimalistFrameOptions): string[] {
+	if (width <= 4) return clampLines(editorLines, width);
+	const contentWidth = Math.max(0, width - 4);
+	const renderStaticBorder = (text: string) =>
+		renderStyleForSourceOrFallback(
+			uiTheme,
+			config.colorSources.editor,
+			config.colors.editorBorder,
+			EDITOR_BORDER_FALLBACK,
+			text,
+		);
+	const renderBorder = (text: string) => {
+		if (config.editorBorderColorMode !== "adaptive" || !borderColor) {
+			return renderStaticBorder(text);
+		}
+		try {
+			const rendered = borderColor(text);
+			return typeof rendered === "string" ? rendered : renderStaticBorder(text);
+		} catch {
+			return renderStaticBorder(text);
+		}
+	};
+	const topLeft = renderTopLeft(inputText, metadata, uiTheme, config);
+	const topRightBudget = Math.max(0, width - 8 - visibleWidth(topLeft));
+	const top = renderLabeledBorder({
+		width,
+		left: topLeft,
+		right: renderTopRight(metadata, uiTheme, config, topRightBudget),
+		leftCorner: "╭",
+		rightCorner: "╮",
+		renderBorder,
+	});
+	const bottom = renderLabeledBorder({
+		width,
+		left: renderBottomLeft(metadata, uiTheme, config),
+		right: renderBottomRight(metadata, uiTheme, config),
+		leftCorner: "╰",
+		rightCorner: "╯",
+		renderBorder,
+	});
+	const content = ["", ...editorLines, ""].map(
+		(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
+	);
+	const autocomplete = autocompleteLines.length
+		? [
+				`${renderBorder("├")}${renderBorder("─".repeat(width - 2))}${renderBorder("┤")}`,
+				...autocompleteLines.map(
+					(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
+				),
+			]
+		: [];
+	return clampLines([top, ...content, ...autocomplete, bottom], width);
+}

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -1,7 +1,7 @@
 import { basename, isAbsolute, relative, sep } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
-import type { PolishedTuiConfig } from "./config";
+import type { ZentuiConfig } from "./config";
 import { sanitizeEditorMetadataText } from "./editor-metadata-format";
 import { buildContextGauge, contextColorTier, formatCount, formatCwdLabel } from "./format";
 import {
@@ -40,7 +40,7 @@ export type MinimalistFrameOptions = {
 	inputText: string;
 	metadata: MinimalistEditorMetadata;
 	uiTheme: Theme;
-	config: PolishedTuiConfig;
+	config: ZentuiConfig;
 	borderColor?: (text: string) => string;
 };
 
@@ -67,7 +67,7 @@ function joinStyled(parts: string[], separator: string): string {
 	return parts.filter(Boolean).join(separator);
 }
 
-function thinkingStyle(config: PolishedTuiConfig, level: string): string | undefined {
+function thinkingStyle(config: ZentuiConfig, level: string): string | undefined {
 	switch (level.toLowerCase()) {
 		case "minimal":
 			return config.colors.editorThinkingMinimal ?? config.colors.editorThinking;
@@ -88,10 +88,10 @@ function renderTopLeft(
 	inputText: string,
 	metadata: MinimalistEditorMetadata,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	includeSessionName = true,
 ): string {
-	const source = config.colorSources.editor;
+	const source = config.components.editor.colorSource;
 	const trimmed = inputText.trimStart();
 	const bashMode = trimmed.startsWith("!!") ? "no-context" : trimmed.startsWith("!") ? "shell" : "";
 	const parts: string[] = [];
@@ -102,7 +102,10 @@ function renderTopLeft(
 				: safeThemeFg(uiTheme, "bashMode", "$"),
 		);
 	}
-	if (config.editorStyles.minimalist.showTimer && metadata.agentDurationMs !== undefined) {
+	if (
+		config.components.editor.styles.minimalist.showTimer &&
+		metadata.agentDurationMs !== undefined
+	) {
 		const duration = formatElapsedDuration(metadata.agentDurationMs);
 		parts.push(
 			metadata.agentActive
@@ -119,7 +122,7 @@ function renderTopLeft(
 	const sessionName = includeSessionName
 		? sanitizeEditorMetadataText(metadata.sessionName ?? "")
 		: "";
-	if (config.editorStyles.minimalist.showSessionName && sessionName) {
+	if (config.components.editor.styles.minimalist.showSessionName && sessionName) {
 		parts.push(renderStyleForSource(uiTheme, source, config.colors.sessionName, sessionName));
 	}
 	return joinStyled(parts, safeThemeFg(uiTheme, "muted", " · "));
@@ -128,12 +131,12 @@ function renderTopLeft(
 function renderTopRight(
 	metadata: MinimalistEditorMetadata,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	availableWidth: number,
 ): string {
-	const source = config.colorSources.editor;
+	const source = config.components.editor.colorSource;
 	const parts: string[] = [];
-	const cost = config.editorStyles.minimalist.showCost
+	const cost = config.components.editor.styles.minimalist.showCost
 		? sanitizeEditorMetadataText(metadata.costLabel ?? "")
 		: "";
 	if (cost) {
@@ -165,7 +168,10 @@ function renderTopRight(
 	}
 	if (metadata.contextPercent !== undefined && Number.isFinite(metadata.contextPercent)) {
 		const percent = Math.round(Math.max(0, Math.min(999, metadata.contextPercent)));
-		const tier = contextColorTier(percent, config.contextThresholds);
+		const tier = contextColorTier(
+			percent,
+			config.components.editor.styles.minimalist.contextThresholds,
+		);
 		const style =
 			tier === "error"
 				? config.colors.contextError
@@ -173,7 +179,7 @@ function renderTopRight(
 					? config.colors.contextWarning
 					: config.colors.contextNormal;
 		const total =
-			config.editorStyles.minimalist.contextFormat === "percent-total" &&
+			config.components.editor.styles.minimalist.contextFormat === "percent-total" &&
 			metadata.contextWindow !== undefined &&
 			Number.isFinite(metadata.contextWindow) &&
 			metadata.contextWindow > 0
@@ -181,7 +187,7 @@ function renderTopRight(
 				: "";
 		const text = `${percent}%${total}`;
 		let context = renderStyleForSource(uiTheme, source, style, text);
-		if (config.editorStyles.minimalist.contextGauge) {
+		if (config.components.editor.styles.minimalist.contextGauge) {
 			for (const gaugeWidth of [5, 3]) {
 				const gauge = `[${buildContextGauge(percent, gaugeWidth, config.icons.mode === "ascii")}] ${text}`;
 				const styledGauge = renderStyleForSource(uiTheme, source, style, gauge);
@@ -200,10 +206,10 @@ function renderTopRight(
 function renderBottomLeft(
 	metadata: MinimalistEditorMetadata,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): string {
-	if (!config.editorStyles.minimalist.showGit) return "";
-	const source = config.colorSources.editor;
+	if (!config.components.editor.styles.minimalist.showGit) return "";
+	const source = config.components.editor.colorSource;
 	const branch = sanitizeEditorMetadataText(metadata.branch ?? "");
 	const parts = branch
 		? [renderStyleForSource(uiTheme, source, config.colors.gitBranch, branch)]
@@ -220,10 +226,10 @@ function renderBottomLeft(
 	return parts.join(" ");
 }
 
-function minimalistCwdLabel(metadata: MinimalistEditorMetadata, config: PolishedTuiConfig): string {
+function minimalistCwdLabel(metadata: MinimalistEditorMetadata, config: ZentuiConfig): string {
 	const full = () => formatCwdLabel(metadata.cwd, "", { mode: "full", depth: 0 });
-	if (config.editorStyles.minimalist.pathDisplay === "full") return full();
-	if (config.editorStyles.minimalist.pathDisplay === "compact")
+	if (config.components.editor.styles.minimalist.pathDisplay === "full") return full();
+	if (config.components.editor.styles.minimalist.pathDisplay === "compact")
 		return basename(metadata.cwd) || metadata.cwd;
 	if (!metadata.projectRoot) return full();
 
@@ -238,11 +244,11 @@ function minimalistCwdLabel(metadata: MinimalistEditorMetadata, config: Polished
 function renderBottomRight(
 	metadata: MinimalistEditorMetadata,
 	uiTheme: Theme,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): string {
 	const cwd = sanitizeEditorMetadataText(minimalistCwdLabel(metadata, config));
 	return cwd
-		? renderStyleForSource(uiTheme, config.colorSources.editor, config.colors.cwd, cwd)
+		? renderStyleForSource(uiTheme, config.components.editor.colorSource, config.colors.cwd, cwd)
 		: "";
 }
 
@@ -327,13 +333,13 @@ export function renderMinimalistFrame({
 	const renderStaticBorder = (text: string) =>
 		renderStyleForSourceOrFallback(
 			uiTheme,
-			config.colorSources.editor,
+			config.components.editor.colorSource,
 			config.colors.editorBorder,
 			EDITOR_BORDER_FALLBACK,
 			text,
 		);
 	const renderBorder = (text: string) => {
-		if (config.editorBorderColorMode !== "adaptive" || !borderColor) {
+		if (config.components.editor.borderColorMode !== "adaptive" || !borderColor) {
 			return renderStaticBorder(text);
 		}
 		try {

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -63,6 +63,28 @@ function clampLines(lines: string[], width: number): string[] {
 	return lines.map((line) => truncateToWidth(line, Math.max(0, width), ""));
 }
 
+export function renderFramedAutocompleteRows({
+	width,
+	lines,
+	renderBorder,
+}: {
+	width: number;
+	lines: string[];
+	renderBorder: (text: string) => string;
+}): string[] {
+	if (width <= 4 || lines.length === 0) return clampLines(lines, width);
+	const contentWidth = width - 4;
+	return clampLines(
+		[
+			`${renderBorder("├")}${renderBorder("─".repeat(width - 2))}${renderBorder("┤")}`,
+			...lines.map(
+				(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
+			),
+		],
+		width,
+	);
+}
+
 function joinStyled(parts: string[], separator: string): string {
 	return parts.filter(Boolean).join(separator);
 }
@@ -386,13 +408,10 @@ export function renderMinimalistFrame({
 	const content = editorLines.map(
 		(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
 	);
-	const autocomplete = autocompleteLines.length
-		? [
-				`${renderBorder("├")}${renderBorder("─".repeat(width - 2))}${renderBorder("┤")}`,
-				...autocompleteLines.map(
-					(line) => `${renderBorder("│")} ${fillLine(line, contentWidth)} ${renderBorder("│")}`,
-				),
-			]
-		: [];
+	const autocomplete = renderFramedAutocompleteRows({
+		width,
+		lines: autocompleteLines,
+		renderBorder,
+	});
 	return clampLines([top, ...content, ...autocomplete, bottom], width);
 }

--- a/extensions/zentui/package-version.ts
+++ b/extensions/zentui/package-version.ts
@@ -90,7 +90,7 @@ export const PACKAGE_VERSION_ECOSYSTEMS = [
  * Empty / whitespace-only values return `undefined`.
  */
 function cleanVersion(value: string | undefined): string | undefined {
-	if (!value) return undefined;
+	if (!value || /[\u0000-\u001f\u007f-\u009f]/.test(value)) return undefined;
 	let text = value.trim();
 	if (!text) return undefined;
 
@@ -113,8 +113,9 @@ function cleanVersion(value: string | undefined): string | undefined {
 	text = text.trim();
 	if (!text) return undefined;
 
-	// Reject obvious junk (whitespace, control chars, braces).
-	if (/[\s\r\n\t]/.test(text)) return undefined;
+	// Reject embedded whitespace and manifest syntax junk. Terminal controls
+	// were rejected before normalization so trimming cannot hide them.
+	if (/\s/.test(text)) return undefined;
 	if (/[{}\\<>]/.test(text)) return undefined;
 
 	return text;

--- a/extensions/zentui/project-refresh.ts
+++ b/extensions/zentui/project-refresh.ts
@@ -4,8 +4,13 @@ export type ScheduleProjectRefreshOptions = {
 	force?: boolean;
 };
 
+export type ProjectRefreshRun = {
+	isCurrent: () => boolean;
+};
+
 export type ProjectRefreshScheduler<T> = {
 	schedule: (target: T, options?: ScheduleProjectRefreshOptions) => void;
+	invalidate: () => void;
 	stop: () => void;
 };
 
@@ -24,7 +29,7 @@ export function startProjectRefreshInterval(
 }
 
 export function createProjectRefreshScheduler<T>(
-	refresh: (target: T) => Promise<void>,
+	refresh: (target: T, run: ProjectRefreshRun) => Promise<void>,
 	afterRefresh: () => void,
 	throttleMs = PROJECT_REFRESH_THROTTLE_MS,
 ): ProjectRefreshScheduler<T> {
@@ -52,9 +57,12 @@ export function createProjectRefreshScheduler<T>(
 		}
 
 		const currentGeneration = generation;
+		const run: ProjectRefreshRun = {
+			isCurrent: () => currentGeneration === generation,
+		};
 		refreshInFlight = true;
 		lastRefreshStartedAt = Date.now();
-		void refresh(target)
+		void refresh(target, run)
 			.catch(() => undefined)
 			.finally(() => {
 				if (currentGeneration !== generation) return;
@@ -94,16 +102,19 @@ export function createProjectRefreshScheduler<T>(
 		delayedRefresh.unref?.();
 	};
 
+	const invalidate = () => {
+		generation += 1;
+		clearDelayedRefresh();
+		refreshInFlight = false;
+		refreshPending = false;
+		pendingForce = false;
+		pendingTarget = undefined;
+		lastRefreshStartedAt = undefined;
+	};
+
 	return {
 		schedule,
-		stop() {
-			generation += 1;
-			clearDelayedRefresh();
-			refreshInFlight = false;
-			refreshPending = false;
-			pendingForce = false;
-			pendingTarget = undefined;
-			lastRefreshStartedAt = undefined;
-		},
+		invalidate,
+		stop: invalidate,
 	};
 }

--- a/extensions/zentui/prototype-patch-registry.ts
+++ b/extensions/zentui/prototype-patch-registry.ts
@@ -31,15 +31,26 @@ type PatchRegistry = Map<PrototypePatchAdapter, PatchRecord>;
 
 type PatchTarget = Record<PropertyKey, unknown>;
 
-function registryFor(target: PatchTarget): PatchRegistry {
+function existingRegistry(target: PatchTarget): PatchRegistry | undefined {
 	const existing = target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
-	if (existing instanceof Map) return existing as PatchRegistry;
+	return existing instanceof Map ? (existing as PatchRegistry) : undefined;
+}
+
+function registryFor(target: PatchTarget): PatchRegistry {
+	const existing = existingRegistry(target);
+	if (existing) return existing;
 	const registry: PatchRegistry = new Map();
 	Object.defineProperty(target, ZENTUI_PROTOTYPE_PATCH_REGISTRY, {
 		value: registry,
 		configurable: true,
 	});
 	return registry;
+}
+
+function deactivateRecord(record: PatchRecord): void {
+	if (!record.registration) return;
+	record.registration.behavior = undefined;
+	record.registration = undefined;
 }
 
 function createCleanup(
@@ -55,8 +66,7 @@ function createCleanup(
 		if (cleaned) return;
 		cleaned = true;
 		if (record.registration?.token !== token) return;
-		record.registration.behavior = undefined;
-		record.registration = undefined;
+		deactivateRecord(record);
 
 		const current = registry.get(adapter);
 		if (current !== record) return;
@@ -77,6 +87,7 @@ export function installPrototypePatch(
 	let record = registry.get(adapter);
 
 	if (!(record && record.method === method && target[method] === record.wrapper)) {
+		const displacedRecord = record;
 		const predecessor = target[method];
 		if (typeof predecessor !== "function") {
 			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
@@ -97,18 +108,34 @@ export function installPrototypePatch(
 				: Reflect.apply(nextRecord.predecessor, this, args);
 		};
 		nextRecord.wrapper = wrapper;
-		record = nextRecord;
-		registry.set(adapter, record);
 		try {
 			target[method] = wrapper;
 		} catch (error) {
-			registry.delete(adapter);
 			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 			throw error;
 		}
+		record = nextRecord;
+		registry.set(adapter, record);
+		if (displacedRecord && displacedRecord !== record) deactivateRecord(displacedRecord);
 	}
 
 	const token = Symbol(adapter);
 	record.registration = { token, behavior };
 	return createCleanup(target, method, adapter, registry, record, token);
+}
+
+export function removePrototypePatch(
+	targetValue: object,
+	method: "render" | "invalidate",
+	adapter: PrototypePatchAdapter,
+): void {
+	const target = targetValue as PatchTarget;
+	const registry = existingRegistry(target);
+	const record = registry?.get(adapter);
+	if (!registry || !record || record.method !== method) return;
+
+	deactivateRecord(record);
+	if (target[method] === record.wrapper) target[method] = record.predecessor;
+	registry.delete(adapter);
+	if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 }

--- a/extensions/zentui/prototype-patch-registry.ts
+++ b/extensions/zentui/prototype-patch-registry.ts
@@ -23,6 +23,7 @@ type Registration = {
 type PatchRecord = {
 	method: "render" | "invalidate";
 	predecessor: PrototypeMethod;
+	predecessorDescriptor?: PropertyDescriptor;
 	wrapper: PrototypeMethod;
 	registration?: Registration;
 };
@@ -53,9 +54,31 @@ function deactivateRecord(record: PatchRecord): void {
 	record.registration = undefined;
 }
 
+function restorePredecessor(target: PatchTarget, record: PatchRecord): void {
+	if (target[record.method] !== record.wrapper) return;
+	if (record.predecessorDescriptor) {
+		Object.defineProperty(target, record.method, record.predecessorDescriptor);
+	} else {
+		delete target[record.method];
+	}
+}
+
+function installWrapper(target: PatchTarget, record: PatchRecord): void {
+	const descriptor = record.predecessorDescriptor;
+	if (descriptor && "value" in descriptor) {
+		Object.defineProperty(target, record.method, { ...descriptor, value: record.wrapper });
+		return;
+	}
+	Object.defineProperty(target, record.method, {
+		value: record.wrapper,
+		writable: true,
+		enumerable: descriptor?.enumerable ?? true,
+		configurable: true,
+	});
+}
+
 function createCleanup(
 	target: PatchTarget,
-	method: "render" | "invalidate",
 	adapter: PrototypePatchAdapter,
 	registry: PatchRegistry,
 	record: PatchRecord,
@@ -70,7 +93,7 @@ function createCleanup(
 
 		const current = registry.get(adapter);
 		if (current !== record) return;
-		if (target[method] === record.wrapper) target[method] = record.predecessor;
+		restorePredecessor(target, record);
 		registry.delete(adapter);
 		if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 	};
@@ -88,6 +111,7 @@ export function installPrototypePatch(
 
 	if (!(record && record.method === method && target[method] === record.wrapper)) {
 		const displacedRecord = record;
+		const predecessorDescriptor = Object.getOwnPropertyDescriptor(target, method);
 		const predecessor = target[method];
 		if (typeof predecessor !== "function") {
 			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
@@ -96,6 +120,7 @@ export function installPrototypePatch(
 		const nextRecord: PatchRecord = {
 			method,
 			predecessor: predecessor as PrototypeMethod,
+			predecessorDescriptor,
 			wrapper: () => undefined,
 		};
 		const wrapper: PrototypeMethod = function zentuiPrototypeWrapper(
@@ -109,7 +134,7 @@ export function installPrototypePatch(
 		};
 		nextRecord.wrapper = wrapper;
 		try {
-			target[method] = wrapper;
+			installWrapper(target, nextRecord);
 		} catch (error) {
 			if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 			throw error;
@@ -121,7 +146,7 @@ export function installPrototypePatch(
 
 	const token = Symbol(adapter);
 	record.registration = { token, behavior };
-	return createCleanup(target, method, adapter, registry, record, token);
+	return createCleanup(target, adapter, registry, record, token);
 }
 
 export function removePrototypePatch(
@@ -135,7 +160,7 @@ export function removePrototypePatch(
 	if (!registry || !record || record.method !== method) return;
 
 	deactivateRecord(record);
-	if (target[method] === record.wrapper) target[method] = record.predecessor;
+	restorePredecessor(target, record);
 	registry.delete(adapter);
 	if (registry.size === 0) delete target[ZENTUI_PROTOTYPE_PATCH_REGISTRY];
 }

--- a/extensions/zentui/selector-border.ts
+++ b/extensions/zentui/selector-border.ts
@@ -3,8 +3,8 @@ import {
 	SettingsSelectorComponent,
 	type Theme,
 } from "@earendil-works/pi-coding-agent";
-import type { PolishedTuiConfig } from "./config";
-import { installPrototypePatch } from "./prototype-patch-registry";
+import type { ZentuiConfig } from "./config";
+import { installPrototypePatch, removePrototypePatch } from "./prototype-patch-registry";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, renderEditorBorder } from "./style";
 
 type PatchableSelectorPrototype = {
@@ -24,11 +24,16 @@ function isHorizontalBorderLine(line: string): boolean {
 function renderBorderLine(
 	width: number,
 	theme: Theme | undefined,
-	config: PolishedTuiConfig | undefined,
+	config: ZentuiConfig | undefined,
 ): string {
 	const text = "─".repeat(Math.max(1, width));
 	if (theme && config) {
-		return renderChromeBorder(theme, config.colorSources.editor, EDITOR_BORDER_STYLE, text);
+		return renderChromeBorder(
+			theme,
+			config.components.selectorBorders.colorSource,
+			EDITOR_BORDER_STYLE,
+			text,
+		);
 	}
 	return renderEditorBorder(text);
 }
@@ -36,7 +41,7 @@ function renderBorderLine(
 export function patchSelectorBorderStyle(
 	prototype: PatchableSelectorPrototype,
 	getTheme?: () => Theme | undefined,
-	getConfig?: () => PolishedTuiConfig,
+	getConfig?: () => ZentuiConfig,
 ): Cleanup {
 	return installPrototypePatch(
 		prototype,
@@ -56,9 +61,14 @@ export function patchSelectorBorderStyle(
 	);
 }
 
+export function removeSelectorBorderStyle(): void {
+	removePrototypePatch(ModelSelectorComponent.prototype, "render", "selector-border-render");
+	removePrototypePatch(SettingsSelectorComponent.prototype, "render", "selector-border-render");
+}
+
 export function installSelectorBorderStyle(
 	getTheme?: () => Theme | undefined,
-	getConfig?: () => PolishedTuiConfig,
+	getConfig?: () => ZentuiConfig,
 ): Cleanup {
 	const cleanupModel = patchSelectorBorderStyle(
 		ModelSelectorComponent.prototype as unknown as PatchableSelectorPrototype,

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -16,6 +16,7 @@ import {
 	type CompactFooterMaxLines,
 	type ContextStyle,
 	type EditorBorderColorMode,
+	type EditorMode,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FixedEditorConfig,
@@ -30,6 +31,9 @@ import {
 	isExtensionStatusColorMode,
 	isExtensionStatusPlacement,
 	isSeparatorStyle,
+	type MinimalistConfig,
+	type MinimalistContextFormat,
+	type MinimalistPathDisplayMode,
 	type ModelLabelSource,
 	type PathDisplayConfig,
 	type PathDisplayMode,
@@ -57,6 +61,9 @@ const pathDepthValues = ["0", "1", "2", "3", "4", "5"] as const;
 const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"] as const;
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
+const editorModeValues: EditorMode[] = ["polished", "minimalist"];
+const minimalistPathDisplayValues: MinimalistPathDisplayMode[] = ["compact", "project", "full"];
+const minimalistContextFormatValues: MinimalistContextFormat[] = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
 const compactFooterMaxLineValues = ["1", "2", "3", "unlimited"] as const;
 type FeatureState = "enabled" | "disabled";
@@ -84,6 +91,13 @@ type BoundedSettingId =
 	| "pathDepth"
 	| "branchLength"
 	| "iconMode"
+	| "editorMode"
+	| "minimalistPathDisplay"
+	| "minimalistContextFormat"
+	| "minimalistContextGauge"
+	| "minimalistShowTimer"
+	| "minimalistShowCost"
+	| "minimalistShowGit"
 	| "editorModelLabel"
 	| "editorBorderColorMode"
 	| "gitCommitOnlyDetached"
@@ -111,6 +125,8 @@ type SettingsCommandDeps = {
 	setSeparator: (separator: SeparatorStyle) => void;
 	setPathDisplay: (patch: Partial<PathDisplayConfig>) => void;
 	setGitBranch: (patch: Partial<GitBranchConfig>) => void;
+	setEditorMode?: (value: EditorMode, ctx: ExtensionContext) => void;
+	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
 	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
 	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
 	setGitCommit?: (
@@ -320,6 +336,13 @@ function isBoundedSettingId(value: string): value is BoundedSettingId {
 		value === "pathDepth" ||
 		value === "branchLength" ||
 		value === "iconMode" ||
+		value === "editorMode" ||
+		value === "minimalistPathDisplay" ||
+		value === "minimalistContextFormat" ||
+		value === "minimalistContextGauge" ||
+		value === "minimalistShowTimer" ||
+		value === "minimalistShowCost" ||
+		value === "minimalistShowGit" ||
 		value === "editorModelLabel" ||
 		value === "editorBorderColorMode" ||
 		value === "gitCommitOnlyDetached" ||
@@ -520,6 +543,13 @@ function buildItems(
 			1,
 			0,
 			{
+				id: "editorMode",
+				label: "Editor mode",
+				description: "Use Zentui's polished rails or a compact metadata frame.",
+				currentValue: config.editorMode,
+				values: editorModeValues,
+			},
+			{
 				id: "editorBorderColorMode",
 				label: "Editor border color",
 				description: "Keep Zentui's configured border color or follow Pi's shell/thinking color.",
@@ -532,6 +562,50 @@ function buildItems(
 				description: "Show the model id or display name in the editor frame.",
 				currentValue: config.editorModelLabel,
 				values: modelLabelValues,
+			},
+		);
+		items.push(
+			{
+				id: "minimalistPathDisplay",
+				label: "Minimalist path",
+				description: "Show the cwd basename, repository-relative path, or full path.",
+				currentValue: config.minimalist.pathDisplay,
+				values: minimalistPathDisplayValues,
+			},
+			{
+				id: "minimalistContextFormat",
+				label: "Minimalist context text",
+				description: "Show context percent alone or with the total context window.",
+				currentValue: config.minimalist.contextFormat,
+				values: minimalistContextFormatValues,
+			},
+			{
+				id: "minimalistContextGauge",
+				label: "Minimalist context gauge",
+				description: "Add a compact gauge before the context text when space allows.",
+				currentValue: featureValue(config.minimalist.contextGauge),
+				values: featureStateValues,
+			},
+			{
+				id: "minimalistShowTimer",
+				label: "Minimalist timer",
+				description: "Show the current or completed turn duration.",
+				currentValue: featureValue(config.minimalist.showTimer),
+				values: featureStateValues,
+			},
+			{
+				id: "minimalistShowCost",
+				label: "Minimalist cost",
+				description: "Show session cost in the top border.",
+				currentValue: featureValue(config.minimalist.showCost),
+				values: featureStateValues,
+			},
+			{
+				id: "minimalistShowGit",
+				label: "Minimalist Git",
+				description: "Show branch and working-tree state in the bottom border.",
+				currentValue: featureValue(config.minimalist.showGit),
+				values: featureStateValues,
 			},
 		);
 		items.push({
@@ -902,6 +976,69 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 								}
 
 								if (isBoundedSettingId(id)) {
+									if (
+										id === "editorMode" &&
+										(newValue === "polished" || newValue === "minimalist")
+									) {
+										if (!deps.setEditorMode) return;
+										deps.setEditorMode(newValue, ctx);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Editor mode: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
+									if (
+										id === "minimalistPathDisplay" &&
+										(newValue === "compact" || newValue === "project" || newValue === "full")
+									) {
+										if (!deps.setMinimalist) return;
+										deps.setMinimalist({ pathDisplay: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Minimalist path: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
+									if (
+										id === "minimalistContextFormat" &&
+										(newValue === "percent" || newValue === "percent-total")
+									) {
+										if (!deps.setMinimalist) return;
+										deps.setMinimalist({ contextFormat: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`Minimalist context text: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
+									if (
+										(id === "minimalistContextGauge" ||
+											id === "minimalistShowTimer" ||
+											id === "minimalistShowCost" ||
+											id === "minimalistShowGit") &&
+										isFeatureState(newValue)
+									) {
+										if (!deps.setMinimalist) return;
+										const key =
+											id === "minimalistContextGauge"
+												? "contextGauge"
+												: id === "minimalistShowTimer"
+													? "showTimer"
+													: id === "minimalistShowCost"
+														? "showCost"
+														: "showGit";
+										deps.setMinimalist({ [key]: newValue === "enabled" }, ctx);
+										settingsList.updateValue(id, newValue);
+										deps.requestRender();
+										ctx.ui.notify(`${id}: ${newValue}`, "info");
+										tui.requestRender();
+										return;
+									}
+
 									if (id === "editorModelLabel" && (newValue === "id" || newValue === "name")) {
 										if (!deps.setEditorModelLabel) return;
 										deps.setEditorModelLabel(newValue, ctx);

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -12,7 +12,6 @@ import {
 } from "@earendil-works/pi-tui";
 import {
 	type ColorSource,
-	type ColorSourcesConfig,
 	type CompactFooterMaxLines,
 	type ContextStyle,
 	type EditorBorderColorMode,
@@ -40,7 +39,6 @@ import {
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
-	type UiFeaturesConfig,
 	type UserMessageStyle,
 	type UserMessagesComponentConfig,
 } from "./config";
@@ -117,17 +115,17 @@ type ApplyResult = { applied: boolean; reason?: string };
 type SettingsCommandDeps = {
 	sessionLifecycle: SessionLifecycle;
 	getConfig: () => PolishedTuiConfig;
-	setEditorComponent?: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
-	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
-	setUserMessagesComponent?: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
-	setSelectorBordersComponent?: (
+	setEditorComponent: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
+	setMinimalist: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
+	setUserMessagesComponent: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
+	setSelectorBordersComponent: (
 		patch: Partial<SelectorBordersComponentConfig>,
 		ctx: ExtensionContext,
 	) => void;
-	setFooterComponent?: (patch: FooterPatch, ctx: ExtensionContext) => void;
+	setFooterComponent: (patch: FooterPatch, ctx: ExtensionContext) => void;
 	setFooterSegments: (patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) => void;
 	setFooterFormat: (value: string, ctx: ExtensionContext) => void;
-	setResponsiveFooter?: (
+	setResponsiveFooter: (
 		patch: Partial<Pick<PolishedTuiConfig, "responsiveFooter" | "compactFooterMaxLines">>,
 		ctx: ExtensionContext,
 	) => void;
@@ -136,24 +134,18 @@ type SettingsCommandDeps = {
 	setSeparator: (separator: SeparatorStyle) => void;
 	setPathDisplay: (patch: Partial<PathDisplayConfig>) => void;
 	setGitBranch: (patch: Partial<GitBranchConfig>) => void;
-	setGitCommit?: (
+	setGitCommit: (
 		patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,
 		ctx: ExtensionContext,
 	) => void;
-	setGitMetrics?: (patch: Partial<GitMetricsConfig>, ctx: ExtensionContext) => void;
+	setGitMetrics: (patch: Partial<GitMetricsConfig>, ctx: ExtensionContext) => void;
 	getActiveExtensionStatuses: () => ReadonlyMap<string, string>;
-	setExtensionStatusDefaultPlacement?: (placement: ExtensionStatusPlacement) => void;
+	setExtensionStatusDefaultPlacement: (placement: ExtensionStatusPlacement) => void;
 	setExtensionStatusPlacement: (key: string, placement: ExtensionStatusPlacement) => void;
 	setExtensionStatusColorMode: (key: string, colorMode: ExtensionStatusColorMode) => void;
 	setFixedEditor: (patch: Partial<FixedEditorConfig>, ctx: ExtensionContext) => void;
 	requestRender: () => void;
 	settingsListTheme?: SettingsListTheme;
-	/** Deprecated dependency fallbacks retained for older internal callers. */
-	setColorSources?: (patch: Partial<ColorSourcesConfig>) => void;
-	setUiFeatures?: (patch: Partial<UiFeaturesConfig>, ctx: ExtensionContext) => ApplyResult;
-	setEditorStyle?: (value: EditorStyle, ctx: ExtensionContext) => void;
-	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
-	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
 };
 
 const sectionLabels: Record<SettingsSection, string> = {
@@ -868,12 +860,12 @@ function withSectionFooter(lines: string[], theme: ExtensionContext["ui"]["theme
 
 export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCommandDeps): void {
 	const setEditor = (patch: EditorPatch, ctx: ExtensionContext): ApplyResult =>
-		deps.setEditorComponent?.(patch, ctx) ?? { applied: true };
+		deps.setEditorComponent(patch, ctx);
 	const setMessages = (patch: UserMessagesPatch, ctx: ExtensionContext) => {
-		deps.setUserMessagesComponent?.(patch, ctx);
+		deps.setUserMessagesComponent(patch, ctx);
 	};
 	const setFooter = (patch: FooterPatch, ctx: ExtensionContext) => {
-		deps.setFooterComponent?.(patch, ctx);
+		deps.setFooterComponent(patch, ctx);
 	};
 
 	pi.registerCommand("zentui", {
@@ -1044,7 +1036,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									notifyChange("Editor viewport indicators", newValue);
 									return;
 								}
-								if (id.startsWith("minimalist") && deps.setMinimalist) {
+								if (id.startsWith("minimalist")) {
 									if (
 										id === "minimalistPathDisplay" &&
 										["compact", "project", "full"].includes(newValue)
@@ -1103,19 +1095,19 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									return;
 								}
 								if (id === "selectorBordersEnabled" && enabled !== undefined) {
-									deps.setSelectorBordersComponent?.({ enabled }, ctx);
+									deps.setSelectorBordersComponent({ enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Selector borders", newValue);
 									return;
 								}
 								if (id === "selectorBordersStyle" && newValue === "zentui") {
-									deps.setSelectorBordersComponent?.({ style: newValue }, ctx);
+									deps.setSelectorBordersComponent({ style: newValue }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Selector border style", newValue);
 									return;
 								}
 								if (id === "selectorBordersColorSource" && isColorSource(newValue)) {
-									deps.setSelectorBordersComponent?.({ colorSource: newValue }, ctx);
+									deps.setSelectorBordersComponent({ colorSource: newValue }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Selector border colors", newValue);
 									return;
@@ -1168,7 +1160,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 								}
 
 								if (id === "responsiveFooter" && enabled !== undefined) {
-									deps.setResponsiveFooter?.({ responsiveFooter: enabled }, ctx);
+									deps.setResponsiveFooter({ responsiveFooter: enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Responsive footer", newValue);
 									return;
@@ -1179,7 +1171,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 								) {
 									const value: CompactFooterMaxLines =
 										newValue === "unlimited" ? "unlimited" : (Number(newValue) as 1 | 2 | 3);
-									deps.setResponsiveFooter?.({ compactFooterMaxLines: value }, ctx);
+									deps.setResponsiveFooter({ compactFooterMaxLines: value }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Compact footer rows", newValue);
 									return;
@@ -1228,25 +1220,25 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									return;
 								}
 								if (id === "gitCommitOnlyDetached" && enabled !== undefined) {
-									deps.setGitCommit?.({ onlyDetached: enabled }, ctx);
+									deps.setGitCommit({ onlyDetached: enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Commit only on detached HEAD", newValue);
 									return;
 								}
 								if (id === "gitCommitShowTag" && enabled !== undefined) {
-									deps.setGitCommit?.({ showTag: enabled }, ctx);
+									deps.setGitCommit({ showTag: enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Show exact-match tag", newValue);
 									return;
 								}
 								if (id === "gitMetricsOnlyNonzero" && enabled !== undefined) {
-									deps.setGitMetrics?.({ onlyNonzero: enabled }, ctx);
+									deps.setGitMetrics({ onlyNonzero: enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Hide zero metrics", newValue);
 									return;
 								}
 								if (id === "gitMetricsIgnoreSubmodules" && enabled !== undefined) {
-									deps.setGitMetrics?.({ ignoreSubmodules: enabled }, ctx);
+									deps.setGitMetrics({ ignoreSubmodules: enabled }, ctx);
 									settingsList.updateValue(id, newValue);
 									notifyChange("Ignore submodules", newValue);
 									return;
@@ -1256,7 +1248,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									id === "extensionStatusDefaultPlacement" &&
 									isExtensionStatusPlacement(newValue)
 								) {
-									deps.setExtensionStatusDefaultPlacement?.(newValue);
+									deps.setExtensionStatusDefaultPlacement(newValue);
 									settingsList = makeSettingsList("extensionStatusDefaultPlacement");
 									notifyChange("Default extension status placement", newValue);
 									return;
@@ -1295,7 +1287,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 					render(width: number) {
 						const border = renderChromeBorder(
 							theme,
-							deps.getConfig().components.editor.colorSource,
+							deps.getConfig().components.selectorBorders.colorSource,
 							EDITOR_BORDER_STYLE,
 							"─".repeat(Math.max(0, width)),
 						);

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -72,6 +72,7 @@ const editorStyleLabels: Record<EditorStyle, string> = {
 const editorStyleValues = Object.values(editorStyleLabels);
 const userMessageStyleLabels: Record<UserMessageStyle, string> = {
 	framed: "Framed",
+	"framed-copy-friendly": "Framed (copy-friendly)",
 	compact: "Compact",
 	labeled: "Labeled",
 };

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -16,11 +16,14 @@ import {
 	type CompactFooterMaxLines,
 	type ContextStyle,
 	type EditorBorderColorMode,
+	type EditorComponentConfig,
 	type EditorStyle,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FixedEditorConfig,
+	type FooterComponentConfig,
 	type FooterSegmentsConfig,
+	type FramedUserMessageStyleConfig,
 	type GitBranchConfig,
 	type GitBranchMaxLength,
 	type GitCommitConfig,
@@ -32,14 +35,14 @@ import {
 	isExtensionStatusPlacement,
 	isSeparatorStyle,
 	type MinimalistConfig,
-	type MinimalistContextFormat,
-	type MinimalistPathDisplayMode,
 	type ModelLabelSource,
 	type PathDisplayConfig,
-	type PathDisplayMode,
+	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
+	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
 	type UiFeaturesConfig,
+	type UserMessagesComponentConfig,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
 import { isIconMode } from "./icons";
@@ -56,65 +59,65 @@ const extensionStatusPlacementValues: ExtensionStatusPlacement[] = [
 const extensionStatusColorModeValues: ExtensionStatusColorMode[] = ["zentui", "original"];
 const contextStyleValues: ContextStyle[] = ["text", "gauge", "text+gauge"];
 const separatorStyleValues: SeparatorStyle[] = ["pipe", "dot", "chevron", "none"];
-const pathDisplayModeValues: PathDisplayMode[] = ["basename", "full"];
-const pathDepthValues = ["0", "1", "2", "3", "4", "5"] as const;
-const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"] as const;
+const pathDisplayModeValues = ["basename", "full"];
+const pathDepthValues = ["0", "1", "2", "3", "4", "5"];
+const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"];
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
 const editorStyleValues: EditorStyle[] = ["polished", "minimalist"];
-const minimalistPathDisplayValues: MinimalistPathDisplayMode[] = ["compact", "project", "full"];
-const minimalistContextFormatValues: MinimalistContextFormat[] = ["percent", "percent-total"];
+const minimalistPathDisplayValues = ["compact", "project", "full"];
+const minimalistContextFormatValues = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
-const compactFooterMaxLineValues = ["1", "2", "3", "unlimited"] as const;
-type FeatureState = "enabled" | "disabled";
-
+const compactFooterMaxLineValues = ["1", "2", "3", "unlimited"];
 const featureStateValues: FeatureState[] = ["enabled", "disabled"];
 const settingsSections = [
 	"appearance",
 	"editor",
+	"userMessages",
+	"layout",
 	"footer",
 	"segments",
 	"git",
 	"extensions",
 ] as const;
 
-type ColorSettingId = "starship" | "editorMessages";
-type FeatureSettingId = keyof UiFeaturesConfig;
-type FooterSegmentSettingId = keyof FooterSegmentsConfig;
+type FeatureState = "enabled" | "disabled";
 type SettingsSection = (typeof settingsSections)[number];
-type BoundedSettingId =
-	| "responsiveFooter"
-	| "compactFooterMaxLines"
-	| "contextStyle"
-	| "separator"
-	| "pathDisplay"
-	| "pathDepth"
-	| "branchLength"
-	| "iconMode"
-	| "editorStyle"
-	| "minimalistPathDisplay"
-	| "minimalistContextFormat"
-	| "minimalistContextGauge"
-	| "minimalistShowSessionName"
-	| "minimalistShowTimer"
-	| "minimalistShowCost"
-	| "minimalistShowGit"
-	| "editorModelLabel"
-	| "editorBorderColorMode"
-	| "gitCommitOnlyDetached"
-	| "gitCommitShowTag"
-	| "gitMetricsOnlyNonzero"
-	| "gitMetricsIgnoreSubmodules"
-	| "extensionStatusDefaultPlacement";
+type FooterSegmentSettingId = keyof FooterSegmentsConfig;
+type EditorPatch = Partial<
+	Pick<
+		EditorComponentConfig,
+		"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+	>
+>;
+type UserMessagesPatch = Partial<
+	Pick<UserMessagesComponentConfig, "enabled" | "style" | "colorSource">
+>;
+type FooterPatch = Partial<
+	Pick<FooterComponentConfig, "enabled" | "style" | "colorSource" | "modelLabel">
+>;
+type ApplyResult = { applied: boolean; reason?: string };
 
 type SettingsCommandDeps = {
 	sessionLifecycle: SessionLifecycle;
 	getConfig: () => PolishedTuiConfig;
-	setColorSources: (patch: Partial<ColorSourcesConfig>) => void;
-	setUiFeatures: (
-		patch: Partial<UiFeaturesConfig>,
+	setEditorComponent?: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
+	setPolishedEditorStyle?: (
+		patch: Partial<PolishedEditorStyleConfig>,
 		ctx: ExtensionContext,
-	) => { applied: boolean; reason?: string };
+	) => void;
+	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
+	setUserMessagesComponent?: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
+	setFramedUserMessagesStyle?: (
+		patch: Partial<FramedUserMessageStyleConfig>,
+		ctx: ExtensionContext,
+	) => void;
+	setSelectorBordersComponent?: (
+		patch: Partial<SelectorBordersComponentConfig>,
+		ctx: ExtensionContext,
+	) => void;
+	setFooterComponent?: (patch: FooterPatch, ctx: ExtensionContext) => void;
+	setCopyFriendlyRecipe?: (enabled: boolean, ctx: ExtensionContext) => void;
 	setFooterSegments: (patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) => void;
 	setFooterFormat: (value: string, ctx: ExtensionContext) => void;
 	setResponsiveFooter?: (
@@ -126,10 +129,6 @@ type SettingsCommandDeps = {
 	setSeparator: (separator: SeparatorStyle) => void;
 	setPathDisplay: (patch: Partial<PathDisplayConfig>) => void;
 	setGitBranch: (patch: Partial<GitBranchConfig>) => void;
-	setEditorStyle?: (value: EditorStyle, ctx: ExtensionContext) => void;
-	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
-	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
-	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
 	setGitCommit?: (
 		patch: Partial<Pick<GitCommitConfig, "onlyDetached" | "showTag">>,
 		ctx: ExtensionContext,
@@ -142,34 +141,23 @@ type SettingsCommandDeps = {
 	setFixedEditor: (patch: Partial<FixedEditorConfig>, ctx: ExtensionContext) => void;
 	requestRender: () => void;
 	settingsListTheme?: SettingsListTheme;
+	/** Deprecated dependency fallbacks retained for older internal callers. */
+	setColorSources?: (patch: Partial<ColorSourcesConfig>) => void;
+	setUiFeatures?: (patch: Partial<UiFeaturesConfig>, ctx: ExtensionContext) => ApplyResult;
+	setEditorStyle?: (value: EditorStyle, ctx: ExtensionContext) => void;
+	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
+	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
 };
 
-const colorSettingLabels: Record<ColorSettingId, string> = {
-	starship: "Starship/footer colors",
-	editorMessages: "Editor + previous messages",
-};
-
-const colorSettingDescriptions: Record<ColorSettingId, string> = {
-	starship:
-		"Choose whether footer runtime/git/context colors use Pi theme tokens or terminal palette styles.",
-	editorMessages:
-		"Choose whether editor and previous user-message borders/rails use Pi theme colors or terminal palette styles.",
-};
-
-const featureSettingLabels: Record<FeatureSettingId, string> = {
+const sectionLabels: Record<SettingsSection, string> = {
+	appearance: "Appearance",
 	editor: "Editor",
-	statusLine: "Status line",
-	copyFriendly: "Copy-friendly mode",
-	viewportIndicators: "Editor viewport indicators",
-};
-
-const featureSettingDescriptions: Record<FeatureSettingId, string> = {
-	editor:
-		"Enable or disable Zentui's custom editor, selector borders, and previous-message chrome.",
-	statusLine: "Enable or disable Zentui's custom footer/status line.",
-	copyFriendly:
-		"Hide editor and previous-message rail glyphs for cleaner native terminal selection.",
-	viewportIndicators: "Show Pi's native wrapped-row counts in the editor's top and bottom borders.",
+	userMessages: "User messages",
+	layout: "Layout",
+	footer: "Footer",
+	segments: "Segments",
+	git: "Git",
+	extensions: "Extensions",
 };
 
 const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
@@ -194,32 +182,37 @@ const footerSegmentSettingLabels: Record<FooterSegmentSettingId, string> = {
 
 const footerSegmentSettingDescriptions: Record<FooterSegmentSettingId, string> = {
 	cwd: "Show or hide the current working directory segment on the left.",
-	sessionName: "Show or hide the current Pi session name on the left, after the current directory.",
+	sessionName: "Show or hide the current Pi session name on the left.",
 	gitBranch: "Show or hide the git branch name on the left.",
 	gitStatus: "Show or hide git status icons and ahead/behind markers.",
-	gitCounts:
-		"Show numeric ahead/behind and stash counts (requires the Git status segment to be enabled).",
-	sessionDuration: "Show session running time on the left, after the runtime.",
+	gitCounts: "Show numeric ahead/behind and stash counts.",
+	sessionDuration: "Show session running time on the left.",
 	username: "Show user@hostname on the left.",
 	time: "Show the current time (HH:MM) on the right.",
 	os: "Show an operating-system icon on the left.",
-	runtime: "Show or hide the detected runtime/language segment on the left.",
-	modelInfo: "Show the selected model and non-duplicate provider on the right.",
+	runtime: "Show or hide the detected runtime/language segment.",
+	modelInfo: "Show the selected model and non-duplicate provider.",
 	context: "Show or hide context usage on the right.",
 	tokens: "Show or hide input/output token counts on the right.",
 	cost: "Show or hide session cost on the right.",
-	packageVersion:
-		"Show the project’s own manifest version (package.json, Cargo.toml, pyproject.toml, …). Distinct from the runtime segment, which shows the installed toolchain version.",
-	gitCommit:
-		"Show the current commit hash (and optional exact-match tag). On detached HEAD this provides context the branch segment can’t. Starship `git_commit`-style; default off.",
-	gitMetrics:
-		"Show aggregate added/deleted line counts (e.g. `+12 −3`) via `git diff HEAD --numstat`. Complements the git status counts. Starship `git_metrics`-style; default off.",
+	packageVersion: "Show the project manifest version.",
+	gitCommit: "Show the current commit hash and optional exact-match tag.",
+	gitMetrics: "Show aggregate added/deleted line counts.",
 };
 
 const directCommandSuggestions = [
 	"editor enable",
 	"editor disable",
 	"editor toggle",
+	"messages enable",
+	"messages disable",
+	"messages toggle",
+	"editor-copy-friendly enable",
+	"editor-copy-friendly disable",
+	"editor-copy-friendly toggle",
+	"message-copy-friendly enable",
+	"message-copy-friendly disable",
+	"message-copy-friendly toggle",
 	"statusline enable",
 	"statusline disable",
 	"statusline toggle",
@@ -232,575 +225,571 @@ const directCommandSuggestions = [
 	"fixed-editor enable",
 	"fixed-editor disable",
 	"fixed-editor toggle",
+	"messages",
+	"user-messages",
+	"layout",
 	"format clear",
 	"format $cwd on $git_branch $fill $context",
-	"format $cwd( on $git_branch)($git_status)$fill($context)( | $cost)",
 ];
-
-const sectionLabels: Record<SettingsSection, string> = {
-	appearance: "Appearance",
-	editor: "Editor",
-	footer: "Footer",
-	segments: "Segments",
-	git: "Git",
-	extensions: "Extensions",
-};
 
 const thirdPartyStatusSettingPrefix = "thirdPartyStatus:";
 const footerSegmentSettingPrefix = "footerSegment:";
 type ThirdPartyStatusSettingKind = "placement" | "colorMode";
 
-function isColorSource(value: string): value is ColorSource {
-	return value === "theme" || value === "terminal";
-}
-
-function isColorSettingId(value: string): value is ColorSettingId {
-	return value === "starship" || value === "editorMessages";
-}
-
-function isFeatureSettingId(value: string): value is FeatureSettingId {
-	return (
-		value === "editor" ||
-		value === "statusLine" ||
-		value === "copyFriendly" ||
-		value === "viewportIndicators"
-	);
-}
-
-function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingId {
-	return (
-		value === "cwd" ||
-		value === "sessionName" ||
-		value === "gitBranch" ||
-		value === "gitStatus" ||
-		value === "gitCounts" ||
-		value === "sessionDuration" ||
-		value === "runtime" ||
-		value === "modelInfo" ||
-		value === "context" ||
-		value === "tokens" ||
-		value === "cost" ||
-		value === "username" ||
-		value === "time" ||
-		value === "os" ||
-		value === "packageVersion" ||
-		value === "gitCommit" ||
-		value === "gitMetrics"
-	);
-}
-
-function isFeatureState(value: string): value is FeatureState {
-	return value === "enabled" || value === "disabled";
-}
-
-function isContextStyle(value: string): value is ContextStyle {
-	return value === "text" || value === "gauge" || value === "text+gauge";
-}
-
-function isPathDisplayMode(value: string): value is PathDisplayMode {
-	return value === "basename" || value === "full";
-}
-
-function isPathDepthValue(value: string): boolean {
-	return (pathDepthValues as readonly string[]).includes(value);
-}
-
-function parseGitBranchLengthValue(value: string): GitBranchMaxLength | undefined {
-	if (value === "full") return value;
-	const parsed = Number(value);
-	return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function branchLengthValues(maxLength: GitBranchMaxLength): string[] {
-	const current = String(maxLength);
-	return (branchLengthPresetValues as readonly string[]).includes(current)
-		? [...branchLengthPresetValues]
-		: [current, ...branchLengthPresetValues];
-}
-
-function isCompactFooterMaxLines(value: string): value is `${CompactFooterMaxLines}` {
-	return (compactFooterMaxLineValues as readonly string[]).includes(value);
-}
-
-function parseCompactFooterMaxLines(value: string): CompactFooterMaxLines | undefined {
-	if (!isCompactFooterMaxLines(value)) return undefined;
-	return value === "unlimited" ? value : (Number(value) as 1 | 2 | 3);
-}
-
-function isBoundedSettingId(value: string): value is BoundedSettingId {
-	return (
-		value === "responsiveFooter" ||
-		value === "compactFooterMaxLines" ||
-		value === "contextStyle" ||
-		value === "separator" ||
-		value === "pathDisplay" ||
-		value === "pathDepth" ||
-		value === "branchLength" ||
-		value === "iconMode" ||
-		value === "editorStyle" ||
-		value === "minimalistPathDisplay" ||
-		value === "minimalistContextFormat" ||
-		value === "minimalistContextGauge" ||
-		value === "minimalistShowSessionName" ||
-		value === "minimalistShowTimer" ||
-		value === "minimalistShowCost" ||
-		value === "minimalistShowGit" ||
-		value === "editorModelLabel" ||
-		value === "editorBorderColorMode" ||
-		value === "gitCommitOnlyDetached" ||
-		value === "gitCommitShowTag" ||
-		value === "gitMetricsOnlyNonzero" ||
-		value === "gitMetricsIgnoreSubmodules" ||
-		value === "extensionStatusDefaultPlacement"
-	);
-}
-
-function editorMessageValue(config: PolishedTuiConfig): ColorSource | "mixed" {
-	return config.colorSources.editor === config.colorSources.userMessages
-		? config.colorSources.editor
-		: "mixed";
-}
-
-function patchForSetting(id: ColorSettingId, value: ColorSource): Partial<ColorSourcesConfig> {
-	return id === "starship" ? { starship: value } : { editor: value, userMessages: value };
-}
-
 function featureValue(enabled: boolean): FeatureState {
 	return enabled ? "enabled" : "disabled";
 }
-
-function featurePatch(id: FeatureSettingId, value: FeatureState): Partial<UiFeaturesConfig> {
-	return { [id]: value === "enabled" } as Partial<UiFeaturesConfig>;
+function isFeatureState(value: string): value is FeatureState {
+	return value === "enabled" || value === "disabled";
+}
+function isColorSource(value: string): value is ColorSource {
+	return value === "theme" || value === "terminal";
+}
+function parseAction(words: string[]): "enable" | "disable" | "toggle" | undefined {
+	if (words.includes("toggle")) return "toggle";
+	if (words.some((word) => ["enable", "enabled", "on"].includes(word))) return "enable";
+	if (words.some((word) => ["disable", "disabled", "off"].includes(word))) return "disable";
+	return undefined;
+}
+function actionValue(action: "enable" | "disable" | "toggle", current: boolean): boolean {
+	return action === "toggle" ? !current : action === "enable";
+}
+function normalizedWords(args: string): string[] {
+	return args.trim().toLowerCase().replaceAll(/[_-]+/g, " ").split(/\s+/g).filter(Boolean);
 }
 
-function footerSegmentSettingId(key: FooterSegmentSettingId): string {
-	return `${footerSegmentSettingPrefix}${key}`;
-}
+type DirectOperation =
+	| { kind: "editor" | "messages" | "footer" | "viewport"; enabled: boolean }
+	| { kind: "copyRecipe" | "editorCopy" | "messageCopy"; enabled: boolean };
 
-function footerSegmentSettingFromId(id: string): FooterSegmentSettingId | undefined {
-	if (!id.startsWith(footerSegmentSettingPrefix)) return undefined;
-	const key = id.slice(footerSegmentSettingPrefix.length);
-	return isFooterSegmentSettingId(key) ? key : undefined;
-}
-
-function footerSegmentPatch(
-	id: FooterSegmentSettingId,
-	value: FeatureState,
-): Partial<FooterSegmentsConfig> {
-	return { [id]: value === "enabled" } as Partial<FooterSegmentsConfig>;
-}
-
-function usageText(): string {
-	return 'Usage: /zentui [editor|statusline|copy-friendly|viewport-indicators] [enable|disable|toggle] or /zentui format "<template>"';
-}
-
-function featureNotification(
-	feature: FeatureSettingId,
-	value: FeatureState,
-	result: { applied: boolean; reason?: string },
-): string {
-	const base = `${featureSettingLabels[feature]}: ${value}`;
-	return result.applied ? base : `${base} (${result.reason ?? "reload Pi to apply this change"})`;
-}
-
-function parseDirectFeatureCommand(
+function parseDirectOperation(
 	args: string,
 	config: PolishedTuiConfig,
-): { feature: FeatureSettingId; enabled: boolean } | undefined {
-	const normalized = args.trim().toLowerCase().replaceAll(/[_-]+/g, " ");
-	if (!normalized) return undefined;
-
-	const words = normalized.split(/\s+/g).filter(Boolean);
-	const hasWord = (value: string) => words.includes(value);
-	const feature =
-		hasWord("viewportindicators") || (hasWord("viewport") && hasWord("indicators"))
-			? "viewportIndicators"
-			: hasWord("editor")
-				? "editor"
-				: hasWord("footer") || hasWord("statusline") || hasWord("status")
-					? "statusLine"
-					: hasWord("copyfriendly") || hasWord("copy")
-						? "copyFriendly"
-						: undefined;
-	const action = hasWord("toggle")
-		? "toggle"
-		: hasWord("enable") || hasWord("enabled") || hasWord("on")
-			? "enable"
-			: hasWord("disable") || hasWord("disabled") || hasWord("off")
-				? "disable"
-				: undefined;
-
-	if (!feature || !action) return undefined;
-
-	return {
-		feature,
-		enabled: action === "toggle" ? !config.features[feature] : action === "enable",
-	};
-}
-
-function parseFixedEditorCommand(
-	args: string,
-	config: PolishedTuiConfig,
-): { enabled: boolean } | undefined {
-	const normalized = args.trim().toLowerCase().replaceAll(/[_-]+/g, " ");
-	if (!normalized) return undefined;
-
-	const words = normalized.split(/\s+/g).filter(Boolean);
-	const hasWord = (value: string) => words.includes(value);
-	if (!hasWord("fixededitor") && !(hasWord("fixed") && hasWord("editor"))) return undefined;
-
-	const action = hasWord("toggle")
-		? "toggle"
-		: hasWord("enable") || hasWord("enabled") || hasWord("on")
-			? "enable"
-			: hasWord("disable") || hasWord("disabled") || hasWord("off")
-				? "disable"
-				: undefined;
+): DirectOperation | undefined {
+	const raw = args.trim().toLowerCase();
+	const words = normalizedWords(args);
+	const action = parseAction(words);
 	if (!action) return undefined;
+	// Component-specific copy commands must win before the generic word-based aliases.
+	if (/^(editor[-_ ]copy[-_ ]friendly)\b/.test(raw)) {
+		return {
+			kind: "editorCopy",
+			enabled: actionValue(action, config.components.editor.styles.polished.copyFriendly),
+		};
+	}
+	if (/^(message[-_ ]copy[-_ ]friendly)\b/.test(raw)) {
+		return {
+			kind: "messageCopy",
+			enabled: actionValue(action, config.components.userMessages.styles.framed.copyFriendly),
+		};
+	}
+	const has = (word: string) => words.includes(word);
+	if (has("viewportindicators") || (has("viewport") && has("indicators"))) {
+		return {
+			kind: "viewport",
+			enabled: actionValue(action, config.components.editor.viewportIndicators),
+		};
+	}
+	if (has("messages") || (has("user") && has("messages"))) {
+		return {
+			kind: "messages",
+			enabled: actionValue(action, config.components.userMessages.enabled),
+		};
+	}
+	if (has("editor")) {
+		return {
+			kind: "editor",
+			enabled: actionValue(action, config.components.editor.enabled),
+		};
+	}
+	if (has("footer") || has("statusline") || has("status")) {
+		return {
+			kind: "footer",
+			enabled: actionValue(action, config.components.footer.enabled),
+		};
+	}
+	if (has("copyfriendly") || has("copy")) {
+		return {
+			kind: "copyRecipe",
+			enabled: actionValue(action, config.features.copyFriendly),
+		};
+	}
+	return undefined;
+}
 
-	return {
-		enabled: action === "toggle" ? !config.fixedEditor.enabled : action === "enable",
-	};
+function parseFixedEditorCommand(args: string, config: PolishedTuiConfig) {
+	const words = normalizedWords(args);
+	if (!words.includes("fixededitor") && !(words.includes("fixed") && words.includes("editor"))) {
+		return undefined;
+	}
+	const action = parseAction(words);
+	return action ? { enabled: actionValue(action, config.layout.fixedEditor.enabled) } : undefined;
 }
 
 function parseFormatCommand(args: string): { value: string | undefined } | undefined {
 	const trimmed = args.trim();
 	if (!trimmed.toLowerCase().startsWith("format")) return undefined;
-
 	const rest = trimmed.slice("format".length).trim();
 	if (!rest || rest.toLowerCase() === "clear") return { value: undefined };
+	return {
+		value:
+			rest.startsWith('"') && rest.endsWith('"') && rest.length >= 2 ? rest.slice(1, -1) : rest,
+	};
+}
 
-	const unquoted =
-		rest.startsWith('"') && rest.endsWith('"') && rest.length >= 2 ? rest.slice(1, -1) : rest;
-	return { value: unquoted };
+function directSection(args: string): SettingsSection | undefined {
+	const normalized = args.trim().toLowerCase().replaceAll("_", "-");
+	if (
+		normalized === "messages" ||
+		normalized === "user-messages" ||
+		normalized === "user messages"
+	) {
+		return "userMessages";
+	}
+	if (normalized === "layout") return "layout";
+	return undefined;
 }
 
 function argumentCompletions(prefix: string): AutocompleteItem[] | null {
-	const trimmedPrefix = prefix.trimStart().toLowerCase();
-	const items = directCommandSuggestions.map((value) => ({ value, label: value }));
-	const matches = items.filter((item) => item.value.startsWith(trimmedPrefix));
-	return matches.length > 0 ? matches : null;
+	const normalized = prefix.trimStart().toLowerCase();
+	const matches = directCommandSuggestions
+		.map((value) => ({ value, label: value }))
+		.filter((item) => item.value.startsWith(normalized));
+	return matches.length ? matches : null;
 }
 
+function usageText(): string {
+	return "Usage: /zentui [editor|messages|statusline|copy-friendly|editor-copy-friendly|message-copy-friendly|viewport-indicators|fixed-editor] [enable|disable|toggle], /zentui [messages|user-messages|layout], or /zentui format <template>";
+}
+
+function buildAppearanceItems(config: PolishedTuiConfig): SettingItem[] {
+	const component = config.components.selectorBorders;
+	return [
+		{
+			id: "selectorBordersEnabled",
+			label: "Selector borders",
+			description: "Enable or disable Zentui borders around Pi selectors.",
+			currentValue: featureValue(component.enabled),
+			values: featureStateValues,
+		},
+		{
+			id: "selectorBordersStyle",
+			label: "Selector border style",
+			description: "Choose the selector-border style.",
+			currentValue: component.style,
+			values: ["zentui"],
+		},
+		{
+			id: "selectorBordersColorSource",
+			label: "Selector border colors",
+			description: "Use Pi theme colors or terminal palette styles.",
+			currentValue: component.colorSource,
+			values: colorSourceValues,
+		},
+		{
+			id: "iconMode",
+			label: "Icon mode",
+			description: "auto/nerd use Nerd Font glyphs; ascii uses plain fallbacks.",
+			currentValue: config.icons.mode,
+			values: iconModeValues,
+		},
+	];
+}
+
+function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
+	const editor = config.components.editor;
+	return [
+		{
+			id: "editorEnabled",
+			label: "Editor",
+			description: "Enable or disable Zentui's custom editor.",
+			currentValue: featureValue(editor.enabled),
+			values: featureStateValues,
+		},
+		{
+			id: "editorStyle",
+			label: "Editor style",
+			description: "Use polished rails or a compact minimalist frame.",
+			currentValue: editor.style,
+			values: editorStyleValues,
+		},
+		{
+			id: "editorColorSource",
+			label: "Editor colors",
+			description: "Use Pi theme colors or terminal palette styles.",
+			currentValue: editor.colorSource,
+			values: colorSourceValues,
+		},
+		{
+			id: "editorModelLabel",
+			label: "Editor model label",
+			description: "Show the model id or display name in the editor frame.",
+			currentValue: editor.modelLabel,
+			values: modelLabelValues,
+		},
+		{
+			id: "editorBorderColorMode",
+			label: "Editor border color",
+			description: "Keep configured color or follow Pi's shell/thinking color.",
+			currentValue: editor.borderColorMode,
+			values: editorBorderColorModeValues,
+		},
+		{
+			id: "editorViewportIndicators",
+			label: "Editor viewport indicators",
+			description: "Show Pi's native wrapped-row counts in editor borders.",
+			currentValue: featureValue(editor.viewportIndicators),
+			values: featureStateValues,
+		},
+	];
+}
+
+function buildPolishedEditorStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	return [
+		{
+			id: "polishedCopyFriendly",
+			label: "Copy-friendly",
+			description: "Hide editor rail glyphs for cleaner native terminal selection.",
+			currentValue: featureValue(config.components.editor.styles.polished.copyFriendly),
+			values: featureStateValues,
+		},
+	];
+}
+
+function buildMinimalistEditorStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	const minimalist = config.components.editor.styles.minimalist;
+	return [
+		{
+			id: "minimalistPathDisplay",
+			label: "Path",
+			description: "Show compact, project-relative, or full path.",
+			currentValue: minimalist.pathDisplay,
+			values: minimalistPathDisplayValues,
+		},
+		{
+			id: "minimalistContextFormat",
+			label: "Context text",
+			description: "Show percent alone or with total context.",
+			currentValue: minimalist.contextFormat,
+			values: minimalistContextFormatValues,
+		},
+		{
+			id: "minimalistContextGauge",
+			label: "Context gauge",
+			description: "Add a compact context gauge.",
+			currentValue: featureValue(minimalist.contextGauge),
+			values: featureStateValues,
+		},
+		{
+			id: "minimalistShowSessionName",
+			label: "Session name",
+			description: "Show the explicit Pi session name.",
+			currentValue: featureValue(minimalist.showSessionName),
+			values: featureStateValues,
+		},
+		{
+			id: "minimalistShowTimer",
+			label: "Timer",
+			description: "Show current or completed turn duration.",
+			currentValue: featureValue(minimalist.showTimer),
+			values: featureStateValues,
+		},
+		{
+			id: "minimalistShowCost",
+			label: "Cost",
+			description: "Show session cost in the top border.",
+			currentValue: featureValue(minimalist.showCost),
+			values: featureStateValues,
+		},
+		{
+			id: "minimalistShowGit",
+			label: "Git",
+			description: "Show branch and working-tree state.",
+			currentValue: featureValue(minimalist.showGit),
+			values: featureStateValues,
+		},
+	];
+}
+
+function buildUserMessagesItems(config: PolishedTuiConfig): SettingItem[] {
+	const messages = config.components.userMessages;
+	return [
+		{
+			id: "userMessagesEnabled",
+			label: "User messages",
+			description: "Enable or disable previous user-message styling.",
+			currentValue: featureValue(messages.enabled),
+			values: featureStateValues,
+		},
+		{
+			id: "userMessagesStyle",
+			label: "Message style",
+			description: "Choose the previous-message style.",
+			currentValue: messages.style,
+			values: ["framed"],
+		},
+		{
+			id: "userMessagesColorSource",
+			label: "Message colors",
+			description: "Use Pi theme colors or terminal palette styles.",
+			currentValue: messages.colorSource,
+			values: colorSourceValues,
+		},
+	];
+}
+function buildFramedUserMessageStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	return [
+		{
+			id: "framedUserMessagesCopyFriendly",
+			label: "Copy-friendly",
+			description: "Hide previous-message rail glyphs.",
+			currentValue: featureValue(config.components.userMessages.styles.framed.copyFriendly),
+			values: featureStateValues,
+		},
+	];
+}
+function buildLayoutItems(config: PolishedTuiConfig): SettingItem[] {
+	const fixed = config.layout.fixedEditor;
+	const items: SettingItem[] = [
+		{
+			id: "fixedEditor",
+			label: "Fixed editor (experimental)",
+			description: "Pin editor + footer at bottom while transcript scrolls.",
+			currentValue: featureValue(fixed.enabled),
+			values: featureStateValues,
+		},
+	];
+	if (fixed.enabled) {
+		items.push(
+			{
+				id: "fixedEditorMouseScroll",
+				label: "Mouse scroll",
+				description: "Scroll transcript with mouse wheel.",
+				currentValue: featureValue(fixed.mouseScroll),
+				values: featureStateValues,
+			},
+			{
+				id: "fixedEditorCopyNotice",
+				label: "Copy notice",
+				description: "Show a clipboard notice after drag selection.",
+				currentValue: featureValue(fixed.copyNotice),
+				values: featureStateValues,
+			},
+		);
+	}
+	return items;
+}
+function buildFooterItems(config: PolishedTuiConfig): SettingItem[] {
+	const footer = config.components.footer;
+	return [
+		{
+			id: "footerEnabled",
+			label: "Footer",
+			description: "Enable or disable Zentui's footer.",
+			currentValue: featureValue(footer.enabled),
+			values: featureStateValues,
+		},
+		{
+			id: "footerStyle",
+			label: "Footer style",
+			description: "Choose the footer style.",
+			currentValue: footer.style,
+			values: ["starship"],
+		},
+		{
+			id: "footerColorSource",
+			label: "Footer colors",
+			description: "Use Pi theme colors or terminal palette styles.",
+			currentValue: footer.colorSource,
+			values: colorSourceValues,
+		},
+		{
+			id: "footerModelLabel",
+			label: "Footer model label",
+			description: "Show the model id or display name in the footer.",
+			currentValue: footer.modelLabel,
+			values: modelLabelValues,
+		},
+	];
+}
+function buildStarshipFooterStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	const footer = config.components.footer.styles.starship;
+	return [
+		{
+			id: "responsiveFooter",
+			label: "Responsive footer",
+			description: "Use the compact template when space is tight.",
+			currentValue: featureValue(footer.responsive),
+			values: featureStateValues,
+		},
+		{
+			id: "compactFooterMaxLines",
+			label: "Compact footer rows",
+			description: "Maximum compact rows before cropping.",
+			currentValue: String(footer.compactMaxLines),
+			values: compactFooterMaxLineValues,
+		},
+		{
+			id: "contextStyle",
+			label: "Context style",
+			description: "Render context as text, gauge, or both.",
+			currentValue: footer.contextStyle,
+			values: contextStyleValues,
+		},
+		{
+			id: "separator",
+			label: "Separator",
+			description: "Choose the separator between default footer segments.",
+			currentValue: footer.separator,
+			values: separatorStyleValues,
+		},
+		{
+			id: "pathDisplay",
+			label: "Path display",
+			description: "Show cwd as basename or full path.",
+			currentValue: footer.pathDisplay.mode,
+			values: pathDisplayModeValues,
+		},
+		{
+			id: "pathDepth",
+			label: "Path depth",
+			description: "Trailing directories in full mode (0 = all).",
+			currentValue: String(footer.pathDisplay.depth),
+			values: pathDepthValues,
+		},
+	];
+}
+
+const nonGitSegmentKeys: FooterSegmentSettingId[] = [
+	"cwd",
+	"sessionName",
+	"runtime",
+	"modelInfo",
+	"context",
+	"tokens",
+	"cost",
+	"sessionDuration",
+	"username",
+	"time",
+	"os",
+	"packageVersion",
+];
+function footerSegmentSettingId(key: FooterSegmentSettingId): string {
+	return `${footerSegmentSettingPrefix}${key}`;
+}
+function isFooterSegmentSettingId(value: string): value is FooterSegmentSettingId {
+	return value in footerSegmentSettingLabels;
+}
+function footerSegmentSettingFromId(id: string): FooterSegmentSettingId | undefined {
+	if (!id.startsWith(footerSegmentSettingPrefix)) return undefined;
+	const key = id.slice(footerSegmentSettingPrefix.length);
+	return isFooterSegmentSettingId(key) ? key : undefined;
+}
+function buildSegmentsItems(config: PolishedTuiConfig): SettingItem[] {
+	const segments = config.components.footer.styles.starship.segments;
+	return nonGitSegmentKeys.map((key) => ({
+		id: footerSegmentSettingId(key),
+		label: footerSegmentSettingLabels[key],
+		description: footerSegmentSettingDescriptions[key],
+		currentValue: featureValue(segments[key]),
+		values: featureStateValues,
+	}));
+}
+function branchLengthValues(maxLength: GitBranchMaxLength): string[] {
+	const current = String(maxLength);
+	return branchLengthPresetValues.includes(current as never)
+		? [...branchLengthPresetValues]
+		: [current, ...branchLengthPresetValues];
+}
+function buildGitItems(config: PolishedTuiConfig): SettingItem[] {
+	const starship = config.components.footer.styles.starship;
+	const segment = (key: FooterSegmentSettingId): SettingItem => ({
+		id: footerSegmentSettingId(key),
+		label: footerSegmentSettingLabels[key],
+		description: footerSegmentSettingDescriptions[key],
+		currentValue: featureValue(starship.segments[key]),
+		values: featureStateValues,
+	});
+	return [
+		segment("gitBranch"),
+		{
+			id: "branchLength",
+			label: "Branch length",
+			description: "Full branch name or a visible-width limit.",
+			currentValue: String(starship.gitBranch.maxLength),
+			values: branchLengthValues(starship.gitBranch.maxLength),
+		},
+		segment("gitStatus"),
+		segment("gitCounts"),
+		segment("gitCommit"),
+		{
+			id: "gitCommitOnlyDetached",
+			label: "Commit only on detached HEAD",
+			description: "Only show commit when HEAD is detached.",
+			currentValue: featureValue(starship.gitCommit.onlyDetached),
+			values: featureStateValues,
+		},
+		{
+			id: "gitCommitShowTag",
+			label: "Show exact-match tag",
+			description: "Append an exact-match tag.",
+			currentValue: featureValue(starship.gitCommit.showTag),
+			values: featureStateValues,
+		},
+		segment("gitMetrics"),
+		{
+			id: "gitMetricsOnlyNonzero",
+			label: "Hide zero metrics",
+			description: "Hide zero added/deleted values.",
+			currentValue: featureValue(starship.gitMetrics.onlyNonzero),
+			values: featureStateValues,
+		},
+		{
+			id: "gitMetricsIgnoreSubmodules",
+			label: "Ignore submodules",
+			description: "Exclude submodule changes.",
+			currentValue: featureValue(starship.gitMetrics.ignoreSubmodules),
+			values: featureStateValues,
+		},
+	];
+}
 function thirdPartyStatusSettingId(key: string, kind: ThirdPartyStatusSettingKind): string {
 	return `${thirdPartyStatusSettingPrefix}${kind}:${key}`;
 }
-
 function thirdPartyStatusSettingFromId(
 	id: string,
 ): { kind: ThirdPartyStatusSettingKind; key: string } | undefined {
 	if (!id.startsWith(thirdPartyStatusSettingPrefix)) return undefined;
-	const rest = id.slice(thirdPartyStatusSettingPrefix.length);
-	const separatorIndex = rest.indexOf(":");
-	if (separatorIndex < 0) return undefined;
-
-	const kind = rest.slice(0, separatorIndex);
-	if (kind !== "placement" && kind !== "colorMode") return undefined;
-
-	return { kind, key: rest.slice(separatorIndex + 1) };
+	const [kind, ...key] = id.slice(thirdPartyStatusSettingPrefix.length).split(":");
+	return kind === "placement" || kind === "colorMode" ? { kind, key: key.join(":") } : undefined;
 }
-
-function buildItems(
-	section: SettingsSection,
+function buildExtensionsItems(
 	config: PolishedTuiConfig,
-	activeStatuses: ReadonlyMap<string, string>,
+	active: ReadonlyMap<string, string>,
 ): SettingItem[] {
-	if (section === "appearance") {
-		const items = (Object.keys(colorSettingLabels) as ColorSettingId[]).map((key) => ({
-			id: key,
-			label: colorSettingLabels[key],
-			description: colorSettingDescriptions[key],
-			currentValue: key === "starship" ? config.colorSources.starship : editorMessageValue(config),
-			values: colorSourceValues,
-		}));
-		return [
-			...items,
-			{
-				id: "separator",
-				label: "Separator",
-				description: "Choose the separator between default footer segments.",
-				currentValue: config.separator,
-				values: separatorStyleValues,
-			},
-			{
-				id: "iconMode",
-				label: "Icon mode",
-				description: "auto/nerd use Nerd Font glyphs; ascii uses plain fallbacks.",
-				currentValue: config.icons.mode,
-				values: iconModeValues,
-			},
-		];
-	}
-
-	if (section === "editor") {
-		const editorFeatureItem = (key: FeatureSettingId): SettingItem => ({
-			id: key,
-			label: featureSettingLabels[key],
-			description: featureSettingDescriptions[key],
-			currentValue: featureValue(config.features[key]),
-			values: featureStateValues,
-		});
-		const items: SettingItem[] = [
-			editorFeatureItem("editor"),
-			{
-				id: "editorStyle",
-				label: "Editor style",
-				description: "Use Zentui's polished rails or a compact metadata frame.",
-				currentValue: config.editorStyle,
-				values: editorStyleValues,
-			},
-		];
-		if (config.editorStyle === "minimalist") {
-			items.push(
-				{
-					id: "minimalistPathDisplay",
-					label: "Path",
-					description: "Show the cwd basename, repository-relative path, or full path.",
-					currentValue: config.editorStyles.minimalist.pathDisplay,
-					values: minimalistPathDisplayValues,
-				},
-				{
-					id: "minimalistContextFormat",
-					label: "Context text",
-					description: "Show context percent alone or with the total context window.",
-					currentValue: config.editorStyles.minimalist.contextFormat,
-					values: minimalistContextFormatValues,
-				},
-				{
-					id: "minimalistContextGauge",
-					label: "Context gauge",
-					description: "Add a compact gauge before the context text when space allows.",
-					currentValue: featureValue(config.editorStyles.minimalist.contextGauge),
-					values: featureStateValues,
-				},
-				{
-					id: "minimalistShowSessionName",
-					label: "Session name",
-					description: "Show the explicit Pi session name after the turn timer.",
-					currentValue: featureValue(config.editorStyles.minimalist.showSessionName),
-					values: featureStateValues,
-				},
-				{
-					id: "minimalistShowTimer",
-					label: "Timer",
-					description: "Show the current or completed turn duration.",
-					currentValue: featureValue(config.editorStyles.minimalist.showTimer),
-					values: featureStateValues,
-				},
-				{
-					id: "minimalistShowCost",
-					label: "Cost",
-					description: "Show session cost in the top border.",
-					currentValue: featureValue(config.editorStyles.minimalist.showCost),
-					values: featureStateValues,
-				},
-				{
-					id: "minimalistShowGit",
-					label: "Git",
-					description: "Show branch and working-tree state in the bottom border.",
-					currentValue: featureValue(config.editorStyles.minimalist.showGit),
-					values: featureStateValues,
-				},
-			);
-		}
-		items.push(
-			{
-				id: "editorBorderColorMode",
-				label: "Editor border color",
-				description: "Keep Zentui's configured border color or follow Pi's shell/thinking color.",
-				currentValue: config.editorBorderColorMode,
-				values: editorBorderColorModeValues,
-			},
-			{
-				id: "editorModelLabel",
-				label: "Editor model label",
-				description: "Show the model id or display name in the editor frame.",
-				currentValue: config.editorModelLabel,
-				values: modelLabelValues,
-			},
-			editorFeatureItem("copyFriendly"),
-			editorFeatureItem("viewportIndicators"),
-		);
-		items.push({
-			id: "fixedEditor",
-			label: "Fixed editor (experimental)",
-			description:
-				"Pin editor + footer at bottom while transcript scrolls. Uses alternate screen mode.",
-			currentValue: featureValue(config.fixedEditor.enabled),
-			values: featureStateValues,
-		});
-		if (config.fixedEditor.enabled) {
-			items.push({
-				id: "fixedEditorMouseScroll",
-				label: "Mouse scroll",
-				description:
-					"Scroll transcript with mouse wheel. Breaks native terminal selection and tmux scrollback.",
-				currentValue: featureValue(config.fixedEditor.mouseScroll),
-				values: featureStateValues,
-			});
-			items.push({
-				id: "fixedEditorCopyNotice",
-				label: "Copy notice",
-				description: "Show a 'Copied to clipboard' message when drag-selecting text.",
-				currentValue: featureValue(config.fixedEditor.copyNotice),
-				values: featureStateValues,
-			});
-		}
-		return items;
-	}
-
-	if (section === "footer") {
-		return [
-			{
-				id: "statusLine",
-				label: featureSettingLabels.statusLine,
-				description: featureSettingDescriptions.statusLine,
-				currentValue: featureValue(config.features.statusLine),
-				values: featureStateValues,
-			},
-			{
-				id: "responsiveFooter",
-				label: "Responsive footer",
-				description: "Reflow complete content, then use the compact template when space is tight.",
-				currentValue: featureValue(config.responsiveFooter),
-				values: featureStateValues,
-			},
-			{
-				id: "compactFooterMaxLines",
-				label: "Compact footer rows",
-				description:
-					"Maximum compact rows before remaining template content is cropped with an ellipsis.",
-				currentValue: String(config.compactFooterMaxLines),
-				values: [...compactFooterMaxLineValues],
-			},
-			{
-				id: "contextStyle",
-				label: "Context style",
-				description: "Render context as text, a gauge bar, or both.",
-				currentValue: config.contextStyle,
-				values: contextStyleValues,
-			},
-			{
-				id: "pathDisplay",
-				label: "Path display",
-				description: "Show cwd as basename or full path (home contracted to ~).",
-				currentValue: config.pathDisplay.mode,
-				values: pathDisplayModeValues,
-			},
-			{
-				id: "pathDepth",
-				label: "Path depth",
-				description:
-					"In full mode, trailing directories to show (0 = all, max 5). Ignored for basename.",
-				currentValue: String(config.pathDisplay.depth),
-				values: [...pathDepthValues],
-			},
-		];
-	}
-
-	const nonGitSegmentKeys: FooterSegmentSettingId[] = [
-		"cwd",
-		"sessionName",
-		"runtime",
-		"modelInfo",
-		"context",
-		"tokens",
-		"cost",
-		"sessionDuration",
-		"username",
-		"time",
-		"os",
-		"packageVersion",
-	];
-	if (section === "segments") {
-		return nonGitSegmentKeys.map((key) => ({
-			id: footerSegmentSettingId(key),
-			label: footerSegmentSettingLabels[key],
-			description: footerSegmentSettingDescriptions[key],
-			currentValue: featureValue(config.footerSegments[key]),
-			values: featureStateValues,
-		}));
-	}
-
-	if (section === "git") {
-		const segmentItem = (key: FooterSegmentSettingId): SettingItem => ({
-			id: footerSegmentSettingId(key),
-			label: footerSegmentSettingLabels[key],
-			description: footerSegmentSettingDescriptions[key],
-			currentValue: featureValue(config.footerSegments[key]),
-			values: featureStateValues,
-		});
-		return [
-			segmentItem("gitBranch"),
-			{
-				id: "branchLength",
-				label: "Branch length",
-				description: "Show the full branch name or truncate it to a preset visible width.",
-				currentValue: String(config.gitBranch.maxLength),
-				values: branchLengthValues(config.gitBranch.maxLength),
-			},
-			segmentItem("gitStatus"),
-			segmentItem("gitCounts"),
-			segmentItem("gitCommit"),
-			{
-				id: "gitCommitOnlyDetached",
-				label: "Commit only on detached HEAD",
-				description: "Show the commit segment only when HEAD is detached.",
-				currentValue: featureValue(config.gitCommit.onlyDetached),
-				values: featureStateValues,
-			},
-			{
-				id: "gitCommitShowTag",
-				label: "Show exact-match tag",
-				description: "Append an exact-match tag to the commit hash.",
-				currentValue: featureValue(config.gitCommit.showTag),
-				values: featureStateValues,
-			},
-			segmentItem("gitMetrics"),
-			{
-				id: "gitMetricsOnlyNonzero",
-				label: "Hide zero metrics",
-				description: "Hide zero added/deleted components and an all-zero metrics segment.",
-				currentValue: featureValue(config.gitMetrics.onlyNonzero),
-				values: featureStateValues,
-			},
-			{
-				id: "gitMetricsIgnoreSubmodules",
-				label: "Ignore submodules",
-				description: "Exclude submodule changes from Git line metrics.",
-				currentValue: featureValue(config.gitMetrics.ignoreSubmodules),
-				values: featureStateValues,
-			},
-		];
-	}
-
-	const defaultPlacementItem: SettingItem = {
+	const defaultItem: SettingItem = {
 		id: "extensionStatusDefaultPlacement",
 		label: "Default placement",
-		description: "Placement used for active statuses without a keyed override.",
-		currentValue: config.extensionStatuses.defaultPlacement,
+		description: "Placement for active statuses without an override.",
+		currentValue: config.components.footer.styles.starship.extensionStatuses.defaultPlacement,
 		values: extensionStatusPlacementValues,
 	};
-	const statuses = Array.from(activeStatuses.entries()).sort(([a], [b]) =>
-		a < b ? -1 : a > b ? 1 : 0,
-	);
-	if (statuses.length === 0) {
+	const statuses = [...active.entries()].sort(([a], [b]) => a.localeCompare(b));
+	if (!statuses.length)
 		return [
-			defaultPlacementItem,
+			defaultItem,
 			{
 				id: "noThirdPartyStatuses",
 				label: "No active statuses",
-				description: "This tab only lists statuses currently published through ctx.ui.setStatus().",
+				description: "Only statuses currently published through ctx.ui.setStatus().",
 				currentValue: "—",
 			},
 		];
-	}
-
 	return [
-		defaultPlacementItem,
+		defaultItem,
 		...statuses.flatMap(([key, value]) => {
-			const sanitizedText = sanitizeExtensionStatusText(value);
-			const description = sanitizedText ? `Current status: ${sanitizedText}` : undefined;
+			const sanitized = sanitizeExtensionStatusText(value);
+			const description = sanitized ? `Current status: ${sanitized}` : undefined;
 			return [
 				{
 					id: thirdPartyStatusSettingId(key, "placement"),
@@ -821,40 +810,68 @@ function buildItems(
 	];
 }
 
-function nextSection(section: SettingsSection): SettingsSection {
-	const currentIndex = settingsSections.indexOf(section);
-	return settingsSections[(currentIndex + 1) % settingsSections.length] ?? "appearance";
+function buildSectionItems(
+	section: SettingsSection,
+	config: PolishedTuiConfig,
+	active: ReadonlyMap<string, string>,
+): SettingItem[] {
+	switch (section) {
+		case "appearance":
+			return buildAppearanceItems(config);
+		case "editor":
+			return [
+				...buildEditorItems(config),
+				...(config.components.editor.style === "polished"
+					? buildPolishedEditorStyleItems(config)
+					: buildMinimalistEditorStyleItems(config)),
+			];
+		case "userMessages":
+			return [...buildUserMessagesItems(config), ...buildFramedUserMessageStyleItems(config)];
+		case "layout":
+			return buildLayoutItems(config);
+		case "footer":
+			return [...buildFooterItems(config), ...buildStarshipFooterStyleItems(config)];
+		case "segments":
+			return buildSegmentsItems(config);
+		case "git":
+			return buildGitItems(config);
+		case "extensions":
+			return buildExtensionsItems(config, active);
+	}
 }
 
-function previousSection(section: SettingsSection): SettingsSection {
-	const currentIndex = settingsSections.indexOf(section);
+function nextSection(section: SettingsSection): SettingsSection {
 	return (
-		settingsSections[(currentIndex - 1 + settingsSections.length) % settingsSections.length] ??
+		settingsSections[(settingsSections.indexOf(section) + 1) % settingsSections.length] ??
 		"appearance"
 	);
 }
-
+function previousSection(section: SettingsSection): SettingsSection {
+	return (
+		settingsSections[
+			(settingsSections.indexOf(section) - 1 + settingsSections.length) % settingsSections.length
+		] ?? "appearance"
+	);
+}
 function formatSectionTabs(
-	activeSection: SettingsSection,
+	active: SettingsSection,
 	theme: ExtensionContext["ui"]["theme"],
 	width: number,
 ): string {
-	const rendered = settingsSections.map((section) => {
-		const label = sectionLabels[section];
-		return section === activeSection ? theme.bold(label) : safeThemeFg(theme, "muted", label);
-	});
+	const rendered = settingsSections.map((section) =>
+		section === active
+			? theme.bold(sectionLabels[section])
+			: safeThemeFg(theme, "muted", sectionLabels[section]),
+	);
 	const full = `  ${rendered.join(safeThemeFg(theme, "muted", " / "))}`;
 	if (visibleWidth(full) <= width) return full;
-
-	const activeIndex = settingsSections.indexOf(activeSection);
-	return `  ${theme.bold(sectionLabels[activeSection])} (${activeIndex + 1}/${settingsSections.length})`;
+	return `  ${theme.bold(sectionLabels[active])} (${settingsSections.indexOf(active) + 1}/${settingsSections.length})`;
 }
-
 function withSectionFooter(lines: string[], theme: ExtensionContext["ui"]["theme"]): string[] {
-	const next = [...lines];
-	for (let index = next.length - 1; index >= 0; index -= 1) {
-		if (next[index]?.includes("Enter/Space")) {
-			next[index] = safeThemeFg(
+	const copy = [...lines];
+	for (let index = copy.length - 1; index >= 0; index -= 1) {
+		if (copy[index]?.includes("Enter/Space")) {
+			copy[index] = safeThemeFg(
 				theme,
 				"muted",
 				"  Enter/Space to change · Tab/Shift+Tab to switch sections · Esc to close",
@@ -862,182 +879,225 @@ function withSectionFooter(lines: string[], theme: ExtensionContext["ui"]["theme
 			break;
 		}
 	}
-	return next;
+	return copy;
 }
 
 export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCommandDeps): void {
+	const setEditor = (patch: EditorPatch, ctx: ExtensionContext): ApplyResult =>
+		deps.setEditorComponent?.(patch, ctx) ?? { applied: true };
+	const setMessages = (patch: UserMessagesPatch, ctx: ExtensionContext) => {
+		deps.setUserMessagesComponent?.(patch, ctx);
+	};
+	const setFooter = (patch: FooterPatch, ctx: ExtensionContext) => {
+		deps.setFooterComponent?.(patch, ctx);
+	};
+
 	pi.registerCommand("zentui", {
 		description: "Configure Zentui",
 		getArgumentCompletions: argumentCompletions,
 		handler: async (_args, ctx) => {
 			const args = typeof _args === "string" ? _args : "";
-
-			const formatCommand = parseFormatCommand(args);
-			if (formatCommand) {
+			const format = parseFormatCommand(args);
+			if (format) {
 				try {
-					deps.setFooterFormat(formatCommand.value ?? "", ctx);
+					deps.setFooterFormat(format.value ?? "", ctx);
 					deps.requestRender();
-					if (ctx.hasUI) {
-						if (formatCommand.value === undefined) {
-							ctx.ui.notify("Footer format cleared (using default layout)", "info");
-						} else {
-							ctx.ui.notify(`Footer format: ${formatCommand.value}`, "info");
-						}
-					}
-				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					if (ctx.hasUI) ctx.ui.notify(`Could not update footer format: ${message}`, "error");
-				}
-				return;
-			}
-
-			const directCommand = parseDirectFeatureCommand(args, deps.getConfig());
-			if (directCommand) {
-				try {
-					const result = deps.setUiFeatures(
-						{ [directCommand.feature]: directCommand.enabled },
-						ctx,
-					);
-					deps.requestRender();
-					if (ctx.hasUI) {
+					if (ctx.hasUI)
 						ctx.ui.notify(
-							featureNotification(
-								directCommand.feature,
-								featureValue(directCommand.enabled),
-								result,
-							),
+							format.value === undefined
+								? "Footer format cleared (using default layout)"
+								: `Footer format: ${format.value}`,
 							"info",
 						);
-					}
 				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					if (ctx.hasUI) ctx.ui.notify(`Could not update Zentui settings: ${message}`, "error");
+					if (ctx.hasUI)
+						ctx.ui.notify(
+							`Could not update footer format: ${error instanceof Error ? error.message : String(error)}`,
+							"error",
+						);
 				}
 				return;
 			}
 
-			const fixedEditorCommand = parseFixedEditorCommand(args, deps.getConfig());
-			if (fixedEditorCommand) {
+			// Fixed-editor aliases contain the word "editor", so they must be parsed
+			// before the generic editor operation.
+			const fixed = parseFixedEditorCommand(args, deps.getConfig());
+			if (fixed) {
 				try {
-					deps.setFixedEditor({ enabled: fixedEditorCommand.enabled }, ctx);
+					deps.setFixedEditor({ enabled: fixed.enabled }, ctx);
 					deps.requestRender();
-					if (ctx.hasUI) {
-						ctx.ui.notify(`Fixed editor: ${featureValue(fixedEditorCommand.enabled)}`, "info");
-					}
+					if (ctx.hasUI) ctx.ui.notify(`Fixed editor: ${featureValue(fixed.enabled)}`, "info");
 				} catch (error) {
-					const message = error instanceof Error ? error.message : String(error);
-					if (ctx.hasUI) ctx.ui.notify(`Could not update fixed editor: ${message}`, "error");
+					if (ctx.hasUI)
+						ctx.ui.notify(
+							`Could not update fixed editor: ${error instanceof Error ? error.message : String(error)}`,
+							"error",
+						);
 				}
 				return;
 			}
 
-			if (args.trim()) {
+			const direct = parseDirectOperation(args, deps.getConfig());
+			if (direct) {
+				try {
+					let result: ApplyResult = { applied: true };
+					let label = "";
+					switch (direct.kind) {
+						case "editor":
+							result = setEditor({ enabled: direct.enabled }, ctx);
+							label = "Editor";
+							break;
+						case "messages":
+							setMessages({ enabled: direct.enabled }, ctx);
+							label = "User messages";
+							break;
+						case "footer":
+							setFooter({ enabled: direct.enabled }, ctx);
+							label = "Footer";
+							break;
+						case "viewport":
+							result = setEditor({ viewportIndicators: direct.enabled }, ctx);
+							label = "Editor viewport indicators";
+							break;
+						case "copyRecipe":
+							deps.setCopyFriendlyRecipe?.(direct.enabled, ctx);
+							label = "Copy-friendly mode";
+							break;
+						case "editorCopy":
+							deps.setPolishedEditorStyle?.({ copyFriendly: direct.enabled }, ctx);
+							label = "Editor copy-friendly";
+							break;
+						case "messageCopy":
+							deps.setFramedUserMessagesStyle?.({ copyFriendly: direct.enabled }, ctx);
+							label = "Message copy-friendly";
+							break;
+					}
+					deps.requestRender();
+					if (ctx.hasUI)
+						ctx.ui.notify(
+							`${label}: ${featureValue(direct.enabled)}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+							"info",
+						);
+				} catch (error) {
+					if (ctx.hasUI)
+						ctx.ui.notify(
+							`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+							"error",
+						);
+				}
+				return;
+			}
+
+			const initialSection = directSection(args);
+			if (args.trim() && !initialSection) {
 				if (ctx.hasUI) ctx.ui.notify(usageText(), "warning");
 				return;
 			}
-
 			const mode = (ctx as typeof ctx & { mode?: string }).mode;
 			if (!ctx.hasUI || (mode !== undefined && mode !== "tui")) return;
 
 			await ctx.ui.custom<void>((tui, theme, _keybindings, done) => {
-				const settingsListTheme = deps.settingsListTheme ?? getSettingsListTheme();
-				let activeSection: SettingsSection = "appearance";
-				const applyFeatureChange = (id: FeatureSettingId, newValue: FeatureState) => {
-					const result = deps.setUiFeatures(featurePatch(id, newValue), ctx);
+				const listTheme = deps.settingsListTheme ?? getSettingsListTheme();
+				let activeSection = initialSection ?? "appearance";
+				let settingsList: SettingsList;
+				const notifyChange = (label: string, value: string) => {
 					deps.requestRender();
-					ctx.ui.notify(featureNotification(id, newValue, result), "info");
+					ctx.ui.notify(`${label}: ${value}`, "info");
 					tui.requestRender();
 				};
-				let settingsList: SettingsList;
-				const makeSettingsList = () =>
-					new SettingsList(
-						buildItems(activeSection, deps.getConfig(), deps.getActiveExtensionStatuses()),
+				const makeSettingsList = (focusId?: string): SettingsList => {
+					const items = buildSectionItems(
+						activeSection,
+						deps.getConfig(),
+						deps.getActiveExtensionStatuses(),
+					);
+					const list = new SettingsList(
+						items,
 						8,
-						settingsListTheme,
+						listTheme,
 						(id, newValue) => {
 							try {
-								if (isColorSettingId(id) && isColorSource(newValue)) {
-									deps.setColorSources(patchForSetting(id, newValue));
+								const enabled = isFeatureState(newValue) ? newValue === "enabled" : undefined;
+								if (id === "editorEnabled" && enabled !== undefined) {
+									done(undefined);
+									deps.sessionLifecycle.defer(() => {
+										try {
+											const result = setEditor({ enabled }, ctx);
+											deps.requestRender();
+											ctx.ui.notify(
+												`Editor: ${newValue}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+												"info",
+											);
+										} catch (error) {
+											ctx.ui.notify(
+												`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+												"error",
+											);
+										}
+									});
+									return;
+								}
+								if (
+									id === "editorStyle" &&
+									(newValue === "polished" || newValue === "minimalist")
+								) {
+									setEditor({ style: newValue }, ctx);
+									settingsList = makeSettingsList("editorStyle");
+									notifyChange("Editor style", newValue);
+									return;
+								}
+								if (id === "editorColorSource" && isColorSource(newValue)) {
+									setEditor({ colorSource: newValue }, ctx);
 									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(`${colorSettingLabels[id]}: ${newValue}`, "info");
-									tui.requestRender();
+									notifyChange("Editor colors", newValue);
+									return;
+								}
+								if (id === "editorModelLabel" && (newValue === "id" || newValue === "name")) {
+									setEditor({ modelLabel: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Editor model label", newValue);
+									return;
+								}
+								if (
+									id === "editorBorderColorMode" &&
+									(newValue === "static" || newValue === "adaptive")
+								) {
+									setEditor({ borderColorMode: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Editor border color", newValue);
+									return;
+								}
+								if (id === "editorViewportIndicators" && enabled !== undefined) {
+									setEditor({ viewportIndicators: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Editor viewport indicators", newValue);
+									return;
+								}
+								if (id === "polishedCopyFriendly" && enabled !== undefined) {
+									deps.setPolishedEditorStyle?.({ copyFriendly: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Copy-friendly", newValue);
 									return;
 								}
 
-								if (isFeatureSettingId(id) && isFeatureState(newValue)) {
-									if (id === "editor") {
-										done(undefined);
-										// Changing the editor component while ctx.ui.custom() is active clears the
-										// custom component without resolving it, leaving Pi's input loop stuck.
-										// Close the settings UI first, then apply the editor swap on the next tick.
-										const applyEditorChange = () => {
-											try {
-												applyFeatureChange(id, newValue);
-											} catch (error) {
-												const message = error instanceof Error ? error.message : String(error);
-												ctx.ui.notify(`Could not update Zentui settings: ${message}`, "error");
-											}
-										};
-										deps.sessionLifecycle.defer(applyEditorChange);
-										return;
-									}
-
-									applyFeatureChange(id, newValue);
-									settingsList.updateValue(id, newValue);
-									return;
-								}
-
-								if (isBoundedSettingId(id)) {
-									if (
-										id === "editorStyle" &&
-										(newValue === "polished" || newValue === "minimalist")
-									) {
-										if (!deps.setEditorStyle) return;
-										deps.setEditorStyle(newValue, ctx);
-										settingsList = makeSettingsList();
-										settingsList.handleInput("\x1b[B");
-										deps.requestRender();
-										ctx.ui.notify(`Editor style: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
+								if (id.startsWith("minimalist") && deps.setMinimalist) {
 									if (
 										id === "minimalistPathDisplay" &&
-										(newValue === "compact" || newValue === "project" || newValue === "full")
-									) {
-										if (!deps.setMinimalist) return;
-										deps.setMinimalist({ pathDisplay: newValue }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Minimalist path: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (
+										["compact", "project", "full"].includes(newValue)
+									)
+										deps.setMinimalist(
+											{ pathDisplay: newValue as MinimalistConfig["pathDisplay"] },
+											ctx,
+										);
+									else if (
 										id === "minimalistContextFormat" &&
-										(newValue === "percent" || newValue === "percent-total")
-									) {
-										if (!deps.setMinimalist) return;
-										deps.setMinimalist({ contextFormat: newValue }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Minimalist context text: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (
-										(id === "minimalistContextGauge" ||
-											id === "minimalistShowSessionName" ||
-											id === "minimalistShowTimer" ||
-											id === "minimalistShowCost" ||
-											id === "minimalistShowGit") &&
-										isFeatureState(newValue)
-									) {
-										if (!deps.setMinimalist) return;
+										["percent", "percent-total"].includes(newValue)
+									)
+										deps.setMinimalist(
+											{ contextFormat: newValue as MinimalistConfig["contextFormat"] },
+											ctx,
+										);
+									else if (enabled !== undefined) {
 										const key =
 											id === "minimalistContextGauge"
 												? "contextGauge"
@@ -1047,258 +1107,240 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 														? "showTimer"
 														: id === "minimalistShowCost"
 															? "showCost"
-															: "showGit";
-										deps.setMinimalist({ [key]: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`${id}: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "editorModelLabel" && (newValue === "id" || newValue === "name")) {
-										if (!deps.setEditorModelLabel) return;
-										deps.setEditorModelLabel(newValue, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Editor model label: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (
-										id === "editorBorderColorMode" &&
-										(newValue === "static" || newValue === "adaptive")
-									) {
-										if (!deps.setEditorBorderColorMode) return;
-										deps.setEditorBorderColorMode(newValue);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Editor border color: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "responsiveFooter" && isFeatureState(newValue)) {
-										deps.setResponsiveFooter?.({ responsiveFooter: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Responsive footer: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "compactFooterMaxLines") {
-										const maxLines = parseCompactFooterMaxLines(newValue);
-										if (maxLines === undefined) return;
-										deps.setResponsiveFooter?.({ compactFooterMaxLines: maxLines }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Compact footer rows: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "contextStyle" && isContextStyle(newValue)) {
-										deps.setContextStyle(newValue);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Context style: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "separator" && isSeparatorStyle(newValue)) {
-										deps.setSeparator(newValue);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Separator: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "pathDisplay" && isPathDisplayMode(newValue)) {
-										deps.setPathDisplay({ mode: newValue });
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Path display: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "pathDepth" && isPathDepthValue(newValue)) {
-										deps.setPathDisplay({ depth: Number(newValue) });
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Path depth: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "branchLength") {
-										const maxLength = parseGitBranchLengthValue(newValue);
-										if (maxLength === undefined) return;
-										deps.setGitBranch({ maxLength });
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Branch length: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "iconMode" && isIconMode(newValue)) {
-										deps.setIconMode(newValue);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Icon mode: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "gitCommitOnlyDetached" && isFeatureState(newValue)) {
-										if (!deps.setGitCommit) return;
-										deps.setGitCommit({ onlyDetached: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Commit only on detached HEAD: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "gitCommitShowTag" && isFeatureState(newValue)) {
-										if (!deps.setGitCommit) return;
-										deps.setGitCommit({ showTag: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Show exact-match tag: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "gitMetricsOnlyNonzero" && isFeatureState(newValue)) {
-										if (!deps.setGitMetrics) return;
-										deps.setGitMetrics({ onlyNonzero: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Hide zero metrics: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (id === "gitMetricsIgnoreSubmodules" && isFeatureState(newValue)) {
-										if (!deps.setGitMetrics) return;
-										deps.setGitMetrics({ ignoreSubmodules: newValue === "enabled" }, ctx);
-										settingsList.updateValue(id, newValue);
-										deps.requestRender();
-										ctx.ui.notify(`Ignore submodules: ${newValue}`, "info");
-										tui.requestRender();
-										return;
-									}
-
-									if (
-										id === "extensionStatusDefaultPlacement" &&
-										isExtensionStatusPlacement(newValue)
-									) {
-										if (!deps.setExtensionStatusDefaultPlacement) return;
-										deps.setExtensionStatusDefaultPlacement(newValue);
-										settingsList = makeSettingsList();
-										deps.requestRender();
-										ctx.ui.notify(`Default extension status placement: ${newValue}`, "info");
-										tui.requestRender();
-									}
-									return;
-								}
-
-								const footerSegmentSetting = footerSegmentSettingFromId(id);
-								if (footerSegmentSetting && isFeatureState(newValue)) {
-									deps.setFooterSegments(footerSegmentPatch(footerSegmentSetting, newValue), ctx);
+															: id === "minimalistShowGit"
+																? "showGit"
+																: undefined;
+										if (!key) return;
+										deps.setMinimalist({ [key]: enabled }, ctx);
+									} else return;
 									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(
-										`${footerSegmentSettingLabels[footerSegmentSetting]}: ${newValue}`,
-										"info",
-									);
-									tui.requestRender();
+									notifyChange(id, newValue);
 									return;
 								}
 
-								if (id === "fixedEditor" && isFeatureState(newValue)) {
-									deps.setFixedEditor({ enabled: newValue === "enabled" }, ctx);
-									settingsList = makeSettingsList();
-									deps.requestRender();
-									ctx.ui.notify(`Fixed editor: ${newValue}`, "info");
-									tui.requestRender();
+								if (id === "userMessagesEnabled" && enabled !== undefined) {
+									setMessages({ enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("User messages", newValue);
 									return;
 								}
-								if (id === "fixedEditorMouseScroll" && isFeatureState(newValue)) {
-									deps.setFixedEditor({ mouseScroll: newValue === "enabled" }, ctx);
+								if (id === "userMessagesStyle" && newValue === "framed") {
+									setMessages({ style: newValue }, ctx);
 									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(`Mouse scroll: ${newValue}`, "info");
-									tui.requestRender();
+									notifyChange("Message style", newValue);
 									return;
 								}
-								if (id === "fixedEditorCopyNotice" && isFeatureState(newValue)) {
-									deps.setFixedEditor({ copyNotice: newValue === "enabled" }, ctx);
+								if (id === "userMessagesColorSource" && isColorSource(newValue)) {
+									setMessages({ colorSource: newValue }, ctx);
 									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(`Copy notice: ${newValue}`, "info");
-									tui.requestRender();
+									notifyChange("Message colors", newValue);
+									return;
+								}
+								if (id === "framedUserMessagesCopyFriendly" && enabled !== undefined) {
+									deps.setFramedUserMessagesStyle?.({ copyFriendly: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Copy-friendly", newValue);
 									return;
 								}
 
-								const thirdPartyStatusSetting = thirdPartyStatusSettingFromId(id);
+								if (id === "selectorBordersEnabled" && enabled !== undefined) {
+									deps.setSelectorBordersComponent?.({ enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Selector borders", newValue);
+									return;
+								}
+								if (id === "selectorBordersStyle" && newValue === "zentui") {
+									deps.setSelectorBordersComponent?.({ style: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Selector border style", newValue);
+									return;
+								}
+								if (id === "selectorBordersColorSource" && isColorSource(newValue)) {
+									deps.setSelectorBordersComponent?.({ colorSource: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Selector border colors", newValue);
+									return;
+								}
+								if (id === "iconMode" && isIconMode(newValue)) {
+									deps.setIconMode(newValue);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Icon mode", newValue);
+									return;
+								}
+
+								if (id === "footerEnabled" && enabled !== undefined) {
+									setFooter({ enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Footer", newValue);
+									return;
+								}
+								if (id === "footerStyle" && newValue === "starship") {
+									setFooter({ style: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Footer style", newValue);
+									return;
+								}
+								if (id === "footerColorSource" && isColorSource(newValue)) {
+									setFooter({ colorSource: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Footer colors", newValue);
+									return;
+								}
+								if (id === "footerModelLabel" && (newValue === "id" || newValue === "name")) {
+									setFooter({ modelLabel: newValue }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Footer model label", newValue);
+									return;
+								}
+
+								if (id === "fixedEditor" && enabled !== undefined) {
+									deps.setFixedEditor({ enabled }, ctx);
+									settingsList = makeSettingsList("fixedEditor");
+									notifyChange("Fixed editor", newValue);
+									return;
+								}
+								if (id === "fixedEditorMouseScroll" && enabled !== undefined) {
+									deps.setFixedEditor({ mouseScroll: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Mouse scroll", newValue);
+									return;
+								}
+								if (id === "fixedEditorCopyNotice" && enabled !== undefined) {
+									deps.setFixedEditor({ copyNotice: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Copy notice", newValue);
+									return;
+								}
+
+								if (id === "responsiveFooter" && enabled !== undefined) {
+									deps.setResponsiveFooter?.({ responsiveFooter: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Responsive footer", newValue);
+									return;
+								}
 								if (
-									thirdPartyStatusSetting?.kind === "placement" &&
+									id === "compactFooterMaxLines" &&
+									compactFooterMaxLineValues.includes(newValue as never)
+								) {
+									const value: CompactFooterMaxLines =
+										newValue === "unlimited" ? "unlimited" : (Number(newValue) as 1 | 2 | 3);
+									deps.setResponsiveFooter?.({ compactFooterMaxLines: value }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Compact footer rows", newValue);
+									return;
+								}
+								if (
+									id === "contextStyle" &&
+									contextStyleValues.includes(newValue as ContextStyle)
+								) {
+									deps.setContextStyle(newValue as ContextStyle);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Context style", newValue);
+									return;
+								}
+								if (id === "separator" && isSeparatorStyle(newValue)) {
+									deps.setSeparator(newValue);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Separator", newValue);
+									return;
+								}
+								if (id === "pathDisplay" && pathDisplayModeValues.includes(newValue as never)) {
+									deps.setPathDisplay({ mode: newValue as PathDisplayConfig["mode"] });
+									settingsList.updateValue(id, newValue);
+									notifyChange("Path display", newValue);
+									return;
+								}
+								if (id === "pathDepth" && pathDepthValues.includes(newValue as never)) {
+									deps.setPathDisplay({ depth: Number(newValue) });
+									settingsList.updateValue(id, newValue);
+									notifyChange("Path depth", newValue);
+									return;
+								}
+
+								const segment = footerSegmentSettingFromId(id);
+								if (segment && enabled !== undefined) {
+									deps.setFooterSegments({ [segment]: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange(footerSegmentSettingLabels[segment], newValue);
+									return;
+								}
+								if (id === "branchLength") {
+									const value = newValue === "full" ? "full" : Number(newValue);
+									if (value !== "full" && (!Number.isInteger(value) || value <= 0)) return;
+									deps.setGitBranch({ maxLength: value });
+									settingsList.updateValue(id, newValue);
+									notifyChange("Branch length", newValue);
+									return;
+								}
+								if (id === "gitCommitOnlyDetached" && enabled !== undefined) {
+									deps.setGitCommit?.({ onlyDetached: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Commit only on detached HEAD", newValue);
+									return;
+								}
+								if (id === "gitCommitShowTag" && enabled !== undefined) {
+									deps.setGitCommit?.({ showTag: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Show exact-match tag", newValue);
+									return;
+								}
+								if (id === "gitMetricsOnlyNonzero" && enabled !== undefined) {
+									deps.setGitMetrics?.({ onlyNonzero: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Hide zero metrics", newValue);
+									return;
+								}
+								if (id === "gitMetricsIgnoreSubmodules" && enabled !== undefined) {
+									deps.setGitMetrics?.({ ignoreSubmodules: enabled }, ctx);
+									settingsList.updateValue(id, newValue);
+									notifyChange("Ignore submodules", newValue);
+									return;
+								}
+
+								if (
+									id === "extensionStatusDefaultPlacement" &&
 									isExtensionStatusPlacement(newValue)
 								) {
-									deps.setExtensionStatusPlacement(thirdPartyStatusSetting.key, newValue);
-									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(
-										`Third-party status ${thirdPartyStatusSetting.key} placement: ${newValue}`,
-										"info",
-									);
-									tui.requestRender();
+									deps.setExtensionStatusDefaultPlacement?.(newValue);
+									settingsList = makeSettingsList("extensionStatusDefaultPlacement");
+									notifyChange("Default extension status placement", newValue);
 									return;
 								}
-
-								if (
-									thirdPartyStatusSetting?.kind === "colorMode" &&
-									isExtensionStatusColorMode(newValue)
-								) {
-									deps.setExtensionStatusColorMode(thirdPartyStatusSetting.key, newValue);
+								const thirdParty = thirdPartyStatusSettingFromId(id);
+								if (thirdParty?.kind === "placement" && isExtensionStatusPlacement(newValue)) {
+									deps.setExtensionStatusPlacement(thirdParty.key, newValue);
 									settingsList.updateValue(id, newValue);
-									deps.requestRender();
-									ctx.ui.notify(
-										`Third-party status ${thirdPartyStatusSetting.key} color: ${newValue}`,
-										"info",
-									);
-									tui.requestRender();
+									notifyChange(`Third-party status ${thirdParty.key} placement`, newValue);
+									return;
+								}
+								if (thirdParty?.kind === "colorMode" && isExtensionStatusColorMode(newValue)) {
+									deps.setExtensionStatusColorMode(thirdParty.key, newValue);
+									settingsList.updateValue(id, newValue);
+									notifyChange(`Third-party status ${thirdParty.key} color`, newValue);
 								}
 							} catch (error) {
-								settingsList = makeSettingsList();
+								settingsList = makeSettingsList(id);
 								tui.requestRender();
-								const message = error instanceof Error ? error.message : String(error);
-								ctx.ui.notify(`Could not update Zentui settings: ${message}`, "error");
+								ctx.ui.notify(
+									`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+									"error",
+								);
 							}
 						},
 						() => done(undefined),
 					);
-				settingsList = makeSettingsList();
-				const switchSection = (direction: "forward" | "backward") => {
-					activeSection =
-						direction === "forward" ? nextSection(activeSection) : previousSection(activeSection);
-					settingsList = makeSettingsList();
-					tui.requestRender();
+					if (focusId) {
+						const target = items.findIndex((item) => item.id === focusId);
+						for (let index = 0; index < target; index += 1) list.handleInput("\x1b[B");
+					}
+					return list;
 				};
-
+				settingsList = makeSettingsList();
 				return {
 					render(width: number) {
-						const colorSource = deps.getConfig().colorSources.editor;
 						const border = renderChromeBorder(
 							theme,
-							colorSource,
+							deps.getConfig().components.editor.colorSource,
 							EDITOR_BORDER_STYLE,
 							"─".repeat(Math.max(0, width)),
 						);
@@ -1317,11 +1359,15 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 					},
 					handleInput(data: string) {
 						if (matchesKey(data, Key.tab)) {
-							switchSection("forward");
+							activeSection = nextSection(activeSection);
+							settingsList = makeSettingsList();
+							tui.requestRender();
 							return;
 						}
 						if (matchesKey(data, Key.shift("tab"))) {
-							switchSection("backward");
+							activeSection = previousSection(activeSection);
+							settingsList = makeSettingsList();
+							tui.requestRender();
 							return;
 						}
 						settingsList.handleInput(data);

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -23,6 +23,7 @@ import {
 	type FixedEditorConfig,
 	type FooterComponentConfig,
 	type FooterSegmentsConfig,
+	type FooterStyle,
 	type GitBranchConfig,
 	type GitBranchMaxLength,
 	type GitCommitConfig,
@@ -64,8 +65,8 @@ const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"];
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
 const editorStyleLabels: Record<EditorStyle, string> = {
-	polished: "Polished",
-	"polished-copy-friendly": "Polished (copy-friendly)",
+	opencode: "Opencode",
+	"opencode-copy-friendly": "Opencode (copy-friendly)",
 	minimalist: "Minimalist",
 };
 const editorStyleValues = Object.values(editorStyleLabels);
@@ -75,6 +76,12 @@ const userMessageStyleLabels: Record<UserMessageStyle, string> = {
 	labeled: "Labeled",
 };
 const userMessageStyleValues = Object.values(userMessageStyleLabels);
+const footerStyleLabels: Record<FooterStyle, string> = {
+	native: "Native",
+	starship: "Starship",
+	hidden: "Hidden",
+};
+const footerStyleValues = Object.values(footerStyleLabels);
 const minimalistPathDisplayValues = ["compact", "project", "full"];
 const minimalistContextFormatValues = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
@@ -103,9 +110,7 @@ type EditorPatch = Partial<
 type UserMessagesPatch = Partial<
 	Pick<UserMessagesComponentConfig, "enabled" | "style" | "colorSource">
 >;
-type FooterPatch = Partial<
-	Pick<FooterComponentConfig, "enabled" | "style" | "colorSource" | "modelLabel">
->;
+type FooterPatch = Partial<Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel">>;
 type ApplyResult = { applied: boolean; reason?: string };
 
 type SettingsCommandDeps = {
@@ -239,6 +244,14 @@ function editorStyleId(label: string): EditorStyle | undefined {
 		([, value]) => value === label,
 	)?.[0];
 }
+function footerStyleLabel(style: FooterStyle): string {
+	return footerStyleLabels[style];
+}
+function footerStyleId(label: string): FooterStyle | undefined {
+	return (Object.entries(footerStyleLabels) as Array<[FooterStyle, string]>).find(
+		([, value]) => value === label,
+	)?.[0];
+}
 function userMessageStyleLabel(style: UserMessageStyle): string {
 	return userMessageStyleLabels[style];
 }
@@ -301,7 +314,7 @@ function parseDirectOperation(
 	if (["footer", "statusline", "status", "status line"].includes(target)) {
 		return {
 			kind: "footer",
-			enabled: actionValue(action, config.components.footer.enabled),
+			enabled: actionValue(action, config.components.footer.style === "starship"),
 		};
 	}
 	return undefined;
@@ -399,7 +412,7 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 		{
 			id: "editorStyle",
 			label: "Editor style",
-			description: "Use polished rails or a compact minimalist frame.",
+			description: "Use Opencode rails or a compact minimalist frame.",
 			currentValue: editorStyleLabel(editor.style),
 			values: editorStyleValues,
 		},
@@ -548,36 +561,34 @@ function buildLayoutItems(config: PolishedTuiConfig): SettingItem[] {
 }
 function buildFooterItems(config: PolishedTuiConfig): SettingItem[] {
 	const footer = config.components.footer;
-	return [
-		{
-			id: "footerEnabled",
-			label: "Footer",
-			description: "Enable or disable Zentui's footer.",
-			currentValue: featureValue(footer.enabled),
-			values: featureStateValues,
-		},
+	const items: SettingItem[] = [
 		{
 			id: "footerStyle",
 			label: "Footer style",
-			description: "Choose the footer style.",
-			currentValue: footer.style,
-			values: ["starship"],
-		},
-		{
-			id: "footerColorSource",
-			label: "Footer colors",
-			description: "Use Pi theme colors or terminal palette styles.",
-			currentValue: footer.colorSource,
-			values: colorSourceValues,
-		},
-		{
-			id: "footerModelLabel",
-			label: "Footer model label",
-			description: "Show the model id or display name in the footer.",
-			currentValue: footer.modelLabel,
-			values: modelLabelValues,
+			description: "Use Pi's native footer, Zentui's Starship footer, or no footer rows.",
+			currentValue: footerStyleLabel(footer.style),
+			values: footerStyleValues,
 		},
 	];
+	if (footer.style === "starship") {
+		items.push(
+			{
+				id: "footerColorSource",
+				label: "Footer colors",
+				description: "Use Pi theme colors or terminal palette styles.",
+				currentValue: footer.colorSource,
+				values: colorSourceValues,
+			},
+			{
+				id: "footerModelLabel",
+				label: "Footer model label",
+				description: "Show the model id or display name in the footer.",
+				currentValue: footer.modelLabel,
+				values: modelLabelValues,
+			},
+		);
+	}
+	return items;
 }
 function buildStarshipFooterStyleItems(config: PolishedTuiConfig): SettingItem[] {
 	const footer = config.components.footer.styles.starship;
@@ -797,7 +808,12 @@ function buildSectionItems(
 		case "layout":
 			return buildLayoutItems(config);
 		case "footer":
-			return [...buildFooterItems(config), ...buildStarshipFooterStyleItems(config)];
+			return [
+				...buildFooterItems(config),
+				...(config.components.footer.style === "starship"
+					? buildStarshipFooterStyleItems(config)
+					: []),
+			];
 		case "segments":
 			return buildSegmentsItems(config);
 		case "git":
@@ -919,7 +935,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 							label = "User messages";
 							break;
 						case "footer":
-							setFooter({ enabled: direct.enabled }, ctx);
+							setFooter({ style: direct.enabled ? "starship" : "native" }, ctx);
 							label = "Footer";
 							break;
 						case "viewport":
@@ -1110,15 +1126,11 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									return;
 								}
 
-								if (id === "footerEnabled" && enabled !== undefined) {
-									setFooter({ enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Footer", newValue);
-									return;
-								}
-								if (id === "footerStyle" && newValue === "starship") {
-									setFooter({ style: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
+								const selectedFooterStyle =
+									id === "footerStyle" ? footerStyleId(newValue) : undefined;
+								if (selectedFooterStyle) {
+									setFooter({ style: selectedFooterStyle }, ctx);
+									settingsList = makeSettingsList("footerStyle");
 									notifyChange("Footer style", newValue);
 									return;
 								}

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -16,7 +16,7 @@ import {
 	type CompactFooterMaxLines,
 	type ContextStyle,
 	type EditorBorderColorMode,
-	type EditorMode,
+	type EditorStyle,
 	type ExtensionStatusColorMode,
 	type ExtensionStatusPlacement,
 	type FixedEditorConfig,
@@ -61,7 +61,7 @@ const pathDepthValues = ["0", "1", "2", "3", "4", "5"] as const;
 const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"] as const;
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
-const editorModeValues: EditorMode[] = ["polished", "minimalist"];
+const editorStyleValues: EditorStyle[] = ["polished", "minimalist"];
 const minimalistPathDisplayValues: MinimalistPathDisplayMode[] = ["compact", "project", "full"];
 const minimalistContextFormatValues: MinimalistContextFormat[] = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
@@ -91,10 +91,11 @@ type BoundedSettingId =
 	| "pathDepth"
 	| "branchLength"
 	| "iconMode"
-	| "editorMode"
+	| "editorStyle"
 	| "minimalistPathDisplay"
 	| "minimalistContextFormat"
 	| "minimalistContextGauge"
+	| "minimalistShowSessionName"
 	| "minimalistShowTimer"
 	| "minimalistShowCost"
 	| "minimalistShowGit"
@@ -125,7 +126,7 @@ type SettingsCommandDeps = {
 	setSeparator: (separator: SeparatorStyle) => void;
 	setPathDisplay: (patch: Partial<PathDisplayConfig>) => void;
 	setGitBranch: (patch: Partial<GitBranchConfig>) => void;
-	setEditorMode?: (value: EditorMode, ctx: ExtensionContext) => void;
+	setEditorStyle?: (value: EditorStyle, ctx: ExtensionContext) => void;
 	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
 	setEditorModelLabel?: (value: ModelLabelSource, ctx: ExtensionContext) => void;
 	setEditorBorderColorMode?: (value: EditorBorderColorMode) => void;
@@ -336,10 +337,11 @@ function isBoundedSettingId(value: string): value is BoundedSettingId {
 		value === "pathDepth" ||
 		value === "branchLength" ||
 		value === "iconMode" ||
-		value === "editorMode" ||
+		value === "editorStyle" ||
 		value === "minimalistPathDisplay" ||
 		value === "minimalistContextFormat" ||
 		value === "minimalistContextGauge" ||
+		value === "minimalistShowSessionName" ||
 		value === "minimalistShowTimer" ||
 		value === "minimalistShowCost" ||
 		value === "minimalistShowGit" ||
@@ -531,24 +533,77 @@ function buildItems(
 	}
 
 	if (section === "editor") {
-		const editorFeatures: FeatureSettingId[] = ["editor", "copyFriendly", "viewportIndicators"];
-		const items: SettingItem[] = editorFeatures.map((key) => ({
+		const editorFeatureItem = (key: FeatureSettingId): SettingItem => ({
 			id: key,
 			label: featureSettingLabels[key],
 			description: featureSettingDescriptions[key],
 			currentValue: featureValue(config.features[key]),
 			values: featureStateValues,
-		}));
-		items.splice(
-			1,
-			0,
+		});
+		const items: SettingItem[] = [
+			editorFeatureItem("editor"),
 			{
-				id: "editorMode",
-				label: "Editor mode",
+				id: "editorStyle",
+				label: "Editor style",
 				description: "Use Zentui's polished rails or a compact metadata frame.",
-				currentValue: config.editorMode,
-				values: editorModeValues,
+				currentValue: config.editorStyle,
+				values: editorStyleValues,
 			},
+		];
+		if (config.editorStyle === "minimalist") {
+			items.push(
+				{
+					id: "minimalistPathDisplay",
+					label: "Path",
+					description: "Show the cwd basename, repository-relative path, or full path.",
+					currentValue: config.editorStyles.minimalist.pathDisplay,
+					values: minimalistPathDisplayValues,
+				},
+				{
+					id: "minimalistContextFormat",
+					label: "Context text",
+					description: "Show context percent alone or with the total context window.",
+					currentValue: config.editorStyles.minimalist.contextFormat,
+					values: minimalistContextFormatValues,
+				},
+				{
+					id: "minimalistContextGauge",
+					label: "Context gauge",
+					description: "Add a compact gauge before the context text when space allows.",
+					currentValue: featureValue(config.editorStyles.minimalist.contextGauge),
+					values: featureStateValues,
+				},
+				{
+					id: "minimalistShowSessionName",
+					label: "Session name",
+					description: "Show the explicit Pi session name after the turn timer.",
+					currentValue: featureValue(config.editorStyles.minimalist.showSessionName),
+					values: featureStateValues,
+				},
+				{
+					id: "minimalistShowTimer",
+					label: "Timer",
+					description: "Show the current or completed turn duration.",
+					currentValue: featureValue(config.editorStyles.minimalist.showTimer),
+					values: featureStateValues,
+				},
+				{
+					id: "minimalistShowCost",
+					label: "Cost",
+					description: "Show session cost in the top border.",
+					currentValue: featureValue(config.editorStyles.minimalist.showCost),
+					values: featureStateValues,
+				},
+				{
+					id: "minimalistShowGit",
+					label: "Git",
+					description: "Show branch and working-tree state in the bottom border.",
+					currentValue: featureValue(config.editorStyles.minimalist.showGit),
+					values: featureStateValues,
+				},
+			);
+		}
+		items.push(
 			{
 				id: "editorBorderColorMode",
 				label: "Editor border color",
@@ -563,50 +618,8 @@ function buildItems(
 				currentValue: config.editorModelLabel,
 				values: modelLabelValues,
 			},
-		);
-		items.push(
-			{
-				id: "minimalistPathDisplay",
-				label: "Minimalist path",
-				description: "Show the cwd basename, repository-relative path, or full path.",
-				currentValue: config.minimalist.pathDisplay,
-				values: minimalistPathDisplayValues,
-			},
-			{
-				id: "minimalistContextFormat",
-				label: "Minimalist context text",
-				description: "Show context percent alone or with the total context window.",
-				currentValue: config.minimalist.contextFormat,
-				values: minimalistContextFormatValues,
-			},
-			{
-				id: "minimalistContextGauge",
-				label: "Minimalist context gauge",
-				description: "Add a compact gauge before the context text when space allows.",
-				currentValue: featureValue(config.minimalist.contextGauge),
-				values: featureStateValues,
-			},
-			{
-				id: "minimalistShowTimer",
-				label: "Minimalist timer",
-				description: "Show the current or completed turn duration.",
-				currentValue: featureValue(config.minimalist.showTimer),
-				values: featureStateValues,
-			},
-			{
-				id: "minimalistShowCost",
-				label: "Minimalist cost",
-				description: "Show session cost in the top border.",
-				currentValue: featureValue(config.minimalist.showCost),
-				values: featureStateValues,
-			},
-			{
-				id: "minimalistShowGit",
-				label: "Minimalist Git",
-				description: "Show branch and working-tree state in the bottom border.",
-				currentValue: featureValue(config.minimalist.showGit),
-				values: featureStateValues,
-			},
+			editorFeatureItem("copyFriendly"),
+			editorFeatureItem("viewportIndicators"),
 		);
 		items.push({
 			id: "fixedEditor",
@@ -977,14 +990,15 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 
 								if (isBoundedSettingId(id)) {
 									if (
-										id === "editorMode" &&
+										id === "editorStyle" &&
 										(newValue === "polished" || newValue === "minimalist")
 									) {
-										if (!deps.setEditorMode) return;
-										deps.setEditorMode(newValue, ctx);
-										settingsList.updateValue(id, newValue);
+										if (!deps.setEditorStyle) return;
+										deps.setEditorStyle(newValue, ctx);
+										settingsList = makeSettingsList();
+										settingsList.handleInput("\x1b[B");
 										deps.requestRender();
-										ctx.ui.notify(`Editor mode: ${newValue}`, "info");
+										ctx.ui.notify(`Editor style: ${newValue}`, "info");
 										tui.requestRender();
 										return;
 									}
@@ -1017,6 +1031,7 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 
 									if (
 										(id === "minimalistContextGauge" ||
+											id === "minimalistShowSessionName" ||
 											id === "minimalistShowTimer" ||
 											id === "minimalistShowCost" ||
 											id === "minimalistShowGit") &&
@@ -1026,11 +1041,13 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 										const key =
 											id === "minimalistContextGauge"
 												? "contextGauge"
-												: id === "minimalistShowTimer"
-													? "showTimer"
-													: id === "minimalistShowCost"
-														? "showCost"
-														: "showGit";
+												: id === "minimalistShowSessionName"
+													? "showSessionName"
+													: id === "minimalistShowTimer"
+														? "showTimer"
+														: id === "minimalistShowCost"
+															? "showCost"
+															: "showGit";
 										deps.setMinimalist({ [key]: newValue === "enabled" }, ctx);
 										settingsList.updateValue(id, newValue);
 										deps.requestRender();

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -23,7 +23,6 @@ import {
 	type FixedEditorConfig,
 	type FooterComponentConfig,
 	type FooterSegmentsConfig,
-	type FramedUserMessageStyleConfig,
 	type GitBranchConfig,
 	type GitBranchMaxLength,
 	type GitCommitConfig,
@@ -37,11 +36,11 @@ import {
 	type MinimalistConfig,
 	type ModelLabelSource,
 	type PathDisplayConfig,
-	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
 	type UiFeaturesConfig,
+	type UserMessageStyle,
 	type UserMessagesComponentConfig,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
@@ -64,7 +63,18 @@ const pathDepthValues = ["0", "1", "2", "3", "4", "5"];
 const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"];
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
 const modelLabelValues: ModelLabelSource[] = ["id", "name"];
-const editorStyleValues: EditorStyle[] = ["polished", "minimalist"];
+const editorStyleLabels: Record<EditorStyle, string> = {
+	polished: "Polished",
+	"polished-copy-friendly": "Polished (copy-friendly)",
+	minimalist: "Minimalist",
+};
+const editorStyleValues = Object.values(editorStyleLabels);
+const userMessageStyleLabels: Record<UserMessageStyle, string> = {
+	framed: "Framed",
+	compact: "Compact",
+	labeled: "Labeled",
+};
+const userMessageStyleValues = Object.values(userMessageStyleLabels);
 const minimalistPathDisplayValues = ["compact", "project", "full"];
 const minimalistContextFormatValues = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
@@ -102,22 +112,13 @@ type SettingsCommandDeps = {
 	sessionLifecycle: SessionLifecycle;
 	getConfig: () => PolishedTuiConfig;
 	setEditorComponent?: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
-	setPolishedEditorStyle?: (
-		patch: Partial<PolishedEditorStyleConfig>,
-		ctx: ExtensionContext,
-	) => void;
 	setMinimalist?: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
 	setUserMessagesComponent?: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
-	setFramedUserMessagesStyle?: (
-		patch: Partial<FramedUserMessageStyleConfig>,
-		ctx: ExtensionContext,
-	) => void;
 	setSelectorBordersComponent?: (
 		patch: Partial<SelectorBordersComponentConfig>,
 		ctx: ExtensionContext,
 	) => void;
 	setFooterComponent?: (patch: FooterPatch, ctx: ExtensionContext) => void;
-	setCopyFriendlyRecipe?: (enabled: boolean, ctx: ExtensionContext) => void;
 	setFooterSegments: (patch: Partial<FooterSegmentsConfig>, ctx: ExtensionContext) => void;
 	setFooterFormat: (value: string, ctx: ExtensionContext) => void;
 	setResponsiveFooter?: (
@@ -207,18 +208,9 @@ const directCommandSuggestions = [
 	"messages enable",
 	"messages disable",
 	"messages toggle",
-	"editor-copy-friendly enable",
-	"editor-copy-friendly disable",
-	"editor-copy-friendly toggle",
-	"message-copy-friendly enable",
-	"message-copy-friendly disable",
-	"message-copy-friendly toggle",
 	"statusline enable",
 	"statusline disable",
 	"statusline toggle",
-	"copy-friendly enable",
-	"copy-friendly disable",
-	"copy-friendly toggle",
 	"viewport-indicators enable",
 	"viewport-indicators disable",
 	"viewport-indicators toggle",
@@ -239,6 +231,22 @@ type ThirdPartyStatusSettingKind = "placement" | "colorMode";
 function featureValue(enabled: boolean): FeatureState {
 	return enabled ? "enabled" : "disabled";
 }
+function editorStyleLabel(style: EditorStyle): string {
+	return editorStyleLabels[style];
+}
+function editorStyleId(label: string): EditorStyle | undefined {
+	return (Object.entries(editorStyleLabels) as Array<[EditorStyle, string]>).find(
+		([, value]) => value === label,
+	)?.[0];
+}
+function userMessageStyleLabel(style: UserMessageStyle): string {
+	return userMessageStyleLabels[style];
+}
+function userMessageStyleId(label: string): UserMessageStyle | undefined {
+	return (Object.entries(userMessageStyleLabels) as Array<[UserMessageStyle, string]>).find(
+		([, value]) => value === label,
+	)?.[0];
+}
 function isFeatureState(value: string): value is FeatureState {
 	return value === "enabled" || value === "disabled";
 }
@@ -258,60 +266,42 @@ function normalizedWords(args: string): string[] {
 	return args.trim().toLowerCase().replaceAll(/[_-]+/g, " ").split(/\s+/g).filter(Boolean);
 }
 
-type DirectOperation =
-	| { kind: "editor" | "messages" | "footer" | "viewport"; enabled: boolean }
-	| { kind: "copyRecipe" | "editorCopy" | "messageCopy"; enabled: boolean };
+type DirectOperation = {
+	kind: "editor" | "messages" | "footer" | "viewport";
+	enabled: boolean;
+};
 
 function parseDirectOperation(
 	args: string,
 	config: PolishedTuiConfig,
 ): DirectOperation | undefined {
-	const raw = args.trim().toLowerCase();
 	const words = normalizedWords(args);
 	const action = parseAction(words);
 	if (!action) return undefined;
-	// Component-specific copy commands must win before the generic word-based aliases.
-	if (/^(editor[-_ ]copy[-_ ]friendly)\b/.test(raw)) {
-		return {
-			kind: "editorCopy",
-			enabled: actionValue(action, config.components.editor.styles.polished.copyFriendly),
-		};
-	}
-	if (/^(message[-_ ]copy[-_ ]friendly)\b/.test(raw)) {
-		return {
-			kind: "messageCopy",
-			enabled: actionValue(action, config.components.userMessages.styles.framed.copyFriendly),
-		};
-	}
-	const has = (word: string) => words.includes(word);
-	if (has("viewportindicators") || (has("viewport") && has("indicators"))) {
+	const actionWords = new Set(["enable", "enabled", "on", "disable", "disabled", "off", "toggle"]);
+	const target = words.filter((word) => !actionWords.has(word)).join(" ");
+	if (target === "viewportindicators" || target === "viewport indicators") {
 		return {
 			kind: "viewport",
 			enabled: actionValue(action, config.components.editor.viewportIndicators),
 		};
 	}
-	if (has("messages") || (has("user") && has("messages"))) {
+	if (target === "messages" || target === "user messages") {
 		return {
 			kind: "messages",
 			enabled: actionValue(action, config.components.userMessages.enabled),
 		};
 	}
-	if (has("editor")) {
+	if (target === "editor") {
 		return {
 			kind: "editor",
 			enabled: actionValue(action, config.components.editor.enabled),
 		};
 	}
-	if (has("footer") || has("statusline") || has("status")) {
+	if (["footer", "statusline", "status", "status line"].includes(target)) {
 		return {
 			kind: "footer",
 			enabled: actionValue(action, config.components.footer.enabled),
-		};
-	}
-	if (has("copyfriendly") || has("copy")) {
-		return {
-			kind: "copyRecipe",
-			enabled: actionValue(action, config.features.copyFriendly),
 		};
 	}
 	return undefined;
@@ -359,7 +349,7 @@ function argumentCompletions(prefix: string): AutocompleteItem[] | null {
 }
 
 function usageText(): string {
-	return "Usage: /zentui [editor|messages|statusline|copy-friendly|editor-copy-friendly|message-copy-friendly|viewport-indicators|fixed-editor] [enable|disable|toggle], /zentui [messages|user-messages|layout], or /zentui format <template>";
+	return "Usage: /zentui [editor|messages|statusline|viewport-indicators|fixed-editor] [enable|disable|toggle], /zentui [messages|user-messages|layout], or /zentui format <template>";
 }
 
 function buildAppearanceItems(config: PolishedTuiConfig): SettingItem[] {
@@ -410,7 +400,7 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 			id: "editorStyle",
 			label: "Editor style",
 			description: "Use polished rails or a compact minimalist frame.",
-			currentValue: editor.style,
+			currentValue: editorStyleLabel(editor.style),
 			values: editorStyleValues,
 		},
 		{
@@ -439,18 +429,6 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 			label: "Editor viewport indicators",
 			description: "Show Pi's native wrapped-row counts in editor borders.",
 			currentValue: featureValue(editor.viewportIndicators),
-			values: featureStateValues,
-		},
-	];
-}
-
-function buildPolishedEditorStyleItems(config: PolishedTuiConfig): SettingItem[] {
-	return [
-		{
-			id: "polishedCopyFriendly",
-			label: "Copy-friendly",
-			description: "Hide editor rail glyphs for cleaner native terminal selection.",
-			currentValue: featureValue(config.components.editor.styles.polished.copyFriendly),
 			values: featureStateValues,
 		},
 	];
@@ -525,8 +503,8 @@ function buildUserMessagesItems(config: PolishedTuiConfig): SettingItem[] {
 			id: "userMessagesStyle",
 			label: "Message style",
 			description: "Choose the previous-message style.",
-			currentValue: messages.style,
-			values: ["framed"],
+			currentValue: userMessageStyleLabel(messages.style),
+			values: userMessageStyleValues,
 		},
 		{
 			id: "userMessagesColorSource",
@@ -534,17 +512,6 @@ function buildUserMessagesItems(config: PolishedTuiConfig): SettingItem[] {
 			description: "Use Pi theme colors or terminal palette styles.",
 			currentValue: messages.colorSource,
 			values: colorSourceValues,
-		},
-	];
-}
-function buildFramedUserMessageStyleItems(config: PolishedTuiConfig): SettingItem[] {
-	return [
-		{
-			id: "framedUserMessagesCopyFriendly",
-			label: "Copy-friendly",
-			description: "Hide previous-message rail glyphs.",
-			currentValue: featureValue(config.components.userMessages.styles.framed.copyFriendly),
-			values: featureStateValues,
 		},
 	];
 }
@@ -821,12 +788,12 @@ function buildSectionItems(
 		case "editor":
 			return [
 				...buildEditorItems(config),
-				...(config.components.editor.style === "polished"
-					? buildPolishedEditorStyleItems(config)
-					: buildMinimalistEditorStyleItems(config)),
+				...(config.components.editor.style === "minimalist"
+					? buildMinimalistEditorStyleItems(config)
+					: []),
 			];
 		case "userMessages":
-			return [...buildUserMessagesItems(config), ...buildFramedUserMessageStyleItems(config)];
+			return buildUserMessagesItems(config);
 		case "layout":
 			return buildLayoutItems(config);
 		case "footer":
@@ -959,18 +926,6 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 							result = setEditor({ viewportIndicators: direct.enabled }, ctx);
 							label = "Editor viewport indicators";
 							break;
-						case "copyRecipe":
-							deps.setCopyFriendlyRecipe?.(direct.enabled, ctx);
-							label = "Copy-friendly mode";
-							break;
-						case "editorCopy":
-							deps.setPolishedEditorStyle?.({ copyFriendly: direct.enabled }, ctx);
-							label = "Editor copy-friendly";
-							break;
-						case "messageCopy":
-							deps.setFramedUserMessagesStyle?.({ copyFriendly: direct.enabled }, ctx);
-							label = "Message copy-friendly";
-							break;
 					}
 					deps.requestRender();
 					if (ctx.hasUI)
@@ -1037,11 +992,10 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									});
 									return;
 								}
-								if (
-									id === "editorStyle" &&
-									(newValue === "polished" || newValue === "minimalist")
-								) {
-									setEditor({ style: newValue }, ctx);
+								const selectedEditorStyle =
+									id === "editorStyle" ? editorStyleId(newValue) : undefined;
+								if (selectedEditorStyle) {
+									setEditor({ style: selectedEditorStyle }, ctx);
 									settingsList = makeSettingsList("editorStyle");
 									notifyChange("Editor style", newValue);
 									return;
@@ -1073,13 +1027,6 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									notifyChange("Editor viewport indicators", newValue);
 									return;
 								}
-								if (id === "polishedCopyFriendly" && enabled !== undefined) {
-									deps.setPolishedEditorStyle?.({ copyFriendly: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Copy-friendly", newValue);
-									return;
-								}
-
 								if (id.startsWith("minimalist") && deps.setMinimalist) {
 									if (
 										id === "minimalistPathDisplay" &&
@@ -1124,9 +1071,11 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									notifyChange("User messages", newValue);
 									return;
 								}
-								if (id === "userMessagesStyle" && newValue === "framed") {
-									setMessages({ style: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
+								const selectedMessageStyle =
+									id === "userMessagesStyle" ? userMessageStyleId(newValue) : undefined;
+								if (selectedMessageStyle) {
+									setMessages({ style: selectedMessageStyle }, ctx);
+									settingsList = makeSettingsList("userMessagesStyle");
 									notifyChange("Message style", newValue);
 									return;
 								}
@@ -1136,13 +1085,6 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 									notifyChange("Message colors", newValue);
 									return;
 								}
-								if (id === "framedUserMessagesCopyFriendly" && enabled !== undefined) {
-									deps.setFramedUserMessagesStyle?.({ copyFriendly: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Copy-friendly", newValue);
-									return;
-								}
-
 								if (id === "selectorBordersEnabled" && enabled !== undefined) {
 									deps.setSelectorBordersComponent?.({ enabled }, ctx);
 									settingsList.updateValue(id, newValue);

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -51,18 +51,27 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 	};
 }
 
+export function modelLabelFor(
+	state: Pick<FooterState, "modelId" | "modelName">,
+	source: ModelLabelSource,
+): string {
+	return source === "name"
+		? state.modelName || state.modelId || "no-model"
+		: state.modelId || "no-model";
+}
+
 export function syncState(
 	state: FooterState,
 	ctx: ExtensionContext,
 	cacheHitIcon: string,
-	modelLabelSource: ModelLabelSource,
 	telemetry: FooterTelemetry = {},
 ): void {
 	const totals = getUsageTotals(ctx);
 	const m = ctx.model;
 	state.modelId = m?.id ?? "";
 	state.modelName = m?.name ?? "";
-	state.modelLabel = (modelLabelSource === "name" ? m?.name || m?.id : m?.id) ?? "no-model";
+	// Retained as a compatibility snapshot only; production surfaces format from raw fields.
+	state.modelLabel = modelLabelFor(state, "id");
 	state.providerLabel = formatProviderLabel(ctx.model?.provider);
 	state.contextLabel = buildContextLabel(ctx);
 	state.tokenLabel = buildTokenLabel(totals, cacheHitIcon);

--- a/extensions/zentui/style.ts
+++ b/extensions/zentui/style.ts
@@ -282,6 +282,21 @@ export function renderThemeStyle(theme: ThemeLike, style: ColorSpec, text: strin
 	return safeThemeFg(theme, color, applyThemeModifiers(theme, tokens, text));
 }
 
+function renderStyleStrict(theme: ThemeLike, style: ColorSpec, text: string): string {
+	if (style.trim() === "") return text;
+	const styled = renderTerminalStyle(style, text);
+	return styled === text ? theme.fg(style, text) : styled;
+}
+
+function renderThemeStyleStrict(theme: ThemeLike, style: ColorSpec, text: string): string {
+	const trimmed = style.trim();
+	if (trimmed === "") return text;
+	const tokens = trimmed.split(/\s+/).filter(Boolean);
+	if (tokens.some(isExplicitTerminalColorToken)) return renderTerminalStyle(style, text);
+	const color = mapThemeColor(tokens) ?? "text";
+	return theme.fg(color, applyThemeModifiers(theme, tokens, text));
+}
+
 export function renderStyleForSource(
 	theme: ThemeLike,
 	source: ColorSource,
@@ -302,6 +317,20 @@ export function renderStyleForSourceOrFallback(
 ): string {
 	const fallbackStyle = typeof fallback === "string" ? fallback : fallback[source];
 	return renderStyleForSource(theme, source, style ?? fallbackStyle, text);
+}
+
+export function renderStyleForSourceOrFallbackStrict(
+	theme: ThemeLike,
+	source: ColorSource,
+	style: ColorSpec | undefined,
+	fallback: ColorSpec | SourceStyleFallback,
+	text: string,
+): string {
+	const fallbackStyle = typeof fallback === "string" ? fallback : fallback[source];
+	const resolvedStyle = style ?? fallbackStyle;
+	return source === "terminal"
+		? renderStyleStrict(theme, resolvedStyle, text)
+		: renderThemeStyleStrict(theme, resolvedStyle, text);
 }
 
 export function renderEditorAccent(text: string): string {

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -27,6 +27,7 @@ type ViewportCounts = {
 
 type PolishedFrameSplit = {
 	editorLines: string[];
+	/** Logical, unframed autocomplete payload rows owned by this module. */
 	trailingLines: string[];
 	viewport: ViewportCounts;
 };
@@ -161,15 +162,15 @@ function fillLine(content: string, width: number): string {
 }
 
 function isLowRailPolishedStyle(style: EditorStyle): boolean {
-	return style === "polished-copy-friendly";
+	return style === "opencode-copy-friendly";
 }
 
 function selectedPolishedConfig(config: ZentuiConfig) {
 	switch (config.components.editor.style) {
-		case "polished":
-			return config.components.editor.styles.polished;
-		case "polished-copy-friendly":
-			return config.components.editor.styles["polished-copy-friendly"];
+		case "opencode":
+			return config.components.editor.styles.opencode;
+		case "opencode-copy-friendly":
+			return config.components.editor.styles["opencode-copy-friendly"];
 		case "minimalist":
 			return undefined;
 	}
@@ -303,12 +304,11 @@ function splitPolishedFrame(
 	uiTheme: Theme,
 ): PolishedFrameSplit | undefined {
 	if (!parseEditorBorder(lines[0] ?? "", "above")) return undefined;
+
 	for (let bottomIndex = lines.length - 1; bottomIndex >= 4; bottomIndex--) {
 		if (!parseEditorBorder(lines[bottomIndex] ?? "", "below")) continue;
 		const frame = unwrapPolishedFrameOnly(lines.slice(0, bottomIndex + 1), config, uiTheme);
-		if (frame) {
-			return { ...frame, trailingLines: lines.slice(bottomIndex + 1) };
-		}
+		if (frame) return { ...frame, trailingLines: lines.slice(bottomIndex + 1) };
 	}
 	return undefined;
 }
@@ -479,7 +479,7 @@ function renderPolishedFrame({
 	};
 	const meta = renderEditorMetadataFormat(
 		selectedPolishedConfig(config)?.metadataFormat ??
-			config.components.editor.styles.polished.metadataFormat,
+			config.components.editor.styles.opencode.metadataFormat,
 		{
 			model: modelMeta.modelLabel,
 			modelId: modelMeta.modelId ?? "",
@@ -556,7 +556,7 @@ function renderPolishedFrame({
 		rows: Object.freeze([...clamped]),
 		split: {
 			editorLines,
-			trailingLines: autocompleteLines.length > 0 ? clamped.slice(-autocompleteLines.length) : [],
+			trailingLines: autocompleteLines,
 			viewport,
 		},
 	});
@@ -630,9 +630,9 @@ export class PolishedEditor extends CustomEditor {
 
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
-		const rendered = super.render(innerWidth);
 		try {
-			return renderPolishedFrame({
+			const rendered = super.render(innerWidth);
+			const result = renderPolishedFrame({
 				width,
 				baseRendered: rendered,
 				autocompleteSource: this as unknown as AutocompleteEditorInternals,
@@ -642,10 +642,12 @@ export class PolishedEditor extends CustomEditor {
 				thinkingLevel: this.getThinkingLevel(),
 				trustedBaseFrame: true,
 				borderColor: this.borderColor,
-			}).lines;
+			});
+			if (result.decorated) return result.lines;
 		} catch {
-			return clampRenderedLines(rendered, width);
+			// Decoration is optional; re-render the base at the caller's width below.
 		}
+		return clampRenderedLines(super.render(width), width);
 	}
 }
 

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -10,6 +10,7 @@ import {
 } from "@earendil-works/pi-tui";
 import type { PolishedTuiConfig } from "./config";
 import { renderEditorMetadataFormat } from "./editor-metadata-format";
+import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
 import {
 	EDITOR_ACCENT_FALLBACK,
 	EDITOR_BORDER_FALLBACK,
@@ -88,6 +89,19 @@ type PolishedFrameOptions = {
 };
 
 type PolishedFrameResult = { lines: string[]; decorated: boolean };
+
+type MinimalistFrameAdapterOptions = {
+	width: number;
+	baseRendered: string[];
+	autocompleteSource: AutocompleteEditorInternals;
+	uiTheme: Theme;
+	config: PolishedTuiConfig;
+	inputText: string;
+	metadata: MinimalistEditorMetadata;
+	ownedFrame?: PolishedFrameSplit;
+	trustedBaseFrame?: boolean;
+	borderColor?: (text: string) => string;
+};
 
 type AutocompleteCount = { known: true; count: number } | { known: false };
 
@@ -283,6 +297,26 @@ function splitPolishedFrame(
 	return undefined;
 }
 
+function inspectPolishedFrameProvenance(
+	base: WrappedEditor,
+	rendered: string[],
+	config: PolishedTuiConfig,
+	uiTheme: Theme,
+): { safe: boolean; ownedFrame?: PolishedFrameSplit } {
+	const provenance = POLISHED_FRAME_SPLITS.get(rendered);
+	const provenanceMatches = Boolean(
+		provenance &&
+			provenance.rows.length === rendered.length &&
+			provenance.rows.every((line, index) => line === rendered[index]),
+	);
+	const ownedFrame = provenanceMatches ? provenance?.split : undefined;
+	const unsafe =
+		Boolean(provenance && !provenanceMatches) ||
+		LEGACY_SPLIT_POLISHED_FRAME in base ||
+		(!ownedFrame && Boolean(splitPolishedFrame(rendered, config, uiTheme)));
+	return { safe: !unsafe, ownedFrame };
+}
+
 function vimModeColor(mode: string): string {
 	switch (mode.toLowerCase()) {
 		case "insert":
@@ -307,6 +341,62 @@ function readVimStatus(editor: WrappedEditor, uiTheme: Theme): string | undefine
 	if (!normalized) return undefined;
 	const label = `${normalized.toUpperCase()} `;
 	return safeThemeFg(uiTheme, vimModeColor(normalized), label);
+}
+
+function renderMinimalistFrameFromBase({
+	width,
+	baseRendered,
+	autocompleteSource,
+	uiTheme,
+	config,
+	inputText,
+	metadata,
+	ownedFrame,
+	trustedBaseFrame = false,
+	borderColor,
+}: MinimalistFrameAdapterOptions): PolishedFrameResult {
+	if (width <= 4 || baseRendered.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	if (ownedFrame && !isPolishedFrameSplit(ownedFrame, baseRendered.length)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const autocomplete = ownedFrame
+		? { known: true as const, count: ownedFrame.trailingLines.length }
+		: readAutocompleteCount(autocompleteSource, Math.max(0, width - 4), baseRendered.length);
+	if (!autocomplete.known) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const editorFrame =
+		!ownedFrame && autocomplete.count > 0
+			? baseRendered.slice(0, -autocomplete.count)
+			: baseRendered;
+	const autocompleteLines = ownedFrame
+		? ownedFrame.trailingLines
+		: autocomplete.count > 0
+			? baseRendered.slice(-autocomplete.count)
+			: [];
+	if (editorFrame.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const parsedTop = parseEditorBorder(editorFrame[0] ?? "", "above");
+	const parsedBottom = parseEditorBorder(editorFrame.at(-1) ?? "", "below");
+	if (!ownedFrame && !trustedBaseFrame && (!parsedTop || !parsedBottom)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	return {
+		lines: renderMinimalistFrame({
+			width,
+			editorLines: ownedFrame?.editorLines ?? editorFrame.slice(1, -1),
+			autocompleteLines,
+			inputText,
+			metadata,
+			uiTheme,
+			config,
+			borderColor,
+		}),
+		decorated: true,
+	};
 }
 
 function renderPolishedFrame({
@@ -451,6 +541,8 @@ function renderPolishedFrame({
 export class PolishedEditor extends CustomEditor {
 	private readonly getModelMeta: () => EditorMeta;
 	private readonly getThinkingLevel: () => string | undefined;
+	private readonly getMinimalistMetadata: () => MinimalistEditorMetadata;
+	private readonly onMinimalistDecorationChange: (active: boolean) => void;
 	private readonly getConfig: () => PolishedTuiConfig;
 	private readonly uiTheme: Theme;
 
@@ -462,6 +554,8 @@ export class PolishedEditor extends CustomEditor {
 		getConfig: () => PolishedTuiConfig,
 		getModelMeta: () => EditorMeta,
 		getThinkingLevel: () => string | undefined,
+		getMinimalistMetadata: () => MinimalistEditorMetadata = () => ({ cwd: "" }),
+		onMinimalistDecorationChange: (active: boolean) => void = () => {},
 	) {
 		super(tui, theme, keybindings, { paddingX: 0 });
 		this.borderColor = (text: string) => safeThemeFg(uiTheme, "border", text);
@@ -469,14 +563,46 @@ export class PolishedEditor extends CustomEditor {
 		this.getConfig = getConfig;
 		this.getModelMeta = getModelMeta;
 		this.getThinkingLevel = getThinkingLevel;
+		this.getMinimalistMetadata = getMinimalistMetadata;
+		this.onMinimalistDecorationChange = onMinimalistDecorationChange;
+	}
+
+	private reportMinimalistDecoration(active: boolean): void {
+		this.onMinimalistDecorationChange(active);
 	}
 
 	render(width: number): string[] {
+		const config = this.getConfig();
+		if (config.editorMode === "minimalist") {
+			if (width <= 4) {
+				this.reportMinimalistDecoration(false);
+				return clampRenderedLines(super.render(width), width);
+			}
+			try {
+				const rendered = super.render(Math.max(0, width - 4));
+				const result = renderMinimalistFrameFromBase({
+					width,
+					baseRendered: rendered,
+					autocompleteSource: this as unknown as AutocompleteEditorInternals,
+					uiTheme: this.uiTheme,
+					config,
+					inputText: this.getText(),
+					metadata: this.getMinimalistMetadata(),
+					trustedBaseFrame: true,
+					borderColor: this.borderColor,
+				});
+				this.reportMinimalistDecoration(result.decorated);
+				return result.lines;
+			} catch {
+				this.reportMinimalistDecoration(false);
+				return clampRenderedLines(super.render(width), width);
+			}
+		}
+		this.reportMinimalistDecoration(false);
 		if (width <= 2) {
 			return clampRenderedLines(super.render(width), width);
 		}
 
-		const config = this.getConfig();
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
 		const rendered = super.render(innerWidth);
@@ -511,6 +637,8 @@ export class WrappedPolishedEditor implements EditorComponent {
 		private readonly getConfig: () => PolishedTuiConfig,
 		private readonly getModelMeta: () => EditorMeta,
 		private readonly getThinkingLevel: () => string | undefined,
+		private readonly getMinimalistMetadata: () => MinimalistEditorMetadata = () => ({ cwd: "" }),
+		private readonly onMinimalistDecorationChange: (active: boolean) => void = () => {},
 	) {
 		if (typeof base.addToHistory === "function") {
 			this.addToHistory = (text) => base.addToHistory?.(text);
@@ -606,10 +734,57 @@ export class WrappedPolishedEditor implements EditorComponent {
 		this.base.disableSubmit = value;
 	}
 
+	private reportMinimalistDecoration(active: boolean): void {
+		this.onMinimalistDecorationChange(active);
+	}
+
 	render(width: number): string[] {
+		const config = this.getConfig();
+		if (config.editorMode === "minimalist") {
+			if (width <= 4) {
+				this.reportMinimalistDecoration(false);
+				return clampRenderedLines(this.base.render(width), width);
+			}
+			let rendered: string[];
+			try {
+				rendered = this.base.render(Math.max(0, width - 4));
+			} catch {
+				this.reportMinimalistDecoration(false);
+				return clampRenderedLines(this.base.render(width), width);
+			}
+			try {
+				const provenance = inspectPolishedFrameProvenance(
+					this.base,
+					rendered,
+					config,
+					this.uiTheme,
+				);
+				if (provenance.safe) {
+					const result = renderMinimalistFrameFromBase({
+						width,
+						baseRendered: rendered,
+						autocompleteSource: this.base,
+						uiTheme: this.uiTheme,
+						config,
+						inputText: this.base.getText(),
+						metadata: this.getMinimalistMetadata(),
+						ownedFrame: provenance.ownedFrame,
+						borderColor: this.borderColor,
+					});
+					if (result.decorated) {
+						this.reportMinimalistDecoration(true);
+						return result.lines;
+					}
+				}
+			} catch {
+				// Decoration is optional; re-render the base at the caller's width below.
+			}
+			this.reportMinimalistDecoration(false);
+			return clampRenderedLines(this.base.render(width), width);
+		}
+		this.reportMinimalistDecoration(false);
 		if (width <= 2) return clampRenderedLines(this.base.render(width), width);
 
-		const config = this.getConfig();
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
 		let rendered: string[];
@@ -620,18 +795,8 @@ export class WrappedPolishedEditor implements EditorComponent {
 		}
 		let result: PolishedFrameResult | undefined;
 		try {
-			const provenance = POLISHED_FRAME_SPLITS.get(rendered);
-			const provenanceMatches = Boolean(
-				provenance &&
-					provenance.rows.length === rendered.length &&
-					provenance.rows.every((line, index) => line === rendered[index]),
-			);
-			const ownedFrame = provenanceMatches ? provenance?.split : undefined;
-			const hasMutatedProvenance = Boolean(provenance && !provenanceMatches);
-			const hasUntrustedLegacySplitter = LEGACY_SPLIT_POLISHED_FRAME in this.base;
-			const hasUnprovenPolishedFrame =
-				!ownedFrame && Boolean(splitPolishedFrame(rendered, config, this.uiTheme));
-			if (!hasMutatedProvenance && !hasUntrustedLegacySplitter && !hasUnprovenPolishedFrame) {
+			const provenance = inspectPolishedFrameProvenance(this.base, rendered, config, this.uiTheme);
+			if (provenance.safe) {
 				result = renderPolishedFrame({
 					width,
 					baseRendered: rendered,
@@ -641,7 +806,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 					modelMeta: this.getModelMeta(),
 					thinkingLevel: this.getThinkingLevel(),
 					rightStatus: readVimStatus(this.base, this.uiTheme),
-					ownedFrame,
+					ownedFrame: provenance.ownedFrame,
 					borderColor: this.borderColor,
 				});
 			}

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -8,7 +8,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import type { PolishedTuiConfig } from "./config";
+import type { ZentuiConfig } from "./config";
 import { renderEditorMetadataFormat } from "./editor-metadata-format";
 import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
 import {
@@ -79,7 +79,7 @@ type PolishedFrameOptions = {
 	baseRendered: string[];
 	autocompleteSource: AutocompleteEditorInternals;
 	uiTheme: Theme;
-	config: PolishedTuiConfig;
+	config: ZentuiConfig;
 	modelMeta: EditorMeta;
 	thinkingLevel: string | undefined;
 	rightStatus?: string;
@@ -95,7 +95,7 @@ type MinimalistFrameAdapterOptions = {
 	baseRendered: string[];
 	autocompleteSource: AutocompleteEditorInternals;
 	uiTheme: Theme;
-	config: PolishedTuiConfig;
+	config: ZentuiConfig;
 	inputText: string;
 	metadata: MinimalistEditorMetadata;
 	ownedFrame?: PolishedFrameSplit;
@@ -160,12 +160,12 @@ function fillLine(content: string, width: number): string {
 	return `${truncated}${pad}`;
 }
 
-function copyFriendlyPrompt(config: PolishedTuiConfig, uiTheme: Theme, reset: string): string {
+function copyFriendlyPrompt(config: ZentuiConfig, uiTheme: Theme, reset: string): string {
 	const promptIcon = config.icons.editorPrompt;
 	return promptIcon
 		? `${renderStyleForSourceOrFallback(
 				uiTheme,
-				config.colorSources.editor,
+				config.components.editor.colorSource,
 				config.colors.editorPrompt ?? config.colors.editorAccent,
 				EDITOR_ACCENT_FALLBACK,
 				promptIcon,
@@ -173,13 +173,13 @@ function copyFriendlyPrompt(config: PolishedTuiConfig, uiTheme: Theme, reset: st
 		: "";
 }
 
-function getEditorChromeWidths(config: PolishedTuiConfig, uiTheme: Theme, reset: string) {
+function getEditorChromeWidths(config: ZentuiConfig, uiTheme: Theme, reset: string) {
 	const prompt = copyFriendlyPrompt(config, uiTheme, reset);
-	const rail = config.features.copyFriendly
+	const rail = config.components.editor.styles.polished.copyFriendly
 		? ""
 		: `${renderStyleForSourceOrFallback(
 				uiTheme,
-				config.colorSources.editor,
+				config.components.editor.colorSource,
 				config.colors.editorAccent,
 				EDITOR_ACCENT_FALLBACK,
 				config.icons.rail,
@@ -188,7 +188,9 @@ function getEditorChromeWidths(config: PolishedTuiConfig, uiTheme: Theme, reset:
 		prompt,
 		promptWidth: visibleWidth(prompt),
 		rail,
-		railWidth: config.features.copyFriendly ? visibleWidth(prompt) : visibleWidth(rail),
+		railWidth: config.components.editor.styles.polished.copyFriendly
+			? visibleWidth(prompt)
+			: visibleWidth(rail),
 	};
 }
 
@@ -237,7 +239,7 @@ function renderEditorBorder(
 
 function unwrapPolishedFrameOnly(
 	lines: string[],
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	uiTheme: Theme,
 ): { editorLines: string[]; viewport: ViewportCounts } | undefined {
 	if (lines.length < 5) return undefined;
@@ -249,7 +251,7 @@ function unwrapPolishedFrameOnly(
 	const interior = lines.slice(1, -1);
 	if (interior.length < 3) return undefined;
 
-	if (config.features.copyFriendly) {
+	if (config.components.editor.styles.polished.copyFriendly) {
 		if (
 			plainRenderedText(interior[0] ?? "").trim() !== "" ||
 			plainRenderedText(interior.at(-2) ?? "").trim() !== "" ||
@@ -283,7 +285,7 @@ function unwrapPolishedFrameOnly(
 
 function splitPolishedFrame(
 	lines: string[],
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	uiTheme: Theme,
 ): PolishedFrameSplit | undefined {
 	if (!parseEditorBorder(lines[0] ?? "", "above")) return undefined;
@@ -300,7 +302,7 @@ function splitPolishedFrame(
 function inspectPolishedFrameProvenance(
 	base: WrappedEditor,
 	rendered: string[],
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 	uiTheme: Theme,
 ): { safe: boolean; ownedFrame?: PolishedFrameSplit } {
 	const provenance = POLISHED_FRAME_SPLITS.get(rendered);
@@ -393,7 +395,7 @@ function renderMinimalistFrameFromBase({
 			width,
 			editorLines: ownedFrame?.editorLines ?? editorFrame.slice(1, -1),
 			autocompleteLines,
-			viewport: config.features.viewportIndicators ? viewport : undefined,
+			viewport: config.components.editor.viewportIndicators ? viewport : undefined,
 			inputText,
 			metadata,
 			uiTheme,
@@ -420,7 +422,7 @@ function renderPolishedFrame({
 	if (width <= 2) return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 
 	const reset = "\x1b[0m";
-	const colorSource = config.colorSources.editor;
+	const colorSource = config.components.editor.colorSource;
 	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
 	const innerWidth = Math.max(0, width - railWidth);
 	const copyFriendlyContinuation = " ".repeat(promptWidth);
@@ -462,7 +464,7 @@ function renderPolishedFrame({
 		below: parsedBottom?.count,
 	};
 	const meta = renderEditorMetadataFormat(
-		config.editorMetadataFormat,
+		config.components.editor.styles.polished.metadataFormat,
 		{
 			model: modelMeta.modelLabel,
 			modelId: modelMeta.modelId ?? "",
@@ -486,7 +488,10 @@ function renderPolishedFrame({
 			text,
 		);
 	const renderBorder = (text: string) => {
-		if (config.editorBorderColorMode !== "adaptive" || typeof borderColor !== "function") {
+		if (
+			config.components.editor.borderColorMode !== "adaptive" ||
+			typeof borderColor !== "function"
+		) {
 			return renderStaticBorder(text);
 		}
 		try {
@@ -500,18 +505,18 @@ function renderPolishedFrame({
 		renderEditorBorder(
 			width,
 			"above",
-			config.features.viewportIndicators ? viewport.above : undefined,
+			config.components.editor.viewportIndicators ? viewport.above : undefined,
 		),
 	);
 	const bottom = renderBorder(
 		renderEditorBorder(
 			width,
 			"below",
-			config.features.viewportIndicators ? viewport.below : undefined,
+			config.components.editor.viewportIndicators ? viewport.below : undefined,
 		),
 	);
 	const lines = ["", ...editorLines, "", railedMeta];
-	const renderedLines = config.features.copyFriendly
+	const renderedLines = config.components.editor.styles.polished.copyFriendly
 		? [
 				top,
 				"",
@@ -548,7 +553,7 @@ export class PolishedEditor extends CustomEditor {
 	private readonly getThinkingLevel: () => string | undefined;
 	private readonly getMinimalistMetadata: () => MinimalistEditorMetadata;
 	private readonly onMinimalistDecorationChange: (active: boolean) => void;
-	private readonly getConfig: () => PolishedTuiConfig;
+	private readonly getConfig: () => ZentuiConfig;
 	private readonly uiTheme: Theme;
 
 	constructor(
@@ -556,7 +561,7 @@ export class PolishedEditor extends CustomEditor {
 		theme: EditorTheme,
 		keybindings: KeybindingsManager,
 		uiTheme: Theme,
-		getConfig: () => PolishedTuiConfig,
+		getConfig: () => ZentuiConfig,
 		getModelMeta: () => EditorMeta,
 		getThinkingLevel: () => string | undefined,
 		getMinimalistMetadata: () => MinimalistEditorMetadata = () => ({ cwd: "" }),
@@ -578,7 +583,7 @@ export class PolishedEditor extends CustomEditor {
 
 	render(width: number): string[] {
 		const config = this.getConfig();
-		if (config.editorStyle === "minimalist") {
+		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(super.render(width), width);
@@ -639,7 +644,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 	constructor(
 		private readonly base: WrappedEditor,
 		private readonly uiTheme: Theme,
-		private readonly getConfig: () => PolishedTuiConfig,
+		private readonly getConfig: () => ZentuiConfig,
 		private readonly getModelMeta: () => EditorMeta,
 		private readonly getThinkingLevel: () => string | undefined,
 		private readonly getMinimalistMetadata: () => MinimalistEditorMetadata = () => ({ cwd: "" }),
@@ -745,7 +750,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 
 	render(width: number): string[] {
 		const config = this.getConfig();
-		if (config.editorStyle === "minimalist") {
+		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(this.base.render(width), width);

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -578,7 +578,7 @@ export class PolishedEditor extends CustomEditor {
 
 	render(width: number): string[] {
 		const config = this.getConfig();
-		if (config.editorMode === "minimalist") {
+		if (config.editorStyle === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(super.render(width), width);
@@ -745,7 +745,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 
 	render(width: number): string[] {
 		const config = this.getConfig();
-		if (config.editorMode === "minimalist") {
+		if (config.editorStyle === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(this.base.render(width), width);

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -8,7 +8,7 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import type { ZentuiConfig } from "./config";
+import type { EditorStyle, ZentuiConfig } from "./config";
 import { renderEditorMetadataFormat } from "./editor-metadata-format";
 import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
 import {
@@ -160,7 +160,22 @@ function fillLine(content: string, width: number): string {
 	return `${truncated}${pad}`;
 }
 
-function copyFriendlyPrompt(config: ZentuiConfig, uiTheme: Theme, reset: string): string {
+function isLowRailPolishedStyle(style: EditorStyle): boolean {
+	return style === "polished-copy-friendly";
+}
+
+function selectedPolishedConfig(config: ZentuiConfig) {
+	switch (config.components.editor.style) {
+		case "polished":
+			return config.components.editor.styles.polished;
+		case "polished-copy-friendly":
+			return config.components.editor.styles["polished-copy-friendly"];
+		case "minimalist":
+			return undefined;
+	}
+}
+
+function lowRailPrompt(config: ZentuiConfig, uiTheme: Theme, reset: string): string {
 	const promptIcon = config.icons.editorPrompt;
 	return promptIcon
 		? `${renderStyleForSourceOrFallback(
@@ -174,8 +189,9 @@ function copyFriendlyPrompt(config: ZentuiConfig, uiTheme: Theme, reset: string)
 }
 
 function getEditorChromeWidths(config: ZentuiConfig, uiTheme: Theme, reset: string) {
-	const prompt = copyFriendlyPrompt(config, uiTheme, reset);
-	const rail = config.components.editor.styles.polished.copyFriendly
+	const lowRail = isLowRailPolishedStyle(config.components.editor.style);
+	const prompt = lowRailPrompt(config, uiTheme, reset);
+	const rail = lowRail
 		? ""
 		: `${renderStyleForSourceOrFallback(
 				uiTheme,
@@ -188,9 +204,7 @@ function getEditorChromeWidths(config: ZentuiConfig, uiTheme: Theme, reset: stri
 		prompt,
 		promptWidth: visibleWidth(prompt),
 		rail,
-		railWidth: config.components.editor.styles.polished.copyFriendly
-			? visibleWidth(prompt)
-			: visibleWidth(rail),
+		railWidth: lowRail ? visibleWidth(prompt) : visibleWidth(rail),
 	};
 }
 
@@ -251,7 +265,7 @@ function unwrapPolishedFrameOnly(
 	const interior = lines.slice(1, -1);
 	if (interior.length < 3) return undefined;
 
-	if (config.components.editor.styles.polished.copyFriendly) {
+	if (isLowRailPolishedStyle(config.components.editor.style)) {
 		if (
 			plainRenderedText(interior[0] ?? "").trim() !== "" ||
 			plainRenderedText(interior.at(-2) ?? "").trim() !== "" ||
@@ -425,7 +439,7 @@ function renderPolishedFrame({
 	const colorSource = config.components.editor.colorSource;
 	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
 	const innerWidth = Math.max(0, width - railWidth);
-	const copyFriendlyContinuation = " ".repeat(promptWidth);
+	const lowRailContinuation = " ".repeat(promptWidth);
 
 	if (baseRendered.length < 2) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
@@ -464,7 +478,8 @@ function renderPolishedFrame({
 		below: parsedBottom?.count,
 	};
 	const meta = renderEditorMetadataFormat(
-		config.components.editor.styles.polished.metadataFormat,
+		selectedPolishedConfig(config)?.metadataFormat ??
+			config.components.editor.styles.polished.metadataFormat,
 		{
 			model: modelMeta.modelLabel,
 			modelId: modelMeta.modelId ?? "",
@@ -476,7 +491,7 @@ function renderPolishedFrame({
 		uiTheme,
 		config,
 	);
-	const copyFriendlyMeta = composeMetadataLine(meta, rightStatus, Math.max(0, width - 1));
+	const lowRailMeta = composeMetadataLine(meta, rightStatus, Math.max(0, width - 1));
 	const railedMeta = composeMetadataLine(meta, rightStatus, innerWidth);
 
 	const renderStaticBorder = (text: string) =>
@@ -516,16 +531,16 @@ function renderPolishedFrame({
 		),
 	);
 	const lines = ["", ...editorLines, "", railedMeta];
-	const renderedLines = config.components.editor.styles.polished.copyFriendly
+	const renderedLines = isLowRailPolishedStyle(config.components.editor.style)
 		? [
 				top,
 				"",
 				...editorLines.map(
 					(line, index) =>
-						`${index === 0 ? prompt : copyFriendlyContinuation}${fillLine(line, innerWidth)}`,
+						`${index === 0 ? prompt : lowRailContinuation}${fillLine(line, innerWidth)}`,
 				),
 				"",
-				` ${truncateToWidth(copyFriendlyMeta, Math.max(0, width - 1), "")}`,
+				` ${truncateToWidth(lowRailMeta, Math.max(0, width - 1), "")}`,
 				bottom,
 				...autocompleteLines,
 			]

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -384,11 +384,16 @@ function renderMinimalistFrameFromBase({
 	if (!ownedFrame && !trustedBaseFrame && (!parsedTop || !parsedBottom)) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
+	const viewport = ownedFrame?.viewport ?? {
+		above: parsedTop?.count,
+		below: parsedBottom?.count,
+	};
 	return {
 		lines: renderMinimalistFrame({
 			width,
 			editorLines: ownedFrame?.editorLines ?? editorFrame.slice(1, -1),
 			autocompleteLines,
+			viewport: config.features.viewportIndicators ? viewport : undefined,
 			inputText,
 			metadata,
 			uiTheme,

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -2,6 +2,7 @@ import { CustomEditor, type KeybindingsManager, type Theme } from "@earendil-wor
 import {
 	type AutocompleteProvider,
 	type Component,
+	CURSOR_MARKER,
 	type EditorComponent,
 	type EditorTheme,
 	type TUI,
@@ -10,6 +11,11 @@ import {
 } from "@earendil-works/pi-tui";
 import type { EditorStyle, ZentuiConfig } from "./config";
 import { renderEditorMetadataFormat } from "./editor-metadata-format";
+import {
+	FIXED_EDITOR_LAYOUT,
+	type FixedEditorLayoutMetadata,
+	validateFixedEditorLayout,
+} from "./fixed-editor/editor-layout";
 import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
 import {
 	EDITOR_ACCENT_FALLBACK,
@@ -39,9 +45,27 @@ type PolishedFrameProvenance = {
 
 const POLISHED_FRAME_SPLITS = new WeakMap<string[], PolishedFrameProvenance>();
 
+type AutocompleteListInternals = Pick<Component, "render"> & {
+	filteredItems?: unknown[];
+	selectedIndex?: number;
+	maxVisible?: number;
+};
+
 type AutocompleteEditorInternals = {
-	autocompleteList?: Pick<Component, "render">;
+	autocompleteList?: AutocompleteListInternals;
 	isShowingAutocomplete?: () => boolean;
+};
+
+type AutocompleteCapture = {
+	compatible: boolean;
+	called: number;
+	rows: string[];
+	selection?: {
+		selectedIndex: number;
+		visibleStart: number;
+		visibleEnd: number;
+		itemRowCount: number;
+	};
 };
 
 type WrappedEditor = EditorComponent &
@@ -79,6 +103,7 @@ type PolishedFrameOptions = {
 	width: number;
 	baseRendered: string[];
 	autocompleteSource: AutocompleteEditorInternals;
+	autocompleteCapture?: AutocompleteCapture;
 	uiTheme: Theme;
 	config: ZentuiConfig;
 	modelMeta: EditorMeta;
@@ -89,12 +114,18 @@ type PolishedFrameOptions = {
 	borderColor?: (text: string) => string;
 };
 
-type PolishedFrameResult = { lines: string[]; decorated: boolean };
+type PolishedFrameResult = {
+	lines: string[];
+	decorated: boolean;
+	editorContentRows?: number;
+	autocompleteSourceRows?: number;
+};
 
 type MinimalistFrameAdapterOptions = {
 	width: number;
 	baseRendered: string[];
 	autocompleteSource: AutocompleteEditorInternals;
+	autocompleteCapture?: AutocompleteCapture;
 	uiTheme: Theme;
 	config: ZentuiConfig;
 	inputText: string;
@@ -129,24 +160,149 @@ function isPolishedFrameSplit(value: unknown, baseLineCount: number): value is P
 	);
 }
 
-function readAutocompleteCount(
+function autocompleteCount(
 	source: AutocompleteEditorInternals,
-	width: number,
+	capture: AutocompleteCapture | undefined,
 	baseLineCount: number,
 ): AutocompleteCount {
 	try {
 		const showing = source.isShowingAutocomplete;
-		if (typeof showing !== "function") return { known: true, count: 0 };
-		if (!showing.call(source)) return { known: true, count: 0 };
-		const list = source.autocompleteList;
-		if (!list || typeof list.render !== "function") return { known: false };
-		const rendered = list.render(width);
-		if (!isStringArray(rendered) || rendered.length <= 0 || rendered.length >= baseLineCount) {
+		if (typeof showing !== "function" || !showing.call(source)) return { known: true, count: 0 };
+		if (
+			!capture?.compatible ||
+			capture.called !== 1 ||
+			capture.rows.length <= 0 ||
+			capture.rows.length >= baseLineCount
+		)
 			return { known: false };
-		}
-		return { known: true, count: rendered.length };
+		return { known: true, count: capture.rows.length };
 	} catch {
 		return { known: false };
+	}
+}
+
+/** @internal Exported only for descriptor-safety regression tests. */
+export function renderWithAutocompleteCapture<T>(
+	source: AutocompleteEditorInternals,
+	render: () => T,
+): { value: T; capture?: AutocompleteCapture } {
+	let showing = false;
+	try {
+		showing =
+			typeof source.isShowingAutocomplete === "function" &&
+			source.isShowingAutocomplete.call(source);
+	} catch {
+		return { value: render() };
+	}
+	if (!showing) return { value: render(), capture: { compatible: true, called: 0, rows: [] } };
+
+	let list: AutocompleteListInternals;
+	let own: PropertyDescriptor | undefined;
+	let predecessor: (...args: unknown[]) => unknown;
+	try {
+		const candidate = source.autocompleteList;
+		if (!candidate) return { value: render() };
+		own = Object.getOwnPropertyDescriptor(candidate, "render");
+		const current = Reflect.get(candidate, "render");
+		if (typeof current !== "function") return { value: render() };
+		if (own && (!("value" in own) || own.writable !== true)) return { value: render() };
+		if (!own && !Object.isExtensible(candidate)) return { value: render() };
+		list = candidate;
+		predecessor = current as (...args: unknown[]) => unknown;
+	} catch {
+		return { value: render() };
+	}
+
+	const capture: AutocompleteCapture = { compatible: true, called: 0, rows: [] };
+	const wrapper = function (this: AutocompleteListInternals, ...args: unknown[]) {
+		const before = {
+			items: Array.isArray(this.filteredItems) ? this.filteredItems : undefined,
+			selected: this.selectedIndex,
+			maxVisible: this.maxVisible,
+		};
+		const result = Reflect.apply(predecessor, this, args);
+		capture.called++;
+		if (!isStringArray(result)) {
+			capture.compatible = false;
+			return result;
+		}
+		capture.rows = [...result];
+		const afterItems = Array.isArray(this.filteredItems) ? this.filteredItems : undefined;
+		if (
+			before.items === afterItems &&
+			Number.isInteger(before.selected) &&
+			Number.isInteger(before.maxVisible) &&
+			before.selected === this.selectedIndex &&
+			before.maxVisible === this.maxVisible &&
+			before.items
+		) {
+			const maxVisible = Math.max(1, before.maxVisible as number);
+			const selectedIndex = before.selected as number;
+			const start = Math.max(
+				0,
+				Math.min(
+					selectedIndex - Math.floor(maxVisible / 2),
+					Math.max(0, before.items.length - maxVisible),
+				),
+			);
+			const end = Math.min(start + maxVisible, before.items.length);
+			if (selectedIndex >= start && selectedIndex < end && result.length >= end - start) {
+				capture.selection = {
+					selectedIndex,
+					visibleStart: start,
+					visibleEnd: end,
+					itemRowCount: end - start,
+				};
+			}
+		}
+		return result;
+	};
+	const installedDescriptor: PropertyDescriptor = {
+		...(own ?? { configurable: true, enumerable: false, writable: true }),
+		value: wrapper,
+	};
+	try {
+		Object.defineProperty(list, "render", installedDescriptor);
+	} catch {
+		return { value: render() };
+	}
+
+	try {
+		return { value: render(), capture };
+	} finally {
+		let current: PropertyDescriptor | undefined;
+		let currentValue: unknown;
+		let descriptorKnown = true;
+		try {
+			current = Object.getOwnPropertyDescriptor(list, "render");
+			currentValue = current && "value" in current ? current.value : Reflect.get(list, "render");
+		} catch {
+			descriptorKnown = false;
+			try {
+				currentValue = Reflect.get(list, "render");
+			} catch {
+				currentValue = undefined;
+			}
+		}
+		if (currentValue === wrapper) {
+			if (
+				!descriptorKnown ||
+				!current ||
+				current.configurable !== installedDescriptor.configurable ||
+				current.enumerable !== installedDescriptor.enumerable ||
+				current.writable !== installedDescriptor.writable
+			)
+				capture.compatible = false;
+			try {
+				if (own) Object.defineProperty(list, "render", own);
+				else Reflect.deleteProperty(list, "render");
+			} catch {
+				capture.compatible = false;
+			}
+		} else {
+			// A synchronous third-party replacement wins; captured semantics are no longer trustworthy.
+			capture.compatible = false;
+		}
 	}
 }
 
@@ -363,6 +519,7 @@ function renderMinimalistFrameFromBase({
 	width,
 	baseRendered,
 	autocompleteSource,
+	autocompleteCapture,
 	uiTheme,
 	config,
 	inputText,
@@ -379,7 +536,7 @@ function renderMinimalistFrameFromBase({
 	}
 	const autocomplete = ownedFrame
 		? { known: true as const, count: ownedFrame.trailingLines.length }
-		: readAutocompleteCount(autocompleteSource, Math.max(0, width - 4), baseRendered.length);
+		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered.length);
 	if (!autocomplete.known) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
@@ -417,6 +574,8 @@ function renderMinimalistFrameFromBase({
 			borderColor,
 		}),
 		decorated: true,
+		editorContentRows: ownedFrame?.editorLines.length ?? Math.max(0, editorFrame.length - 2),
+		autocompleteSourceRows: autocompleteLines.length,
 	};
 }
 
@@ -424,6 +583,7 @@ function renderPolishedFrame({
 	width,
 	baseRendered,
 	autocompleteSource,
+	autocompleteCapture,
 	uiTheme,
 	config,
 	modelMeta,
@@ -450,7 +610,7 @@ function renderPolishedFrame({
 
 	const autocomplete = ownedFrame
 		? { known: true, count: ownedFrame.trailingLines.length }
-		: readAutocompleteCount(autocompleteSource, innerWidth, baseRendered.length);
+		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered.length);
 	if (!autocomplete.known) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
@@ -560,7 +720,127 @@ function renderPolishedFrame({
 			viewport,
 		},
 	});
-	return { lines: clamped, decorated: true };
+	return {
+		lines: clamped,
+		decorated: true,
+		editorContentRows: editorLines.length,
+		autocompleteSourceRows: autocompleteLines.length,
+	};
+}
+
+function fixedLayoutForFrame(
+	style: EditorStyle,
+	width: number,
+	result: PolishedFrameResult,
+	capture: AutocompleteCapture | undefined,
+): FixedEditorLayoutMetadata | undefined {
+	if (
+		!result.decorated ||
+		result.editorContentRows === undefined ||
+		result.autocompleteSourceRows === undefined
+	)
+		return undefined;
+	const lines = result.lines;
+	const cursorRow = lines.findIndex((line) => line.includes(CURSOR_MARKER));
+	if (cursorRow < 0 || lines.length < 2) return undefined;
+	const autoSourceRows = result.autocompleteSourceRows;
+	let editorRows: { start: number; end: number }[];
+	let autocompleteRows: { start: number; end: number } | undefined;
+	let editorContent: { start: number; end: number }[];
+	let editorStructural: number[];
+	let autoStructural: number[] = [];
+	let autoClosure: number[] = [];
+	if (style === "minimalist" && autoSourceRows > 0) {
+		const autoStart = 1 + result.editorContentRows;
+		const autoEnd = autoStart + 1 + autoSourceRows;
+		editorRows = [
+			{ start: 0, end: autoStart },
+			{ start: autoEnd, end: lines.length },
+		];
+		autocompleteRows = { start: autoStart, end: autoEnd };
+		editorContent = result.editorContentRows > 0 ? [{ start: 1, end: autoStart }] : [];
+		editorStructural = [0, lines.length - 1];
+		autoStructural = [autoStart];
+		autoClosure = [autoStart];
+	} else {
+		const autoStart = lines.length - autoSourceRows;
+		editorRows = [{ start: 0, end: autoStart }];
+		autocompleteRows = autoSourceRows > 0 ? { start: autoStart, end: lines.length } : undefined;
+		editorContent = autoStart > 2 ? [{ start: 1, end: autoStart - 1 }] : [];
+		editorStructural = [0, autoStart - 1];
+	}
+	let autocomplete: FixedEditorLayoutMetadata["autocomplete"];
+	if (autocompleteRows) {
+		const itemCount = Math.min(capture?.selection?.itemRowCount ?? 0, autoSourceRows);
+		const itemStart = style === "minimalist" ? autocompleteRows.start + 1 : autocompleteRows.start;
+		for (let row = itemStart + itemCount; row < autocompleteRows.end; row++)
+			autoStructural.push(row);
+		const selectionCapture = capture?.selection;
+		const selection =
+			capture?.compatible && capture.called === 1 && selectionCapture && itemCount > 0
+				? {
+						known: true as const,
+						selectedIndex: selectionCapture.selectedIndex,
+						visibleWindow: {
+							start: selectionCapture.visibleStart,
+							end: selectionCapture.visibleEnd,
+						},
+						itemToOutputRows: Array.from({ length: itemCount }, (_, index) => ({
+							itemIndex: selectionCapture.visibleStart + index,
+							outputRow: itemStart + index,
+						})),
+						selectedRow: itemStart + selectionCapture.selectedIndex - selectionCapture.visibleStart,
+					}
+				: { known: false as const };
+		autocomplete = {
+			rows: autocompleteRows,
+			structuralRows: autoStructural,
+			closureRows: autoClosure,
+			borderPairs: [],
+			selection,
+		};
+	}
+	const editorBottom =
+		style === "minimalist" ? lines.length - 1 : lines.length - autoSourceRows - 1;
+	const metadata: FixedEditorLayoutMetadata = {
+		width,
+		renderedRowCount: lines.length,
+		editor: {
+			rows: editorRows,
+			frame: [
+				{ start: 0, end: 1 },
+				{ start: editorBottom, end: editorBottom + 1 },
+			],
+			content:
+				editorContent.length > 0 ? editorContent : [{ start: cursorRow, end: cursorRow + 1 }],
+			structuralRows: editorStructural,
+			cursorRow,
+			borderPairs: [{ top: 0, bottom: editorBottom }],
+		},
+		...(autocomplete ? { autocomplete } : {}),
+	};
+	return validateFixedEditorLayout(metadata, lines, width);
+}
+
+type RecordedFixedLayout = {
+	width: number;
+	rows: readonly string[];
+	metadata: FixedEditorLayoutMetadata;
+};
+
+function readRecordedFixedLayout(
+	record: RecordedFixedLayout | null,
+	rows: readonly string[],
+	width: number,
+): FixedEditorLayoutMetadata | undefined {
+	if (
+		!record ||
+		record.width !== width ||
+		record.rows.length !== rows.length ||
+		!record.rows.every((line, index) => line === rows[index])
+	)
+		return undefined;
+	return validateFixedEditorLayout(record.metadata, rows, width);
 }
 
 export class PolishedEditor extends CustomEditor {
@@ -570,6 +850,7 @@ export class PolishedEditor extends CustomEditor {
 	private readonly onMinimalistDecorationChange: (active: boolean) => void;
 	private readonly getConfig: () => ZentuiConfig;
 	private readonly uiTheme: Theme;
+	private latestFixedLayout: RecordedFixedLayout | null = null;
 
 	constructor(
 		tui: TUI,
@@ -596,7 +877,15 @@ export class PolishedEditor extends CustomEditor {
 		this.onMinimalistDecorationChange(active);
 	}
 
+	[FIXED_EDITOR_LAYOUT](
+		rows: readonly string[],
+		width: number,
+	): FixedEditorLayoutMetadata | undefined {
+		return readRecordedFixedLayout(this.latestFixedLayout, rows, width);
+	}
+
 	render(width: number): string[] {
+		this.latestFixedLayout = null;
 		const config = this.getConfig();
 		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
@@ -604,11 +893,15 @@ export class PolishedEditor extends CustomEditor {
 				return clampRenderedLines(super.render(width), width);
 			}
 			try {
-				const rendered = super.render(Math.max(0, width - 4));
+				const captured = renderWithAutocompleteCapture(
+					this as unknown as AutocompleteEditorInternals,
+					() => super.render(Math.max(0, width - 4)),
+				);
 				const result = renderMinimalistFrameFromBase({
 					width,
-					baseRendered: rendered,
+					baseRendered: captured.value,
 					autocompleteSource: this as unknown as AutocompleteEditorInternals,
+					autocompleteCapture: captured.capture,
 					uiTheme: this.uiTheme,
 					config,
 					inputText: this.getText(),
@@ -617,6 +910,9 @@ export class PolishedEditor extends CustomEditor {
 					borderColor: this.borderColor,
 				});
 				this.reportMinimalistDecoration(result.decorated);
+				const metadata = fixedLayoutForFrame("minimalist", width, result, captured.capture);
+				if (metadata)
+					this.latestFixedLayout = { width, rows: Object.freeze([...result.lines]), metadata };
 				return result.lines;
 			} catch {
 				this.reportMinimalistDecoration(false);
@@ -631,11 +927,15 @@ export class PolishedEditor extends CustomEditor {
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
 		try {
-			const rendered = super.render(innerWidth);
+			const captured = renderWithAutocompleteCapture(
+				this as unknown as AutocompleteEditorInternals,
+				() => super.render(innerWidth),
+			);
 			const result = renderPolishedFrame({
 				width,
-				baseRendered: rendered,
+				baseRendered: captured.value,
 				autocompleteSource: this as unknown as AutocompleteEditorInternals,
+				autocompleteCapture: captured.capture,
 				uiTheme: this.uiTheme,
 				config,
 				modelMeta: this.getModelMeta(),
@@ -643,7 +943,17 @@ export class PolishedEditor extends CustomEditor {
 				trustedBaseFrame: true,
 				borderColor: this.borderColor,
 			});
-			if (result.decorated) return result.lines;
+			if (result.decorated) {
+				const metadata = fixedLayoutForFrame(
+					config.components.editor.style,
+					width,
+					result,
+					captured.capture,
+				);
+				if (metadata)
+					this.latestFixedLayout = { width, rows: Object.freeze([...result.lines]), metadata };
+				return result.lines;
+			}
 		} catch {
 			// Decoration is optional; re-render the base at the caller's width below.
 		}
@@ -657,6 +967,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 	declare readonly setAutocompleteProvider?: (provider: AutocompleteProvider) => void;
 	declare readonly setPaddingX?: (padding: number) => void;
 	declare readonly setAutocompleteMaxVisible?: (maxVisible: number) => void;
+	private latestFixedLayout: RecordedFixedLayout | null = null;
 
 	constructor(
 		private readonly base: WrappedEditor,
@@ -765,16 +1076,26 @@ export class WrappedPolishedEditor implements EditorComponent {
 		this.onMinimalistDecorationChange(active);
 	}
 
+	[FIXED_EDITOR_LAYOUT](
+		rows: readonly string[],
+		width: number,
+	): FixedEditorLayoutMetadata | undefined {
+		return readRecordedFixedLayout(this.latestFixedLayout, rows, width);
+	}
+
 	render(width: number): string[] {
+		this.latestFixedLayout = null;
 		const config = this.getConfig();
 		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(this.base.render(width), width);
 			}
-			let rendered: string[];
+			let captured: { value: string[]; capture?: AutocompleteCapture };
 			try {
-				rendered = this.base.render(Math.max(0, width - 4));
+				captured = renderWithAutocompleteCapture(this.base, () =>
+					this.base.render(Math.max(0, width - 4)),
+				);
 			} catch {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(this.base.render(width), width);
@@ -782,15 +1103,16 @@ export class WrappedPolishedEditor implements EditorComponent {
 			try {
 				const provenance = inspectPolishedFrameProvenance(
 					this.base,
-					rendered,
+					captured.value,
 					config,
 					this.uiTheme,
 				);
 				if (provenance.safe) {
 					const result = renderMinimalistFrameFromBase({
 						width,
-						baseRendered: rendered,
+						baseRendered: captured.value,
 						autocompleteSource: this.base,
+						autocompleteCapture: captured.capture,
 						uiTheme: this.uiTheme,
 						config,
 						inputText: this.base.getText(),
@@ -800,6 +1122,9 @@ export class WrappedPolishedEditor implements EditorComponent {
 					});
 					if (result.decorated) {
 						this.reportMinimalistDecoration(true);
+						const metadata = fixedLayoutForFrame("minimalist", width, result, captured.capture);
+						if (metadata)
+							this.latestFixedLayout = { width, rows: Object.freeze([...result.lines]), metadata };
 						return result.lines;
 					}
 				}
@@ -814,20 +1139,26 @@ export class WrappedPolishedEditor implements EditorComponent {
 
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
-		let rendered: string[];
+		let captured: { value: string[]; capture?: AutocompleteCapture };
 		try {
-			rendered = this.base.render(innerWidth);
+			captured = renderWithAutocompleteCapture(this.base, () => this.base.render(innerWidth));
 		} catch {
 			return clampRenderedLines(this.base.render(width), width);
 		}
 		let result: PolishedFrameResult | undefined;
 		try {
-			const provenance = inspectPolishedFrameProvenance(this.base, rendered, config, this.uiTheme);
+			const provenance = inspectPolishedFrameProvenance(
+				this.base,
+				captured.value,
+				config,
+				this.uiTheme,
+			);
 			if (provenance.safe) {
 				result = renderPolishedFrame({
 					width,
-					baseRendered: rendered,
+					baseRendered: captured.value,
 					autocompleteSource: this.base,
+					autocompleteCapture: captured.capture,
 					uiTheme: this.uiTheme,
 					config,
 					modelMeta: this.getModelMeta(),
@@ -840,7 +1171,18 @@ export class WrappedPolishedEditor implements EditorComponent {
 		} catch {
 			// Decoration is optional; re-render the base at the caller's width below.
 		}
-		return result?.decorated ? result.lines : clampRenderedLines(this.base.render(width), width);
+		if (result?.decorated) {
+			const metadata = fixedLayoutForFrame(
+				config.components.editor.style,
+				width,
+				result,
+				captured.capture,
+			);
+			if (metadata)
+				this.latestFixedLayout = { width, rows: Object.freeze([...result.lines]), metadata };
+			return result.lines;
+		}
+		return clampRenderedLines(this.base.render(width), width);
 	}
 
 	invalidate(): void {

--- a/extensions/zentui/user-message-osc.ts
+++ b/extensions/zentui/user-message-osc.ts
@@ -1,0 +1,298 @@
+const ESC = "\x1b";
+const BEL = "\x07";
+const C1_DCS = "\x90";
+const C1_SOS = "\x98";
+const C1_CSI = "\x9b";
+const C1_ST = "\x9c";
+const C1_OSC = "\x9d";
+const C1_PM = "\x9e";
+const C1_APC = "\x9f";
+const CAN = 0x18;
+const SUB = 0x1a;
+
+export type UserMessageOscSequence = {
+	end: number;
+	payload: string;
+	validOsc8: boolean;
+};
+
+type ControlBoundary =
+	| { kind: "terminator"; index: number; length: number; safeOsc8Terminator: boolean }
+	| { kind: "start"; index: number };
+
+type FilterOptions = {
+	preserveValidOsc8: boolean;
+	preserveSourceWhitespace: boolean;
+	preserveSgr: boolean;
+};
+
+type FilterResult = {
+	text: string;
+	balancedOsc8: boolean;
+};
+
+/** Only 7-bit OSC is preserved; C1 controls are always removed. */
+export function userMessageOscStartLength(text: string, index: number): number {
+	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
+}
+
+function anyOscStartLength(text: string, index: number): number {
+	if (text[index] === C1_OSC) return 1;
+	return userMessageOscStartLength(text, index);
+}
+
+function findOscBoundary(text: string, payloadStart: number): ControlBoundary | undefined {
+	for (let index = payloadStart; index < text.length; index += 1) {
+		if (anyOscStartLength(text, index) > 0) return { kind: "start", index };
+		if (text[index] === BEL) {
+			return { kind: "terminator", index, length: 1, safeOsc8Terminator: true };
+		}
+		if (text[index] === C1_ST) {
+			return { kind: "terminator", index, length: 1, safeOsc8Terminator: false };
+		}
+		if (text[index] === ESC && text[index + 1] === "\\") {
+			return { kind: "terminator", index, length: 2, safeOsc8Terminator: true };
+		}
+	}
+	return undefined;
+}
+
+const terminalControlPattern = /[\u0000-\u001f\u007f-\u009f]/;
+const safeParameterKeyPattern = /^[A-Za-z0-9_.-]+$/;
+
+export function isValidUserMessageOsc8Payload(payload: string): boolean {
+	if (!payload.startsWith("8;")) return false;
+	const uriSeparator = payload.indexOf(";", 2);
+	if (uriSeparator < 0) return false;
+
+	const params = payload.slice(2, uriSeparator);
+	const uri = payload.slice(uriSeparator + 1);
+	if (params === "" && uri === "") return true;
+	if (uri === "" || /\s/.test(uri) || terminalControlPattern.test(uri)) return false;
+	if (params === "") return true;
+
+	return params.split(":").every((entry) => {
+		const equals = entry.indexOf("=");
+		if (equals <= 0) return false;
+		const key = entry.slice(0, equals);
+		const value = entry.slice(equals + 1);
+		return (
+			safeParameterKeyPattern.test(key) &&
+			!terminalControlPattern.test(key) &&
+			!terminalControlPattern.test(value)
+		);
+	});
+}
+
+export function readUserMessageOscSequence(
+	text: string,
+	index: number,
+): UserMessageOscSequence | undefined {
+	const startLength = userMessageOscStartLength(text, index);
+	if (startLength === 0) return undefined;
+	const payloadStart = index + startLength;
+	const boundary = findOscBoundary(text, payloadStart);
+	if (boundary?.kind !== "terminator") return undefined;
+	const payload = text.slice(payloadStart, boundary.index);
+	return {
+		end: boundary.index + boundary.length,
+		payload,
+		validOsc8: boundary.safeOsc8Terminator && isValidUserMessageOsc8Payload(payload),
+	};
+}
+
+function incompleteOsc133PrefixLength(payload: string): number {
+	if (payload.length > 0 && "133".startsWith(payload)) return payload.length;
+	if (!payload.startsWith("133;")) return 0;
+
+	let length = 4;
+	if (/^[A-D]$/.test(payload[length] ?? "")) length += 1;
+	if (payload[length] === ";") length += 1;
+	return length;
+}
+
+function consumeCsi(value: string, start: number): number {
+	for (let index = start; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code === CAN || code === SUB) return index + 1;
+		if (code >= 0x40 && code <= 0x7e) return index + 1;
+	}
+	return value.length;
+}
+
+function consumeControlString(value: string, start: number, allowBel: boolean): number {
+	for (let index = start; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code === CAN || code === SUB) return index + 1;
+		if (allowBel && code === BEL.charCodeAt(0)) return index + 1;
+		if (code === C1_ST.charCodeAt(0)) return index + 1;
+		if (code === ESC.charCodeAt(0) && value[index + 1] === "\\") return index + 2;
+	}
+	return value.length;
+}
+
+function consumeEscape(value: string, start: number): number {
+	if (start + 1 >= value.length) return value.length;
+	const next = value[start + 1];
+	if (next === "[") return consumeCsi(value, start + 2);
+	if (next === "P" || next === "X" || next === "^" || next === "_") {
+		return consumeControlString(value, start + 2, false);
+	}
+
+	let index = start + 1;
+	while (index < value.length) {
+		const code = value.charCodeAt(index);
+		if (code >= 0x20 && code <= 0x2f) {
+			index += 1;
+			continue;
+		}
+		return code >= 0x30 && code <= 0x7e ? index + 1 : index;
+	}
+	return value.length;
+}
+
+function isSafeSgr(sequence: string): boolean {
+	return /^\x1b\[[0-9:;]*m$/.test(sequence);
+}
+
+function isOsc8Close(payload: string): boolean {
+	return payload === "8;;";
+}
+
+function updateOsc8Balance(payload: string, state: { open: boolean; invalid: boolean }): void {
+	if (isOsc8Close(payload)) {
+		if (!state.open) state.invalid = true;
+		state.open = false;
+		return;
+	}
+	if (state.open) state.invalid = true;
+	state.open = true;
+}
+
+export function hasBalancedUserMessageOsc8(text: string): boolean {
+	const state = { open: false, invalid: false };
+	for (let index = 0; index < text.length; index += 1) {
+		const startLength = userMessageOscStartLength(text, index);
+		if (startLength === 0) continue;
+		const sequence = readUserMessageOscSequence(text, index);
+		if (!sequence?.validOsc8) return false;
+		updateOsc8Balance(sequence.payload, state);
+		index = sequence.end - 1;
+	}
+	return !state.open && !state.invalid;
+}
+
+function filterUserMessageTerminalText(text: string, options: FilterOptions): FilterResult {
+	let output = "";
+	let index = 0;
+	const osc8 = { open: false, invalid: false };
+	while (index < text.length) {
+		const oscStartLength = anyOscStartLength(text, index);
+		if (oscStartLength > 0) {
+			const payloadStart = index + oscStartLength;
+			const boundary = findOscBoundary(text, payloadStart);
+			if (boundary?.kind === "terminator") {
+				const end = boundary.index + boundary.length;
+				const payload = text.slice(payloadStart, boundary.index);
+				if (
+					options.preserveValidOsc8 &&
+					oscStartLength === 2 &&
+					boundary.safeOsc8Terminator &&
+					isValidUserMessageOsc8Payload(payload)
+				) {
+					updateOsc8Balance(payload, osc8);
+					output += text.slice(index, end);
+				}
+				index = end;
+				continue;
+			}
+
+			// Removing an unterminated introducer prevents it from consuming
+			// Zentui's prompt markers. Preserve visible trailing payload, except
+			// for a recognized partial OSC 133 command prefix.
+			const payloadEnd = boundary?.index ?? text.length;
+			const payload = text.slice(payloadStart, payloadEnd);
+			index = payloadStart + incompleteOsc133PrefixLength(payload);
+			continue;
+		}
+
+		const code = text.charCodeAt(index);
+		if (code === ESC.charCodeAt(0)) {
+			if (text[index + 1] === "[") {
+				const end = consumeCsi(text, index + 2);
+				const sequence = text.slice(index, end);
+				if (options.preserveSgr && isSafeSgr(sequence)) output += sequence;
+				index = end;
+				continue;
+			}
+			index = consumeEscape(text, index);
+			continue;
+		}
+		if (text[index] === C1_CSI) {
+			index = consumeCsi(text, index + 1);
+			continue;
+		}
+		if (
+			text[index] === C1_DCS ||
+			text[index] === C1_SOS ||
+			text[index] === C1_PM ||
+			text[index] === C1_APC
+		) {
+			index = consumeControlString(text, index + 1, false);
+			continue;
+		}
+		if (code === 0x09 || code === 0x0a) {
+			if (options.preserveSourceWhitespace) output += text[index];
+			index += 1;
+			continue;
+		}
+		if (code < 0x20 || (code >= 0x7f && code <= 0x9f)) {
+			index += 1;
+			continue;
+		}
+		output += text[index];
+		index += 1;
+	}
+	return { text: output, balancedOsc8: !osc8.open && !osc8.invalid };
+}
+
+function filterBalancedUserMessageTerminalText(text: string, options: FilterOptions): string {
+	const filtered = filterUserMessageTerminalText(text, options);
+	if (!options.preserveValidOsc8 || filtered.balancedOsc8) return filtered.text;
+	return filterUserMessageTerminalText(text, { ...options, preserveValidOsc8: false }).text;
+}
+
+/** Sanitize raw Markdown input, preserving only balanced, validated 7-bit OSC 8 controls. */
+export function sanitizeUserMessageOscText(text: string): string {
+	return filterBalancedUserMessageTerminalText(text, {
+		preserveValidOsc8: true,
+		preserveSourceWhitespace: true,
+		preserveSgr: false,
+	});
+}
+
+/** Remove every source terminal control for fail-closed Markdown rerendering. */
+export function stripUserMessageOscText(text: string): string {
+	return filterBalancedUserMessageTerminalText(text, {
+		preserveValidOsc8: false,
+		preserveSourceWhitespace: true,
+		preserveSgr: false,
+	});
+}
+
+/**
+ * Sanitize a predecessor-rendered row. Pi formatting needs only SGR and
+ * structurally valid 7-bit OSC 8; every other terminal control is removed.
+ */
+export function sanitizeRenderedUserMessageText(text: string): string {
+	return filterBalancedUserMessageTerminalText(text, {
+		preserveValidOsc8: true,
+		preserveSourceWhitespace: true,
+		preserveSgr: true,
+	});
+}
+
+/** Sanitize one predecessor output stream while retaining its row boundaries. */
+export function sanitizeRenderedUserMessageLines(lines: string[]): string[] {
+	return sanitizeRenderedUserMessageText(lines.join("\n")).split("\n");
+}

--- a/extensions/zentui/user-message-osc.ts
+++ b/extensions/zentui/user-message-osc.ts
@@ -10,12 +10,6 @@ const C1_APC = "\x9f";
 const CAN = 0x18;
 const SUB = 0x1a;
 
-export type UserMessageOscSequence = {
-	end: number;
-	payload: string;
-	validOsc8: boolean;
-};
-
 type ControlBoundary =
 	| { kind: "terminator"; index: number; length: number; safeOsc8Terminator: boolean }
 	| { kind: "start"; index: number };
@@ -31,14 +25,9 @@ type FilterResult = {
 	balancedOsc8: boolean;
 };
 
-/** Only 7-bit OSC is preserved; C1 controls are always removed. */
-export function userMessageOscStartLength(text: string, index: number): number {
-	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
-}
-
 function anyOscStartLength(text: string, index: number): number {
 	if (text[index] === C1_OSC) return 1;
-	return userMessageOscStartLength(text, index);
+	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
 }
 
 function findOscBoundary(text: string, payloadStart: number): ControlBoundary | undefined {
@@ -82,23 +71,6 @@ export function isValidUserMessageOsc8Payload(payload: string): boolean {
 			!terminalControlPattern.test(value)
 		);
 	});
-}
-
-export function readUserMessageOscSequence(
-	text: string,
-	index: number,
-): UserMessageOscSequence | undefined {
-	const startLength = userMessageOscStartLength(text, index);
-	if (startLength === 0) return undefined;
-	const payloadStart = index + startLength;
-	const boundary = findOscBoundary(text, payloadStart);
-	if (boundary?.kind !== "terminator") return undefined;
-	const payload = text.slice(payloadStart, boundary.index);
-	return {
-		end: boundary.index + boundary.length,
-		payload,
-		validOsc8: boundary.safeOsc8Terminator && isValidUserMessageOsc8Payload(payload),
-	};
 }
 
 function incompleteOsc133PrefixLength(payload: string): number {
@@ -167,19 +139,6 @@ function updateOsc8Balance(payload: string, state: { open: boolean; invalid: boo
 	}
 	if (state.open) state.invalid = true;
 	state.open = true;
-}
-
-export function hasBalancedUserMessageOsc8(text: string): boolean {
-	const state = { open: false, invalid: false };
-	for (let index = 0; index < text.length; index += 1) {
-		const startLength = userMessageOscStartLength(text, index);
-		if (startLength === 0) continue;
-		const sequence = readUserMessageOscSequence(text, index);
-		if (!sequence?.validOsc8) return false;
-		updateOsc8Balance(sequence.payload, state);
-		index = sequence.end - 1;
-	}
-	return !state.open && !state.invalid;
 }
 
 function filterUserMessageTerminalText(text: string, options: FilterOptions): FilterResult {
@@ -262,17 +221,8 @@ function filterBalancedUserMessageTerminalText(text: string, options: FilterOpti
 	return filterUserMessageTerminalText(text, { ...options, preserveValidOsc8: false }).text;
 }
 
-/** Sanitize raw Markdown input, preserving only balanced, validated 7-bit OSC 8 controls. */
-export function sanitizeUserMessageOscText(text: string): string {
-	return filterBalancedUserMessageTerminalText(text, {
-		preserveValidOsc8: true,
-		preserveSourceWhitespace: true,
-		preserveSgr: false,
-	});
-}
-
-/** Remove every source terminal control for fail-closed Markdown rerendering. */
-export function stripUserMessageOscText(text: string): string {
+/** Strip every terminal control from untrusted source text before Markdown rendering. */
+export function sanitizeUserMessageSourceText(text: string): string {
 	return filterBalancedUserMessageTerminalText(text, {
 		preserveValidOsc8: false,
 		preserveSourceWhitespace: true,

--- a/extensions/zentui/user-message-styles.ts
+++ b/extensions/zentui/user-message-styles.ts
@@ -191,7 +191,10 @@ function renderFramedCopyFriendly({
 	config,
 }: UserMessageStyleRenderInput): string[] {
 	if (width <= 0) return [""];
-	const body = renderMarkdown(text, width, theme).map((line) => truncateToWidth(line, width, ""));
+	const prefix = width > 1 ? " " : "";
+	const body = renderMarkdown(text, width - prefix.length, theme).map((line) =>
+		fillLine(`${prefix}${line}`, width),
+	);
 	const rule = truncateToWidth(border(theme, config, "─".repeat(width)), width, "");
 	return [rule, "", ...body, "", rule];
 }

--- a/extensions/zentui/user-message-styles.ts
+++ b/extensions/zentui/user-message-styles.ts
@@ -184,6 +184,18 @@ function renderFramed({ text, width, theme, config }: UserMessageStyleRenderInpu
 	return [rule, row(""), ...body.map(row), row(""), rule];
 }
 
+function renderFramedCopyFriendly({
+	text,
+	width,
+	theme,
+	config,
+}: UserMessageStyleRenderInput): string[] {
+	if (width <= 0) return [""];
+	const body = renderMarkdown(text, width, theme).map((line) => truncateToWidth(line, width, ""));
+	const rule = truncateToWidth(border(theme, config, "─".repeat(width)), width, "");
+	return [rule, "", ...body, "", rule];
+}
+
 function renderCompact({ text, width, theme, config }: UserMessageStyleRenderInput): string[] {
 	if (width <= 0) return [""];
 	const rail = renderRail(theme, config);
@@ -238,6 +250,10 @@ export function userMessageStyleCacheKey(config: ZentuiConfig): string {
 				config.colors.editorBorder ?? "",
 				config.icons.rail,
 			].join("\0");
+		case "framed-copy-friendly":
+			return ["framed-copy-friendly", messages.colorSource, config.colors.editorBorder ?? ""].join(
+				"\0",
+			);
 		case "compact":
 			return [
 				"compact",
@@ -263,6 +279,9 @@ export function renderUserMessageStyle(input: UserMessageStyleRenderInput): stri
 	switch (input.config.components.userMessages.style) {
 		case "framed":
 			lines = renderFramed(shieldedInput);
+			break;
+		case "framed-copy-friendly":
+			lines = renderFramedCopyFriendly(shieldedInput);
 			break;
 		case "compact":
 			lines = renderCompact(shieldedInput);

--- a/extensions/zentui/user-message-styles.ts
+++ b/extensions/zentui/user-message-styles.ts
@@ -11,13 +11,7 @@ import {
 	EDITOR_BORDER_FALLBACK,
 	renderStyleForSourceOrFallbackStrict,
 } from "./style";
-import {
-	hasBalancedUserMessageOsc8,
-	readUserMessageOscSequence,
-	sanitizeUserMessageOscText,
-	stripUserMessageOscText,
-	userMessageOscStartLength,
-} from "./user-message-osc";
+import { sanitizeUserMessageSourceText } from "./user-message-osc";
 
 export type UserMessageStyleRenderInput = {
 	text: string;
@@ -25,99 +19,6 @@ export type UserMessageStyleRenderInput = {
 	theme?: Theme;
 	config: ZentuiConfig;
 };
-
-const ESC = "\x1b";
-
-type OscShield = {
-	placeholder: string;
-	original: string;
-};
-
-// Markdown carries active OSC 8 state across rows and can rewrite an OSC-based
-// close shield at a newline. Inert zero-width Unicode keeps the marker attached
-// to its source position without affecting wrapping or terminal state.
-function makeOscShield(index: number, source: string): string {
-	let suffix = index;
-	while (true) {
-		const encodedSuffix = suffix.toString(2).replaceAll("0", "\u200b").replaceAll("1", "\u200c");
-		const placeholder = `\u2060\u200b\u2060${encodedSuffix}\u2060\u200c\u2060`;
-		if (!source.includes(placeholder)) return placeholder;
-		suffix += 1;
-	}
-}
-
-function shieldValidatedOsc8Sequences(text: string): { text: string; shields: OscShield[] } {
-	let output = "";
-	let index = 0;
-	const shields: OscShield[] = [];
-	while (index < text.length) {
-		const startLength = userMessageOscStartLength(text, index);
-		if (startLength === 0) {
-			output += text[index];
-			index += 1;
-			continue;
-		}
-
-		const sequence = readUserMessageOscSequence(text, index);
-		if (!sequence?.validOsc8) throw new Error("unexpected unsafe OSC after sanitization");
-		const original = text.slice(index, sequence.end);
-		const placeholder = makeOscShield(shields.length, `${text}\0${output}`);
-		shields.push({ placeholder, original });
-		output += placeholder;
-		index = sequence.end;
-	}
-	return { text: output, shields };
-}
-
-function isInsideOscSequence(text: string, target: number): boolean {
-	let open = false;
-	for (let index = 0; index < target; index += 1) {
-		if (text[index] === "\x9d" || (text[index] === ESC && text[index + 1] === "]")) {
-			open = true;
-			if (text[index] === ESC) index += 1;
-			continue;
-		}
-		if (!open) continue;
-		if (text[index] === "\x07" || text[index] === "\x9c") {
-			open = false;
-			continue;
-		}
-		if (text[index] === ESC && text[index + 1] === "\\") {
-			open = false;
-			index += 1;
-		}
-	}
-	return open;
-}
-
-function restoreValidatedOsc8Sequences(lines: string[], shields: OscShield[]): string[] {
-	if (shields.length === 0) return lines;
-	const rendered = lines.join("\n");
-	for (const { placeholder } of shields) {
-		let occurrences = 0;
-		let index = rendered.indexOf(placeholder);
-		while (index >= 0) {
-			occurrences += 1;
-			index = rendered.indexOf(placeholder, index + placeholder.length);
-		}
-		if (occurrences !== 1) {
-			throw new Error(occurrences === 0 ? "lost OSC shield" : "duplicated OSC shield");
-		}
-		const occurrence = rendered.indexOf(placeholder);
-		if (isInsideOscSequence(rendered, occurrence)) throw new Error("nested OSC shield");
-	}
-	const restored = lines.map((line) => {
-		let output = line;
-		for (const { placeholder, original } of shields) {
-			output = output.replace(placeholder, original);
-		}
-		return output;
-	});
-	if (!hasBalancedUserMessageOsc8(restored.join("\n"))) {
-		throw new Error("unbalanced OSC shield stream");
-	}
-	return restored;
-}
 
 function themeFg(theme: Theme | undefined, color: ThemeColor, text: string): string {
 	return theme ? theme.fg(color, text) : text;
@@ -305,20 +206,10 @@ function renderSelectedUserMessageStyle(input: UserMessageStyleRenderInput): str
 }
 
 export function renderUserMessageStyle(input: UserMessageStyleRenderInput): string[] {
-	const sanitizedText = sanitizeUserMessageOscText(input.text);
-	try {
-		const shielded = shieldValidatedOsc8Sequences(sanitizedText);
-		return restoreValidatedOsc8Sequences(
-			renderSelectedUserMessageStyle({ ...input, text: shielded.text }),
-			shielded.shields,
-		);
-	} catch {
-		// Markdown may duplicate a shield when raw OSC 8 appears inside link
-		// syntax. Re-render without any source OSC instead of restoring a nested
-		// terminal control or delegating unsafe source text.
-		return renderSelectedUserMessageStyle({
-			...input,
-			text: stripUserMessageOscText(sanitizedText),
-		});
-	}
+	// Raw user input is a terminal trust boundary. Strip every source control,
+	// including OSC 8; Markdown may add its own validated links afterward.
+	return renderSelectedUserMessageStyle({
+		...input,
+		text: sanitizeUserMessageSourceText(input.text),
+	});
 }

--- a/extensions/zentui/user-message-styles.ts
+++ b/extensions/zentui/user-message-styles.ts
@@ -11,6 +11,13 @@ import {
 	EDITOR_BORDER_FALLBACK,
 	renderStyleForSourceOrFallbackStrict,
 } from "./style";
+import {
+	hasBalancedUserMessageOsc8,
+	readUserMessageOscSequence,
+	sanitizeUserMessageOscText,
+	stripUserMessageOscText,
+	userMessageOscStartLength,
+} from "./user-message-osc";
 
 export type UserMessageStyleRenderInput = {
 	text: string;
@@ -20,86 +27,95 @@ export type UserMessageStyleRenderInput = {
 };
 
 const ESC = "\x1b";
-const BEL = "\x07";
-const C1_OSC = "\x9d";
-const C1_ST = "\x9c";
 
 type OscShield = {
 	placeholder: string;
 	original: string;
 };
 
-function oscStartLength(text: string, index: number): number {
-	if (text[index] === C1_OSC) return 1;
-	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
-}
-
-function findCompleteOscEnd(text: string, payloadStart: number): number | undefined {
-	for (let index = payloadStart; index < text.length; index += 1) {
-		if (oscStartLength(text, index) > 0) return undefined;
-		if (text[index] === BEL || text[index] === C1_ST) return index + 1;
-		if (text[index] === ESC && text[index + 1] === "\\") return index + 2;
-	}
-	return undefined;
-}
-
+// Markdown carries active OSC 8 state across rows and can rewrite an OSC-based
+// close shield at a newline. Inert zero-width Unicode keeps the marker attached
+// to its source position without affecting wrapping or terminal state.
 function makeOscShield(index: number, source: string): string {
 	let suffix = index;
 	while (true) {
-		const id = `zentuioscshield${suffix}`;
-		const placeholder = `${ESC}]8;id=${id};zentuioscshield:${suffix}${ESC}\\${ESC}]8;;${ESC}\\`;
+		const encodedSuffix = suffix.toString(2).replaceAll("0", "\u200b").replaceAll("1", "\u200c");
+		const placeholder = `\u2060\u200b\u2060${encodedSuffix}\u2060\u200c\u2060`;
 		if (!source.includes(placeholder)) return placeholder;
 		suffix += 1;
 	}
 }
 
-function shieldCompleteOscSequences(text: string): { text: string; shields: OscShield[] } {
+function shieldValidatedOsc8Sequences(text: string): { text: string; shields: OscShield[] } {
 	let output = "";
 	let index = 0;
 	const shields: OscShield[] = [];
 	while (index < text.length) {
-		const startLength = oscStartLength(text, index);
+		const startLength = userMessageOscStartLength(text, index);
 		if (startLength === 0) {
 			output += text[index];
 			index += 1;
 			continue;
 		}
 
-		const end = findCompleteOscEnd(text, index + startLength);
-		if (end === undefined) {
-			// Incomplete controls should already have been neutralized by the adapter.
-			// Preserve direct-render behavior rather than inventing another sanitizer here.
-			output += text[index];
-			index += 1;
-			continue;
-		}
-
-		const original = text.slice(index, end);
+		const sequence = readUserMessageOscSequence(text, index);
+		if (!sequence?.validOsc8) throw new Error("unexpected unsafe OSC after sanitization");
+		const original = text.slice(index, sequence.end);
 		const placeholder = makeOscShield(shields.length, `${text}\0${output}`);
 		shields.push({ placeholder, original });
 		output += placeholder;
-		index = end;
+		index = sequence.end;
 	}
 	return { text: output, shields };
 }
 
-function restoreCompleteOscSequences(lines: string[], shields: OscShield[]): string[] {
+function isInsideOscSequence(text: string, target: number): boolean {
+	let open = false;
+	for (let index = 0; index < target; index += 1) {
+		if (text[index] === "\x9d" || (text[index] === ESC && text[index + 1] === "]")) {
+			open = true;
+			if (text[index] === ESC) index += 1;
+			continue;
+		}
+		if (!open) continue;
+		if (text[index] === "\x07" || text[index] === "\x9c") {
+			open = false;
+			continue;
+		}
+		if (text[index] === ESC && text[index + 1] === "\\") {
+			open = false;
+			index += 1;
+		}
+	}
+	return open;
+}
+
+function restoreValidatedOsc8Sequences(lines: string[], shields: OscShield[]): string[] {
 	if (shields.length === 0) return lines;
-	const remaining = new Set(shields.map(({ placeholder }) => placeholder));
+	const rendered = lines.join("\n");
+	for (const { placeholder } of shields) {
+		let occurrences = 0;
+		let index = rendered.indexOf(placeholder);
+		while (index >= 0) {
+			occurrences += 1;
+			index = rendered.indexOf(placeholder, index + placeholder.length);
+		}
+		if (occurrences !== 1) {
+			throw new Error(occurrences === 0 ? "lost OSC shield" : "duplicated OSC shield");
+		}
+		const occurrence = rendered.indexOf(placeholder);
+		if (isInsideOscSequence(rendered, occurrence)) throw new Error("nested OSC shield");
+	}
 	const restored = lines.map((line) => {
 		let output = line;
 		for (const { placeholder, original } of shields) {
-			const first = output.indexOf(placeholder);
-			if (first < 0) continue;
-			if (output.indexOf(placeholder, first + placeholder.length) >= 0) {
-				throw new Error("duplicated OSC shield");
-			}
-			output = `${output.slice(0, first)}${original}${output.slice(first + placeholder.length)}`;
-			remaining.delete(placeholder);
+			output = output.replace(placeholder, original);
 		}
 		return output;
 	});
-	if (remaining.size > 0) throw new Error("lost OSC shield");
+	if (!hasBalancedUserMessageOsc8(restored.join("\n"))) {
+		throw new Error("unbalanced OSC shield stream");
+	}
 	return restored;
 }
 
@@ -275,23 +291,34 @@ export function userMessageStyleCacheKey(config: ZentuiConfig): string {
 	}
 }
 
-export function renderUserMessageStyle(input: UserMessageStyleRenderInput): string[] {
-	const shielded = shieldCompleteOscSequences(input.text);
-	const shieldedInput = { ...input, text: shielded.text };
-	let lines: string[];
+function renderSelectedUserMessageStyle(input: UserMessageStyleRenderInput): string[] {
 	switch (input.config.components.userMessages.style) {
 		case "framed":
-			lines = renderFramed(shieldedInput);
-			break;
+			return renderFramed(input);
 		case "framed-copy-friendly":
-			lines = renderFramedCopyFriendly(shieldedInput);
-			break;
+			return renderFramedCopyFriendly(input);
 		case "compact":
-			lines = renderCompact(shieldedInput);
-			break;
+			return renderCompact(input);
 		case "labeled":
-			lines = renderLabeled(shieldedInput);
-			break;
+			return renderLabeled(input);
 	}
-	return restoreCompleteOscSequences(lines, shielded.shields);
+}
+
+export function renderUserMessageStyle(input: UserMessageStyleRenderInput): string[] {
+	const sanitizedText = sanitizeUserMessageOscText(input.text);
+	try {
+		const shielded = shieldValidatedOsc8Sequences(sanitizedText);
+		return restoreValidatedOsc8Sequences(
+			renderSelectedUserMessageStyle({ ...input, text: shielded.text }),
+			shielded.shields,
+		);
+	} catch {
+		// Markdown may duplicate a shield when raw OSC 8 appears inside link
+		// syntax. Re-render without any source OSC instead of restoring a nested
+		// terminal control or delegating unsafe source text.
+		return renderSelectedUserMessageStyle({
+			...input,
+			text: stripUserMessageOscText(sanitizedText),
+		});
+	}
 }

--- a/extensions/zentui/user-message-styles.ts
+++ b/extensions/zentui/user-message-styles.ts
@@ -1,0 +1,275 @@
+import type { Theme, ThemeColor } from "@earendil-works/pi-coding-agent";
+import {
+	Markdown,
+	type MarkdownTheme,
+	truncateToWidth,
+	visibleWidth,
+} from "@earendil-works/pi-tui";
+import type { ZentuiConfig } from "./config";
+import {
+	EDITOR_ACCENT_FALLBACK,
+	EDITOR_BORDER_FALLBACK,
+	renderStyleForSourceOrFallbackStrict,
+} from "./style";
+
+export type UserMessageStyleRenderInput = {
+	text: string;
+	width: number;
+	theme?: Theme;
+	config: ZentuiConfig;
+};
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const C1_OSC = "\x9d";
+const C1_ST = "\x9c";
+
+type OscShield = {
+	placeholder: string;
+	original: string;
+};
+
+function oscStartLength(text: string, index: number): number {
+	if (text[index] === C1_OSC) return 1;
+	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
+}
+
+function findCompleteOscEnd(text: string, payloadStart: number): number | undefined {
+	for (let index = payloadStart; index < text.length; index += 1) {
+		if (oscStartLength(text, index) > 0) return undefined;
+		if (text[index] === BEL || text[index] === C1_ST) return index + 1;
+		if (text[index] === ESC && text[index + 1] === "\\") return index + 2;
+	}
+	return undefined;
+}
+
+function makeOscShield(index: number, source: string): string {
+	let suffix = index;
+	while (true) {
+		const id = `zentuioscshield${suffix}`;
+		const placeholder = `${ESC}]8;id=${id};zentuioscshield:${suffix}${ESC}\\${ESC}]8;;${ESC}\\`;
+		if (!source.includes(placeholder)) return placeholder;
+		suffix += 1;
+	}
+}
+
+function shieldCompleteOscSequences(text: string): { text: string; shields: OscShield[] } {
+	let output = "";
+	let index = 0;
+	const shields: OscShield[] = [];
+	while (index < text.length) {
+		const startLength = oscStartLength(text, index);
+		if (startLength === 0) {
+			output += text[index];
+			index += 1;
+			continue;
+		}
+
+		const end = findCompleteOscEnd(text, index + startLength);
+		if (end === undefined) {
+			// Incomplete controls should already have been neutralized by the adapter.
+			// Preserve direct-render behavior rather than inventing another sanitizer here.
+			output += text[index];
+			index += 1;
+			continue;
+		}
+
+		const original = text.slice(index, end);
+		const placeholder = makeOscShield(shields.length, `${text}\0${output}`);
+		shields.push({ placeholder, original });
+		output += placeholder;
+		index = end;
+	}
+	return { text: output, shields };
+}
+
+function restoreCompleteOscSequences(lines: string[], shields: OscShield[]): string[] {
+	if (shields.length === 0) return lines;
+	const remaining = new Set(shields.map(({ placeholder }) => placeholder));
+	const restored = lines.map((line) => {
+		let output = line;
+		for (const { placeholder, original } of shields) {
+			const first = output.indexOf(placeholder);
+			if (first < 0) continue;
+			if (output.indexOf(placeholder, first + placeholder.length) >= 0) {
+				throw new Error("duplicated OSC shield");
+			}
+			output = `${output.slice(0, first)}${original}${output.slice(first + placeholder.length)}`;
+			remaining.delete(placeholder);
+		}
+		return output;
+	});
+	if (remaining.size > 0) throw new Error("lost OSC shield");
+	return restored;
+}
+
+function themeFg(theme: Theme | undefined, color: ThemeColor, text: string): string {
+	return theme ? theme.fg(color, text) : text;
+}
+
+function makeMarkdownTheme(theme: Theme | undefined): MarkdownTheme {
+	return {
+		heading: (text) => themeFg(theme, "mdHeading", text),
+		link: (text) => themeFg(theme, "mdLink", text),
+		linkUrl: (text) => themeFg(theme, "mdLinkUrl", text),
+		code: (text) => themeFg(theme, "mdCode", text),
+		codeBlock: (text) => themeFg(theme, "mdCodeBlock", text),
+		codeBlockBorder: (text) => themeFg(theme, "mdCodeBlockBorder", text),
+		quote: (text) => themeFg(theme, "mdQuote", text),
+		quoteBorder: (text) => themeFg(theme, "mdQuoteBorder", text),
+		hr: (text) => themeFg(theme, "mdHr", text),
+		listBullet: (text) => themeFg(theme, "mdListBullet", text),
+		bold: (text) => (theme ? theme.bold(text) : text),
+		italic: (text) => (theme ? theme.italic(text) : text),
+		underline: (text) => (theme ? theme.underline(text) : text),
+		strikethrough: (text) => (theme ? theme.strikethrough(text) : text),
+	};
+}
+
+function renderMarkdown(text: string, width: number, theme: Theme | undefined): string[] {
+	const renderer = new Markdown(text, 0, 0, makeMarkdownTheme(theme), {
+		color: (content) => themeFg(theme, "userMessageText", content),
+	});
+	const lines = renderer.render(Math.max(1, width));
+	return lines.length > 0 ? lines : [""];
+}
+
+function trimMarkdownPadding(line: string): string {
+	return line.replace(/ +((?:\x1b\[[0-?]*[ -/]*[@-~])*)$/, "$1");
+}
+
+function fillLine(content: string, width: number): string {
+	const truncated = truncateToWidth(content, Math.max(0, width), "");
+	return `${truncated}${" ".repeat(Math.max(0, width - visibleWidth(truncated)))}`;
+}
+
+function accent(theme: Theme | undefined, config: ZentuiConfig, text: string): string {
+	return theme
+		? renderStyleForSourceOrFallbackStrict(
+				theme,
+				config.components.userMessages.colorSource,
+				config.colors.editorAccent,
+				EDITOR_ACCENT_FALLBACK,
+				text,
+			)
+		: text;
+}
+
+function border(theme: Theme | undefined, config: ZentuiConfig, text: string): string {
+	return theme
+		? renderStyleForSourceOrFallbackStrict(
+				theme,
+				config.components.userMessages.colorSource,
+				config.colors.editorBorder,
+				EDITOR_BORDER_FALLBACK,
+				text,
+			)
+		: text;
+}
+
+function renderRail(theme: Theme | undefined, config: ZentuiConfig): string {
+	return `${accent(theme, config, config.icons.rail)} `;
+}
+
+function renderFramed({ text, width, theme, config }: UserMessageStyleRenderInput): string[] {
+	if (width <= 0) return [""];
+	const rail = renderRail(theme, config);
+	const contentWidth = Math.max(1, width - visibleWidth(rail));
+	const body = renderMarkdown(text, contentWidth, theme);
+	const row = (line: string) => {
+		const available = Math.max(0, width - visibleWidth(rail));
+		return truncateToWidth(`${rail}${fillLine(line, available)}`, width, "");
+	};
+	const rule = truncateToWidth(border(theme, config, "─".repeat(width)), width, "");
+	return [rule, row(""), ...body.map(row), row(""), rule];
+}
+
+function renderCompact({ text, width, theme, config }: UserMessageStyleRenderInput): string[] {
+	if (width <= 0) return [""];
+	const rail = renderRail(theme, config);
+	const railWidth = visibleWidth(rail);
+	if (width <= railWidth) {
+		return renderMarkdown(text, width, theme).map((line) =>
+			truncateToWidth(trimMarkdownPadding(line), width, ""),
+		);
+	}
+	const contentWidth = width - railWidth;
+	return renderMarkdown(text, contentWidth, theme).map((line) =>
+		truncateToWidth(`${rail}${trimMarkdownPadding(line)}`, width, ""),
+	);
+}
+
+function renderLabeled({ text, width, theme, config }: UserMessageStyleRenderInput): string[] {
+	if (width <= 0) return [""];
+	if (width <= 2) {
+		return renderMarkdown(text, width, theme).map((line) => truncateToWidth(line, width, ""));
+	}
+
+	const horizontalPadding = width >= 5 ? 1 : 0;
+	const contentWidth = Math.max(1, width - 2 - horizontalPadding * 2);
+	const body = renderMarkdown(text, contentWidth, theme);
+	const top =
+		width >= 9
+			? `${border(theme, config, "╭─")}${accent(theme, config, " User ")}${border(
+					theme,
+					config,
+					`${"─".repeat(Math.max(0, width - 9))}╮`,
+				)}`
+			: border(theme, config, `╭${"─".repeat(Math.max(0, width - 2))}╮`);
+	const padding = " ".repeat(horizontalPadding);
+	const side = (line: string) =>
+		`${border(theme, config, "│")}${padding}${fillLine(line, contentWidth)}${padding}${border(
+			theme,
+			config,
+			"│",
+		)}`;
+	const bottom = border(theme, config, `╰${"─".repeat(Math.max(0, width - 2))}╯`);
+	return [top, ...body.map(side), bottom];
+}
+
+export function userMessageStyleCacheKey(config: ZentuiConfig): string {
+	const messages = config.components.userMessages;
+	switch (messages.style) {
+		case "framed":
+			return [
+				"framed",
+				messages.colorSource,
+				config.colors.editorAccent ?? "",
+				config.colors.editorBorder ?? "",
+				config.icons.rail,
+			].join("\0");
+		case "compact":
+			return [
+				"compact",
+				messages.colorSource,
+				config.colors.editorAccent ?? "",
+				config.icons.rail,
+			].join("\0");
+		case "labeled":
+			return [
+				"labeled",
+				messages.colorSource,
+				config.colors.editorAccent ?? "",
+				config.colors.editorBorder ?? "",
+				"User:v1",
+			].join("\0");
+	}
+}
+
+export function renderUserMessageStyle(input: UserMessageStyleRenderInput): string[] {
+	const shielded = shieldCompleteOscSequences(input.text);
+	const shieldedInput = { ...input, text: shielded.text };
+	let lines: string[];
+	switch (input.config.components.userMessages.style) {
+		case "framed":
+			lines = renderFramed(shieldedInput);
+			break;
+		case "compact":
+			lines = renderCompact(shieldedInput);
+			break;
+		case "labeled":
+			lines = renderLabeled(shieldedInput);
+			break;
+	}
+	return restoreCompleteOscSequences(lines, shielded.shields);
+}

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -5,8 +5,8 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
-import type { PolishedTuiConfig } from "./config";
-import { installPrototypePatch } from "./prototype-patch-registry";
+import type { ZentuiConfig } from "./config";
+import { installPrototypePatch, removePrototypePatch } from "./prototype-patch-registry";
 import {
 	EDITOR_ACCENT_FALLBACK,
 	EDITOR_BORDER_FALLBACK,
@@ -68,10 +68,11 @@ function getCachedMarkdownText(instance: object): string | undefined {
 	return text;
 }
 
-function getUserMessageConfigKey(config: PolishedTuiConfig): string {
+function getUserMessageConfigKey(config: ZentuiConfig): string {
 	return [
-		config.features.copyFriendly ? "copy" : "chrome",
-		config.colorSources.userMessages,
+		config.components.userMessages.style,
+		config.components.userMessages.styles.framed.copyFriendly ? "copy" : "chrome",
+		config.components.userMessages.colorSource,
 		config.colors.editorAccent ?? "",
 		config.colors.editorBorder ?? "",
 		config.icons.rail,
@@ -112,15 +113,15 @@ function fillLine(content: string, width: number): string {
 	return `${truncated}${pad}`;
 }
 
-function renderPromptBoxRail(theme: Theme | undefined, config: PolishedTuiConfig): string {
-	if (config.features.copyFriendly) return "";
+function renderPromptBoxRail(theme: Theme | undefined, config: ZentuiConfig): string {
+	if (config.components.userMessages.styles.framed.copyFriendly) return "";
 	const railGlyph = config.icons.rail;
 
 	return `${
 		theme
 			? renderStyleForSourceOrFallback(
 					theme,
-					config.colorSources.userMessages,
+					config.components.userMessages.colorSource,
 					config.colors.editorAccent,
 					EDITOR_ACCENT_FALLBACK,
 					railGlyph,
@@ -133,12 +134,12 @@ function renderPromptBoxLine(
 	line: string,
 	width: number,
 	theme: Theme | undefined,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): string {
 	if (width <= 0) return "";
 	const rail = renderPromptBoxRail(theme, config);
 	const contentWidth = Math.max(0, width - visibleWidth(rail));
-	const content = config.features.copyFriendly
+	const content = config.components.userMessages.styles.framed.copyFriendly
 		? truncateToWidth(line, contentWidth, "")
 		: fillLine(line, contentWidth);
 	return truncateToWidth(`${rail}${content}`, width, "");
@@ -148,7 +149,7 @@ function renderZentuiUserMessage(
 	instance: PatchableUserMessagePrototype,
 	width: number,
 	theme: Theme | undefined,
-	config: PolishedTuiConfig,
+	config: ZentuiConfig,
 ): string[] | undefined {
 	if (!isRecord(instance)) return undefined;
 
@@ -178,7 +179,7 @@ function renderZentuiUserMessage(
 	const border = theme
 		? renderStyleForSourceOrFallback(
 				theme,
-				config.colorSources.userMessages,
+				config.components.userMessages.colorSource,
 				config.colors.editorBorder,
 				EDITOR_BORDER_FALLBACK,
 				"─".repeat(width),
@@ -211,9 +212,15 @@ function withPromptZoneMarkers(lines: string[]): string[] {
 	return markedLines;
 }
 
+export function removeUserMessageStyle(): void {
+	const prototype = UserMessageComponent.prototype;
+	removePrototypePatch(prototype, "render", "user-message-render");
+	removePrototypePatch(prototype, "invalidate", "user-message-invalidate");
+}
+
 export function installUserMessageStyle(
 	getTheme: () => Theme | undefined,
-	getConfig: () => PolishedTuiConfig,
+	getConfig: () => ZentuiConfig,
 ): Cleanup {
 	const prototype = UserMessageComponent.prototype;
 	const cleanupInvalidate = installPrototypePatch(

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -5,7 +5,7 @@ import { installPrototypePatch, removePrototypePatch } from "./prototype-patch-r
 import {
 	sanitizeRenderedUserMessageLines,
 	sanitizeRenderedUserMessageText,
-	stripUserMessageOscText,
+	sanitizeUserMessageSourceText,
 } from "./user-message-osc";
 import { renderUserMessageStyle, userMessageStyleCacheKey } from "./user-message-styles";
 
@@ -124,7 +124,7 @@ function sanitizePredecessorRender(result: unknown): unknown {
 	);
 }
 
-function renderSafeOscFallback(
+function renderSafeSourceFallback(
 	instance: PatchableUserMessagePrototype,
 	width: number,
 ): string[] | undefined {
@@ -135,7 +135,7 @@ function renderSafeOscFallback(
 		return undefined;
 	}
 	if (text === undefined) return undefined;
-	const stripped = stripUserMessageOscText(text);
+	const stripped = sanitizeUserMessageSourceText(text);
 	if (stripped === text) return undefined;
 	const lines = (width > 0 ? wrapTextWithAnsi(stripped, width) : [""]).map(
 		sanitizeRenderedUserMessageText,
@@ -184,7 +184,7 @@ export function installUserMessageStyle(
 					if (!lines) return renderPredecessor();
 					return lines.length ? withPromptZoneMarkers(lines) : lines;
 				} catch {
-					const safeFallback = renderSafeOscFallback(
+					const safeFallback = renderSafeSourceFallback(
 						receiver as PatchableUserMessagePrototype,
 						width,
 					);

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -1,21 +1,85 @@
-import { type Theme, type ThemeColor, UserMessageComponent } from "@earendil-works/pi-coding-agent";
-import {
-	Markdown,
-	type MarkdownTheme,
-	truncateToWidth,
-	visibleWidth,
-} from "@earendil-works/pi-tui";
+import { type Theme, UserMessageComponent } from "@earendil-works/pi-coding-agent";
 import type { ZentuiConfig } from "./config";
 import { installPrototypePatch, removePrototypePatch } from "./prototype-patch-registry";
-import {
-	EDITOR_ACCENT_FALLBACK,
-	EDITOR_BORDER_FALLBACK,
-	renderStyleForSourceOrFallback,
-} from "./style";
+import { renderUserMessageStyle, userMessageStyleCacheKey } from "./user-message-styles";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
+const ESC = "\x1b";
+const BEL = "\x07";
+const C1_OSC = "\x9d";
+const C1_ST = "\x9c";
+
+function oscStartLength(text: string, index: number): number {
+	if (text[index] === C1_OSC) return 1;
+	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
+}
+
+type OscBoundary =
+	| { kind: "terminator"; index: number; length: number }
+	| { kind: "start"; index: number };
+
+function findOscBoundary(text: string, payloadStart: number): OscBoundary | undefined {
+	for (let index = payloadStart; index < text.length; index += 1) {
+		if (oscStartLength(text, index) > 0) return { kind: "start", index };
+		if (text[index] === BEL || text[index] === C1_ST) {
+			return { kind: "terminator", index, length: 1 };
+		}
+		if (text[index] === ESC && text[index + 1] === "\\") {
+			return { kind: "terminator", index, length: 2 };
+		}
+	}
+	return undefined;
+}
+
+function isCompleteOsc133Payload(payload: string): boolean {
+	return payload === "133" || payload.startsWith("133;");
+}
+
+function incompleteOsc133PrefixLength(payload: string): number {
+	if (payload.length > 0 && "133".startsWith(payload)) return payload.length;
+	if (!payload.startsWith("133;")) return 0;
+
+	let length = 4;
+	if (/^[A-D]$/.test(payload[length] ?? "")) length += 1;
+	if (payload[length] === ";") length += 1;
+	return length;
+}
+
+function stripOsc133Sequences(text: string): string {
+	let output = "";
+	let index = 0;
+	while (index < text.length) {
+		const startLength = oscStartLength(text, index);
+		if (startLength === 0) {
+			output += text[index];
+			index += 1;
+			continue;
+		}
+
+		const payloadStart = index + startLength;
+		const boundary = findOscBoundary(text, payloadStart);
+		const payloadEnd = boundary?.index ?? text.length;
+		const payload = text.slice(payloadStart, payloadEnd);
+		if (boundary?.kind === "terminator") {
+			const sequenceEnd = boundary.index + boundary.length;
+			if (!isCompleteOsc133Payload(payload)) output += text.slice(index, sequenceEnd);
+			index = sequenceEnd;
+			continue;
+		}
+
+		// An unterminated OSC introducer must not remain open and consume a later
+		// Zentui prompt marker. Preserve its human-readable payload, but remove a
+		// recognized (including partial) OSC 133 command prefix. A nested OSC start
+		// is processed independently on the next loop iteration.
+		const prefixLength = incompleteOsc133PrefixLength(payload);
+		output += payload.slice(prefixLength);
+		index = payloadEnd;
+		if (!boundary) break;
+	}
+	return output;
+}
 
 type PatchableUserMessagePrototype = {
 	children?: unknown[];
@@ -68,83 +132,6 @@ function getCachedMarkdownText(instance: object): string | undefined {
 	return text;
 }
 
-function getUserMessageConfigKey(config: ZentuiConfig): string {
-	return [
-		config.components.userMessages.style,
-		config.components.userMessages.styles.framed.copyFriendly ? "copy" : "chrome",
-		config.components.userMessages.colorSource,
-		config.colors.editorAccent ?? "",
-		config.colors.editorBorder ?? "",
-		config.icons.rail,
-	].join("\0");
-}
-
-function themeFg(theme: Theme | undefined, color: ThemeColor, text: string): string {
-	if (!theme) return text;
-	try {
-		return theme.fg(color, text);
-	} catch {
-		return text;
-	}
-}
-
-function makeMarkdownTheme(theme: Theme | undefined): MarkdownTheme {
-	return {
-		heading: (text) => themeFg(theme, "mdHeading", text),
-		link: (text) => themeFg(theme, "mdLink", text),
-		linkUrl: (text) => themeFg(theme, "mdLinkUrl", text),
-		code: (text) => themeFg(theme, "mdCode", text),
-		codeBlock: (text) => themeFg(theme, "mdCodeBlock", text),
-		codeBlockBorder: (text) => themeFg(theme, "mdCodeBlockBorder", text),
-		quote: (text) => themeFg(theme, "mdQuote", text),
-		quoteBorder: (text) => themeFg(theme, "mdQuoteBorder", text),
-		hr: (text) => themeFg(theme, "mdHr", text),
-		listBullet: (text) => themeFg(theme, "mdListBullet", text),
-		bold: (text) => (theme ? theme.bold(text) : text),
-		italic: (text) => (theme ? theme.italic(text) : text),
-		underline: (text) => (theme ? theme.underline(text) : text),
-		strikethrough: (text) => (theme ? theme.strikethrough(text) : text),
-	};
-}
-
-function fillLine(content: string, width: number): string {
-	const truncated = truncateToWidth(content, Math.max(0, width), "");
-	const pad = " ".repeat(Math.max(0, width - visibleWidth(truncated)));
-	return `${truncated}${pad}`;
-}
-
-function renderPromptBoxRail(theme: Theme | undefined, config: ZentuiConfig): string {
-	if (config.components.userMessages.styles.framed.copyFriendly) return "";
-	const railGlyph = config.icons.rail;
-
-	return `${
-		theme
-			? renderStyleForSourceOrFallback(
-					theme,
-					config.components.userMessages.colorSource,
-					config.colors.editorAccent,
-					EDITOR_ACCENT_FALLBACK,
-					railGlyph,
-				)
-			: railGlyph
-	} `;
-}
-
-function renderPromptBoxLine(
-	line: string,
-	width: number,
-	theme: Theme | undefined,
-	config: ZentuiConfig,
-): string {
-	if (width <= 0) return "";
-	const rail = renderPromptBoxRail(theme, config);
-	const contentWidth = Math.max(0, width - visibleWidth(rail));
-	const content = config.components.userMessages.styles.framed.copyFriendly
-		? truncateToWidth(line, contentWidth, "")
-		: fillLine(line, contentWidth);
-	return truncateToWidth(`${rail}${content}`, width, "");
-}
-
 function renderZentuiUserMessage(
 	instance: PatchableUserMessagePrototype,
 	width: number,
@@ -155,9 +142,7 @@ function renderZentuiUserMessage(
 
 	const text = getCachedMarkdownText(instance);
 	if (text === undefined) return undefined;
-	if (width <= 0) return [""];
-
-	const configKey = getUserMessageConfigKey(config);
+	const configKey = userMessageStyleCacheKey(config);
 	const cached = userMessageRenderCache.get(instance);
 	if (
 		cached?.hasMarkdownText &&
@@ -169,30 +154,12 @@ function renderZentuiUserMessage(
 		return cached.renderedLines;
 	}
 
-	const railWidth = visibleWidth(renderPromptBoxRail(theme, config));
-	const contentWidth = Math.max(1, width - railWidth);
-	const renderer = new Markdown(text, 0, 0, makeMarkdownTheme(theme), {
-		color: (content) => themeFg(theme, "userMessageText", content),
+	const lines = renderUserMessageStyle({
+		text: stripOsc133Sequences(text),
+		width,
+		theme,
+		config,
 	});
-	const body = renderer.render(contentWidth);
-	const contentLines = body.length > 0 ? body : [""];
-	const border = theme
-		? renderStyleForSourceOrFallback(
-				theme,
-				config.components.userMessages.colorSource,
-				config.colors.editorBorder,
-				EDITOR_BORDER_FALLBACK,
-				"─".repeat(width),
-			)
-		: "─".repeat(width);
-	const lines = [
-		truncateToWidth(border, width, ""),
-		renderPromptBoxLine("", width, theme, config),
-		...contentLines.map((line) => renderPromptBoxLine(line, width, theme, config)),
-		renderPromptBoxLine("", width, theme, config),
-		truncateToWidth(border, width, ""),
-	];
-
 	userMessageRenderCache.set(instance, {
 		hasMarkdownText: true,
 		text,
@@ -205,6 +172,9 @@ function renderZentuiUserMessage(
 }
 
 function withPromptZoneMarkers(lines: string[]): string[] {
+	if (lines.length === 1) {
+		return [`${OSC133_ZONE_START}${lines[0]}${OSC133_ZONE_END}${OSC133_ZONE_FINAL}`];
+	}
 	const markedLines = [...lines];
 	markedLines[0] = OSC133_ZONE_START + markedLines[0];
 	markedLines[markedLines.length - 1] =
@@ -241,15 +211,18 @@ export function installUserMessageStyle(
 			({ predecessor, receiver, args }) => {
 				const width = args[0];
 				if (typeof width !== "number") return Reflect.apply(predecessor, receiver, args);
-				const lines = renderZentuiUserMessage(
-					receiver as PatchableUserMessagePrototype,
-					width,
-					getTheme(),
-					getConfig(),
-				);
-				if (!lines) return Reflect.apply(predecessor, receiver, args);
-				if (lines.length === 0) return lines;
-				return withPromptZoneMarkers(lines);
+				try {
+					const lines = renderZentuiUserMessage(
+						receiver as PatchableUserMessagePrototype,
+						width,
+						getTheme(),
+						getConfig(),
+					);
+					if (!lines) return Reflect.apply(predecessor, receiver, args);
+					return lines.length ? withPromptZoneMarkers(lines) : lines;
+				} catch {
+					return Reflect.apply(predecessor, receiver, args);
+				}
 			},
 		);
 	} catch (error) {

--- a/extensions/zentui/user-message.ts
+++ b/extensions/zentui/user-message.ts
@@ -1,85 +1,17 @@
 import { type Theme, UserMessageComponent } from "@earendil-works/pi-coding-agent";
+import { wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { ZentuiConfig } from "./config";
 import { installPrototypePatch, removePrototypePatch } from "./prototype-patch-registry";
+import {
+	sanitizeRenderedUserMessageLines,
+	sanitizeRenderedUserMessageText,
+	stripUserMessageOscText,
+} from "./user-message-osc";
 import { renderUserMessageStyle, userMessageStyleCacheKey } from "./user-message-styles";
 
 const OSC133_ZONE_START = "\x1b]133;A\x07";
 const OSC133_ZONE_END = "\x1b]133;B\x07";
 const OSC133_ZONE_FINAL = "\x1b]133;C\x07";
-const ESC = "\x1b";
-const BEL = "\x07";
-const C1_OSC = "\x9d";
-const C1_ST = "\x9c";
-
-function oscStartLength(text: string, index: number): number {
-	if (text[index] === C1_OSC) return 1;
-	return text[index] === ESC && text[index + 1] === "]" ? 2 : 0;
-}
-
-type OscBoundary =
-	| { kind: "terminator"; index: number; length: number }
-	| { kind: "start"; index: number };
-
-function findOscBoundary(text: string, payloadStart: number): OscBoundary | undefined {
-	for (let index = payloadStart; index < text.length; index += 1) {
-		if (oscStartLength(text, index) > 0) return { kind: "start", index };
-		if (text[index] === BEL || text[index] === C1_ST) {
-			return { kind: "terminator", index, length: 1 };
-		}
-		if (text[index] === ESC && text[index + 1] === "\\") {
-			return { kind: "terminator", index, length: 2 };
-		}
-	}
-	return undefined;
-}
-
-function isCompleteOsc133Payload(payload: string): boolean {
-	return payload === "133" || payload.startsWith("133;");
-}
-
-function incompleteOsc133PrefixLength(payload: string): number {
-	if (payload.length > 0 && "133".startsWith(payload)) return payload.length;
-	if (!payload.startsWith("133;")) return 0;
-
-	let length = 4;
-	if (/^[A-D]$/.test(payload[length] ?? "")) length += 1;
-	if (payload[length] === ";") length += 1;
-	return length;
-}
-
-function stripOsc133Sequences(text: string): string {
-	let output = "";
-	let index = 0;
-	while (index < text.length) {
-		const startLength = oscStartLength(text, index);
-		if (startLength === 0) {
-			output += text[index];
-			index += 1;
-			continue;
-		}
-
-		const payloadStart = index + startLength;
-		const boundary = findOscBoundary(text, payloadStart);
-		const payloadEnd = boundary?.index ?? text.length;
-		const payload = text.slice(payloadStart, payloadEnd);
-		if (boundary?.kind === "terminator") {
-			const sequenceEnd = boundary.index + boundary.length;
-			if (!isCompleteOsc133Payload(payload)) output += text.slice(index, sequenceEnd);
-			index = sequenceEnd;
-			continue;
-		}
-
-		// An unterminated OSC introducer must not remain open and consume a later
-		// Zentui prompt marker. Preserve its human-readable payload, but remove a
-		// recognized (including partial) OSC 133 command prefix. A nested OSC start
-		// is processed independently on the next loop iteration.
-		const prefixLength = incompleteOsc133PrefixLength(payload);
-		output += payload.slice(prefixLength);
-		index = payloadEnd;
-		if (!boundary) break;
-	}
-	return output;
-}
 
 type PatchableUserMessagePrototype = {
 	children?: unknown[];
@@ -155,7 +87,7 @@ function renderZentuiUserMessage(
 	}
 
 	const lines = renderUserMessageStyle({
-		text: stripOsc133Sequences(text),
+		text,
 		width,
 		theme,
 		config,
@@ -180,6 +112,35 @@ function withPromptZoneMarkers(lines: string[]): string[] {
 	markedLines[markedLines.length - 1] =
 		OSC133_ZONE_END + OSC133_ZONE_FINAL + markedLines[markedLines.length - 1];
 	return markedLines;
+}
+
+function sanitizePredecessorRender(result: unknown): unknown {
+	if (typeof result === "string") return sanitizeRenderedUserMessageText(result);
+	if (!Array.isArray(result)) return result;
+	const stringRows = result.every((line): line is string => typeof line === "string");
+	if (stringRows) return sanitizeRenderedUserMessageLines(result);
+	return result.map((line) =>
+		typeof line === "string" ? sanitizeRenderedUserMessageText(line) : line,
+	);
+}
+
+function renderSafeOscFallback(
+	instance: PatchableUserMessagePrototype,
+	width: number,
+): string[] | undefined {
+	let text: string | undefined;
+	try {
+		text = isRecord(instance) ? getCachedMarkdownText(instance) : undefined;
+	} catch {
+		return undefined;
+	}
+	if (text === undefined) return undefined;
+	const stripped = stripUserMessageOscText(text);
+	if (stripped === text) return undefined;
+	const lines = (width > 0 ? wrapTextWithAnsi(stripped, width) : [""]).map(
+		sanitizeRenderedUserMessageText,
+	);
+	return withPromptZoneMarkers(lines.length > 0 ? lines : [""]);
 }
 
 export function removeUserMessageStyle(): void {
@@ -209,8 +170,10 @@ export function installUserMessageStyle(
 			"render",
 			"user-message-render",
 			({ predecessor, receiver, args }) => {
+				const renderPredecessor = () =>
+					sanitizePredecessorRender(Reflect.apply(predecessor, receiver, args));
 				const width = args[0];
-				if (typeof width !== "number") return Reflect.apply(predecessor, receiver, args);
+				if (typeof width !== "number") return renderPredecessor();
 				try {
 					const lines = renderZentuiUserMessage(
 						receiver as PatchableUserMessagePrototype,
@@ -218,10 +181,14 @@ export function installUserMessageStyle(
 						getTheme(),
 						getConfig(),
 					);
-					if (!lines) return Reflect.apply(predecessor, receiver, args);
+					if (!lines) return renderPredecessor();
 					return lines.length ? withPromptZoneMarkers(lines) : lines;
 				} catch {
-					return Reflect.apply(predecessor, receiver, args);
+					const safeFallback = renderSafeOscFallback(
+						receiver as PatchableUserMessagePrototype,
+						width,
+					);
+					return safeFallback ?? renderPredecessor();
 				}
 			},
 		);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
 				"@earendil-works/pi-coding-agent": "^0.82.1",
 				"@earendil-works/pi-tui": "^0.82.1",
 				"@types/node": "^26.0.0",
+				"node-pty": "^1.1.0",
 				"typescript": "^7.0.2",
 				"vitest": "^4.1.8"
 			},
@@ -4599,6 +4600,13 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/node-addon-api": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/node-domexception": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -4637,6 +4645,17 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/node-pty": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+			"integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"node-addon-api": "^7.1.0"
 			}
 		},
 		"node_modules/obug": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit",
 		"test": "vitest run",
+		"test:fixed-editor": "vitest run --maxWorkers=1 test/fixed-editor-editor-layout.test.ts test/fixed-editor-layout.test.ts test/fixed-editor.test.ts test/editor-viewport-indicators.test.ts test/minimalist-editor.test.ts test/session-lifecycle.test.ts test/fixed-editor-terminal-state.test.ts test/fixed-editor-pty.test.ts && vitest run --maxWorkers=1 test/extension-compliance.test.ts -t 'fixed editor|fixed-editor|fixed layout|fixed-layout'",
 		"pi:dev": "${PI_BIN:-/opt/homebrew/bin/pi} --no-extensions -e ./extensions/zentui/index.ts",
 		"pi:install-local": "${PI_BIN:-/opt/homebrew/bin/pi} install ./ -l",
 		"fmt": "biome format --write .",
@@ -54,6 +55,7 @@
 		"@earendil-works/pi-coding-agent": "^0.82.1",
 		"@earendil-works/pi-tui": "^0.82.1",
 		"@types/node": "^26.0.0",
+		"node-pty": "^1.1.0",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.8"
 	}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"pi:dev": "${PI_BIN:-/opt/homebrew/bin/pi} --no-extensions -e ./extensions/zentui/index.ts",
 		"pi:install-local": "${PI_BIN:-/opt/homebrew/bin/pi} install ./ -l",
 		"fmt": "biome format --write .",
-		"fmt:check": "biome format --check .",
+		"fmt:check": "biome format .",
 		"verify": "npm run lint && npm run typecheck && npm run test",
 		"pack:check": "npm pack --dry-run",
 		"prepublishOnly": "npm run verify && npm run pack:check"

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -21,6 +21,9 @@ import {
 	defaultConfig,
 	ensureConfigExists,
 	FOOTER_FORMAT_VARIABLES,
+	getExtensionStatusColorMode,
+	getExtensionStatusPlacement,
+	hasUnsupportedComponentStyle,
 	mergeConfig,
 	saveColorSourcesPatch,
 	saveContextStylePatch,
@@ -764,13 +767,15 @@ describe("Phase 4 style migration", () => {
 					},
 				},
 				(path) => {
-					saveUnrelated(path);
+					const unrelatedConfig = saveUnrelated(path);
+					expect(hasUnsupportedComponentStyle(unrelatedConfig, owner)).toBe(true);
 					const preserved = readRaw(path);
 					expect(preserved.components[owner].style).toBe(`future-${owner}`);
 					expect(preserved.components[owner].futureOption).toBe("keep");
 					expect(preserved.components[owner].styles.future).toEqual({ keep: true });
 
-					saveStyle(path);
+					const replacedConfig = saveStyle(path);
+					expect(hasUnsupportedComponentStyle(replacedConfig, owner)).toBe(false);
 					const replaced = readRaw(path);
 					expect(replaced.components[owner].style).toBe(expectedStyle);
 					expect(replaced.components[owner].futureOption).toBe("keep");
@@ -2717,6 +2722,66 @@ describe("Opencode and Footer follow-up migration", () => {
 				"native",
 			);
 		});
+	});
+
+	it("ignores inherited extension-status overrides and validates runtime mutations", () => {
+		const config = structuredClone(defaultConfig);
+		const statuses = config.components.footer.styles.starship.extensionStatuses;
+		statuses.placements = Object.create({ constructor: "left" }) as Record<
+			string,
+			(typeof statuses.placements)[string]
+		>;
+		statuses.colorModes = Object.create({ constructor: "original" }) as Record<
+			string,
+			(typeof statuses.colorModes)[string]
+		>;
+		expect(getExtensionStatusPlacement(config, "constructor")).toBe("right");
+		expect(getExtensionStatusColorMode(config, "constructor")).toBe("zentui");
+
+		Object.defineProperty(statuses.placements, "constructor", {
+			value: "left",
+			enumerable: true,
+			configurable: true,
+		});
+		Object.defineProperty(statuses.colorModes, "constructor", {
+			value: "original",
+			enumerable: true,
+			configurable: true,
+		});
+		expect(getExtensionStatusPlacement(config, "constructor")).toBe("left");
+		expect(getExtensionStatusColorMode(config, "constructor")).toBe("original");
+
+		(statuses as unknown as { defaultPlacement: string }).defaultPlacement = "center";
+		(statuses.placements as unknown as Record<string, string>).alpha = "explode";
+		(statuses.colorModes as unknown as Record<string, string>).alpha = "rainbow";
+		expect(getExtensionStatusPlacement(config, "missing")).toBe("right");
+		expect(getExtensionStatusPlacement(config, "alpha")).toBe("right");
+		expect(getExtensionStatusColorMode(config, "alpha")).toBe("zentui");
+	});
+
+	it("marks only explicit non-empty unknown canonical component styles", () => {
+		const future = mergeConfig({
+			components: {
+				editor: { style: "future-editor" },
+				userMessages: { style: "future-messages" },
+				selectorBorders: { style: "future-selectors" },
+				footer: { style: "future-footer" },
+			},
+		});
+		for (const owner of ["editor", "userMessages", "selectorBorders", "footer"] as const) {
+			expect(hasUnsupportedComponentStyle(future, owner)).toBe(true);
+		}
+
+		for (const style of [undefined, "", "   ", null, false, {}, []]) {
+			const ordinary = mergeConfig({ components: { editor: { style } } });
+			expect(hasUnsupportedComponentStyle(ordinary, "editor")).toBe(false);
+		}
+		expect(
+			hasUnsupportedComponentStyle(
+				mergeConfig({ components: { editor: { style: "polished" } } }),
+				"editor",
+			),
+		).toBe(false);
 	});
 
 	it.each([

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -24,6 +24,7 @@ import {
 	saveColorSourcesPatch,
 	saveContextThresholdsPatch,
 	saveEditorBorderColorMode,
+	saveEditorMode,
 	saveEditorModelLabel,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
@@ -34,6 +35,7 @@ import {
 	saveGitBranchPatch,
 	saveGitCommitPatch,
 	saveGitMetricsPatch,
+	saveMinimalistPatch,
 	savePathDisplayPatch,
 	saveResponsiveFooterPatch,
 	saveSeparatorPatch,
@@ -453,6 +455,105 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ editorModelLabel: "name" }).editorModelLabel).toBe("name");
 		expect(mergeConfig({ editorModelLabel: "id" }).editorModelLabel).toBe("id");
 		expect(mergeConfig({ editorModelLabel: "title" }).editorModelLabel).toBe("id");
+	});
+
+	it("defaults and normalizes editor mode", () => {
+		expect(defaultConfig.editorMode).toBe("polished");
+		expect(mergeConfig({}).editorMode).toBe("polished");
+		expect(mergeConfig({ editorMode: "polished" }).editorMode).toBe("polished");
+		expect(mergeConfig({ editorMode: "minimalist" }).editorMode).toBe("minimalist");
+		for (const value of ["amp", "", 1, null, true]) {
+			expect(mergeConfig({ editorMode: value }).editorMode).toBe("polished");
+		}
+	});
+
+	it("normalizes focused minimalist settings", () => {
+		expect(defaultConfig.minimalist).toEqual({
+			pathDisplay: "compact",
+			contextFormat: "percent",
+			contextGauge: false,
+			showTimer: true,
+			showCost: true,
+			showGit: true,
+		});
+		expect(
+			mergeConfig({
+				minimalist: {
+					pathDisplay: "project",
+					contextFormat: "percent-total",
+					contextGauge: true,
+					showTimer: false,
+					showCost: false,
+					showGit: false,
+				},
+			}).minimalist,
+		).toEqual({
+			pathDisplay: "project",
+			contextFormat: "percent-total",
+			contextGauge: true,
+			showTimer: false,
+			showCost: false,
+			showGit: false,
+		});
+		expect(
+			mergeConfig({
+				minimalist: {
+					pathDisplay: "basename",
+					contextFormat: "tokens",
+					contextGauge: "yes",
+					showTimer: null,
+				},
+			}).minimalist,
+		).toEqual(defaultConfig.minimalist);
+	});
+
+	it("saves minimalist patches while preserving unknown nested config", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(
+				path,
+				JSON.stringify({ unknownTop: true, minimalist: { unknownNested: "keep", showGit: true } }),
+			);
+			const config = saveMinimalistPatch(
+				{ pathDisplay: "full", contextFormat: "percent-total", showGit: false },
+				path,
+			);
+			expect(config.minimalist.pathDisplay).toBe("full");
+			expect(config.minimalist.contextFormat).toBe("percent-total");
+			expect(config.minimalist.showGit).toBe(false);
+			expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+				unknownTop: true,
+				minimalist: { unknownNested: "keep", pathDisplay: "full", showGit: false },
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("saves editor mode without erasing sibling config", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+		const path = join(dir, "zentui.json");
+		try {
+			writeFileSync(path, JSON.stringify({ unknown: { keep: true }, editorModelLabel: "name" }));
+			const minimalist = saveEditorMode("minimalist", path);
+			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+				unknown: { keep: true },
+				editorModelLabel: "name",
+				editorMode: "minimalist",
+			});
+			expect(minimalist.editorMode).toBe("minimalist");
+
+			const polished = saveEditorMode("polished", path);
+			expect(polished.editorMode).toBe("polished");
+			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
+				unknown: { keep: true },
+				editorModelLabel: "name",
+				editorMode: "polished",
+			});
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 
 	it("defaults and normalizes editor border color mode", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -36,7 +36,6 @@ import {
 	saveFooterComponentPatch,
 	saveFooterFormatPatch,
 	saveFooterSegmentsPatch,
-	saveFramedUserMessagesStylePatch,
 	saveGitBranchPatch,
 	saveGitCommitPatch,
 	saveGitMetricsPatch,
@@ -44,6 +43,7 @@ import {
 	saveMinimalistEditorStylePatch,
 	saveMinimalistPatch,
 	savePathDisplayPatch,
+	savePolishedCopyFriendlyEditorStylePatch,
 	savePolishedEditorStylePatch,
 	saveResponsiveFooterPatch,
 	saveSelectorBordersComponentPatch,
@@ -98,7 +98,9 @@ describe("canonical config resolution", () => {
 				viewportIndicators: true,
 				styles: {
 					polished: {
-						copyFriendly: false,
+						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+					},
+					"polished-copy-friendly": {
 						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
 					},
 					minimalist: {
@@ -117,7 +119,7 @@ describe("canonical config resolution", () => {
 				enabled: true,
 				style: "framed",
 				colorSource: "theme",
-				styles: { framed: { copyFriendly: false } },
+				styles: { framed: {}, compact: {}, labeled: {} },
 			},
 			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 			footer: {
@@ -197,8 +199,8 @@ describe("canonical config resolution", () => {
 			false,
 		]);
 		expect(editor.viewportIndicators).toBe(false);
-		expect(editor.styles.polished.copyFriendly).toBe(true);
-		expect(userMessages.styles.framed.copyFriendly).toBe(true);
+		expect(editor.style).toBe("polished-copy-friendly");
+		expect(userMessages.enabled).toBe(false);
 		expect([editor.colorSource, selectorBorders.colorSource]).toEqual(["terminal", "terminal"]);
 		expect(userMessages.colorSource).toBe("terminal");
 		expect(footer.colorSource).toBe("terminal");
@@ -252,7 +254,6 @@ describe("canonical config resolution", () => {
 		expect(config.components.editor.enabled).toBe(false);
 		expect(config.components.editor.style).toBe("polished");
 		expect(config.components.editor.colorSource).toBe("theme");
-		expect(config.components.editor.styles.polished.copyFriendly).toBe(false);
 		// Missing canonical siblings still migrate independently.
 		expect(config.components.editor.viewportIndicators).toBe(false);
 		expect(config.components.editor.borderColorMode).toBe("adaptive");
@@ -432,7 +433,6 @@ describe("canonical config resolution", () => {
 		expect(config.features).toEqual({
 			editor: false,
 			statusLine: true,
-			copyFriendly: true,
 			viewportIndicators: true,
 		});
 		expect(config.colorSources).toEqual({
@@ -468,6 +468,276 @@ describe("canonical config resolution", () => {
 			expect.arrayContaining(["cache_read", "cache_write", "subscription", "auto_compaction"]),
 		);
 	});
+});
+
+describe("Phase 4 style migration", () => {
+	it.each([
+		[true, "polished-copy-friendly"],
+		[false, "polished"],
+		["invalid", "polished"],
+	] as const)("maps a present nested Editor flag %s deterministically", (copyFriendly, style) => {
+		const config = mergeConfig({
+			features: { copyFriendly: true },
+			components: {
+				editor: { style: "polished", styles: { polished: { copyFriendly } } },
+			},
+		});
+		expect(config.components.editor.style).toBe(style);
+	});
+
+	it.each([
+		[true, false],
+		[false, true],
+		["invalid", true],
+	] as const)(
+		"maps a present nested message flag %s deterministically",
+		(copyFriendly, enabled) => {
+			const config = mergeConfig({
+				features: { editor: true, copyFriendly: true },
+				components: {
+					userMessages: {
+						enabled: true,
+						style: "framed",
+						styles: { framed: { copyFriendly } },
+					},
+				},
+			});
+			expect(config.components.userMessages.style).toBe("framed");
+			expect(config.components.userMessages.enabled).toBe(enabled);
+		},
+	);
+
+	it("maps the released feature flag to low-rail Editor and native messages", () => {
+		const migrated = mergeConfig({ features: { copyFriendly: true } });
+		expect(migrated.components.editor.style).toBe("polished-copy-friendly");
+		expect(migrated.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+
+		const regular = mergeConfig({ features: { copyFriendly: false } });
+		expect(regular.components.editor.style).toBe("polished");
+		expect(regular.components.userMessages).toMatchObject({ style: "framed", enabled: true });
+	});
+
+	it.each([
+		[undefined, true, "polished-copy-friendly"],
+		[undefined, false, "polished"],
+		[undefined, "invalid", "polished"],
+		["future", true, "polished-copy-friendly"],
+		["future", false, "polished"],
+		["future", "invalid", "polished"],
+	] as const)(
+		"resolves absent or invalid Editor style %s from nested flag %s",
+		(rawStyle, copyFriendly, expected) => {
+			const config = mergeConfig({
+				features: { copyFriendly: copyFriendly !== true },
+				components: {
+					editor: {
+						...(rawStyle === undefined ? {} : { style: rawStyle }),
+						styles: { polished: { copyFriendly } },
+					},
+				},
+			});
+			expect(config.components.editor.style).toBe(expected);
+		},
+	);
+
+	it.each([
+		[undefined, true, false],
+		[undefined, false, true],
+		[undefined, "invalid", true],
+		["future", true, false],
+		["future", false, true],
+		["future", "invalid", true],
+	] as const)(
+		"resolves absent or invalid message style %s from nested flag %s",
+		(rawStyle, copyFriendly, expectedEnabled) => {
+			const config = mergeConfig({
+				features: { editor: true, copyFriendly: copyFriendly !== true },
+				components: {
+					userMessages: {
+						enabled: true,
+						...(rawStyle === undefined ? {} : { style: rawStyle }),
+						styles: { framed: { copyFriendly } },
+					},
+				},
+			});
+			expect(config.components.userMessages).toMatchObject({
+				style: "framed",
+				enabled: expectedEnabled,
+			});
+		},
+	);
+
+	it("treats ambiguous explicit styles without nested flags as authoritative", () => {
+		const config = mergeConfig({
+			features: { editor: true, copyFriendly: true },
+			components: {
+				editor: { style: "polished" },
+				userMessages: { enabled: true, style: "framed" },
+			},
+		});
+		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.userMessages).toMatchObject({ style: "framed", enabled: true });
+	});
+
+	it("uses released flags for absent or invalid styles without nested flags", () => {
+		for (const style of [undefined, "future"] as const) {
+			const config = mergeConfig({
+				features: { editor: true, copyFriendly: true },
+				components: {
+					editor: style === undefined ? {} : { style },
+					userMessages: style === undefined ? { enabled: true } : { enabled: true, style },
+				},
+			});
+			expect(config.components.editor.style).toBe("polished-copy-friendly");
+			expect(config.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+		}
+	});
+
+	it.each([
+		["minimalist", "compact"],
+		["polished-copy-friendly", "labeled"],
+	] as const)("preserves unambiguous explicit styles %s and %s", (editorStyle, messageStyle) => {
+		const config = mergeConfig({
+			features: { copyFriendly: true },
+			components: {
+				editor: {
+					style: editorStyle,
+					styles: { polished: { copyFriendly: true } },
+				},
+				userMessages: {
+					enabled: true,
+					style: messageStyle,
+					styles: { framed: { copyFriendly: true } },
+				},
+			},
+		});
+		expect(config.components.editor.style).toBe(editorStyle);
+		expect(config.components.userMessages).toMatchObject({ style: messageStyle, enabled: true });
+	});
+
+	it("seeds and parses polished metadata independently", () => {
+		const seeded = mergeConfig({ editorMetadataFormat: "$legacy" });
+		expect(seeded.components.editor.styles.polished.metadataFormat).toBe("$legacy");
+		expect(seeded.components.editor.styles["polished-copy-friendly"].metadataFormat).toBe(
+			"$legacy",
+		);
+		const independent = mergeConfig({
+			editorMetadataFormat: "$flat",
+			components: {
+				editor: {
+					styles: {
+						polished: { metadataFormat: "$regular" },
+						"polished-copy-friendly": { metadataFormat: "$low" },
+					},
+				},
+			},
+		});
+		expect(independent.components.editor.styles.polished.metadataFormat).toBe("$regular");
+		expect(independent.components.editor.styles["polished-copy-friendly"].metadataFormat).toBe(
+			"$low",
+		);
+	});
+
+	it("deletes only obsolete owning leaves on explicit style saves", () => {
+		withConfig(
+			{
+				features: { copyFriendly: true },
+				components: {
+					editor: {
+						styles: {
+							polished: { copyFriendly: true, sibling: "keep" },
+							future: { keep: true },
+						},
+					},
+					userMessages: {
+						styles: { framed: { copyFriendly: true, sibling: "keep" }, future: { keep: true } },
+					},
+				},
+			},
+			(path) => {
+				saveEditorComponentPatch({ style: "polished" }, path);
+				const afterEditor = readRaw(path);
+				expect(afterEditor.components.editor.styles.polished).toMatchObject({ sibling: "keep" });
+				expect(afterEditor.components.editor.styles.polished).not.toHaveProperty("copyFriendly");
+				expect(afterEditor.components.userMessages.styles.framed).toMatchObject({
+					copyFriendly: true,
+					sibling: "keep",
+				});
+
+				saveUserMessagesComponentPatch({ style: "framed" }, path);
+				const raw = readRaw(path);
+				expect(raw.components.editor.styles.polished).toMatchObject({ sibling: "keep" });
+				expect(raw.components.editor.styles.polished).not.toHaveProperty("copyFriendly");
+				expect(raw.components.userMessages.styles.framed).toMatchObject({ sibling: "keep" });
+				expect(raw.components.userMessages.styles.framed).not.toHaveProperty("copyFriendly");
+				expect(raw.components.editor.styles.future).toEqual({ keep: true });
+				expect(raw.components.userMessages.styles.future).toEqual({ keep: true });
+				expect(raw.features.copyFriendly).toBe(true);
+				const reloaded = mergeConfig(raw);
+				expect(reloaded.components.editor.style).toBe("polished");
+				expect(reloaded.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+			},
+		);
+	});
+
+	it.each([
+		[
+			"Editor",
+			"editor",
+			(path: string) => saveEditorComponentPatch({ enabled: false }, path),
+			(path: string) => saveEditorComponentPatch({ style: "polished" }, path),
+			"polished",
+		],
+		[
+			"User messages",
+			"userMessages",
+			(path: string) => saveUserMessagesComponentPatch({ enabled: false }, path),
+			(path: string) => saveUserMessagesComponentPatch({ style: "framed" }, path),
+			"framed",
+		],
+		[
+			"Selector borders",
+			"selectorBorders",
+			(path: string) => saveSelectorBordersComponentPatch({ enabled: false }, path),
+			(path: string) => saveSelectorBordersComponentPatch({ style: "zentui" }, path),
+			"zentui",
+		],
+		[
+			"Footer",
+			"footer",
+			(path: string) => saveFooterComponentPatch({ enabled: false }, path),
+			(path: string) => saveFooterComponentPatch({ style: "starship" }, path),
+			"starship",
+		],
+	] as const)(
+		"preserves an unknown raw %s style until its owning style is explicitly selected",
+		(_label, owner, saveUnrelated, saveStyle, expectedStyle) => {
+			withConfig(
+				{
+					components: {
+						[owner]: {
+							style: `future-${owner}`,
+							futureOption: "keep",
+							styles: { future: { keep: true } },
+						},
+					},
+				},
+				(path) => {
+					saveUnrelated(path);
+					const preserved = readRaw(path);
+					expect(preserved.components[owner].style).toBe(`future-${owner}`);
+					expect(preserved.components[owner].futureOption).toBe("keep");
+					expect(preserved.components[owner].styles.future).toEqual({ keep: true });
+
+					saveStyle(path);
+					const replaced = readRaw(path);
+					expect(replaced.components[owner].style).toBe(expectedStyle);
+					expect(replaced.components[owner].futureOption).toBe("keep");
+					expect(replaced.components[owner].styles.future).toEqual({ keep: true });
+				},
+			);
+		},
+	);
 });
 
 describe("canonical snapshot persistence", () => {
@@ -512,8 +782,8 @@ describe("canonical snapshot persistence", () => {
 				expect(raw.components.editor.enabled).toBe(true);
 				expect(raw.components.userMessages.enabled).toBe(false);
 				expect(raw.components.selectorBorders.enabled).toBe(false);
-				expect(raw.components.editor.styles.polished.copyFriendly).toBe(true);
-				expect(raw.components.userMessages.styles.framed.copyFriendly).toBe(true);
+				expect(raw.components.editor.style).toBe("polished-copy-friendly");
+				expect(raw.components.userMessages.enabled).toBe(false);
 				expect(raw.components.editor.colorSource).toBe("terminal");
 				expect(raw.components.selectorBorders.colorSource).toBe("terminal");
 				expect(raw.features).toEqual({ editor: false, copyFriendly: true });
@@ -537,8 +807,8 @@ describe("canonical snapshot persistence", () => {
 			expect(raw.components.editor.enabled).toBe(true);
 			expect(raw.components.userMessages.enabled).toBe(false);
 			expect(raw.components.selectorBorders.enabled).toBe(false);
-			expect(raw.components.editor.styles.polished.copyFriendly).toBe(true);
-			expect(raw.components.userMessages.styles.framed.copyFriendly).toBe(true);
+			expect(raw.components.editor.style).toBe("polished-copy-friendly");
+			expect(raw.components.userMessages.enabled).toBe(false);
 			raw.features.editor = true;
 			raw.features.copyFriendly = false;
 			writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`);
@@ -546,17 +816,17 @@ describe("canonical snapshot persistence", () => {
 			expect(reloaded.components.editor.enabled).toBe(true);
 			expect(reloaded.components.userMessages.enabled).toBe(false);
 			expect(reloaded.components.selectorBorders.enabled).toBe(false);
-			expect(reloaded.components.editor.styles.polished.copyFriendly).toBe(true);
-			expect(reloaded.components.userMessages.styles.framed.copyFriendly).toBe(true);
+			expect(reloaded.components.editor.style).toBe("polished-copy-friendly");
+			expect(reloaded.components.userMessages.enabled).toBe(false);
 		});
 	});
 
 	it("supports every typed component saver without discarding inactive styles", () => {
 		withConfig(undefined, (path) => {
-			savePolishedEditorStylePatch({ copyFriendly: true, metadataFormat: "$provider" }, path);
+			savePolishedEditorStylePatch({ metadataFormat: "$provider" }, path);
+			savePolishedCopyFriendlyEditorStylePatch({ metadataFormat: "$model" }, path);
 			saveMinimalistEditorStylePatch({ showGit: false, contextGauge: true }, path);
 			saveUserMessagesComponentPatch({ enabled: false, colorSource: "terminal" }, path);
-			saveFramedUserMessagesStylePatch({ copyFriendly: true }, path);
 			saveSelectorBordersComponentPatch({ enabled: false, colorSource: "terminal" }, path);
 			saveFooterComponentPatch({ enabled: false, modelLabel: "name" }, path);
 			saveStarshipFooterStylePatch(
@@ -564,9 +834,11 @@ describe("canonical snapshot persistence", () => {
 				path,
 			);
 			const config = mergeConfig(readRaw(path));
-			expect(config.components.editor.styles.polished).toMatchObject({
-				copyFriendly: true,
+			expect(config.components.editor.styles.polished).toEqual({
 				metadataFormat: "$provider",
+			});
+			expect(config.components.editor.styles["polished-copy-friendly"]).toEqual({
+				metadataFormat: "$model",
 			});
 			expect(config.components.editor.styles.minimalist).toMatchObject({
 				showGit: false,
@@ -576,7 +848,6 @@ describe("canonical snapshot persistence", () => {
 				enabled: false,
 				colorSource: "terminal",
 			});
-			expect(config.components.userMessages.styles.framed.copyFriendly).toBe(true);
 			expect(config.components.selectorBorders).toMatchObject({
 				enabled: false,
 				colorSource: "terminal",
@@ -638,10 +909,7 @@ describe("compatibility saver recipes", () => {
 					{ editor: "terminal", starship: "terminal", userMessages: "terminal" },
 					path,
 				);
-				saveUiFeaturesPatch(
-					{ editor: false, statusLine: false, copyFriendly: true, viewportIndicators: false },
-					path,
-				);
+				saveUiFeaturesPatch({ editor: false, statusLine: false, viewportIndicators: false }, path);
 				saveEditorModelLabel("name", path);
 				saveEditorStyle("minimalist", path);
 				saveMinimalistPatch({ showTimer: false, showGit: false }, path);
@@ -687,8 +955,6 @@ describe("compatibility saver recipes", () => {
 					enabled: false,
 					colorSource: "terminal",
 				});
-				expect(config.components.editor.styles.polished.copyFriendly).toBe(true);
-				expect(config.components.userMessages.styles.framed.copyFriendly).toBe(true);
 				expect(config.components.editor.styles.minimalist).toMatchObject({
 					showTimer: false,
 					showGit: false,
@@ -779,7 +1045,6 @@ describe("mergeConfig", () => {
 		expect(config.features).toEqual({
 			editor: true,
 			statusLine: true,
-			copyFriendly: false,
 			viewportIndicators: true,
 		});
 		expect(config.footerSegments).toEqual({
@@ -1405,7 +1670,6 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ features: { editor: false } }).features).toEqual({
 			editor: false,
 			statusLine: true,
-			copyFriendly: false,
 			viewportIndicators: true,
 		});
 		expect(
@@ -1420,12 +1684,11 @@ describe("mergeConfig", () => {
 		).toEqual({
 			editor: true,
 			statusLine: false,
-			copyFriendly: true,
 			viewportIndicators: false,
 		});
 		expect(
 			mergeConfig({ features: { copyFriendly: "on", viewportIndicators: "off" } }).features,
-		).toMatchObject({ copyFriendly: false, viewportIndicators: true });
+		).toEqual({ editor: true, statusLine: true, viewportIndicators: true });
 	});
 
 	it("accepts valid footer segment preferences and ignores invalid values", () => {
@@ -1620,7 +1883,6 @@ describe("mergeConfig", () => {
 			expect(config.features).toEqual({
 				editor: true,
 				statusLine: false,
-				copyFriendly: false,
 				viewportIndicators: false,
 			});
 			expect(raw.unknown).toBe(true);
@@ -1643,7 +1905,6 @@ describe("mergeConfig", () => {
 			expect(config.features).toEqual({
 				editor: false,
 				statusLine: true,
-				copyFriendly: false,
 				viewportIndicators: true,
 			});
 			expect(Object.keys(raw)).toEqual(["components"]);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -91,16 +91,16 @@ describe("canonical config resolution", () => {
 		expect(config.components).toEqual({
 			editor: {
 				enabled: true,
-				style: "polished",
+				style: "opencode",
 				colorSource: "theme",
 				borderColorMode: "static",
 				modelLabel: "id",
 				viewportIndicators: true,
 				styles: {
-					polished: {
+					opencode: {
 						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
 					},
-					"polished-copy-friendly": {
+					"opencode-copy-friendly": {
 						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
 					},
 					minimalist: {
@@ -123,7 +123,6 @@ describe("canonical config resolution", () => {
 			},
 			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 			footer: {
-				enabled: true,
 				style: "starship",
 				colorSource: "theme",
 				modelLabel: "id",
@@ -199,14 +198,14 @@ describe("canonical config resolution", () => {
 			false,
 		]);
 		expect(editor.viewportIndicators).toBe(false);
-		expect(editor.style).toBe("polished-copy-friendly");
+		expect(editor.style).toBe("opencode-copy-friendly");
 		expect(userMessages.enabled).toBe(false);
 		expect([editor.colorSource, selectorBorders.colorSource]).toEqual(["terminal", "terminal"]);
 		expect(userMessages.colorSource).toBe("terminal");
 		expect(footer.colorSource).toBe("terminal");
 		expect(editor.borderColorMode).toBe("adaptive");
 		expect([editor.modelLabel, footer.modelLabel]).toEqual(["name", "name"]);
-		expect(editor.styles.polished.metadataFormat).toBe("$model");
+		expect(editor.styles.opencode.metadataFormat).toBe("$model");
 		expect(editor.styles.minimalist.contextThresholds).toEqual({ warning: 55, error: 88 });
 		expect(starship).toMatchObject({
 			format: "$cwd",
@@ -252,12 +251,12 @@ describe("canonical config resolution", () => {
 			},
 		});
 		expect(config.components.editor.enabled).toBe(false);
-		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.editor.style).toBe("opencode");
 		expect(config.components.editor.colorSource).toBe("theme");
 		// Missing canonical siblings still migrate independently.
 		expect(config.components.editor.viewportIndicators).toBe(false);
 		expect(config.components.editor.borderColorMode).toBe("adaptive");
-		expect(config.components.editor.styles.polished.metadataFormat).toBe("$legacy");
+		expect(config.components.editor.styles.opencode.metadataFormat).toBe("$legacy");
 	});
 
 	it("normalizes every canonical minimalist leaf without reviving branch-only inputs", () => {
@@ -354,7 +353,7 @@ describe("canonical config resolution", () => {
 				footer: { style: "future" },
 			},
 		});
-		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.editor.style).toBe("opencode");
 		expect(config.components.editor.styles.minimalist.showGit).toBe(true);
 		expect(config.components.userMessages.style).toBe("framed");
 		expect(config.components.selectorBorders.style).toBe("zentui");
@@ -401,7 +400,7 @@ describe("canonical config resolution", () => {
 					style: "minimalist",
 					colorSource: "terminal",
 					modelLabel: "name",
-					styles: { polished: { copyFriendly: true, metadataFormat: "$model" } },
+					styles: { opencode: { copyFriendly: true, metadataFormat: "$model" } },
 				},
 				userMessages: {
 					enabled: true,
@@ -447,7 +446,7 @@ describe("canonical config resolution", () => {
 	it("does not mutate the parsed record", () => {
 		const parsed = {
 			features: { editor: false },
-			components: { editor: { styles: { polished: { copyFriendly: true } } } },
+			components: { editor: { styles: { opencode: { copyFriendly: true } } } },
 		};
 		const before = structuredClone(parsed);
 		mergeConfig(parsed);
@@ -472,9 +471,9 @@ describe("canonical config resolution", () => {
 
 describe("Phase 4 style migration", () => {
 	it.each([
-		[true, "polished-copy-friendly"],
-		[false, "polished"],
-		["invalid", "polished"],
+		[true, "opencode-copy-friendly"],
+		[false, "opencode"],
+		["invalid", "opencode"],
 	] as const)("maps a present nested Editor flag %s deterministically", (copyFriendly, style) => {
 		const config = mergeConfig({
 			features: { copyFriendly: true },
@@ -509,21 +508,21 @@ describe("Phase 4 style migration", () => {
 
 	it("maps the released feature flag to low-rail Editor and native messages", () => {
 		const migrated = mergeConfig({ features: { copyFriendly: true } });
-		expect(migrated.components.editor.style).toBe("polished-copy-friendly");
+		expect(migrated.components.editor.style).toBe("opencode-copy-friendly");
 		expect(migrated.components.userMessages).toMatchObject({ style: "framed", enabled: false });
 
 		const regular = mergeConfig({ features: { copyFriendly: false } });
-		expect(regular.components.editor.style).toBe("polished");
+		expect(regular.components.editor.style).toBe("opencode");
 		expect(regular.components.userMessages).toMatchObject({ style: "framed", enabled: true });
 	});
 
 	it.each([
-		[undefined, true, "polished-copy-friendly"],
-		[undefined, false, "polished"],
-		[undefined, "invalid", "polished"],
-		["future", true, "polished-copy-friendly"],
-		["future", false, "polished"],
-		["future", "invalid", "polished"],
+		[undefined, true, "opencode-copy-friendly"],
+		[undefined, false, "opencode"],
+		[undefined, "invalid", "opencode"],
+		["future", true, "opencode-copy-friendly"],
+		["future", false, "opencode"],
+		["future", "invalid", "opencode"],
 	] as const)(
 		"resolves absent or invalid Editor style %s from nested flag %s",
 		(rawStyle, copyFriendly, expected) => {
@@ -571,11 +570,11 @@ describe("Phase 4 style migration", () => {
 		const config = mergeConfig({
 			features: { editor: true, copyFriendly: true },
 			components: {
-				editor: { style: "polished" },
+				editor: { style: "opencode" },
 				userMessages: { enabled: true, style: "framed" },
 			},
 		});
-		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.editor.style).toBe("opencode");
 		expect(config.components.userMessages).toMatchObject({ style: "framed", enabled: true });
 	});
 
@@ -588,21 +587,21 @@ describe("Phase 4 style migration", () => {
 					userMessages: style === undefined ? { enabled: true } : { enabled: true, style },
 				},
 			});
-			expect(config.components.editor.style).toBe("polished-copy-friendly");
+			expect(config.components.editor.style).toBe("opencode-copy-friendly");
 			expect(config.components.userMessages).toMatchObject({ style: "framed", enabled: false });
 		}
 	});
 
 	it.each([
 		["minimalist", "compact"],
-		["polished-copy-friendly", "labeled"],
+		["opencode-copy-friendly", "labeled"],
 	] as const)("preserves unambiguous explicit styles %s and %s", (editorStyle, messageStyle) => {
 		const config = mergeConfig({
 			features: { copyFriendly: true },
 			components: {
 				editor: {
 					style: editorStyle,
-					styles: { polished: { copyFriendly: true } },
+					styles: { opencode: { copyFriendly: true } },
 				},
 				userMessages: {
 					enabled: true,
@@ -617,8 +616,8 @@ describe("Phase 4 style migration", () => {
 
 	it("seeds and parses polished metadata independently", () => {
 		const seeded = mergeConfig({ editorMetadataFormat: "$legacy" });
-		expect(seeded.components.editor.styles.polished.metadataFormat).toBe("$legacy");
-		expect(seeded.components.editor.styles["polished-copy-friendly"].metadataFormat).toBe(
+		expect(seeded.components.editor.styles.opencode.metadataFormat).toBe("$legacy");
+		expect(seeded.components.editor.styles["opencode-copy-friendly"].metadataFormat).toBe(
 			"$legacy",
 		);
 		const independent = mergeConfig({
@@ -627,13 +626,13 @@ describe("Phase 4 style migration", () => {
 				editor: {
 					styles: {
 						polished: { metadataFormat: "$regular" },
-						"polished-copy-friendly": { metadataFormat: "$low" },
+						"opencode-copy-friendly": { metadataFormat: "$low" },
 					},
 				},
 			},
 		});
-		expect(independent.components.editor.styles.polished.metadataFormat).toBe("$regular");
-		expect(independent.components.editor.styles["polished-copy-friendly"].metadataFormat).toBe(
+		expect(independent.components.editor.styles.opencode.metadataFormat).toBe("$regular");
+		expect(independent.components.editor.styles["opencode-copy-friendly"].metadataFormat).toBe(
 			"$low",
 		);
 	});
@@ -655,10 +654,11 @@ describe("Phase 4 style migration", () => {
 				},
 			},
 			(path) => {
-				saveEditorComponentPatch({ style: "polished" }, path);
+				saveEditorComponentPatch({ style: "opencode" }, path);
 				const afterEditor = readRaw(path);
 				expect(afterEditor.components.editor.styles.polished).toMatchObject({ sibling: "keep" });
 				expect(afterEditor.components.editor.styles.polished).not.toHaveProperty("copyFriendly");
+				expect(afterEditor.components.editor.styles.opencode).toHaveProperty("metadataFormat");
 				expect(afterEditor.components.userMessages.styles.framed).toMatchObject({
 					copyFriendly: true,
 					sibling: "keep",
@@ -674,7 +674,7 @@ describe("Phase 4 style migration", () => {
 				expect(raw.components.userMessages.styles.future).toEqual({ keep: true });
 				expect(raw.features.copyFriendly).toBe(true);
 				const reloaded = mergeConfig(raw);
-				expect(reloaded.components.editor.style).toBe("polished");
+				expect(reloaded.components.editor.style).toBe("opencode");
 				expect(reloaded.components.userMessages).toMatchObject({ style: "framed", enabled: false });
 			},
 		);
@@ -685,8 +685,8 @@ describe("Phase 4 style migration", () => {
 			"Editor",
 			"editor",
 			(path: string) => saveEditorComponentPatch({ enabled: false }, path),
-			(path: string) => saveEditorComponentPatch({ style: "polished" }, path),
-			"polished",
+			(path: string) => saveEditorComponentPatch({ style: "opencode" }, path),
+			"opencode",
 		],
 		[
 			"User messages",
@@ -705,7 +705,7 @@ describe("Phase 4 style migration", () => {
 		[
 			"Footer",
 			"footer",
-			(path: string) => saveFooterComponentPatch({ enabled: false }, path),
+			(path: string) => saveFooterComponentPatch({ colorSource: "terminal" }, path),
 			(path: string) => saveFooterComponentPatch({ style: "starship" }, path),
 			"starship",
 		],
@@ -782,7 +782,7 @@ describe("canonical snapshot persistence", () => {
 				expect(raw.components.editor.enabled).toBe(true);
 				expect(raw.components.userMessages.enabled).toBe(false);
 				expect(raw.components.selectorBorders.enabled).toBe(false);
-				expect(raw.components.editor.style).toBe("polished-copy-friendly");
+				expect(raw.components.editor.style).toBe("opencode-copy-friendly");
 				expect(raw.components.userMessages.enabled).toBe(false);
 				expect(raw.components.editor.colorSource).toBe("terminal");
 				expect(raw.components.selectorBorders.colorSource).toBe("terminal");
@@ -807,7 +807,7 @@ describe("canonical snapshot persistence", () => {
 			expect(raw.components.editor.enabled).toBe(true);
 			expect(raw.components.userMessages.enabled).toBe(false);
 			expect(raw.components.selectorBorders.enabled).toBe(false);
-			expect(raw.components.editor.style).toBe("polished-copy-friendly");
+			expect(raw.components.editor.style).toBe("opencode-copy-friendly");
 			expect(raw.components.userMessages.enabled).toBe(false);
 			raw.features.editor = true;
 			raw.features.copyFriendly = false;
@@ -816,7 +816,7 @@ describe("canonical snapshot persistence", () => {
 			expect(reloaded.components.editor.enabled).toBe(true);
 			expect(reloaded.components.userMessages.enabled).toBe(false);
 			expect(reloaded.components.selectorBorders.enabled).toBe(false);
-			expect(reloaded.components.editor.style).toBe("polished-copy-friendly");
+			expect(reloaded.components.editor.style).toBe("opencode-copy-friendly");
 			expect(reloaded.components.userMessages.enabled).toBe(false);
 		});
 	});
@@ -828,16 +828,16 @@ describe("canonical snapshot persistence", () => {
 			saveMinimalistEditorStylePatch({ showGit: false, contextGauge: true }, path);
 			saveUserMessagesComponentPatch({ enabled: false, colorSource: "terminal" }, path);
 			saveSelectorBordersComponentPatch({ enabled: false, colorSource: "terminal" }, path);
-			saveFooterComponentPatch({ enabled: false, modelLabel: "name" }, path);
+			saveFooterComponentPatch({ style: "native", modelLabel: "name" }, path);
 			saveStarshipFooterStylePatch(
 				{ separator: "chevron", pathDisplay: { mode: "full", depth: 2 } },
 				path,
 			);
 			const config = mergeConfig(readRaw(path));
-			expect(config.components.editor.styles.polished).toEqual({
+			expect(config.components.editor.styles.opencode).toEqual({
 				metadataFormat: "$provider",
 			});
-			expect(config.components.editor.styles["polished-copy-friendly"]).toEqual({
+			expect(config.components.editor.styles["opencode-copy-friendly"]).toEqual({
 				metadataFormat: "$model",
 			});
 			expect(config.components.editor.styles.minimalist).toMatchObject({
@@ -852,7 +852,7 @@ describe("canonical snapshot persistence", () => {
 				enabled: false,
 				colorSource: "terminal",
 			});
-			expect(config.components.footer).toMatchObject({ enabled: false, modelLabel: "name" });
+			expect(config.components.footer).toMatchObject({ style: "native", modelLabel: "name" });
 			expect(config.components.footer.styles.starship).toMatchObject({
 				separator: "chevron",
 				pathDisplay: { mode: "full", depth: 2 },
@@ -961,7 +961,7 @@ describe("compatibility saver recipes", () => {
 					contextThresholds: { warning: 45, error: 75 },
 				});
 				expect(config.components.footer).toMatchObject({
-					enabled: false,
+					style: "native",
 					colorSource: "terminal",
 					modelLabel: "name",
 				});
@@ -1335,12 +1335,12 @@ describe("mergeConfig", () => {
 			expect(raw.components.editor.style).toBe("minimalist");
 			expect(minimalist.editorStyle).toBe("minimalist");
 
-			const polished = saveEditorStyle("polished", path);
+			const polished = saveEditorStyle("opencode", path);
 			raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(polished.editorStyle).toBe("polished");
+			expect(polished.editorStyle).toBe("opencode");
 			expect(raw.unknown).toEqual({ keep: true });
 			expect(raw.editorModelLabel).toBe("name");
-			expect(raw.components.editor.style).toBe("polished");
+			expect(raw.components.editor.style).toBe("opencode");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1889,7 +1889,7 @@ describe("mergeConfig", () => {
 			expect(raw.features).toEqual({ editor: true, futureKey: "future" });
 			expect(raw.components.editor.enabled).toBe(true);
 			expect(raw.components.editor.viewportIndicators).toBe(false);
-			expect(raw.components.footer.enabled).toBe(false);
+			expect(raw.components.footer.style).toBe("native");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -2591,4 +2591,125 @@ describe("startup and file safety", () => {
 			expect(configTempFiles(dir)).toEqual([]);
 		});
 	});
+});
+
+describe("Opencode and Footer follow-up migration", () => {
+	it("resolves canonical and alias editor metadata in documented precedence", () => {
+		const config = mergeConfig({
+			editorMetadataFormat: "$flat",
+			components: {
+				editor: {
+					styles: {
+						opencode: { metadataFormat: "$canonical" },
+						polished: { metadataFormat: "$alias" },
+						"polished-copy-friendly": { metadataFormat: "$alias-copy" },
+					},
+				},
+			},
+		});
+		expect(config.components.editor.styles.opencode.metadataFormat).toBe("$canonical");
+		expect(config.components.editor.styles["opencode-copy-friendly"].metadataFormat).toBe(
+			"$alias-copy",
+		);
+		expect(
+			mergeConfig({
+				editorMetadataFormat: "$flat",
+				components: { editor: { styles: { polished: { metadataFormat: "$alias" } } } },
+			}).components.editor.styles.opencode.metadataFormat,
+		).toBe("$alias");
+	});
+
+	it("resolves Footer style from valid style, enabled, released statusLine, then default", () => {
+		expect(
+			mergeConfig({
+				features: { statusLine: false },
+				components: { footer: { style: "hidden", enabled: true } },
+			}).components.footer.style,
+		).toBe("hidden");
+		expect(
+			mergeConfig({
+				features: { statusLine: true },
+				components: { footer: { style: "future", enabled: false } },
+			}).components.footer.style,
+		).toBe("native");
+		expect(mergeConfig({ features: { statusLine: false } }).components.footer.style).toBe("native");
+		expect(mergeConfig({}).components.footer.style).toBe("starship");
+		expect(mergeConfig({ components: { footer: { style: "hidden" } } }).features.statusLine).toBe(
+			false,
+		);
+	});
+
+	it("saves Footer styles canonically and removes only obsolete enabled", () => {
+		withConfig(
+			{
+				features: { statusLine: true, future: "keep" },
+				components: {
+					footer: {
+						enabled: true,
+						future: "keep",
+						styles: { starship: { format: "$cwd", future: "keep" }, future: { keep: true } },
+					},
+				},
+			},
+			(path) => {
+				saveFooterComponentPatch({ style: "hidden" }, path);
+				const raw = readRaw(path);
+				expect(raw.components.footer.style).toBe("hidden");
+				expect(raw.components.footer).not.toHaveProperty("enabled");
+				expect(raw.components.footer.future).toBe("keep");
+				expect(raw.components.footer.styles.starship).toMatchObject({
+					format: "$cwd",
+					future: "keep",
+				});
+				expect(raw.components.footer.styles.future).toEqual({ keep: true });
+				expect(raw.features).toEqual({ statusLine: true, future: "keep" });
+			},
+		);
+	});
+
+	it("keeps saveUiFeaturesPatch as a Starship/Native compatibility API", () => {
+		withConfig({ components: { footer: { style: "hidden" } } }, (path) => {
+			expect(saveUiFeaturesPatch({ statusLine: true }, path).components.footer.style).toBe(
+				"starship",
+			);
+			expect(saveUiFeaturesPatch({ statusLine: false }, path).components.footer.style).toBe(
+				"native",
+			);
+		});
+	});
+
+	it.each([
+		[true, "starship"],
+		[false, "native"],
+	] as const)(
+		"makes compatibility statusLine=%s authoritative over unknown Footer state",
+		(statusLine, expectedStyle) => {
+			withConfig(
+				{
+					features: { statusLine: !statusLine, future: "keep" },
+					components: {
+						footer: {
+							style: "future-footer",
+							enabled: true,
+							future: "keep",
+							styles: {
+								starship: { format: "$cwd" },
+								future: { keep: true },
+							},
+						},
+					},
+				},
+				(path) => {
+					const config = saveUiFeaturesPatch({ statusLine }, path);
+					const raw = readRaw(path);
+					expect(config.components.footer.style).toBe(expectedStyle);
+					expect(raw.components.footer.style).toBe(expectedStyle);
+					expect(raw.components.footer).not.toHaveProperty("enabled");
+					expect(raw.components.footer.future).toBe("keep");
+					expect(raw.components.footer.styles.future).toEqual({ keep: true });
+					expect(raw.features).toEqual({ statusLine: !statusLine, future: "keep" });
+				},
+			);
+		},
+	);
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -119,7 +119,7 @@ describe("canonical config resolution", () => {
 				enabled: true,
 				style: "framed",
 				colorSource: "theme",
-				styles: { framed: {}, compact: {}, labeled: {} },
+				styles: { framed: {}, "framed-copy-friendly": {}, compact: {}, labeled: {} },
 			},
 			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 			footer: {
@@ -199,7 +199,7 @@ describe("canonical config resolution", () => {
 		]);
 		expect(editor.viewportIndicators).toBe(false);
 		expect(editor.style).toBe("opencode-copy-friendly");
-		expect(userMessages.enabled).toBe(false);
+		expect(userMessages).toMatchObject({ enabled: false, style: "framed-copy-friendly" });
 		expect([editor.colorSource, selectorBorders.colorSource]).toEqual(["terminal", "terminal"]);
 		expect(userMessages.colorSource).toBe("terminal");
 		expect(footer.colorSource).toBe("terminal");
@@ -360,6 +360,13 @@ describe("canonical config resolution", () => {
 		expect(config.components.footer.style).toBe("starship");
 	});
 
+	it("does not treat native as a User-message style", () => {
+		expect(
+			mergeConfig({ components: { userMessages: { style: "native" } } }).components.userMessages
+				.style,
+		).toBe("framed");
+	});
+
 	it("normalizes nested canonical leaves without falling through to contradictory legacy leaves", () => {
 		const config = mergeConfig({
 			contextThresholds: { warning: 20, error: 80 },
@@ -485,35 +492,35 @@ describe("Phase 4 style migration", () => {
 	});
 
 	it.each([
-		[true, false],
-		[false, true],
-		["invalid", true],
-	] as const)(
-		"maps a present nested message flag %s deterministically",
-		(copyFriendly, enabled) => {
-			const config = mergeConfig({
-				features: { editor: true, copyFriendly: true },
-				components: {
-					userMessages: {
-						enabled: true,
-						style: "framed",
-						styles: { framed: { copyFriendly } },
-					},
+		[true, "framed-copy-friendly"],
+		[false, "framed"],
+		["invalid", "framed"],
+	] as const)("maps a present nested message flag %s deterministically", (copyFriendly, style) => {
+		const config = mergeConfig({
+			features: { editor: true, copyFriendly: true },
+			components: {
+				userMessages: {
+					enabled: true,
+					style: "framed",
+					styles: { framed: { copyFriendly } },
 				},
-			});
-			expect(config.components.userMessages.style).toBe("framed");
-			expect(config.components.userMessages.enabled).toBe(enabled);
-		},
-	);
+			},
+		});
+		expect(config.components.userMessages).toMatchObject({ style, enabled: true });
+	});
 
-	it("maps the released feature flag to low-rail Editor and native messages", () => {
+	it("maps the released feature flag to copy-friendly Editor and messages", () => {
 		const migrated = mergeConfig({ features: { copyFriendly: true } });
 		expect(migrated.components.editor.style).toBe("opencode-copy-friendly");
-		expect(migrated.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+		expect(migrated.components.userMessages).toMatchObject({
+			style: "framed-copy-friendly",
+			enabled: true,
+		});
 
 		const regular = mergeConfig({ features: { copyFriendly: false } });
 		expect(regular.components.editor.style).toBe("opencode");
 		expect(regular.components.userMessages).toMatchObject({ style: "framed", enabled: true });
+		expect(migrated.features).not.toHaveProperty("copyFriendly");
 	});
 
 	it.each([
@@ -540,15 +547,15 @@ describe("Phase 4 style migration", () => {
 	);
 
 	it.each([
-		[undefined, true, false],
-		[undefined, false, true],
-		[undefined, "invalid", true],
-		["future", true, false],
-		["future", false, true],
-		["future", "invalid", true],
+		[undefined, true, "framed-copy-friendly"],
+		[undefined, false, "framed"],
+		[undefined, "invalid", "framed"],
+		["future", true, "framed-copy-friendly"],
+		["future", false, "framed"],
+		["future", "invalid", "framed"],
 	] as const)(
 		"resolves absent or invalid message style %s from nested flag %s",
-		(rawStyle, copyFriendly, expectedEnabled) => {
+		(rawStyle, copyFriendly, expectedStyle) => {
 			const config = mergeConfig({
 				features: { editor: true, copyFriendly: copyFriendly !== true },
 				components: {
@@ -560,8 +567,8 @@ describe("Phase 4 style migration", () => {
 				},
 			});
 			expect(config.components.userMessages).toMatchObject({
-				style: "framed",
-				enabled: expectedEnabled,
+				style: expectedStyle,
+				enabled: true,
 			});
 		},
 	);
@@ -588,13 +595,17 @@ describe("Phase 4 style migration", () => {
 				},
 			});
 			expect(config.components.editor.style).toBe("opencode-copy-friendly");
-			expect(config.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+			expect(config.components.userMessages).toMatchObject({
+				style: "framed-copy-friendly",
+				enabled: true,
+			});
 		}
 	});
 
 	it.each([
 		["minimalist", "compact"],
 		["opencode-copy-friendly", "labeled"],
+		["opencode", "framed-copy-friendly"],
 	] as const)("preserves unambiguous explicit styles %s and %s", (editorStyle, messageStyle) => {
 		const config = mergeConfig({
 			features: { copyFriendly: true },
@@ -675,10 +686,40 @@ describe("Phase 4 style migration", () => {
 				expect(raw.features.copyFriendly).toBe(true);
 				const reloaded = mergeConfig(raw);
 				expect(reloaded.components.editor.style).toBe("opencode");
-				expect(reloaded.components.userMessages).toMatchObject({ style: "framed", enabled: false });
+				expect(reloaded.components.userMessages).toMatchObject({ style: "framed", enabled: true });
 			},
 		);
 	});
+
+	it.each(["framed", "framed-copy-friendly"] as const)(
+		"cleans only the obsolete nested flag when explicitly saving %s",
+		(style) => {
+			withConfig(
+				{
+					features: { copyFriendly: true },
+					components: {
+						userMessages: {
+							styles: {
+								framed: { copyFriendly: true, sibling: "keep" },
+								future: { keep: true },
+							},
+							futureComponent: "keep",
+						},
+					},
+				},
+				(path) => {
+					saveUserMessagesComponentPatch({ style }, path);
+					const raw = readRaw(path);
+					expect(raw.components.userMessages.style).toBe(style);
+					expect(raw.components.userMessages.styles.framed).toEqual({ sibling: "keep" });
+					expect(raw.components.userMessages.styles.future).toEqual({ keep: true });
+					expect(raw.components.userMessages.futureComponent).toBe("keep");
+					expect(raw.features.copyFriendly).toBe(true);
+					expect(mergeConfig(raw).components.userMessages.style).toBe(style);
+				},
+			);
+		},
+	);
 
 	it.each([
 		[

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -19,27 +19,38 @@ import {
 	DEFAULT_COMPACT_FOOTER_FORMAT,
 	DEFAULT_EDITOR_METADATA_FORMAT,
 	defaultConfig,
+	ensureConfigExists,
 	FOOTER_FORMAT_VARIABLES,
 	mergeConfig,
 	saveColorSourcesPatch,
+	saveContextStylePatch,
 	saveContextThresholdsPatch,
 	saveEditorBorderColorMode,
+	saveEditorComponentPatch,
 	saveEditorModelLabel,
 	saveEditorStyle,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
 	saveExtensionStatusPlacement,
 	saveFixedEditorPatch,
+	saveFooterComponentPatch,
 	saveFooterFormatPatch,
 	saveFooterSegmentsPatch,
+	saveFramedUserMessagesStylePatch,
 	saveGitBranchPatch,
 	saveGitCommitPatch,
 	saveGitMetricsPatch,
+	saveLayoutFixedEditorPatch,
+	saveMinimalistEditorStylePatch,
 	saveMinimalistPatch,
 	savePathDisplayPatch,
+	savePolishedEditorStylePatch,
 	saveResponsiveFooterPatch,
+	saveSelectorBordersComponentPatch,
 	saveSeparatorPatch,
+	saveStarshipFooterStylePatch,
 	saveUiFeaturesPatch,
+	saveUserMessagesComponentPatch,
 } from "../extensions/zentui/config";
 import {
 	colorize,
@@ -54,6 +65,693 @@ function configTempFiles(dir: string, filename = "zentui.json"): string[] {
 		(name) => name.startsWith(`.${filename}.`) && name.endsWith(".tmp"),
 	);
 }
+
+function withConfig(
+	initial: Record<string, unknown> | undefined,
+	assertions: (path: string, dir: string) => void,
+): void {
+	const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
+	const path = join(dir, "zentui.json");
+	try {
+		if (initial !== undefined) writeFileSync(path, `${JSON.stringify(initial, null, 2)}\n`);
+		assertions(path, dir);
+	} finally {
+		rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: Tests intentionally inspect arbitrary JSON fixture shapes.
+function readRaw(path: string): Record<string, any> {
+	return JSON.parse(readFileSync(path, "utf8"));
+}
+
+describe("canonical config resolution", () => {
+	it("provides complete canonical defaults and the established palette defaults", () => {
+		const config = mergeConfig({});
+		expect(config.components).toEqual({
+			editor: {
+				enabled: true,
+				style: "polished",
+				colorSource: "theme",
+				borderColorMode: "static",
+				modelLabel: "id",
+				viewportIndicators: true,
+				styles: {
+					polished: {
+						copyFriendly: false,
+						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+					},
+					minimalist: {
+						pathDisplay: "compact",
+						contextFormat: "percent",
+						contextGauge: false,
+						showSessionName: true,
+						showTimer: true,
+						showCost: true,
+						showGit: true,
+						contextThresholds: { warning: 70, error: 90 },
+					},
+				},
+			},
+			userMessages: {
+				enabled: true,
+				style: "framed",
+				colorSource: "theme",
+				styles: { framed: { copyFriendly: false } },
+			},
+			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
+			footer: {
+				enabled: true,
+				style: "starship",
+				colorSource: "theme",
+				modelLabel: "id",
+				styles: {
+					starship: {
+						format: "",
+						responsive: true,
+						compactFormat: DEFAULT_COMPACT_FOOTER_FORMAT,
+						compactMaxLines: 2,
+						separator: "pipe",
+						contextStyle: "text",
+						contextThresholds: { warning: 70, error: 90 },
+						pathDisplay: { mode: "basename", depth: 0 },
+						segments: defaultConfig.footerSegments,
+						gitBranch: { maxLength: "full" },
+						gitCommit: { hashLength: 7, onlyDetached: true, showTag: true },
+						gitMetrics: { onlyNonzero: true, ignoreSubmodules: false },
+						extensionStatuses: {
+							defaultPlacement: "right",
+							placements: {},
+							colorModes: {},
+						},
+					},
+				},
+			},
+		});
+		expect(config.layout).toEqual({
+			fixedEditor: { enabled: false, mouseScroll: true, copyNotice: true },
+		});
+		expect(config.projectRefreshIntervalMs).toBe(30_000);
+		expect(config.icons.cacheHit).toBe("󰆼");
+		expect(config.colors).toEqual(defaultConfig.colors);
+		expect(defaultConfig.components).toEqual(config.components);
+		expect(defaultConfig.layout).toEqual(config.layout);
+	});
+
+	it("migrates every released legacy field leaf-by-leaf", () => {
+		const config = mergeConfig({
+			features: {
+				editor: false,
+				statusLine: false,
+				viewportIndicators: false,
+				copyFriendly: true,
+			},
+			colorSources: { editor: "terminal", userMessages: "terminal", starship: "terminal" },
+			editorBorderColorMode: "adaptive",
+			editorModelLabel: "name",
+			editorMetadataFormat: "$model",
+			contextThresholds: { warning: 55, error: 88 },
+			footerFormat: "$cwd",
+			responsiveFooter: false,
+			compactFooterFormat: "$context",
+			compactFooterMaxLines: 3,
+			separator: "dot",
+			contextStyle: "gauge",
+			pathDisplay: { mode: "full", depth: 2 },
+			footerSegments: { cwd: false, modelInfo: true },
+			gitBranch: { maxLength: 18 },
+			gitCommit: { hashLength: 12, onlyDetached: false, showTag: false },
+			gitMetrics: { onlyNonzero: false, ignoreSubmodules: true },
+			extensionStatuses: {
+				defaultPlacement: "middle",
+				placements: { alpha: "left" },
+				colorModes: { alpha: "original" },
+			},
+			fixedEditor: { enabled: true, mouseScroll: false, copyNotice: false },
+		});
+		const { editor, userMessages, selectorBorders, footer } = config.components;
+		const starship = footer.styles.starship;
+		expect([editor.enabled, userMessages.enabled, selectorBorders.enabled]).toEqual([
+			false,
+			false,
+			false,
+		]);
+		expect(editor.viewportIndicators).toBe(false);
+		expect(editor.styles.polished.copyFriendly).toBe(true);
+		expect(userMessages.styles.framed.copyFriendly).toBe(true);
+		expect([editor.colorSource, selectorBorders.colorSource]).toEqual(["terminal", "terminal"]);
+		expect(userMessages.colorSource).toBe("terminal");
+		expect(footer.colorSource).toBe("terminal");
+		expect(editor.borderColorMode).toBe("adaptive");
+		expect([editor.modelLabel, footer.modelLabel]).toEqual(["name", "name"]);
+		expect(editor.styles.polished.metadataFormat).toBe("$model");
+		expect(editor.styles.minimalist.contextThresholds).toEqual({ warning: 55, error: 88 });
+		expect(starship).toMatchObject({
+			format: "$cwd",
+			responsive: false,
+			compactFormat: "$context",
+			compactMaxLines: 3,
+			separator: "dot",
+			contextStyle: "gauge",
+			contextThresholds: { warning: 55, error: 88 },
+			pathDisplay: { mode: "full", depth: 2 },
+			gitBranch: { maxLength: 18 },
+			gitCommit: { hashLength: 12, onlyDetached: false, showTag: false },
+			gitMetrics: { onlyNonzero: false, ignoreSubmodules: true },
+			extensionStatuses: {
+				defaultPlacement: "middle",
+				placements: { alpha: "left" },
+				colorModes: { alpha: "original" },
+			},
+		});
+		expect(starship.segments).toMatchObject({ cwd: false, modelInfo: true });
+		expect(config.layout.fixedEditor).toEqual({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: false,
+		});
+	});
+
+	it("gives canonical leaves precedence, including false and invalid-but-present values", () => {
+		const config = mergeConfig({
+			features: { editor: true, copyFriendly: true, viewportIndicators: false },
+			colorSources: { editor: "terminal" },
+			editorBorderColorMode: "adaptive",
+			editorMetadataFormat: "$legacy",
+			components: {
+				editor: {
+					enabled: false,
+					style: "unknown",
+					colorSource: "unknown",
+					styles: {
+						polished: { copyFriendly: "yes" },
+					},
+				},
+			},
+		});
+		expect(config.components.editor.enabled).toBe(false);
+		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.editor.colorSource).toBe("theme");
+		expect(config.components.editor.styles.polished.copyFriendly).toBe(false);
+		// Missing canonical siblings still migrate independently.
+		expect(config.components.editor.viewportIndicators).toBe(false);
+		expect(config.components.editor.borderColorMode).toBe("adaptive");
+		expect(config.components.editor.styles.polished.metadataFormat).toBe("$legacy");
+	});
+
+	it("normalizes every canonical minimalist leaf without reviving branch-only inputs", () => {
+		for (const pathDisplay of ["compact", "project", "full"]) {
+			expect(
+				mergeConfig({
+					components: { editor: { styles: { minimalist: { pathDisplay } } } },
+				}).components.editor.styles.minimalist.pathDisplay,
+			).toBe(pathDisplay);
+		}
+		for (const pathDisplay of ["basename", "", 1, null, true]) {
+			expect(
+				mergeConfig({
+					editorStyles: { minimalist: { pathDisplay: "full" } },
+					components: { editor: { styles: { minimalist: { pathDisplay } } } },
+				}).components.editor.styles.minimalist.pathDisplay,
+			).toBe("compact");
+		}
+
+		for (const contextFormat of ["percent", "percent-total"]) {
+			expect(
+				mergeConfig({
+					components: { editor: { styles: { minimalist: { contextFormat } } } },
+				}).components.editor.styles.minimalist.contextFormat,
+			).toBe(contextFormat);
+		}
+		for (const contextFormat of ["tokens", "", 1, null, true]) {
+			expect(
+				mergeConfig({
+					editorStyles: { minimalist: { contextFormat: "percent-total" } },
+					components: { editor: { styles: { minimalist: { contextFormat } } } },
+				}).components.editor.styles.minimalist.contextFormat,
+			).toBe("percent");
+		}
+
+		const valid = mergeConfig({
+			components: {
+				editor: {
+					styles: {
+						minimalist: {
+							contextGauge: true,
+							showSessionName: false,
+							showTimer: false,
+							showCost: false,
+							showGit: false,
+						},
+					},
+				},
+			},
+		}).components.editor.styles.minimalist;
+		expect(valid).toMatchObject({
+			contextGauge: true,
+			showSessionName: false,
+			showTimer: false,
+			showCost: false,
+			showGit: false,
+		});
+
+		const invalid = mergeConfig({
+			editorStyles: {
+				minimalist: {
+					contextGauge: true,
+					showSessionName: false,
+					showTimer: false,
+					showCost: false,
+					showGit: false,
+				},
+			},
+			components: {
+				editor: {
+					styles: {
+						minimalist: {
+							contextGauge: "yes",
+							showSessionName: "yes",
+							showTimer: null,
+							showCost: 0,
+							showGit: "no",
+						},
+					},
+				},
+			},
+		}).components.editor.styles.minimalist;
+		expect(invalid).toEqual(defaultConfig.components.editor.styles.minimalist);
+	});
+
+	it("ignores branch-only editorStyle/editorStyles and safely defaults closed style IDs", () => {
+		const config = mergeConfig({
+			editorStyle: "minimalist",
+			editorStyles: { minimalist: { showGit: false } },
+			components: {
+				editor: { style: "future" },
+				userMessages: { style: "future" },
+				selectorBorders: { style: "future" },
+				footer: { style: "future" },
+			},
+		});
+		expect(config.components.editor.style).toBe("polished");
+		expect(config.components.editor.styles.minimalist.showGit).toBe(true);
+		expect(config.components.userMessages.style).toBe("framed");
+		expect(config.components.selectorBorders.style).toBe("zentui");
+		expect(config.components.footer.style).toBe("starship");
+	});
+
+	it("normalizes nested canonical leaves without falling through to contradictory legacy leaves", () => {
+		const config = mergeConfig({
+			contextThresholds: { warning: 20, error: 80 },
+			pathDisplay: { mode: "full", depth: 4 },
+			components: {
+				editor: {
+					styles: { minimalist: { contextThresholds: { warning: "bad" } } },
+				},
+				footer: {
+					styles: {
+						starship: {
+							contextThresholds: { warning: "bad" },
+							pathDisplay: { mode: "bad" },
+						},
+					},
+				},
+			},
+		});
+		expect(config.components.editor.styles.minimalist.contextThresholds).toEqual({
+			warning: 70,
+			error: 80,
+		});
+		expect(config.components.footer.styles.starship.contextThresholds).toEqual({
+			warning: 70,
+			error: 80,
+		});
+		expect(config.components.footer.styles.starship.pathDisplay).toEqual({
+			mode: "basename",
+			depth: 4,
+		});
+	});
+
+	it("projects the intentionally lossy flat compatibility view from canonical sources", () => {
+		const config = mergeConfig({
+			components: {
+				editor: {
+					enabled: false,
+					style: "minimalist",
+					colorSource: "terminal",
+					modelLabel: "name",
+					styles: { polished: { copyFriendly: true, metadataFormat: "$model" } },
+				},
+				userMessages: {
+					enabled: true,
+					colorSource: "theme",
+					styles: { framed: { copyFriendly: false } },
+				},
+				selectorBorders: { enabled: true, colorSource: "theme" },
+				footer: {
+					modelLabel: "id",
+					colorSource: "terminal",
+					styles: { starship: { contextThresholds: { warning: 40, error: 60 } } },
+				},
+			},
+		});
+		const starship = config.components.footer.styles.starship;
+		expect(config.footerFormat).toBe(starship.format);
+		expect(config.responsiveFooter).toBe(starship.responsive);
+		expect(config.compactFooterFormat).toBe(starship.compactFormat);
+		expect(config.compactFooterMaxLines).toBe(starship.compactMaxLines);
+		expect(config.separator).toBe(starship.separator);
+		expect(config.contextStyle).toBe(starship.contextStyle);
+		expect(config.contextThresholds).toBe(starship.contextThresholds);
+		expect(config.pathDisplay).toBe(starship.pathDisplay);
+		expect(config.footerSegments).toBe(starship.segments);
+		expect(config.gitBranch).toBe(starship.gitBranch);
+		expect(config.gitCommit).toBe(starship.gitCommit);
+		expect(config.gitMetrics).toBe(starship.gitMetrics);
+		expect(config.extensionStatuses).toBe(starship.extensionStatuses);
+		expect(config.features).toEqual({
+			editor: false,
+			statusLine: true,
+			copyFriendly: true,
+			viewportIndicators: true,
+		});
+		expect(config.colorSources).toEqual({
+			starship: "terminal",
+			editor: "terminal",
+			userMessages: "theme",
+		});
+		expect(config.editorModelLabel).toBe("name");
+		expect(config.contextThresholds).toEqual({ warning: 40, error: 60 });
+	});
+
+	it("does not mutate the parsed record", () => {
+		const parsed = {
+			features: { editor: false },
+			components: { editor: { styles: { polished: { copyFriendly: true } } } },
+		};
+		const before = structuredClone(parsed);
+		mergeConfig(parsed);
+		expect(parsed).toEqual(before);
+	});
+
+	it("retains root parsing behavior for intervals, icons, colors, and telemetry variables", () => {
+		const config = mergeConfig({
+			projectRefreshIntervalMs: 100,
+			icons: { mode: "ascii", cwd: "DIR" },
+			colors: { gitBranch: "syntaxKeyword", editorAccent: "accent" },
+		});
+		expect(config.projectRefreshIntervalMs).toBe(5_000);
+		expect(config.icons.cwd).toBe("DIR");
+		expect(config.colors.gitBranch).toBe("syntaxKeyword");
+		expect(config.colors.editorAccent).toBe("accent");
+		expect(FOOTER_FORMAT_VARIABLES).toEqual(
+			expect.arrayContaining(["cache_read", "cache_write", "subscription", "auto_compaction"]),
+		);
+	});
+});
+
+describe("canonical snapshot persistence", () => {
+	it("materializes every component from legacy inputs and preserves unknown data", () => {
+		withConfig(
+			{
+				unknownTop: { keep: true },
+				features: { editor: false, copyFriendly: true },
+				colorSources: { editor: "terminal" },
+				components: {
+					futureDomain: { keep: true },
+					editor: {
+						futureComponent: true,
+						styles: {
+							futureStyle: { keep: true },
+							polished: { futurePolished: true },
+						},
+					},
+					footer: {
+						styles: {
+							starship: {
+								futureStarship: true,
+								pathDisplay: { futurePath: true },
+								extensionStatuses: { futureStatuses: true },
+							},
+						},
+					},
+				},
+			},
+			(path) => {
+				const config = saveEditorComponentPatch({ enabled: true }, path);
+				const raw = readRaw(path);
+				expect(Object.keys(raw.components)).toEqual(
+					expect.arrayContaining([
+						"editor",
+						"userMessages",
+						"selectorBorders",
+						"footer",
+						"futureDomain",
+					]),
+				);
+				expect(raw.components.editor.enabled).toBe(true);
+				expect(raw.components.userMessages.enabled).toBe(false);
+				expect(raw.components.selectorBorders.enabled).toBe(false);
+				expect(raw.components.editor.styles.polished.copyFriendly).toBe(true);
+				expect(raw.components.userMessages.styles.framed.copyFriendly).toBe(true);
+				expect(raw.components.editor.colorSource).toBe("terminal");
+				expect(raw.components.selectorBorders.colorSource).toBe("terminal");
+				expect(raw.features).toEqual({ editor: false, copyFriendly: true });
+				expect(raw.unknownTop).toEqual({ keep: true });
+				expect(raw.components.futureDomain).toEqual({ keep: true });
+				expect(raw.components.editor.futureComponent).toBe(true);
+				expect(raw.components.editor.styles.futureStyle).toEqual({ keep: true });
+				expect(raw.components.editor.styles.polished.futurePolished).toBe(true);
+				expect(raw.components.footer.styles.starship.futureStarship).toBe(true);
+				expect(raw.components.footer.styles.starship.pathDisplay.futurePath).toBe(true);
+				expect(raw.components.footer.styles.starship.extensionStatuses.futureStatuses).toBe(true);
+				expect(config).toEqual(mergeConfig(raw));
+			},
+		);
+	});
+
+	it("prevents legacy edits from recoupling surfaces after the first save", () => {
+		withConfig({ features: { editor: false, copyFriendly: true } }, (path) => {
+			saveEditorComponentPatch({ enabled: true }, path);
+			const raw = readRaw(path);
+			expect(raw.components.editor.enabled).toBe(true);
+			expect(raw.components.userMessages.enabled).toBe(false);
+			expect(raw.components.selectorBorders.enabled).toBe(false);
+			expect(raw.components.editor.styles.polished.copyFriendly).toBe(true);
+			expect(raw.components.userMessages.styles.framed.copyFriendly).toBe(true);
+			raw.features.editor = true;
+			raw.features.copyFriendly = false;
+			writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`);
+			const reloaded = mergeConfig(readRaw(path));
+			expect(reloaded.components.editor.enabled).toBe(true);
+			expect(reloaded.components.userMessages.enabled).toBe(false);
+			expect(reloaded.components.selectorBorders.enabled).toBe(false);
+			expect(reloaded.components.editor.styles.polished.copyFriendly).toBe(true);
+			expect(reloaded.components.userMessages.styles.framed.copyFriendly).toBe(true);
+		});
+	});
+
+	it("supports every typed component saver without discarding inactive styles", () => {
+		withConfig(undefined, (path) => {
+			savePolishedEditorStylePatch({ copyFriendly: true, metadataFormat: "$provider" }, path);
+			saveMinimalistEditorStylePatch({ showGit: false, contextGauge: true }, path);
+			saveUserMessagesComponentPatch({ enabled: false, colorSource: "terminal" }, path);
+			saveFramedUserMessagesStylePatch({ copyFriendly: true }, path);
+			saveSelectorBordersComponentPatch({ enabled: false, colorSource: "terminal" }, path);
+			saveFooterComponentPatch({ enabled: false, modelLabel: "name" }, path);
+			saveStarshipFooterStylePatch(
+				{ separator: "chevron", pathDisplay: { mode: "full", depth: 2 } },
+				path,
+			);
+			const config = mergeConfig(readRaw(path));
+			expect(config.components.editor.styles.polished).toMatchObject({
+				copyFriendly: true,
+				metadataFormat: "$provider",
+			});
+			expect(config.components.editor.styles.minimalist).toMatchObject({
+				showGit: false,
+				contextGauge: true,
+			});
+			expect(config.components.userMessages).toMatchObject({
+				enabled: false,
+				colorSource: "terminal",
+			});
+			expect(config.components.userMessages.styles.framed.copyFriendly).toBe(true);
+			expect(config.components.selectorBorders).toMatchObject({
+				enabled: false,
+				colorSource: "terminal",
+			});
+			expect(config.components.footer).toMatchObject({ enabled: false, modelLabel: "name" });
+			expect(config.components.footer.styles.starship).toMatchObject({
+				separator: "chevron",
+				pathDisplay: { mode: "full", depth: 2 },
+			});
+		});
+	});
+
+	it("materializes layout.fixedEditor while preserving layout and legacy data", () => {
+		withConfig(
+			{
+				fixedEditor: { enabled: true, mouseScroll: false, legacyUnknown: true },
+				layout: { futureLayout: true, fixedEditor: { futureFixed: true } },
+			},
+			(path) => {
+				const config = saveLayoutFixedEditorPatch({ copyNotice: false }, path);
+				const raw = readRaw(path);
+				expect(raw.layout).toEqual({
+					futureLayout: true,
+					fixedEditor: {
+						futureFixed: true,
+						enabled: true,
+						mouseScroll: false,
+						copyNotice: false,
+					},
+				});
+				expect(raw.fixedEditor).toEqual({
+					enabled: true,
+					mouseScroll: false,
+					legacyUnknown: true,
+				});
+				expect(config.fixedEditor).toEqual({
+					enabled: true,
+					mouseScroll: false,
+					copyNotice: false,
+				});
+			},
+		);
+	});
+});
+
+describe("compatibility saver recipes", () => {
+	it("writes canonical paths only and updates all historically coupled destinations", () => {
+		withConfig(
+			{
+				features: { editor: true, statusLine: true, copyFriendly: false },
+				colorSources: { editor: "theme", starship: "theme", userMessages: "theme" },
+				editorModelLabel: "id",
+				footerFormat: "$legacy",
+				unknown: true,
+			},
+			(path) => {
+				const legacyBefore = structuredClone(readRaw(path));
+				saveColorSourcesPatch(
+					{ editor: "terminal", starship: "terminal", userMessages: "terminal" },
+					path,
+				);
+				saveUiFeaturesPatch(
+					{ editor: false, statusLine: false, copyFriendly: true, viewportIndicators: false },
+					path,
+				);
+				saveEditorModelLabel("name", path);
+				saveEditorStyle("minimalist", path);
+				saveMinimalistPatch({ showTimer: false, showGit: false }, path);
+				saveEditorBorderColorMode("adaptive", path);
+				saveFooterFormatPatch("$cwd", path);
+				saveResponsiveFooterPatch(
+					{ responsiveFooter: false, compactFooterFormat: "$context", compactFooterMaxLines: 3 },
+					path,
+				);
+				saveSeparatorPatch("dot", path);
+				saveContextStylePatch("text+gauge", path);
+				saveContextThresholdsPatch({ warning: 45, error: 75 }, path);
+				savePathDisplayPatch({ mode: "full", depth: 3 }, path);
+				saveFooterSegmentsPatch({ modelInfo: true, tokens: false }, path);
+				saveGitBranchPatch({ maxLength: 24 }, path);
+				saveGitCommitPatch({ onlyDetached: false, showTag: false }, path);
+				saveGitMetricsPatch({ onlyNonzero: false, ignoreSubmodules: true }, path);
+				saveExtensionStatusDefaultPlacement("middle", path);
+				saveExtensionStatusPlacement("alpha", "left", path);
+				saveExtensionStatusColorMode("alpha", "original", path);
+				const raw = readRaw(path);
+				const config = mergeConfig(raw);
+				expect(raw.features).toEqual(legacyBefore.features);
+				expect(raw.colorSources).toEqual(legacyBefore.colorSources);
+				expect(raw.editorModelLabel).toBe("id");
+				expect(raw.footerFormat).toBe("$legacy");
+				expect(raw.unknown).toBe(true);
+				expect(raw).not.toHaveProperty("editorStyle");
+				expect(raw).not.toHaveProperty("editorStyles");
+				expect(config.components.editor).toMatchObject({
+					enabled: false,
+					style: "minimalist",
+					colorSource: "terminal",
+					borderColorMode: "adaptive",
+					modelLabel: "name",
+					viewportIndicators: false,
+				});
+				expect(config.components.userMessages).toMatchObject({
+					enabled: false,
+					colorSource: "terminal",
+				});
+				expect(config.components.selectorBorders).toMatchObject({
+					enabled: false,
+					colorSource: "terminal",
+				});
+				expect(config.components.editor.styles.polished.copyFriendly).toBe(true);
+				expect(config.components.userMessages.styles.framed.copyFriendly).toBe(true);
+				expect(config.components.editor.styles.minimalist).toMatchObject({
+					showTimer: false,
+					showGit: false,
+					contextThresholds: { warning: 45, error: 75 },
+				});
+				expect(config.components.footer).toMatchObject({
+					enabled: false,
+					colorSource: "terminal",
+					modelLabel: "name",
+				});
+				expect(config.components.footer.styles.starship).toMatchObject({
+					format: "$cwd",
+					responsive: false,
+					compactFormat: "$context",
+					compactMaxLines: 3,
+					separator: "dot",
+					contextStyle: "text+gauge",
+					contextThresholds: { warning: 45, error: 75 },
+					pathDisplay: { mode: "full", depth: 3 },
+					segments: { modelInfo: true, tokens: false },
+					gitBranch: { maxLength: 24 },
+					gitCommit: { onlyDetached: false, showTag: false },
+					gitMetrics: { onlyNonzero: false, ignoreSubmodules: true },
+					extensionStatuses: {
+						defaultPlacement: "middle",
+						placements: { alpha: "left" },
+						colorModes: { alpha: "original" },
+					},
+				});
+			},
+		);
+	});
+
+	it("materializes a complete snapshot when a compatibility saver creates the file", () => {
+		withConfig(undefined, (path) => {
+			saveUiFeaturesPatch({ editor: false }, path);
+			const raw = readRaw(path);
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(Object.keys(raw.components).sort()).toEqual([
+				"editor",
+				"footer",
+				"selectorBorders",
+				"userMessages",
+			]);
+			expect(raw.components.editor.enabled).toBe(false);
+			expect(raw.components.userMessages.enabled).toBe(false);
+			expect(raw.components.selectorBorders.enabled).toBe(false);
+			expect(raw).not.toHaveProperty("features");
+		});
+	});
+
+	it("routes saveFixedEditorPatch to canonical layout only", () => {
+		withConfig(undefined, (path) => {
+			const config = saveFixedEditorPatch({ enabled: true }, path);
+			const raw = readRaw(path);
+			expect(raw).toEqual({
+				layout: { fixedEditor: { enabled: true, mouseScroll: true, copyNotice: true } },
+			});
+			expect(config.fixedEditor.enabled).toBe(true);
+			expect(raw).not.toHaveProperty("fixedEditor");
+		});
+	});
+});
 
 describe("mergeConfig", () => {
 	it("defaults project refresh polling to 30 seconds and Starship styles", () => {
@@ -203,11 +901,12 @@ describe("mergeConfig", () => {
 				path,
 			);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(raw).toMatchObject({
-				unknown: { keep: true },
-				footerFormat: "$cwd",
-				responsiveFooter: false,
-				compactFooterMaxLines: 3,
+			expect(raw.unknown).toEqual({ keep: true });
+			expect(raw.footerFormat).toBe("$cwd");
+			expect(raw.components.footer.styles.starship).toMatchObject({
+				format: "$cwd",
+				responsive: false,
+				compactMaxLines: 3,
 			});
 			expect(config.responsiveFooter).toBe(false);
 			expect(config.compactFooterMaxLines).toBe(3);
@@ -279,158 +978,13 @@ describe("mergeConfig", () => {
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.separator).toBe("chevron");
-			expect(raw).toEqual({
-				unknown: true,
+			expect(raw.unknown).toBe(true);
+			expect(raw.contextStyle).toBe("gauge");
+			expect(raw.separator).toBeUndefined();
+			expect(raw.components.footer.styles.starship).toMatchObject({
 				contextStyle: "gauge",
 				separator: "chevron",
 			});
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("refuses corrupt config without changing its bytes", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const path = join(dir, "zentui.json");
-		const original = "{ invalid json\n";
-		try {
-			writeFileSync(path, original);
-
-			expect(() => saveSeparatorPatch("dot", path)).toThrow(
-				/Refusing to save Zentui config.*corrupt/,
-			);
-			expect(readFileSync(path, "utf8")).toBe(original);
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("creates missing config atomically and returns the config written to disk", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const path = join(dir, "zentui.json");
-		try {
-			expect(existsSync(path)).toBe(false);
-			const config = saveFooterFormatPatch("$cwd $fill $context", path);
-			const raw = JSON.parse(readFileSync(path, "utf8"));
-
-			expect(raw).toEqual({ footerFormat: "$cwd $fill $context" });
-			expect(config).toEqual(mergeConfig(raw));
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("preserves the existing destination mode during atomic replacement", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const path = join(dir, "zentui.json");
-		try {
-			writeFileSync(path, `${JSON.stringify({ separator: "pipe" }, null, 2)}\n`);
-			chmodSync(path, 0o600);
-
-			saveSeparatorPatch("dot", path);
-
-			expect(statSync(path).mode & 0o777).toBe(0o600);
-			expect(JSON.parse(readFileSync(path, "utf8")).separator).toBe("dot");
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("updates a symlink target atomically without replacing the symlink", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const targetDir = join(dir, "target");
-		const targetPath = join(targetDir, "actual.json");
-		const linkPath = join(dir, "zentui.json");
-		try {
-			mkdirSync(targetDir);
-			writeFileSync(targetPath, `${JSON.stringify({ unknown: true }, null, 2)}\n`);
-			chmodSync(targetPath, 0o600);
-			symlinkSync(targetPath, linkPath);
-			const originalLink = readlinkSync(linkPath);
-
-			const config = saveSeparatorPatch("chevron", linkPath);
-			const raw = JSON.parse(readFileSync(targetPath, "utf8"));
-
-			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
-			expect(readlinkSync(linkPath)).toBe(originalLink);
-			expect(raw).toEqual({ unknown: true, separator: "chevron" });
-			expect(config).toEqual(mergeConfig(raw));
-			expect(statSync(targetPath).mode & 0o777).toBe(0o600);
-			expect(configTempFiles(targetDir, "actual.json")).toEqual([]);
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("refuses a dangling symlink without changing it", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const targetDir = join(dir, "target");
-		const missingTarget = join(targetDir, "missing.json");
-		const linkPath = join(dir, "zentui.json");
-		try {
-			mkdirSync(targetDir);
-			symlinkSync(missingTarget, linkPath);
-			const originalLink = readlinkSync(linkPath);
-
-			expect(() => saveSeparatorPatch("dot", linkPath)).toThrow(/Refusing to save Zentui config/);
-			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
-			expect(readlinkSync(linkPath)).toBe(originalLink);
-			expect(existsSync(missingTarget)).toBe(false);
-			expect(configTempFiles(targetDir, "missing.json")).toEqual([]);
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("preserves scalar and nested unknown keys through the shared mutation path", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const path = join(dir, "zentui.json");
-		try {
-			writeFileSync(
-				path,
-				`${JSON.stringify(
-					{
-						futureScalar: "keep",
-						pathDisplay: { mode: "basename", depth: 2, futureNested: { keep: true } },
-					},
-					null,
-					2,
-				)}\n`,
-			);
-
-			saveSeparatorPatch("dot", path);
-			const config = savePathDisplayPatch({ mode: "full" }, path);
-			const raw = JSON.parse(readFileSync(path, "utf8"));
-
-			expect(raw.futureScalar).toBe("keep");
-			expect(raw.separator).toBe("dot");
-			expect(raw.pathDisplay).toEqual({
-				mode: "full",
-				depth: 2,
-				futureNested: { keep: true },
-			});
-			expect(config).toEqual(mergeConfig(raw));
-			expect(configTempFiles(dir)).toEqual([]);
-		} finally {
-			rmSync(dir, { recursive: true, force: true });
-		}
-	});
-
-	it("keeps the destination and removes the temp file when serialization fails", () => {
-		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
-		const path = join(dir, "zentui.json");
-		const original = `${JSON.stringify({ unknown: true }, null, 2)}\n`;
-		try {
-			writeFileSync(path, original);
-
-			expect(() => saveContextThresholdsPatch({ warning: 1n as never }, path)).toThrow();
-			expect(readFileSync(path, "utf8")).toBe(original);
-			expect(configTempFiles(dir)).toEqual([]);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -455,82 +1009,6 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ editorModelLabel: "name" }).editorModelLabel).toBe("name");
 		expect(mergeConfig({ editorModelLabel: "id" }).editorModelLabel).toBe("id");
 		expect(mergeConfig({ editorModelLabel: "title" }).editorModelLabel).toBe("id");
-	});
-
-	it("defaults and normalizes editor style", () => {
-		expect(defaultConfig.editorStyle).toBe("polished");
-		expect(mergeConfig({}).editorStyle).toBe("polished");
-		expect(mergeConfig({ editorStyle: "polished" }).editorStyle).toBe("polished");
-		expect(mergeConfig({ editorStyle: "minimalist" }).editorStyle).toBe("minimalist");
-		for (const value of ["amp", "", 1, null, true]) {
-			expect(mergeConfig({ editorStyle: value }).editorStyle).toBe("polished");
-		}
-	});
-
-	it("ignores unreleased legacy editor style keys", () => {
-		const legacyOnly = mergeConfig({
-			editorMode: "minimalist",
-			minimalist: { showGit: false, showTimer: false },
-		});
-		expect(legacyOnly.editorStyle).toBe("polished");
-		expect(legacyOnly.editorStyles.minimalist).toEqual(defaultConfig.editorStyles.minimalist);
-
-		const canonical = mergeConfig({
-			editorMode: "polished",
-			minimalist: { showGit: true },
-			editorStyle: "minimalist",
-			editorStyles: { minimalist: { showGit: false } },
-		});
-		expect(canonical.editorStyle).toBe("minimalist");
-		expect(canonical.editorStyles.minimalist.showGit).toBe(false);
-	});
-
-	it("normalizes focused minimalist settings", () => {
-		expect(defaultConfig.editorStyles.minimalist).toEqual({
-			pathDisplay: "compact",
-			contextFormat: "percent",
-			contextGauge: false,
-			showSessionName: true,
-			showTimer: true,
-			showCost: true,
-			showGit: true,
-		});
-		expect(
-			mergeConfig({
-				editorStyles: {
-					minimalist: {
-						pathDisplay: "project",
-						contextFormat: "percent-total",
-						contextGauge: true,
-						showSessionName: false,
-						showTimer: false,
-						showCost: false,
-						showGit: false,
-					},
-				},
-			}).editorStyles.minimalist,
-		).toEqual({
-			pathDisplay: "project",
-			contextFormat: "percent-total",
-			contextGauge: true,
-			showSessionName: false,
-			showTimer: false,
-			showCost: false,
-			showGit: false,
-		});
-		expect(
-			mergeConfig({
-				editorStyles: {
-					minimalist: {
-						pathDisplay: "basename",
-						contextFormat: "tokens",
-						contextGauge: "yes",
-						showSessionName: "yes",
-						showTimer: null,
-					},
-				},
-			}).editorStyles.minimalist,
-		).toEqual(defaultConfig.editorStyles.minimalist);
 	});
 
 	it("saves minimalist patches while preserving unknown nested config", () => {
@@ -560,17 +1038,19 @@ describe("mergeConfig", () => {
 			expect(config.editorStyles.minimalist.contextFormat).toBe("percent-total");
 			expect(config.editorStyles.minimalist.showSessionName).toBe(false);
 			expect(config.editorStyles.minimalist.showGit).toBe(false);
-			expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
+			const raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(raw).toMatchObject({
 				unknownTop: true,
 				editorStyles: {
 					unknownStyle: { keep: true },
-					minimalist: {
-						unknownNested: "keep",
-						pathDisplay: "full",
-						showSessionName: false,
-						showGit: false,
-					},
+					minimalist: { unknownNested: "keep", showGit: true },
 				},
+			});
+			expect(raw.components.editor.styles.minimalist).toMatchObject({
+				pathDisplay: "full",
+				contextFormat: "percent-total",
+				showSessionName: false,
+				showGit: false,
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -583,20 +1063,19 @@ describe("mergeConfig", () => {
 		try {
 			writeFileSync(path, JSON.stringify({ unknown: { keep: true }, editorModelLabel: "name" }));
 			const minimalist = saveEditorStyle("minimalist", path);
-			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
-				unknown: { keep: true },
-				editorModelLabel: "name",
-				editorStyle: "minimalist",
-			});
+			let raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(raw.unknown).toEqual({ keep: true });
+			expect(raw.editorModelLabel).toBe("name");
+			expect(raw.editorStyle).toBeUndefined();
+			expect(raw.components.editor.style).toBe("minimalist");
 			expect(minimalist.editorStyle).toBe("minimalist");
 
 			const polished = saveEditorStyle("polished", path);
+			raw = JSON.parse(readFileSync(path, "utf8"));
 			expect(polished.editorStyle).toBe("polished");
-			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
-				unknown: { keep: true },
-				editorModelLabel: "name",
-				editorStyle: "polished",
-			});
+			expect(raw.unknown).toEqual({ keep: true });
+			expect(raw.editorModelLabel).toBe("name");
+			expect(raw.components.editor.style).toBe("polished");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -625,11 +1104,10 @@ describe("mergeConfig", () => {
 
 			const config = saveEditorBorderColorMode("adaptive", path);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(raw).toEqual({
-				unknown: { keep: true },
-				editorModelLabel: "name",
-				editorBorderColorMode: "adaptive",
-			});
+			expect(raw.unknown).toEqual({ keep: true });
+			expect(raw.editorModelLabel).toBe("name");
+			expect(raw.editorBorderColorMode).toBeUndefined();
+			expect(raw.components.editor.borderColorMode).toBe("adaptive");
 			expect(config.editorBorderColorMode).toBe("adaptive");
 			expect(config.editorModelLabel).toBe("name");
 			expect(configTempFiles(dir)).toEqual([]);
@@ -692,9 +1170,13 @@ describe("mergeConfig", () => {
 			expect(config.pathDisplay).toEqual({ mode: "full", depth: 3 });
 			expect(raw.unknown).toBe(true);
 			expect(raw.pathDisplay).toEqual({
-				mode: "full",
+				mode: "basename",
 				depth: 3,
 				futureKey: "future",
+			});
+			expect(raw.components.footer.styles.starship.pathDisplay).toEqual({
+				mode: "full",
+				depth: 3,
 			});
 
 			const depthConfig = savePathDisplayPatch({ depth: 1 }, path);
@@ -736,10 +1218,9 @@ describe("mergeConfig", () => {
 			const config = saveGitBranchPatch({ maxLength: 30 }, path);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 			expect(config.gitBranch).toEqual({ maxLength: 30 });
-			expect(raw).toEqual({
-				unknown: true,
-				gitBranch: { maxLength: 30, future: true },
-			});
+			expect(raw.unknown).toBe(true);
+			expect(raw.gitBranch).toEqual({ maxLength: 17, future: true });
+			expect(raw.components.footer.styles.starship.gitBranch).toEqual({ maxLength: 30 });
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1045,10 +1526,9 @@ describe("mergeConfig", () => {
 			expect(raw.colors.futureKey).toBe("future");
 			expect(raw.colors.gitBranch).toBe("syntaxKeyword");
 			expect(raw.colors.cost).toBe("success");
-			expect(raw.colorSources).toEqual({
-				starship: "terminal",
-				editor: "terminal",
-			});
+			expect(raw.colorSources).toEqual({ editor: "terminal" });
+			expect(raw.components.footer.colorSource).toBe("terminal");
+			expect(raw.components.editor.colorSource).toBe("terminal");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1085,9 +1565,10 @@ describe("mergeConfig", () => {
 			expect(raw.colorSources).toEqual({
 				starship: "neon",
 				editor: "terminal",
-				userMessages: "terminal",
+				userMessages: "invalid",
 				extra: "terminal",
 			});
+			expect(raw.components.userMessages.colorSource).toBe("terminal");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1105,7 +1586,10 @@ describe("mergeConfig", () => {
 				editor: "theme",
 				userMessages: "theme",
 			});
-			expect(raw).toEqual({ colorSources: { starship: "terminal" } });
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.footer.colorSource).toBe("terminal");
+			expect(raw.components.editor.colorSource).toBe("theme");
+			expect(raw.components.userMessages.colorSource).toBe("theme");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1140,12 +1624,10 @@ describe("mergeConfig", () => {
 				viewportIndicators: false,
 			});
 			expect(raw.unknown).toBe(true);
-			expect(raw.features).toEqual({
-				editor: true,
-				futureKey: "future",
-				statusLine: false,
-				viewportIndicators: false,
-			});
+			expect(raw.features).toEqual({ editor: true, futureKey: "future" });
+			expect(raw.components.editor.enabled).toBe(true);
+			expect(raw.components.editor.viewportIndicators).toBe(false);
+			expect(raw.components.footer.enabled).toBe(false);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1164,7 +1646,10 @@ describe("mergeConfig", () => {
 				copyFriendly: false,
 				viewportIndicators: true,
 			});
-			expect(raw).toEqual({ features: { editor: false } });
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.editor.enabled).toBe(false);
+			expect(raw.components.userMessages.enabled).toBe(false);
+			expect(raw.components.selectorBorders.enabled).toBe(false);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1212,9 +1697,9 @@ describe("mergeConfig", () => {
 				cost: false,
 			});
 			expect(raw.unknown).toBe(true);
-			expect(raw.footerSegments).toEqual({
+			expect(raw.footerSegments).toEqual({ cwd: true, futureKey: "future" });
+			expect(raw.components.footer.styles.starship.segments).toMatchObject({
 				cwd: true,
-				futureKey: "future",
 				modelInfo: true,
 				tokens: false,
 				cost: false,
@@ -1225,15 +1710,12 @@ describe("mergeConfig", () => {
 			const disabledRaw = JSON.parse(readFileSync(path, "utf8"));
 			expect(disabled.footerSegments.modelInfo).toBe(false);
 			expect(mergeConfig(disabledRaw).footerSegments.modelInfo).toBe(false);
-			expect(disabledRaw).toEqual({
-				unknown: true,
-				footerSegments: {
-					cwd: true,
-					futureKey: "future",
-					modelInfo: false,
-					tokens: false,
-					cost: false,
-				},
+			expect(disabledRaw.unknown).toBe(true);
+			expect(disabledRaw.footerSegments).toEqual({ cwd: true, futureKey: "future" });
+			expect(disabledRaw.components.footer.styles.starship.segments).toMatchObject({
+				modelInfo: false,
+				tokens: false,
+				cost: false,
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -1266,7 +1748,8 @@ describe("mergeConfig", () => {
 				tokens: true,
 				cost: true,
 			});
-			expect(raw).toEqual({ footerSegments: { runtime: false } });
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.footer.styles.starship.segments.runtime).toBe(false);
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1280,7 +1763,7 @@ describe("mergeConfig", () => {
 			expect(config.footerSegments.packageVersion).toBe(true);
 
 			const raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(raw.footerSegments).toEqual({ packageVersion: true });
+			expect(raw.components.footer.styles.starship.segments.packageVersion).toBe(true);
 
 			const reloaded = mergeConfig(raw);
 			expect(reloaded.footerSegments.packageVersion).toBe(true);
@@ -1298,7 +1781,10 @@ describe("mergeConfig", () => {
 			expect(config.footerSegments.gitMetrics).toBe(true);
 
 			const raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(raw.footerSegments).toEqual({ gitCommit: true, gitMetrics: true });
+			expect(raw.components.footer.styles.starship.segments).toMatchObject({
+				gitCommit: true,
+				gitMetrics: true,
+			});
 
 			const reloaded = mergeConfig(raw);
 			expect(reloaded.footerSegments.gitCommit).toBe(true);
@@ -1339,7 +1825,8 @@ describe("mergeConfig", () => {
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.footerFormat).toBe("$cwd on $git_branch $fill $cost");
-			expect(raw).toEqual({ footerFormat: "$cwd on $git_branch $fill $cost" });
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.footer.styles.starship.format).toBe("$cwd on $git_branch $fill $cost");
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
@@ -1364,12 +1851,9 @@ describe("mergeConfig", () => {
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.extensionStatuses.placements).toEqual({ "plugin.key": "middle" });
-			expect(raw).toEqual({
-				extensionStatuses: {
-					placements: {
-						"plugin.key": "middle",
-					},
-				},
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.footer.styles.starship.extensionStatuses.placements).toEqual({
+				"plugin.key": "middle",
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -1384,12 +1868,9 @@ describe("mergeConfig", () => {
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 
 			expect(config.extensionStatuses.colorModes).toEqual({ "plugin.key": "original" });
-			expect(raw).toEqual({
-				extensionStatuses: {
-					colorModes: {
-						"plugin.key": "original",
-					},
-				},
+			expect(Object.keys(raw)).toEqual(["components"]);
+			expect(raw.components.footer.styles.starship.extensionStatuses.colorModes).toEqual({
+				"plugin.key": "original",
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
@@ -1442,6 +1923,9 @@ describe("mergeConfig", () => {
 			expect(raw.extensionStatuses.colorModes).toEqual({
 				alpha: "zentui",
 				invalid: "muted",
+			});
+			expect(raw.components.footer.styles.starship.extensionStatuses.colorModes).toEqual({
+				alpha: "zentui",
 				beta: "original",
 			});
 		} finally {
@@ -1487,6 +1971,9 @@ describe("mergeConfig", () => {
 			expect(raw.extensionStatuses.placements).toEqual({
 				alpha: "right",
 				invalid: "center",
+			});
+			expect(raw.components.footer.styles.starship.extensionStatuses.placements).toEqual({
+				alpha: "right",
 				beta: "off",
 			});
 		} finally {
@@ -1630,7 +2117,10 @@ describe("bounded settings persistence", () => {
 			const config = saveEditorModelLabel("name", path);
 			const raw = JSON.parse(readFileSync(path, "utf8"));
 			expect(config.editorModelLabel).toBe("name");
-			expect(raw).toEqual({ editorModelLabel: "name", unknown: { keep: true } });
+			expect(raw.editorModelLabel).toBe("id");
+			expect(raw.unknown).toEqual({ keep: true });
+			expect(raw.components.editor.modelLabel).toBe("name");
+			expect(raw.components.footer.modelLabel).toBe("name");
 		});
 	});
 
@@ -1646,9 +2136,14 @@ describe("bounded settings persistence", () => {
 				expect(config.gitCommit).toEqual({ hashLength: 12, onlyDetached: false, showTag: false });
 				expect(raw.gitCommit).toEqual({
 					hashLength: 12,
+					onlyDetached: true,
+					showTag: true,
+					future: "keep",
+				});
+				expect(raw.components.footer.styles.starship.gitCommit).toEqual({
+					hashLength: 12,
 					onlyDetached: false,
 					showTag: false,
-					future: "keep",
 				});
 				expect(raw.unknown).toBe(true);
 			},
@@ -1663,9 +2158,13 @@ describe("bounded settings persistence", () => {
 				const raw = JSON.parse(readFileSync(path, "utf8"));
 				expect(config.gitMetrics).toEqual({ onlyNonzero: false, ignoreSubmodules: true });
 				expect(raw.gitMetrics).toEqual({
+					onlyNonzero: true,
+					ignoreSubmodules: false,
+					future: 1,
+				});
+				expect(raw.components.footer.styles.starship.gitMetrics).toEqual({
 					onlyNonzero: false,
 					ignoreSubmodules: true,
-					future: 1,
 				});
 				expect(raw.unknown).toBe(true);
 			},
@@ -1694,6 +2193,9 @@ describe("bounded settings persistence", () => {
 				expect(raw.extensionStatuses.future).toBe("keep");
 				expect(raw.extensionStatuses.placements).toEqual({ alpha: "left" });
 				expect(raw.extensionStatuses.colorModes).toEqual({ alpha: "original" });
+				expect(raw.components.footer.styles.starship.extensionStatuses.defaultPlacement).toBe(
+					"middle",
+				);
 				expect(raw.unknown).toBe(true);
 			},
 		);
@@ -1709,7 +2211,8 @@ describe("saveFixedEditorPatch", () => {
 			expect(config.fixedEditor.enabled).toBe(true);
 
 			const raw = JSON.parse(readFileSync(path, "utf8"));
-			expect(raw.fixedEditor.enabled).toBe(true);
+			expect(raw.fixedEditor).toBeUndefined();
+			expect(raw.layout.fixedEditor.enabled).toBe(true);
 		} finally {
 			rmSync(dir, { recursive: true });
 		}
@@ -1725,5 +2228,106 @@ describe("saveFixedEditorPatch", () => {
 		} finally {
 			rmSync(dir, { recursive: true });
 		}
+	});
+});
+describe("startup and file safety", () => {
+	it("does not create, rewrite, or materialize config at startup", () => {
+		withConfig(undefined, (path) => {
+			ensureConfigExists(path);
+			expect(existsSync(path)).toBe(false);
+		});
+		withConfig({ features: { editor: false }, unknown: true }, (path) => {
+			const before = readFileSync(path, "utf8");
+			ensureConfigExists(path);
+			expect(readFileSync(path, "utf8")).toBe(before);
+			expect(readRaw(path)).not.toHaveProperty("components");
+		});
+	});
+
+	it("refuses corrupt config without changing bytes or leaving a temporary file", () => {
+		withConfig(undefined, (path, dir) => {
+			const original = "{ invalid json\n";
+			writeFileSync(path, original);
+			expect(() => saveSeparatorPatch("dot", path)).toThrow(
+				/Refusing to save Zentui config.*corrupt/,
+			);
+			expect(readFileSync(path, "utf8")).toBe(original);
+			expect(configTempFiles(dir)).toEqual([]);
+		});
+	});
+
+	it("creates a missing config atomically and returns the re-merged file", () => {
+		withConfig(undefined, (path, dir) => {
+			const config = saveFooterFormatPatch("$cwd", path);
+			const raw = readRaw(path);
+			expect(raw.components.footer.styles.starship.format).toBe("$cwd");
+			expect(config).toEqual(mergeConfig(raw));
+			expect(configTempFiles(dir)).toEqual([]);
+		});
+	});
+
+	it("preserves destination mode during atomic replacement", () => {
+		withConfig({ separator: "pipe" }, (path, dir) => {
+			chmodSync(path, 0o600);
+			saveSeparatorPatch("dot", path);
+			expect(statSync(path).mode & 0o777).toBe(0o600);
+			expect(readRaw(path).components.footer.styles.starship.separator).toBe("dot");
+			expect(configTempFiles(dir)).toEqual([]);
+		});
+	});
+
+	it("updates a symlink target atomically without replacing the symlink", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-symlink-config-"));
+		const targetDir = join(dir, "target");
+		const targetPath = join(targetDir, "actual.json");
+		const linkPath = join(dir, "zentui.json");
+		try {
+			mkdirSync(targetDir);
+			writeFileSync(targetPath, `${JSON.stringify({ unknown: true }, null, 2)}\n`);
+			chmodSync(targetPath, 0o600);
+			symlinkSync(targetPath, linkPath);
+			const originalLink = readlinkSync(linkPath);
+			const config = saveSeparatorPatch("chevron", linkPath);
+			const raw = readRaw(targetPath);
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(linkPath)).toBe(originalLink);
+			expect(raw.unknown).toBe(true);
+			expect(raw.components.footer.styles.starship.separator).toBe("chevron");
+			expect(config).toEqual(mergeConfig(raw));
+			expect(statSync(targetPath).mode & 0o777).toBe(0o600);
+			expect(configTempFiles(targetDir, "actual.json")).toEqual([]);
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses a dangling symlink without changing it", () => {
+		const dir = mkdtempSync(join(tmpdir(), "zentui-dangling-config-"));
+		const targetDir = join(dir, "target");
+		const missingTarget = join(targetDir, "missing.json");
+		const linkPath = join(dir, "zentui.json");
+		try {
+			mkdirSync(targetDir);
+			symlinkSync(missingTarget, linkPath);
+			const originalLink = readlinkSync(linkPath);
+			expect(() => saveSeparatorPatch("dot", linkPath)).toThrow(/Refusing to save Zentui config/);
+			expect(lstatSync(linkPath).isSymbolicLink()).toBe(true);
+			expect(readlinkSync(linkPath)).toBe(originalLink);
+			expect(existsSync(missingTarget)).toBe(false);
+			expect(configTempFiles(targetDir, "missing.json")).toEqual([]);
+			expect(configTempFiles(dir)).toEqual([]);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps the destination and leaves no temp file when serialization input is invalid", () => {
+		withConfig({ unknown: true }, (path, dir) => {
+			const original = readFileSync(path, "utf8");
+			expect(() => saveContextThresholdsPatch({ warning: 1n as never }, path)).toThrow();
+			expect(readFileSync(path, "utf8")).toBe(original);
+			expect(configTempFiles(dir)).toEqual([]);
+		});
 	});
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -24,8 +24,8 @@ import {
 	saveColorSourcesPatch,
 	saveContextThresholdsPatch,
 	saveEditorBorderColorMode,
-	saveEditorMode,
 	saveEditorModelLabel,
+	saveEditorStyle,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
 	saveExtensionStatusPlacement,
@@ -457,54 +457,80 @@ describe("mergeConfig", () => {
 		expect(mergeConfig({ editorModelLabel: "title" }).editorModelLabel).toBe("id");
 	});
 
-	it("defaults and normalizes editor mode", () => {
-		expect(defaultConfig.editorMode).toBe("polished");
-		expect(mergeConfig({}).editorMode).toBe("polished");
-		expect(mergeConfig({ editorMode: "polished" }).editorMode).toBe("polished");
-		expect(mergeConfig({ editorMode: "minimalist" }).editorMode).toBe("minimalist");
+	it("defaults and normalizes editor style", () => {
+		expect(defaultConfig.editorStyle).toBe("polished");
+		expect(mergeConfig({}).editorStyle).toBe("polished");
+		expect(mergeConfig({ editorStyle: "polished" }).editorStyle).toBe("polished");
+		expect(mergeConfig({ editorStyle: "minimalist" }).editorStyle).toBe("minimalist");
 		for (const value of ["amp", "", 1, null, true]) {
-			expect(mergeConfig({ editorMode: value }).editorMode).toBe("polished");
+			expect(mergeConfig({ editorStyle: value }).editorStyle).toBe("polished");
 		}
 	});
 
+	it("ignores unreleased legacy editor style keys", () => {
+		const legacyOnly = mergeConfig({
+			editorMode: "minimalist",
+			minimalist: { showGit: false, showTimer: false },
+		});
+		expect(legacyOnly.editorStyle).toBe("polished");
+		expect(legacyOnly.editorStyles.minimalist).toEqual(defaultConfig.editorStyles.minimalist);
+
+		const canonical = mergeConfig({
+			editorMode: "polished",
+			minimalist: { showGit: true },
+			editorStyle: "minimalist",
+			editorStyles: { minimalist: { showGit: false } },
+		});
+		expect(canonical.editorStyle).toBe("minimalist");
+		expect(canonical.editorStyles.minimalist.showGit).toBe(false);
+	});
+
 	it("normalizes focused minimalist settings", () => {
-		expect(defaultConfig.minimalist).toEqual({
+		expect(defaultConfig.editorStyles.minimalist).toEqual({
 			pathDisplay: "compact",
 			contextFormat: "percent",
 			contextGauge: false,
+			showSessionName: true,
 			showTimer: true,
 			showCost: true,
 			showGit: true,
 		});
 		expect(
 			mergeConfig({
-				minimalist: {
-					pathDisplay: "project",
-					contextFormat: "percent-total",
-					contextGauge: true,
-					showTimer: false,
-					showCost: false,
-					showGit: false,
+				editorStyles: {
+					minimalist: {
+						pathDisplay: "project",
+						contextFormat: "percent-total",
+						contextGauge: true,
+						showSessionName: false,
+						showTimer: false,
+						showCost: false,
+						showGit: false,
+					},
 				},
-			}).minimalist,
+			}).editorStyles.minimalist,
 		).toEqual({
 			pathDisplay: "project",
 			contextFormat: "percent-total",
 			contextGauge: true,
+			showSessionName: false,
 			showTimer: false,
 			showCost: false,
 			showGit: false,
 		});
 		expect(
 			mergeConfig({
-				minimalist: {
-					pathDisplay: "basename",
-					contextFormat: "tokens",
-					contextGauge: "yes",
-					showTimer: null,
+				editorStyles: {
+					minimalist: {
+						pathDisplay: "basename",
+						contextFormat: "tokens",
+						contextGauge: "yes",
+						showSessionName: "yes",
+						showTimer: null,
+					},
 				},
-			}).minimalist,
-		).toEqual(defaultConfig.minimalist);
+			}).editorStyles.minimalist,
+		).toEqual(defaultConfig.editorStyles.minimalist);
 	});
 
 	it("saves minimalist patches while preserving unknown nested config", () => {
@@ -513,43 +539,63 @@ describe("mergeConfig", () => {
 		try {
 			writeFileSync(
 				path,
-				JSON.stringify({ unknownTop: true, minimalist: { unknownNested: "keep", showGit: true } }),
+				JSON.stringify({
+					unknownTop: true,
+					editorStyles: {
+						unknownStyle: { keep: true },
+						minimalist: { unknownNested: "keep", showGit: true },
+					},
+				}),
 			);
 			const config = saveMinimalistPatch(
-				{ pathDisplay: "full", contextFormat: "percent-total", showGit: false },
+				{
+					pathDisplay: "full",
+					contextFormat: "percent-total",
+					showSessionName: false,
+					showGit: false,
+				},
 				path,
 			);
-			expect(config.minimalist.pathDisplay).toBe("full");
-			expect(config.minimalist.contextFormat).toBe("percent-total");
-			expect(config.minimalist.showGit).toBe(false);
+			expect(config.editorStyles.minimalist.pathDisplay).toBe("full");
+			expect(config.editorStyles.minimalist.contextFormat).toBe("percent-total");
+			expect(config.editorStyles.minimalist.showSessionName).toBe(false);
+			expect(config.editorStyles.minimalist.showGit).toBe(false);
 			expect(JSON.parse(readFileSync(path, "utf8"))).toMatchObject({
 				unknownTop: true,
-				minimalist: { unknownNested: "keep", pathDisplay: "full", showGit: false },
+				editorStyles: {
+					unknownStyle: { keep: true },
+					minimalist: {
+						unknownNested: "keep",
+						pathDisplay: "full",
+						showSessionName: false,
+						showGit: false,
+					},
+				},
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}
 	});
 
-	it("saves editor mode without erasing sibling config", () => {
+	it("saves editor style without erasing sibling config", () => {
 		const dir = mkdtempSync(join(tmpdir(), "zentui-config-"));
 		const path = join(dir, "zentui.json");
 		try {
 			writeFileSync(path, JSON.stringify({ unknown: { keep: true }, editorModelLabel: "name" }));
-			const minimalist = saveEditorMode("minimalist", path);
+			const minimalist = saveEditorStyle("minimalist", path);
 			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
 				unknown: { keep: true },
 				editorModelLabel: "name",
-				editorMode: "minimalist",
+				editorStyle: "minimalist",
 			});
-			expect(minimalist.editorMode).toBe("minimalist");
+			expect(minimalist.editorStyle).toBe("minimalist");
 
-			const polished = saveEditorMode("polished", path);
-			expect(polished.editorMode).toBe("polished");
+			const polished = saveEditorStyle("polished", path);
+			expect(polished.editorStyle).toBe("polished");
 			expect(JSON.parse(readFileSync(path, "utf8"))).toEqual({
 				unknown: { keep: true },
 				editorModelLabel: "name",
-				editorMode: "polished",
+				editorStyle: "polished",
 			});
 		} finally {
 			rmSync(dir, { recursive: true, force: true });

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -1,7 +1,11 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
-import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import {
+	defaultConfig,
+	type EditorStyle,
+	type PolishedTuiConfig,
+} from "../extensions/zentui/config";
 import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
 
 function theme(): Theme {
@@ -17,8 +21,10 @@ function theme(): Theme {
 	} as Theme;
 }
 
+type EditorOptions = Partial<PolishedTuiConfig["features"]> & { style?: EditorStyle };
+
 function config(
-	features: Partial<PolishedTuiConfig["features"]> = {},
+	options: EditorOptions = {},
 	editorBorderColorMode: PolishedTuiConfig["editorBorderColorMode"] = "static",
 ): PolishedTuiConfig {
 	return {
@@ -27,20 +33,20 @@ function config(
 			...defaultConfig.components,
 			editor: {
 				...defaultConfig.components.editor,
+				style: options.style ?? defaultConfig.components.editor.style,
 				borderColorMode: editorBorderColorMode,
 				viewportIndicators:
-					features.viewportIndicators ?? defaultConfig.components.editor.viewportIndicators,
-				styles: {
-					...defaultConfig.components.editor.styles,
-					polished: {
-						...defaultConfig.components.editor.styles.polished,
-						copyFriendly:
-							features.copyFriendly ?? defaultConfig.components.editor.styles.polished.copyFriendly,
-					},
-				},
+					options.viewportIndicators ?? defaultConfig.components.editor.viewportIndicators,
 			},
 		},
-		features: { ...defaultConfig.features, ...features },
+		features: {
+			...defaultConfig.features,
+			...(options.editor === undefined ? {} : { editor: options.editor }),
+			...(options.statusLine === undefined ? {} : { statusLine: options.statusLine }),
+			...(options.viewportIndicators === undefined
+				? {}
+				: { viewportIndicators: options.viewportIndicators }),
+		},
 	};
 }
 
@@ -99,7 +105,7 @@ function baseEditor(options: {
 
 function wrapped(
 	base: ReturnType<typeof baseEditor> | WrappedPolishedEditor,
-	features: Partial<PolishedTuiConfig["features"]> = {},
+	features: EditorOptions = {},
 	editorBorderColorMode: PolishedTuiConfig["editorBorderColorMode"] = "static",
 ): WrappedPolishedEditor {
 	return new WrappedPolishedEditor(
@@ -209,10 +215,10 @@ describe("adaptive editor border colors", () => {
 		expect(rendered.match(/model/g)).toHaveLength(1);
 	});
 
-	it("preserves copy-friendly viewport layout, clamping, and static fallback", () => {
+	it("preserves low-rail polished viewport layout, clamping, and static fallback", () => {
 		const editor = wrapped(
 			baseEditor({ above: 123456, below: 654321, ansi: true }),
-			{ copyFriendly: true },
+			{ style: "polished-copy-friendly" },
 			"adaptive",
 		);
 		editor.borderColor = () => {
@@ -531,10 +537,10 @@ describe("editor viewport indicators", () => {
 	});
 
 	it("keeps every rendered line within narrow ANSI-aware widths in both chrome modes", () => {
-		for (const copyFriendly of [false, true]) {
+		for (const style of ["polished", "polished-copy-friendly"] as const) {
 			for (const width of [3, 8, 12, 16]) {
 				const lines = wrapped(baseEditor({ above: 12, below: 34, ansi: true }), {
-					copyFriendly,
+					style,
 				}).render(width);
 				expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
 			}
@@ -567,6 +573,51 @@ describe("minimalist editor integration", () => {
 		expect(minimalist[0]).toMatch(/^╭.*╮$/);
 		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
 		expect(minimalist.join("\n")).toContain("$0.100 – model");
+	});
+
+	it("cycles one wrapped adapter through every style without nesting owned chrome", () => {
+		let current = config({ style: "polished" });
+		const rawWidths: number[] = [];
+		const raw = baseEditor({});
+		const rawRender = raw.render.bind(raw);
+		raw.render = (width: number) => {
+			rawWidths.push(width);
+			return rawRender(width);
+		};
+		const inner = new WrappedPolishedEditor(
+			raw as never,
+			theme(),
+			() => config({ style: "polished" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+		);
+		const decoration = vi.fn();
+		const editor = new WrappedPolishedEditor(
+			inner as never,
+			theme(),
+			() => current,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp/project", modelLabel: "model", costLabel: "$0.100" }),
+			decoration,
+		);
+
+		const polished = editor.render(40);
+		current = withEditorStyle(current, "polished-copy-friendly");
+		const lowRail = editor.render(40);
+		current = withEditorStyle(current, "minimalist");
+		const minimalist = editor.render(40);
+		current = withEditorStyle(current, "polished");
+		const polishedAgain = editor.render(40);
+
+		expect(rawWidths).toEqual([36, 38, 34, 36]);
+		expect(polished.join("\n").match(/provider/g)).toHaveLength(1);
+		expect(lowRail.join("\n").match(/provider/g)).toHaveLength(1);
+		expect(minimalist[0]).toMatch(/^╭.*╮$/);
+		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
+		expect(polishedAgain.join("\n").match(/provider/g)).toHaveLength(1);
+		expect(polishedAgain.join("\n")).not.toContain("╭");
+		expect(decoration.mock.calls.map(([active]) => active)).toEqual([false, false, true, false]);
 	});
 
 	it("places native viewport counts at the far left before minimalist metadata", () => {

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -533,7 +533,7 @@ describe("minimalist editor integration", () => {
 		);
 
 		expect(editor.render(80)[0]).toMatch(/^─+$/);
-		current = { ...current, editorMode: "minimalist" };
+		current = { ...current, editorStyle: "minimalist" };
 		const minimalist = editor.render(80);
 		expect(minimalist[0]).toMatch(/^╭.*╮$/);
 		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
@@ -544,7 +544,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			baseEditor({ above: 7, below: 11 }) as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({
@@ -567,7 +567,7 @@ describe("minimalist editor integration", () => {
 			theme(),
 			() => ({
 				...config({ viewportIndicators: false }),
-				editorMode: "minimalist",
+				editorStyle: "minimalist",
 			}),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
@@ -582,7 +582,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -613,7 +613,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -629,7 +629,7 @@ describe("minimalist editor integration", () => {
 		const outer = new WrappedPolishedEditor(
 			inner as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "outer", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp", modelLabel: "minimal-model" }),
@@ -662,7 +662,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -685,7 +685,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -720,7 +720,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -739,7 +739,7 @@ describe("minimalist editor integration", () => {
 				setText() {},
 			} as never,
 			theme(),
-			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ ...config(), editorStyle: "minimalist" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -540,8 +540,45 @@ describe("minimalist editor integration", () => {
 		expect(minimalist.join("\n")).toContain("$0.100 – model");
 	});
 
+	it("places native viewport counts at the far left before minimalist metadata", () => {
+		const editor = new WrappedPolishedEditor(
+			baseEditor({ above: 7, below: 11 }) as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({
+				cwd: "/tmp/project",
+				branch: "main",
+				ahead: 2,
+				behind: 1,
+				agentDurationMs: 5000,
+			}),
+		);
+
+		const lines = editor.render(80);
+		expect(lines[0]).toMatch(/^╭─ ↑ 7 more · 5s/);
+		expect(lines.at(-1)).toMatch(/^╰─ ↓ 11 more · main ↑2 ↓1/);
+	});
+
+	it("honors the shared viewport indicator toggle in minimalist mode", () => {
+		const editor = new WrappedPolishedEditor(
+			baseEditor({ above: 7, below: 11 }) as never,
+			theme(),
+			() => ({
+				...config({ viewportIndicators: false }),
+				editorMode: "minimalist",
+			}),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp/project" }),
+		);
+
+		expect(editor.render(80).join("\n")).not.toContain("more");
+	});
+
 	it("keeps known autocomplete rows inside the minimalist frame", () => {
-		const base = baseEditor({ autocomplete: ["one", "two"] });
+		const base = baseEditor({ below: 5, autocomplete: ["one", "two"] });
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
@@ -555,6 +592,8 @@ describe("minimalist editor integration", () => {
 		expect(lines.findIndex((line) => line.includes("one"))).toBeGreaterThan(
 			lines.findIndex((line) => line.startsWith("├")),
 		);
+		expect(lines.findIndex((line) => line.includes("one"))).toBeLessThan(lines.length - 1);
+		expect(lines.at(-1)).toContain("↓ 5 more");
 		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
 	});
 
@@ -585,8 +624,8 @@ describe("minimalist editor integration", () => {
 		expect(decoration).toHaveBeenLastCalledWith(false);
 	});
 
-	it("unwraps module-owned polished chrome and autocomplete before minimalist decoration", () => {
-		const inner = wrapped(baseEditor({ autocomplete: ["one", "two"] }));
+	it("unwraps module-owned polished chrome, viewport counts, and autocomplete", () => {
+		const inner = wrapped(baseEditor({ above: 3, below: 8, autocomplete: ["one", "two"] }));
 		const outer = new WrappedPolishedEditor(
 			inner as never,
 			theme(),
@@ -603,6 +642,8 @@ describe("minimalist editor integration", () => {
 		expect(rendered).toContain("minimal-model");
 		expect(rendered).not.toContain("provider");
 		expect(rendered.match(/minimal-model/g)).toHaveLength(1);
+		expect(rendered.match(/↑ 3 more/g)).toHaveLength(1);
+		expect(rendered.match(/↓ 8 more/g)).toHaveLength(1);
 		expect(lines.some((line) => /^├─+┤$/.test(line))).toBe(true);
 		expect(lines.filter((line) => line.includes("one") || line.includes("two"))).toHaveLength(2);
 	});
@@ -688,7 +729,6 @@ describe("minimalist editor integration", () => {
 		expect(lines[1]).toMatch(/^│\s+│$/);
 		expect(lines.join("\n")).toContain(inverseCursor);
 		expect(lines.join("\n")).toContain("second line");
-		expect(lines.at(-2)).toMatch(/^│\s+│$/);
 
 		const empty = new WrappedPolishedEditor(
 			{
@@ -704,7 +744,8 @@ describe("minimalist editor integration", () => {
 			() => "off",
 			() => ({ cwd: "/tmp" }),
 		).render(40);
-		expect(empty).toHaveLength(4);
-		expect(empty.slice(1, -1).every((line) => /^│\s+│$/.test(line))).toBe(true);
+		expect(empty).toHaveLength(2);
+		expect(empty[0]).toMatch(/^╭.*╮$/);
+		expect(empty[1]).toMatch(/^╰.*╯$/);
 	});
 });

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -117,6 +117,20 @@ function wrapped(
 	);
 }
 
+function standalone(style: EditorStyle = "opencode"): PolishedEditor {
+	const editor = new PolishedEditor(
+		{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+		{ borderColor: (text: string) => text, selectList: {} } as never,
+		{} as never,
+		theme(),
+		() => config({ style }),
+		() => ({ modelLabel: "model", providerLabel: "provider" }),
+		() => "off",
+	);
+	editor.setText("typed text");
+	return editor;
+}
+
 const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
 type SemanticBorderState = (typeof thinkingLevels)[number] | "shell";
 
@@ -218,7 +232,7 @@ describe("adaptive editor border colors", () => {
 	it("preserves low-rail polished viewport layout, clamping, and static fallback", () => {
 		const editor = wrapped(
 			baseEditor({ above: 123456, below: 654321, ansi: true }),
-			{ style: "polished-copy-friendly" },
+			{ style: "opencode-copy-friendly" },
 			"adaptive",
 		);
 		editor.borderColor = () => {
@@ -291,14 +305,87 @@ describe("editor viewport indicators", () => {
 		expect(narrowLines.at(-1)).toContain("↓");
 	});
 
-	it("keeps autocomplete rows after the counted bottom border", () => {
-		const suggestions = ["suggestion-one", "suggestion-two"];
-		const lines = wrapped(baseEditor({ below: 5, autocomplete: suggestions })).render(80);
-		const bottom = lines.findIndex((line) => line.includes("↓ 5 more"));
-		expect(bottom).toBeGreaterThanOrEqual(0);
-		for (const suggestion of suggestions) {
-			expect(lines.findIndex((line) => line.includes(suggestion))).toBeGreaterThan(bottom);
-		}
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"keeps ANSI and Unicode autocomplete rows raw after the terminal bottom border in %s",
+		(style) => {
+			const suggestions = ["\x1b[31msuggestion-one\x1b[0m", "emoji 😀 e\u0301 界"];
+			const lines = wrapped(baseEditor({ below: 5, autocomplete: suggestions }), { style }).render(
+				80,
+			);
+			const bottom = lines.findIndex((line) => line.includes("↓ 5 more"));
+			expect(lines.some((line) => line.includes("├") || line.includes("┤"))).toBe(false);
+			expect(bottom).toBe(lines.length - suggestions.length - 1);
+			expect(lines.slice(bottom + 1)).toEqual(suggestions);
+			expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+		},
+	);
+
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"keeps exact no-autocomplete output in %s",
+		(style) => {
+			const ordinary = baseEditor({ below: 2 });
+			const guarded = baseEditor({ below: 2 });
+			guarded.autocompleteList.render = () => {
+				throw new Error("must not inspect an inactive menu");
+			};
+			expect(wrapped(guarded, { style }).render(80)).toEqual(
+				wrapped(ordinary, { style }).render(80),
+			);
+		},
+	);
+
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"keeps raw trailing autocomplete width-safe at widths 5 and 4 in %s",
+		(style) => {
+			for (const width of [5, 4]) {
+				const lines = wrapped(baseEditor({ autocomplete: ["界😀e\u0301"] }), { style }).render(
+					width,
+				);
+				expect(lines.some((line) => line.includes("├") || line.includes("┤"))).toBe(false);
+				expect(lines.at(-2)).toMatch(/^─+$/);
+				expect(visibleWidth(lines.at(-1) ?? "")).toBeLessThanOrEqual(width);
+				expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			}
+		},
+	);
+
+	it("rerenders standalone Opencode at caller width when reduced-width autocomplete rendering throws", () => {
+		const editor = standalone();
+		let calls = 0;
+		Object.assign(editor as unknown as Record<string, unknown>, {
+			autocompleteState: {},
+			autocompleteList: {
+				render() {
+					calls += 1;
+					if (calls === 1) throw new Error("reduced-width autocomplete failed");
+					return ["caller-width-suggestion"];
+				},
+			},
+		});
+		const lines = editor.render(80);
+		expect(calls).toBe(2);
+		expect(lines.some((line) => line.includes("├"))).toBe(false);
+		expect(lines).toContain("caller-width-suggestion".padEnd(80));
+		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+	});
+
+	it("rerenders standalone Opencode at caller width when autocomplete extraction becomes unknown", () => {
+		const editor = standalone("opencode-copy-friendly");
+		let calls = 0;
+		Object.assign(editor as unknown as Record<string, unknown>, {
+			autocompleteState: {},
+			autocompleteList: {
+				render() {
+					calls += 1;
+					return calls === 2 ? [] : ["caller-width-suggestion"];
+				},
+			},
+		});
+		const lines = editor.render(80);
+		expect(calls).toBe(3);
+		expect(lines.some((line) => line.includes("├"))).toBe(false);
+		expect(lines).toContain("caller-width-suggestion".padEnd(80));
+		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
 
 	it.each([
@@ -537,7 +624,7 @@ describe("editor viewport indicators", () => {
 	});
 
 	it("keeps every rendered line within narrow ANSI-aware widths in both chrome modes", () => {
-		for (const style of ["polished", "polished-copy-friendly"] as const) {
+		for (const style of ["opencode", "opencode-copy-friendly"] as const) {
 			for (const width of [3, 8, 12, 16]) {
 				const lines = wrapped(baseEditor({ above: 12, below: 34, ansi: true }), {
 					style,
@@ -576,7 +663,7 @@ describe("minimalist editor integration", () => {
 	});
 
 	it("cycles one wrapped adapter through every style without nesting owned chrome", () => {
-		let current = config({ style: "polished" });
+		let current = config({ style: "opencode" });
 		const rawWidths: number[] = [];
 		const raw = baseEditor({});
 		const rawRender = raw.render.bind(raw);
@@ -587,7 +674,7 @@ describe("minimalist editor integration", () => {
 		const inner = new WrappedPolishedEditor(
 			raw as never,
 			theme(),
-			() => config({ style: "polished" }),
+			() => config({ style: "opencode" }),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 		);
@@ -603,11 +690,11 @@ describe("minimalist editor integration", () => {
 		);
 
 		const polished = editor.render(40);
-		current = withEditorStyle(current, "polished-copy-friendly");
+		current = withEditorStyle(current, "opencode-copy-friendly");
 		const lowRail = editor.render(40);
 		current = withEditorStyle(current, "minimalist");
 		const minimalist = editor.render(40);
-		current = withEditorStyle(current, "polished");
+		current = withEditorStyle(current, "opencode");
 		const polishedAgain = editor.render(40);
 
 		expect(rawWidths).toEqual([36, 38, 34, 36]);

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -1,12 +1,18 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { CURSOR_MARKER, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import {
 	defaultConfig,
 	type EditorStyle,
 	type PolishedTuiConfig,
 } from "../extensions/zentui/config";
-import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
+import { FIXED_EDITOR_LAYOUT } from "../extensions/zentui/fixed-editor/editor-layout";
+import { planFixedLayout } from "../extensions/zentui/fixed-editor/layout";
+import {
+	PolishedEditor,
+	renderWithAutocompleteCapture,
+	WrappedPolishedEditor,
+} from "../extensions/zentui/ui";
 
 function theme(): Theme {
 	return {
@@ -85,13 +91,19 @@ function baseEditor(options: {
 	autocomplete?: string[];
 }) {
 	const autocomplete = options.autocomplete ?? [];
+	const autocompleteList = {
+		filteredItems: autocomplete.map((value) => ({ value })),
+		selectedIndex: 0,
+		maxVisible: Math.max(1, autocomplete.length),
+		render: (_width?: number) => autocomplete,
+	};
 	return {
 		render(width: number) {
 			return [
 				options.malformedTop ?? nativeBorder(width, "above", options.above, options.ansi),
 				"typed text",
 				nativeBorder(width, "below", options.below, options.ansi),
-				...autocomplete,
+				...(autocomplete.length > 0 ? autocompleteList.render(width) : []),
 			];
 		},
 		invalidate() {},
@@ -99,7 +111,7 @@ function baseEditor(options: {
 		getText: () => "typed text",
 		setText() {},
 		isShowingAutocomplete: () => autocomplete.length > 0,
-		autocompleteList: { render: () => autocomplete },
+		autocompleteList,
 	};
 }
 
@@ -369,7 +381,7 @@ describe("editor viewport indicators", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
 
-	it("rerenders standalone Opencode at caller width when autocomplete extraction becomes unknown", () => {
+	it("captures standalone Opencode autocomplete from the base render without an extra render", () => {
 		const editor = standalone("opencode-copy-friendly");
 		let calls = 0;
 		Object.assign(editor as unknown as Record<string, unknown>, {
@@ -382,9 +394,9 @@ describe("editor viewport indicators", () => {
 			},
 		});
 		const lines = editor.render(80);
-		expect(calls).toBe(3);
+		expect(calls).toBe(1);
 		expect(lines.some((line) => line.includes("├"))).toBe(false);
-		expect(lines).toContain("caller-width-suggestion".padEnd(80));
+		expect(lines.some((line) => line.includes("caller-width-suggestion"))).toBe(true);
 		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
 
@@ -638,6 +650,197 @@ describe("editor viewport indicators", () => {
 		const truncatedNativeTop = truncateToWidth("─── ↑ 12 more ", 10, "");
 		const lines = wrapped(baseEditor({ below: 1, malformedTop: truncatedNativeTop })).render(40);
 		expect(lines[0]).toBe(truncatedNativeTop);
+	});
+});
+
+describe("same-render autocomplete capture", () => {
+	function source(render: (width: number) => string[]) {
+		return {
+			isShowingAutocomplete: () => true,
+			autocompleteList: {
+				filteredItems: [{ value: "one" }],
+				selectedIndex: 0,
+				maxVisible: 1,
+				render,
+			},
+		};
+	}
+
+	it("restores the exact predecessor after descriptor flags mutate", () => {
+		const predecessor = vi.fn(() => ["one"]);
+		const autocomplete = source(predecessor);
+		const original = Object.getOwnPropertyDescriptor(autocomplete.autocompleteList, "render");
+		const result = renderWithAutocompleteCapture(autocomplete as never, () => {
+			const rows = autocomplete.autocompleteList.render(20);
+			const wrapper = autocomplete.autocompleteList.render;
+			Object.defineProperty(autocomplete.autocompleteList, "render", {
+				value: wrapper,
+				configurable: true,
+				enumerable: false,
+				writable: false,
+			});
+			return rows;
+		});
+		expect(result.capture?.compatible).toBe(false);
+		expect(Object.getOwnPropertyDescriptor(autocomplete.autocompleteList, "render")).toEqual(
+			original,
+		);
+		expect(predecessor).toHaveBeenCalledTimes(1);
+	});
+
+	it("preserves a synchronous third-party replacement and suppresses metadata", () => {
+		const autocomplete = source(vi.fn(() => ["one"]));
+		const replacement = vi.fn(() => ["replacement"]);
+		const result = renderWithAutocompleteCapture(autocomplete as never, () => {
+			const rows = autocomplete.autocompleteList.render(20);
+			autocomplete.autocompleteList.render = replacement;
+			return rows;
+		});
+		expect(result.capture?.compatible).toBe(false);
+		expect(autocomplete.autocompleteList.render).toBe(replacement);
+	});
+
+	it("restores through a cleanup descriptor trap when the wrapper is still owned", () => {
+		const predecessor = vi.fn(() => ["one"]);
+		const target = source(predecessor).autocompleteList;
+		let descriptorReads = 0;
+		const proxy = new Proxy(target, {
+			getOwnPropertyDescriptor(current, property) {
+				descriptorReads++;
+				if (descriptorReads === 2) throw new Error("descriptor trap");
+				return Reflect.getOwnPropertyDescriptor(current, property);
+			},
+		});
+		const result = renderWithAutocompleteCapture(
+			{ isShowingAutocomplete: () => true, autocompleteList: proxy } as never,
+			() => proxy.render(20),
+		);
+		expect(result.capture?.compatible).toBe(false);
+		expect(target.render).toBe(predecessor);
+		expect(predecessor).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores after throwing and supports nested capture without extra renders", () => {
+		const predecessor = vi.fn(() => ["one"]);
+		const autocomplete = source(predecessor);
+		const original = autocomplete.autocompleteList.render;
+		expect(() =>
+			renderWithAutocompleteCapture(autocomplete as never, () => {
+				autocomplete.autocompleteList.render(20);
+				throw new Error("render failed");
+			}),
+		).toThrow("render failed");
+		expect(autocomplete.autocompleteList.render).toBe(original);
+
+		predecessor.mockClear();
+		const outer = renderWithAutocompleteCapture(autocomplete as never, () =>
+			renderWithAutocompleteCapture(autocomplete as never, () =>
+				autocomplete.autocompleteList.render(20),
+			),
+		);
+		expect(predecessor).toHaveBeenCalledTimes(1);
+		expect(outer.capture).toMatchObject({ compatible: true, called: 1 });
+		expect(outer.value.capture).toMatchObject({ compatible: true, called: 1 });
+		expect(autocomplete.autocompleteList.render).toBe(original);
+	});
+});
+
+describe("fixed-editor semantic publication", () => {
+	it.each([
+		[
+			"opencode",
+			{
+				rowCount: 9,
+				cursorRow: 2,
+				borderBottom: 5,
+				minimumEditorRows: [0, 2, 5],
+				plannerRawRows: 5,
+				selectedIndex: 0,
+				itemRows: [6, 7, 8],
+				selectedRow: 6,
+			},
+		],
+		[
+			"opencode-copy-friendly",
+			{
+				rowCount: 9,
+				cursorRow: 2,
+				borderBottom: 5,
+				minimumEditorRows: [0, 2, 5],
+				plannerRawRows: 5,
+				selectedIndex: 1,
+				itemRows: [6, 7, 8],
+				selectedRow: 7,
+			},
+		],
+		[
+			"minimalist",
+			{
+				rowCount: 7,
+				cursorRow: 1,
+				borderBottom: 6,
+				minimumEditorRows: [0, 1, 6],
+				plannerRawRows: 6,
+				selectedIndex: 2,
+				itemRows: [3, 4, 5],
+				selectedRow: 5,
+			},
+		],
+	] as const)("publishes exact cursor and autocomplete rows for %s", (style, expected) => {
+		const autocomplete = {
+			filteredItems: [{ value: "one" }, { value: "two" }, { value: "three" }],
+			selectedIndex: expected.selectedIndex,
+			maxVisible: 3,
+			render: () => ["one", "two", "three"],
+		};
+		const base = {
+			render(width: number) {
+				return [
+					nativeBorder(width, "above"),
+					`typed${CURSOR_MARKER}`,
+					nativeBorder(width, "below"),
+					...autocomplete.render(),
+				];
+			},
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed",
+			setText() {},
+			isShowingAutocomplete: () => true,
+			autocompleteList: autocomplete,
+		};
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => withEditorStyle(config(), style),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+		);
+		const lines = editor.render(60);
+		const metadata = editor[FIXED_EDITOR_LAYOUT](lines, 60);
+		expect(metadata?.renderedRowCount).toBe(expected.rowCount);
+		expect(metadata?.editor.cursorRow).toBe(expected.cursorRow);
+		expect(metadata?.editor.borderPairs).toEqual([{ top: 0, bottom: expected.borderBottom }]);
+		expect(metadata?.autocomplete?.selection).toEqual({
+			known: true,
+			selectedIndex: expected.selectedIndex,
+			visibleWindow: { start: 0, end: 3 },
+			itemToOutputRows: [
+				{ itemIndex: 0, outputRow: expected.itemRows[0] },
+				{ itemIndex: 1, outputRow: expected.itemRows[1] },
+				{ itemIndex: 2, outputRow: expected.itemRows[2] },
+			],
+			selectedRow: expected.selectedRow,
+		});
+		if (!metadata) throw new Error("expected fixed-editor metadata");
+		expect(
+			planFixedLayout({ rawRows: expected.plannerRawRows, editorRows: lines, metadata }),
+		).toMatchObject({
+			mode: "fixed",
+			selectedEditorRows: expected.minimumEditorRows,
+			selectedAutocompleteRows: expect.arrayContaining([expected.selectedRow]),
+		});
 	});
 });
 

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -23,8 +23,37 @@ function config(
 ): PolishedTuiConfig {
 	return {
 		...defaultConfig,
-		editorBorderColorMode,
+		components: {
+			...defaultConfig.components,
+			editor: {
+				...defaultConfig.components.editor,
+				borderColorMode: editorBorderColorMode,
+				viewportIndicators:
+					features.viewportIndicators ?? defaultConfig.components.editor.viewportIndicators,
+				styles: {
+					...defaultConfig.components.editor.styles,
+					polished: {
+						...defaultConfig.components.editor.styles.polished,
+						copyFriendly:
+							features.copyFriendly ?? defaultConfig.components.editor.styles.polished.copyFriendly,
+					},
+				},
+			},
+		},
 		features: { ...defaultConfig.features, ...features },
+	};
+}
+
+function withEditorStyle(
+	base: PolishedTuiConfig,
+	style: PolishedTuiConfig["components"]["editor"]["style"],
+): PolishedTuiConfig {
+	return {
+		...base,
+		components: {
+			...base.components,
+			editor: { ...base.components.editor, style },
+		},
 	};
 }
 
@@ -533,7 +562,7 @@ describe("minimalist editor integration", () => {
 		);
 
 		expect(editor.render(80)[0]).toMatch(/^─+$/);
-		current = { ...current, editorStyle: "minimalist" };
+		current = withEditorStyle(current, "minimalist");
 		const minimalist = editor.render(80);
 		expect(minimalist[0]).toMatch(/^╭.*╮$/);
 		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
@@ -544,7 +573,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			baseEditor({ above: 7, below: 11 }) as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({
@@ -565,10 +594,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			baseEditor({ above: 7, below: 11 }) as never,
 			theme(),
-			() => ({
-				...config({ viewportIndicators: false }),
-				editorStyle: "minimalist",
-			}),
+			() => withEditorStyle(config({ viewportIndicators: false }), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp/project" }),
@@ -582,7 +608,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -613,7 +639,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -629,7 +655,7 @@ describe("minimalist editor integration", () => {
 		const outer = new WrappedPolishedEditor(
 			inner as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "outer", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp", modelLabel: "minimal-model" }),
@@ -662,7 +688,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -685,7 +711,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -720,7 +746,7 @@ describe("minimalist editor integration", () => {
 		const editor = new WrappedPolishedEditor(
 			base as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),
@@ -739,7 +765,7 @@ describe("minimalist editor integration", () => {
 				setText() {},
 			} as never,
 			theme(),
-			() => ({ ...config(), editorStyle: "minimalist" }),
+			() => withEditorStyle(config(), "minimalist"),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 			() => ({ cwd: "/tmp" }),

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -518,3 +518,193 @@ describe("editor viewport indicators", () => {
 		expect(lines[0]).toBe(truncatedNativeTop);
 	});
 });
+
+describe("minimalist editor integration", () => {
+	it("switches renderer modes without replacing the wrapped editor", () => {
+		let current = config();
+		const base = baseEditor({});
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => current,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp/project", modelLabel: "model", costLabel: "$0.100" }),
+		);
+
+		expect(editor.render(80)[0]).toMatch(/^─+$/);
+		current = { ...current, editorMode: "minimalist" };
+		const minimalist = editor.render(80);
+		expect(minimalist[0]).toMatch(/^╭.*╮$/);
+		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
+		expect(minimalist.join("\n")).toContain("$0.100 – model");
+	});
+
+	it("keeps known autocomplete rows inside the minimalist frame", () => {
+		const base = baseEditor({ autocomplete: ["one", "two"] });
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+		);
+		const lines = editor.render(40);
+		expect(lines.some((line) => /^├─+┤$/.test(line))).toBe(true);
+		expect(lines.findIndex((line) => line.includes("one"))).toBeGreaterThan(
+			lines.findIndex((line) => line.startsWith("├")),
+		);
+		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+	});
+
+	it("fails open at caller width for unknown third-party output", () => {
+		const widths: number[] = [];
+		const decoration = vi.fn();
+		const base = {
+			render(width: number) {
+				widths.push(width);
+				return [`header-${width}`, "body", `help-${width}`];
+			},
+			invalidate() {},
+			handleInput() {},
+			getText: () => "body",
+			setText() {},
+		};
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+			decoration,
+		);
+		expect(editor.render(40)).toEqual(["header-40", "body", "help-40"]);
+		expect(widths).toEqual([36, 40]);
+		expect(decoration).toHaveBeenLastCalledWith(false);
+	});
+
+	it("unwraps module-owned polished chrome and autocomplete before minimalist decoration", () => {
+		const inner = wrapped(baseEditor({ autocomplete: ["one", "two"] }));
+		const outer = new WrappedPolishedEditor(
+			inner as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "outer", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp", modelLabel: "minimal-model" }),
+		);
+
+		const lines = outer.render(80);
+		const rendered = lines.join("\n");
+		expect(lines[0]).toMatch(/^╭.*╮$/);
+		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+		expect(rendered).toContain("minimal-model");
+		expect(rendered).not.toContain("provider");
+		expect(rendered.match(/minimal-model/g)).toHaveLength(1);
+		expect(lines.some((line) => /^├─+┤$/.test(line))).toBe(true);
+		expect(lines.filter((line) => line.includes("one") || line.includes("two"))).toHaveLength(2);
+	});
+
+	it("rejects mutated module-owned polished provenance in minimalist mode", () => {
+		const owned = wrapped(baseEditor({ above: 2, below: 3 })).render(36);
+		owned[1] = "mutated-row";
+		const base = {
+			render: () => owned,
+			invalidate() {},
+			handleInput() {},
+			getText: () => "typed text",
+			setText() {},
+		};
+		const decoration = vi.fn();
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+			decoration,
+		);
+
+		expect(editor.render(40)).toEqual(owned);
+		expect(decoration).toHaveBeenLastCalledWith(false);
+	});
+
+	it("falls back at four columns and decorates after resizing to five", () => {
+		const widths: number[] = [];
+		const decoration = vi.fn();
+		const base = baseEditor({});
+		const renderBase = base.render.bind(base);
+		base.render = (width: number) => {
+			widths.push(width);
+			return renderBase(width);
+		};
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+			decoration,
+		);
+
+		const narrow = editor.render(4);
+		expect(narrow[0]).not.toContain("╭");
+		expect(narrow.every((line) => visibleWidth(line) <= 4)).toBe(true);
+		const decorated = editor.render(5);
+		expect(decorated[0]).toMatch(/^╭.*╮$/);
+		expect(decorated.every((line) => visibleWidth(line) <= 5)).toBe(true);
+		expect(widths).toEqual([4, 1]);
+		expect(decoration.mock.calls.map(([active]) => active)).toEqual([false, true]);
+	});
+
+	it("preserves empty, multiline, blank, and inverse-video editor rows", () => {
+		const inverseCursor = "\x1b[7m \x1b[0m";
+		const base = {
+			render: (width: number) => [
+				nativeBorder(width, "above"),
+				"",
+				inverseCursor,
+				"second line",
+				nativeBorder(width, "below"),
+			],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "\nsecond line",
+			setText() {},
+		};
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+		);
+		const lines = editor.render(40);
+		expect(lines[1]).toMatch(/^│\s+│$/);
+		expect(lines.join("\n")).toContain(inverseCursor);
+		expect(lines.join("\n")).toContain("second line");
+		expect(lines.at(-2)).toMatch(/^│\s+│$/);
+
+		const empty = new WrappedPolishedEditor(
+			{
+				render: (width: number) => [nativeBorder(width, "above"), nativeBorder(width, "below")],
+				invalidate() {},
+				handleInput() {},
+				getText: () => "",
+				setText() {},
+			} as never,
+			theme(),
+			() => ({ ...config(), editorMode: "minimalist" }),
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/tmp" }),
+		).render(40);
+		expect(empty).toHaveLength(4);
+		expect(empty.slice(1, -1).every((line) => /^│\s+│$/.test(line))).toBe(true);
+	});
+});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -15,19 +15,22 @@ import {
 	type PolishedTuiConfig,
 	type SeparatorStyle,
 } from "../extensions/zentui/config";
-import { installFooter } from "../extensions/zentui/footer";
+import { installFooter as installFooterProduction } from "../extensions/zentui/footer";
 import { emptyGitStatus } from "../extensions/zentui/git";
 import zentui, { activeFooterReferences } from "../extensions/zentui/index";
 import { ZENTUI_PROTOTYPE_PATCH_REGISTRY } from "../extensions/zentui/prototype-patch-registry";
 import {
-	installSelectorBorderStyle,
-	patchSelectorBorderStyle,
+	installSelectorBorderStyle as installSelectorBorderStyleProduction,
+	patchSelectorBorderStyle as patchSelectorBorderStyleProduction,
 } from "../extensions/zentui/selector-border";
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-command";
 import { createInitialState } from "../extensions/zentui/state";
-import { PolishedEditor, WrappedPolishedEditor } from "../extensions/zentui/ui";
-import { installUserMessageStyle } from "../extensions/zentui/user-message";
+import {
+	PolishedEditor as PolishedEditorProduction,
+	WrappedPolishedEditor as WrappedPolishedEditorProduction,
+} from "../extensions/zentui/ui";
+import { installUserMessageStyle as installUserMessageStyleProduction } from "../extensions/zentui/user-message";
 
 const isolatedAgentDir = vi.hoisted(() => {
 	const previous = process.env.PI_CODING_AGENT_DIR;
@@ -50,6 +53,179 @@ const originalUserMessageInvalidate = UserMessageComponent.prototype.invalidate;
 const originalModelSelectorRender = ModelSelectorComponent.prototype.render;
 const originalSettingsSelectorRender = SettingsSelectorComponent.prototype.render;
 const inactiveSessionLifecycle = new SessionLifecycle();
+
+function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
+	const editor = config.components.editor;
+	const messages = config.components.userMessages;
+	const selectors = config.components.selectorBorders;
+	const footer = config.components.footer;
+	const starship = footer.styles.starship;
+	const flatChanged = <K extends keyof PolishedTuiConfig>(key: K) =>
+		config[key] !== defaultConfig[key];
+	return {
+		...config,
+		components: {
+			editor: {
+				...editor,
+				enabled: flatChanged("features") ? config.features.editor : editor.enabled,
+				style: flatChanged("editorStyle") ? config.editorStyle : editor.style,
+				colorSource: flatChanged("colorSources") ? config.colorSources.editor : editor.colorSource,
+				borderColorMode: flatChanged("editorBorderColorMode")
+					? config.editorBorderColorMode
+					: editor.borderColorMode,
+				modelLabel: flatChanged("editorModelLabel") ? config.editorModelLabel : editor.modelLabel,
+				viewportIndicators: flatChanged("features")
+					? config.features.viewportIndicators
+					: editor.viewportIndicators,
+				styles: {
+					polished: {
+						...editor.styles.polished,
+						copyFriendly: flatChanged("features")
+							? config.features.copyFriendly
+							: editor.styles.polished.copyFriendly,
+						metadataFormat: flatChanged("editorMetadataFormat")
+							? config.editorMetadataFormat
+							: editor.styles.polished.metadataFormat,
+					},
+					minimalist: flatChanged("editorStyles")
+						? { ...editor.styles.minimalist, ...config.editorStyles.minimalist }
+						: editor.styles.minimalist,
+				},
+			},
+			userMessages: {
+				...messages,
+				enabled: flatChanged("features") ? config.features.editor : messages.enabled,
+				colorSource: flatChanged("colorSources")
+					? config.colorSources.userMessages
+					: messages.colorSource,
+				styles: {
+					framed: {
+						...messages.styles.framed,
+						copyFriendly: flatChanged("features")
+							? config.features.copyFriendly
+							: messages.styles.framed.copyFriendly,
+					},
+				},
+			},
+			selectorBorders: {
+				...selectors,
+				enabled: flatChanged("features") ? config.features.editor : selectors.enabled,
+				colorSource: flatChanged("colorSources")
+					? config.colorSources.editor
+					: selectors.colorSource,
+			},
+			footer: {
+				...footer,
+				enabled: flatChanged("features") ? config.features.statusLine : footer.enabled,
+				colorSource: flatChanged("colorSources")
+					? config.colorSources.starship
+					: footer.colorSource,
+				modelLabel: flatChanged("editorModelLabel") ? config.editorModelLabel : footer.modelLabel,
+				styles: {
+					starship: {
+						...starship,
+						format: flatChanged("footerFormat") ? config.footerFormat : starship.format,
+						responsive: flatChanged("responsiveFooter")
+							? config.responsiveFooter
+							: starship.responsive,
+						compactFormat: flatChanged("compactFooterFormat")
+							? config.compactFooterFormat
+							: starship.compactFormat,
+						compactMaxLines: flatChanged("compactFooterMaxLines")
+							? config.compactFooterMaxLines
+							: starship.compactMaxLines,
+						separator: flatChanged("separator") ? config.separator : starship.separator,
+						contextStyle: flatChanged("contextStyle") ? config.contextStyle : starship.contextStyle,
+						contextThresholds: flatChanged("contextThresholds")
+							? config.contextThresholds
+							: starship.contextThresholds,
+						pathDisplay: flatChanged("pathDisplay") ? config.pathDisplay : starship.pathDisplay,
+						segments: flatChanged("footerSegments") ? config.footerSegments : starship.segments,
+						gitBranch: flatChanged("gitBranch") ? config.gitBranch : starship.gitBranch,
+						gitCommit: flatChanged("gitCommit") ? config.gitCommit : starship.gitCommit,
+						gitMetrics: flatChanged("gitMetrics") ? config.gitMetrics : starship.gitMetrics,
+						extensionStatuses: flatChanged("extensionStatuses")
+							? config.extensionStatuses
+							: starship.extensionStatuses,
+					},
+				},
+			},
+		},
+		layout: {
+			...config.layout,
+			fixedEditor: flatChanged("fixedEditor") ? config.fixedEditor : config.layout.fixedEditor,
+		},
+	};
+}
+
+function installFooter(...args: Parameters<typeof installFooterProduction>) {
+	const getConfig = args[2];
+	return installFooterProduction(
+		args[0],
+		args[1],
+		() => canonicalizeTestConfig(getConfig() as PolishedTuiConfig),
+		args[3],
+	);
+}
+
+function installUserMessageStyle(...args: Parameters<typeof installUserMessageStyleProduction>) {
+	return installUserMessageStyleProduction(args[0], () =>
+		canonicalizeTestConfig(args[1]() as PolishedTuiConfig),
+	);
+}
+
+function installSelectorBorderStyle(
+	...args: Parameters<typeof installSelectorBorderStyleProduction>
+) {
+	return installSelectorBorderStyleProduction(
+		args[0],
+		args[1]
+			? () => canonicalizeTestConfig((args[1]?.() ?? defaultConfig) as PolishedTuiConfig)
+			: undefined,
+	);
+}
+
+function patchSelectorBorderStyle(...args: Parameters<typeof patchSelectorBorderStyleProduction>) {
+	return patchSelectorBorderStyleProduction(
+		args[0],
+		args[1],
+		args[2]
+			? () => canonicalizeTestConfig((args[2]?.() ?? defaultConfig) as PolishedTuiConfig)
+			: undefined,
+	);
+}
+
+class PolishedEditor extends PolishedEditorProduction {
+	constructor(...args: ConstructorParameters<typeof PolishedEditorProduction>) {
+		const getConfig = args[4];
+		super(
+			args[0],
+			args[1],
+			args[2],
+			args[3],
+			() => canonicalizeTestConfig(getConfig() as PolishedTuiConfig),
+			args[5],
+			args[6],
+			args[7],
+			args[8],
+		);
+	}
+}
+
+class WrappedPolishedEditor extends WrappedPolishedEditorProduction {
+	constructor(...args: ConstructorParameters<typeof WrappedPolishedEditorProduction>) {
+		const getConfig = args[2];
+		super(
+			args[0],
+			args[1],
+			() => canonicalizeTestConfig(getConfig() as PolishedTuiConfig),
+			args[3],
+			args[4],
+			args[5],
+			args[6],
+		);
+	}
+}
 
 function makeTheme(): Theme {
 	return {
@@ -171,11 +347,22 @@ function makeUi(prefix = "") {
 function configWithColorSources(
 	colorSources: Partial<PolishedTuiConfig["colorSources"]>,
 ): PolishedTuiConfig {
+	const merged = { ...defaultConfig.colorSources, ...colorSources };
 	return {
 		...defaultConfig,
-		colorSources: {
-			...defaultConfig.colorSources,
-			...colorSources,
+		colorSources: merged,
+		components: {
+			...defaultConfig.components,
+			editor: { ...defaultConfig.components.editor, colorSource: merged.editor },
+			selectorBorders: {
+				...defaultConfig.components.selectorBorders,
+				colorSource: merged.editor,
+			},
+			userMessages: {
+				...defaultConfig.components.userMessages,
+				colorSource: merged.userMessages,
+			},
+			footer: { ...defaultConfig.components.footer, colorSource: merged.starship },
 		},
 	};
 }
@@ -185,14 +372,10 @@ function configWithColors(
 	colorSources: Partial<PolishedTuiConfig["colorSources"]> = {},
 ): PolishedTuiConfig {
 	return {
-		...defaultConfig,
+		...configWithColorSources(colorSources),
 		colors: {
 			...defaultConfig.colors,
 			...colors,
-		},
-		colorSources: {
-			...defaultConfig.colorSources,
-			...colorSources,
 		},
 	};
 }
@@ -200,25 +383,55 @@ function configWithColors(
 function configWithExtensionStatuses(
 	extensionStatuses: Partial<PolishedTuiConfig["extensionStatuses"]>,
 ): PolishedTuiConfig {
+	const merged = {
+		...defaultConfig.extensionStatuses,
+		...extensionStatuses,
+		placements: {
+			...defaultConfig.extensionStatuses.placements,
+			...(extensionStatuses.placements ?? {}),
+		},
+	};
+	const footer = defaultConfig.components.footer;
 	return {
 		...defaultConfig,
-		extensionStatuses: {
-			...defaultConfig.extensionStatuses,
-			...extensionStatuses,
-			placements: {
-				...defaultConfig.extensionStatuses.placements,
-				...(extensionStatuses.placements ?? {}),
+		extensionStatuses: merged,
+		components: {
+			...defaultConfig.components,
+			footer: {
+				...footer,
+				styles: { starship: { ...footer.styles.starship, extensionStatuses: merged } },
 			},
 		},
 	};
 }
 
 function configWithFeatures(features: Partial<PolishedTuiConfig["features"]>): PolishedTuiConfig {
+	const merged = { ...defaultConfig.features, ...features };
+	const editor = defaultConfig.components.editor;
+	const messages = defaultConfig.components.userMessages;
 	return {
 		...defaultConfig,
-		features: {
-			...defaultConfig.features,
-			...features,
+		features: merged,
+		components: {
+			...defaultConfig.components,
+			editor: {
+				...editor,
+				enabled: merged.editor,
+				viewportIndicators: merged.viewportIndicators,
+				styles: {
+					...editor.styles,
+					polished: { ...editor.styles.polished, copyFriendly: merged.copyFriendly },
+				},
+			},
+			userMessages: {
+				...messages,
+				enabled: merged.editor,
+				styles: {
+					framed: { ...messages.styles.framed, copyFriendly: merged.copyFriendly },
+				},
+			},
+			selectorBorders: { ...defaultConfig.components.selectorBorders, enabled: merged.editor },
+			footer: { ...defaultConfig.components.footer, enabled: merged.statusLine },
 		},
 	};
 }
@@ -315,23 +528,329 @@ afterEach(() => {
 
 describe("Pi docs compliance", () => {
 	it("derives lazy data requirements from only the active wide and compact candidates", () => {
+		const starship = defaultConfig.components.footer.styles.starship;
 		const customWide = {
 			...defaultConfig,
-			footerFormat: "$cwd",
-			compactFooterFormat: "$package $git_tag $git_metrics $time",
-			footerSegments: {
-				...defaultConfig.footerSegments,
-				packageVersion: true,
-				gitCommit: true,
+			components: {
+				...defaultConfig.components,
+				footer: {
+					...defaultConfig.components.footer,
+					styles: {
+						starship: {
+							...starship,
+							format: "$cwd",
+							compactFormat: "$package $git_tag $git_metrics $time",
+							segments: { ...starship.segments, packageVersion: true, gitCommit: true },
+						},
+					},
+				},
 			},
 		};
 		expect(activeFooterReferences(customWide)).toEqual(
 			new Set(["cwd", "package", "git_tag", "git_metrics", "time"]),
 		);
-		expect(activeFooterReferences({ ...customWide, responsiveFooter: false })).toEqual(
-			new Set(["cwd"]),
-		);
+		expect(
+			activeFooterReferences({
+				...customWide,
+				components: {
+					...customWide.components,
+					footer: {
+						...customWide.components.footer,
+						styles: {
+							starship: {
+								...customWide.components.footer.styles.starship,
+								responsive: false,
+							},
+						},
+					},
+				},
+			}),
+		).toEqual(new Set(["cwd"]));
 	});
+	it("installs message and selector surfaces while the editor is canonically disabled", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { enabled: false },
+					userMessages: { enabled: true },
+					selectorBorders: { enabled: true },
+					footer: { enabled: false },
+				},
+			}),
+		);
+		const handlers = loadExtension();
+		const existingFactory = () => ({ render: () => ["native"] });
+		let editorFactory: unknown = existingFactory;
+		let footerFactory: unknown = "untouched";
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		expect(editorFactory).toBe(existingFactory);
+		expect(footerFactory).toBe("untouched");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("installs only the editor and footer when message and selector surfaces are disabled", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { enabled: true },
+					userMessages: { enabled: false },
+					selectorBorders: { enabled: false },
+					footer: { enabled: true },
+				},
+			}),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		let footerFactory: unknown;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		expect(editorFactory).toBeTypeOf("function");
+		expect(footerFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("reconciles footer and fixed layout independently of all chrome surfaces", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { enabled: false },
+					userMessages: { enabled: false },
+					selectorBorders: { enabled: false },
+					footer: { enabled: true },
+				},
+				layout: { fixedEditor: { enabled: true } },
+			}),
+		);
+		const handlers = loadExtension();
+		const existingFactory = () => ({ render: () => ["native"] });
+		let editorFactory: unknown = existingFactory;
+		let footerFactory: unknown;
+		let probeFactory: unknown;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+				setWidget(key: string, factory: unknown) {
+					if (key === "zentui-fixed-editor-probe") probeFactory = factory;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		expect(editorFactory).toBe(existingFactory);
+		expect(footerFactory).toBeTypeOf("function");
+		expect(probeFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
+		expect(probeFactory).toBeUndefined();
+	});
+
+	it("keeps every surface active when fixed-layout compatibility inspection fails", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ layout: { fixedEditor: { enabled: true } } }),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		let footerFactory: unknown;
+		let probeFactory: ((tui: unknown) => { render(): string[] }) | undefined;
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+				setWidget(key: string, factory: unknown) {
+					if (key === "zentui-fixed-editor-probe") {
+						probeFactory =
+							typeof factory === "function" ? (factory as typeof probeFactory) : undefined;
+					}
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		const tui = new Proxy(
+			{
+				terminal: { columns: 80, rows: 24, write() {} },
+				render: () => [],
+				doRender() {},
+				addInputListener: () => () => {},
+				removeInputListener() {},
+			},
+			{
+				get(target, property, receiver) {
+					if (property === "children") throw new Error("private shape changed");
+					return Reflect.get(target, property, receiver);
+				},
+			},
+		);
+		probeFactory?.(tui).render();
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(warning).toHaveBeenCalledTimes(1);
+		expect(editorFactory).toBeTypeOf("function");
+		expect(footerFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("removes the fixed-layout probe and other surfaces when disposal cleanup throws", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ layout: { fixedEditor: { enabled: true } } }),
+		);
+		const handlers = loadExtension();
+		const existingFactory = () => ({
+			render: () => ["native"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+		});
+		let editorFactory: unknown = existingFactory;
+		let footerFactory: unknown;
+		let throwCopyNoticeCleanup = false;
+		let probeRemovals = 0;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				getEditorText: () => "",
+				setEditorText() {},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+				setWidget(key: string, factory: unknown) {
+					if (key === "zentui-copy-notice" && factory === undefined && throwCopyNoticeCleanup) {
+						throw new Error("copy notice cleanup failed");
+					}
+					if (key === "zentui-fixed-editor-probe" && factory === undefined) probeRemovals += 1;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		expect(editorFactory).not.toBe(existingFactory);
+		expect(footerFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		const removalsBeforeShutdown = probeRemovals;
+		throwCopyNoticeCleanup = true;
+
+		await expect(emit(handlers, "session_shutdown", ctx)).resolves.toBeUndefined();
+		expect(probeRemovals).toBe(removalsBeforeShutdown + 1);
+		expect(editorFactory).toBe(existingFactory);
+		expect(footerFactory).toBeUndefined();
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+	});
+
+	it("isolates footer installation failure from editor and prototype surfaces", async () => {
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					if (factory) throw new Error("footer unavailable");
+				},
+			},
+		});
+
+		await expect(emit(handlers, "session_start", ctx)).resolves.toBeUndefined();
+		expect(editorFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("isolates selector installation failure from editor, messages, and footer", async () => {
+		const settingsPrototype = SettingsSelectorComponent.prototype as unknown as {
+			render: typeof originalSettingsSelectorRender | undefined;
+		};
+		settingsPrototype.render = undefined;
+		try {
+			const handlers = loadExtension();
+			let editorFactory: unknown;
+			let footerFactory: unknown;
+			const ctx = makeContext({
+				ui: {
+					theme: makeTheme(),
+					setEditorComponent(factory: unknown) {
+						editorFactory = factory;
+					},
+					getEditorComponent: () => editorFactory,
+					setFooter(factory: unknown) {
+						footerFactory = factory;
+					},
+				},
+			});
+
+			await emit(handlers, "session_start", ctx);
+			expect(editorFactory).toBeTypeOf("function");
+			expect(footerFactory).toBeTypeOf("function");
+			expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+			await emit(handlers, "session_shutdown", ctx);
+		} finally {
+			settingsPrototype.render = originalSettingsSelectorRender;
+		}
+	});
+
 	it("uses the current @earendil-works Pi packages instead of the old @mariozechner scope", () => {
 		const files = [
 			"package.json",
@@ -486,7 +1005,7 @@ describe("Pi docs compliance", () => {
 		);
 		expect(transferred).toEqual(Array.from({ length: 5 }, () => expanded));
 		expect(transferred).not.toContain(marker);
-		expect(patchPresenceDuringReplacements).toEqual([false, true, true, false, true]);
+		expect(patchPresenceDuringReplacements).toEqual([false, false, true, false, true]);
 	});
 
 	it("keeps the active factory when expanded editor text cannot be read", async () => {
@@ -500,12 +1019,15 @@ describe("Pi docs compliance", () => {
 			setText() {},
 		});
 		const editorFactory: unknown = existingFactory;
+		let footerFactory: unknown;
 		let setEditorCalls = 0;
 		const notifications: string[] = [];
 		const ctx = makeContext({
 			ui: {
 				theme: makeTheme(),
-				setFooter() {},
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
 				getEditorText() {
 					throw new Error("unavailable");
 				},
@@ -530,12 +1052,13 @@ describe("Pi docs compliance", () => {
 
 		expect(setEditorCalls).toBe(0);
 		expect(editorFactory).toBe(existingFactory);
-		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
-		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		expect(footerFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
 		expect(notifications.at(-1)).toContain("expanded editor text could not be read safely");
 	});
 
-	it("rolls back editor activation and all prototype patches when patch installation fails", async () => {
+	it("isolates user-message patch failure from editor and selector activation", async () => {
 		const handlers = loadExtension();
 		let editorFactory: unknown;
 		let setEditorCalls = 0;
@@ -558,20 +1081,16 @@ describe("Pi docs compliance", () => {
 		userPrototype.render = undefined;
 		try {
 			await emit(handlers, "session_start", ctx);
-			expect(editorFactory).toBeUndefined();
-			expect(setEditorCalls).toBe(2);
-			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
-			expect(SettingsSelectorComponent.prototype.render).toBe(originalSettingsSelectorRender);
+			expect(editorFactory).toBeTypeOf("function");
+			expect(setEditorCalls).toBe(1);
+			expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+			expect(SettingsSelectorComponent.prototype.render).not.toBe(originalSettingsSelectorRender);
 			expect(UserMessageComponent.prototype.invalidate).toBe(originalUserMessageInvalidate);
-			for (const prototype of [
-				ModelSelectorComponent.prototype,
-				SettingsSelectorComponent.prototype,
-				UserMessageComponent.prototype,
-			]) {
-				expect(
-					(prototype as unknown as Record<PropertyKey, unknown>)[ZENTUI_PROTOTYPE_PATCH_REGISTRY],
-				).toBeUndefined();
-			}
+			expect(
+				(UserMessageComponent.prototype as unknown as Record<PropertyKey, unknown>)[
+					ZENTUI_PROTOTYPE_PATCH_REGISTRY
+				],
+			).toBeUndefined();
 			await emit(handlers, "session_shutdown", ctx);
 		} finally {
 			userPrototype.render = originalUserMessageRender;
@@ -617,16 +1136,18 @@ describe("Pi docs compliance", () => {
 			await emit(handlers, "session_start", ctx);
 			expect(editorFactory).toBeTypeOf("function");
 			expect(editorFactory).not.toBe(existingFactory);
-			expect(assignedFactories).toHaveLength(3);
+			expect(assignedFactories).toHaveLength(1);
 			userPrototype.render = originalUserMessageRender;
 
 			const command = commands.get("zentui") as {
 				handler(args: string, ctx: unknown): Promise<void>;
 			};
 			await command.handler("editor disable", ctx);
+			expect(editorFactory).not.toBe(existingFactory);
+			expect(assignedFactories).toHaveLength(3);
+			await emit(handlers, "session_shutdown", ctx);
 			expect(editorFactory).toBe(existingFactory);
 			expect(assignedFactories).toHaveLength(4);
-			await emit(handlers, "session_shutdown", ctx);
 		} finally {
 			userPrototype.render = originalUserMessageRender;
 		}
@@ -817,6 +1338,66 @@ describe("Pi docs compliance", () => {
 		expect(editorFactory).toBeTypeOf("function");
 	});
 
+	it("cleans every stale owned surface on an enabled-to-disabled extension reload", async () => {
+		const firstHandlers = loadExtension();
+		const existingFactory = () => ({
+			render: () => ["native"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+		});
+		let editorFactory: unknown = existingFactory;
+		let footerFactory: unknown;
+		let setEditorCalls = 0;
+		let setFooterCalls = 0;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				getEditorText: () => "",
+				setEditorText() {},
+				setEditorComponent(factory: unknown) {
+					setEditorCalls += 1;
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					setFooterCalls += 1;
+					footerFactory = factory;
+				},
+			},
+		});
+
+		await emit(firstHandlers, "session_start", ctx);
+		expect(editorFactory).not.toBe(existingFactory);
+		expect(footerFactory).toBeTypeOf("function");
+		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
+
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { enabled: false },
+					userMessages: { enabled: false },
+					selectorBorders: { enabled: false },
+					footer: { enabled: false },
+				},
+			}),
+		);
+		const secondHandlers = loadExtension();
+		await emit(secondHandlers, "session_start", ctx);
+
+		expect(editorFactory).toBe(existingFactory);
+		expect(footerFactory).toBeUndefined();
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(UserMessageComponent.prototype.invalidate).toBe(originalUserMessageInvalidate);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		expect(SettingsSelectorComponent.prototype.render).toBe(originalSettingsSelectorRender);
+		expect(setEditorCalls).toBe(2);
+		expect(setFooterCalls).toBe(2);
+	});
+
 	it("refreshes a stale wrapped Zentui editor without wrapping the old Zentui wrapper", async () => {
 		const firstHandlers = loadExtension();
 		let baseFactoryCalls = 0;
@@ -912,8 +1493,8 @@ describe("Pi docs compliance", () => {
 
 			await new Promise((resolve) => setTimeout(resolve, 1));
 			expect(editorFactory).toBe(takeoverFactory);
-			expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
-			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+			expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
 
 			const command = commands.get("zentui") as {
 				handler(args: string, ctx: unknown): Promise<void>;
@@ -924,6 +1505,7 @@ describe("Pi docs compliance", () => {
 			editorFactory = takeoverFactory;
 			await command.handler("editor disable", ctx);
 			expect(editorFactory).toBe(takeoverFactory);
+			// The historical command remains a compatibility recipe that disables all three.
 			expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
 			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
 			await emit(handlers, "session_shutdown", ctx);
@@ -971,6 +1553,72 @@ describe("Pi docs compliance", () => {
 			expect(editorFactory).toBe(laterEditorFactory);
 		} finally {
 			vi.useRealTimers();
+		}
+	});
+
+	it("renders polished-editor and framed-message copy-friendly settings independently", () => {
+		let config: PolishedTuiConfig = {
+			...defaultConfig,
+			components: {
+				...defaultConfig.components,
+				editor: {
+					...defaultConfig.components.editor,
+					styles: {
+						...defaultConfig.components.editor.styles,
+						polished: {
+							...defaultConfig.components.editor.styles.polished,
+							copyFriendly: true,
+						},
+					},
+				},
+				userMessages: {
+					...defaultConfig.components.userMessages,
+					styles: { framed: { copyFriendly: false } },
+				},
+			},
+		};
+		const cleanup = installUserMessageStyleProduction(
+			() => makeTheme(),
+			() => config,
+		);
+		try {
+			const editor = new PolishedEditorProduction(
+				{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+				{ borderColor: (text: string) => text, selectList: {} } as never,
+				{} as never,
+				makeTheme(),
+				() => config,
+				() => ({ modelLabel: "model", providerLabel: "provider" }),
+				() => "off",
+			);
+			editor.setText("draft");
+			expect(editor.render(80).join("\n")).not.toContain("│");
+			expect(new UserMessageComponent("message").render(80).join("\n")).toContain("│");
+
+			config = {
+				...config,
+				components: {
+					...config.components,
+					editor: {
+						...config.components.editor,
+						styles: {
+							...config.components.editor.styles,
+							polished: {
+								...config.components.editor.styles.polished,
+								copyFriendly: false,
+							},
+						},
+					},
+					userMessages: {
+						...config.components.userMessages,
+						styles: { framed: { copyFriendly: true } },
+					},
+				},
+			};
+			expect(editor.render(80).join("\n")).toContain("│");
+			expect(new UserMessageComponent("message 2").render(80).join("\n")).not.toContain("│");
+		} finally {
+			cleanup();
 		}
 	});
 
@@ -1088,7 +1736,7 @@ describe("Pi docs compliance", () => {
 		expect(invalidatedRender).not.toContain("[first:userMessageText]hello");
 	});
 
-	it("renders selector top and bottom borders from the editor color source", () => {
+	it("renders selector borders from their independent canonical color source", () => {
 		const prototype = {
 			render(width: number) {
 				return ["─".repeat(width), "body", "─".repeat(width)];
@@ -1113,10 +1761,20 @@ describe("Pi docs compliance", () => {
 			},
 		};
 
-		patchSelectorBorderStyle(
+		patchSelectorBorderStyleProduction(
 			terminalPrototype,
 			() => makeTaggedTheme(),
-			() => configWithColorSources({ editor: "terminal" }),
+			() => ({
+				...defaultConfig,
+				components: {
+					...defaultConfig.components,
+					editor: { ...defaultConfig.components.editor, colorSource: "theme" },
+					selectorBorders: {
+						...defaultConfig.components.selectorBorders,
+						colorSource: "terminal",
+					},
+				},
+			}),
 		);
 		const terminalLines = terminalPrototype.render(8);
 
@@ -1210,7 +1868,7 @@ describe("Pi docs compliance", () => {
 		const prototype = { render: predecessor };
 		const firstTheme = vi.fn(() => makeTaggedTheme("first:"));
 		const secondTheme = vi.fn(() => makeTaggedTheme("second:"));
-		const cleanupFirst = patchSelectorBorderStyle(prototype, firstTheme, () => defaultConfig);
+		patchSelectorBorderStyle(prototype, firstTheme, () => defaultConfig);
 		const firstWrapper = prototype.render;
 		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
 			return ["third-party", ...firstWrapper.call(this, width)];
@@ -1218,7 +1876,6 @@ describe("Pi docs compliance", () => {
 		prototype.render = thirdParty;
 		const cleanupSecond = patchSelectorBorderStyle(prototype, secondTheme, () => defaultConfig);
 
-		cleanupFirst();
 		cleanupSecond();
 		firstTheme.mockClear();
 		secondTheme.mockClear();
@@ -1357,7 +2014,7 @@ describe("Pi docs compliance", () => {
 		prototype.invalidate = predecessorInvalidate;
 		const firstTheme = vi.fn(() => makeTaggedTheme("first:"));
 		const secondTheme = vi.fn(() => makeTaggedTheme("second:"));
-		const cleanupFirst = installUserMessageStyle(firstTheme, () => defaultConfig);
+		installUserMessageStyle(firstTheme, () => defaultConfig);
 		const firstWrapper = prototype.render;
 		const thirdParty = function thirdParty(this: unknown, width: number): string[] {
 			return ["third-party", ...firstWrapper.call(this as never, width)];
@@ -1365,7 +2022,6 @@ describe("Pi docs compliance", () => {
 		prototype.render = thirdParty;
 		const cleanupSecond = installUserMessageStyle(secondTheme, () => defaultConfig);
 
-		cleanupFirst();
 		cleanupSecond();
 		firstTheme.mockClear();
 		secondTheme.mockClear();
@@ -1433,9 +2089,57 @@ describe("Pi docs compliance", () => {
 		await emit(handlers, "session_shutdown", ctx);
 	});
 
-	it("suppresses footer rows only while minimalist editor output is active", () => {
+	it("renders editor and footer model labels from independent canonical owners", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { modelLabel: "name" },
+					userMessages: { enabled: false },
+					selectorBorders: { enabled: false },
+					footer: {
+						modelLabel: "id",
+						styles: { starship: { format: "$model", responsive: false } },
+					},
+				},
+			}),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
 		let footerFactory: FooterFactory | undefined;
-		let suppressed = true;
+		const ctx = makeContext({
+			model: { id: "model-id", name: "Model Name", provider: "provider", contextWindow: 1000 },
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		const editor = (editorFactory as (...args: unknown[]) => { render(width: number): string[] })(
+			{ requestRender() {}, terminal: { rows: 24, cols: 100 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+		);
+		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+		expect(editor.render(100).join("\n")).toContain("Model Name");
+		expect(footer?.render(100).join("\n")).toContain("model-id");
+		expect(footer?.render(100).join("\n")).not.toContain("Model Name");
+		footer?.dispose?.();
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("renders footer rows independently of editor decoration", () => {
+		let footerFactory: FooterFactory | undefined;
 		const ctx = makeContext({
 			ui: {
 				theme: makeTheme(),
@@ -1448,18 +2152,15 @@ describe("Pi docs compliance", () => {
 		installFooter(ctx as never, createInitialState(emptyGitStatus()), () => defaultConfig, {
 			setRequestRender() {},
 			scheduleProjectRefresh() {},
-			suppressVisibleOutput: () => suppressed,
 		});
 		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
 			onBranchChange: () => () => {},
 			getExtensionStatuses: () => new Map<string, string>(),
 		});
-		expect(footer?.render(80)).toEqual([]);
-		suppressed = false;
 		expect(footer?.render(80).length).toBeGreaterThan(0);
 	});
 
-	it("suppresses the production footer only while the installed minimalist editor decorates", async () => {
+	it("keeps the production footer visible while the minimalist editor decorates", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
@@ -1508,7 +2209,7 @@ describe("Pi docs compliance", () => {
 		const namedFrame = editor.render(80)[0];
 		expect(namedFrame).toMatch(/^╭.*╮$/);
 		expect(namedFrame).toContain("release prep");
-		expect(footer?.render(80)).toEqual([]);
+		expect(footer?.render(80).length).toBeGreaterThan(0);
 		const rendersBeforeRename = tui.requestRender.mock.calls.length;
 		sessionName = "ship it";
 		await handlers.get("session_info_changed")?.[0]?.(
@@ -1521,7 +2222,7 @@ describe("Pi docs compliance", () => {
 		expect(editor.render(4)[0]).not.toContain("╭");
 		expect(footer?.render(80).length).toBeGreaterThan(0);
 		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
-		expect(footer?.render(80)).toEqual([]);
+		expect(footer?.render(80).length).toBeGreaterThan(0);
 
 		const nativeEditorPrototype = Object.getPrototypeOf(PolishedEditor.prototype) as {
 			render(width: number): string[];
@@ -1537,7 +2238,7 @@ describe("Pi docs compliance", () => {
 		}
 
 		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
-		expect(footer?.render(80)).toEqual([]);
+		expect(footer?.render(80).length).toBeGreaterThan(0);
 		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
 		await emit(handlers, "agent_start", ctx);
 		const thirdPartyFactory = () => ({ render: () => ["third-party"] });
@@ -1959,6 +2660,8 @@ describe("Pi docs compliance", () => {
 		});
 		const state = createInitialState(emptyGitStatus());
 		state.modelLabel = "GPT-5.6 Terra";
+		state.modelId = "GPT-5.6 Terra";
+		state.modelName = "GPT-5.6 Terra";
 		state.providerLabel = "OpenAI";
 		state.contextLabel = "0.5%/200k";
 		state.tokenLabel = "↑1 ↓2";
@@ -2002,12 +2705,14 @@ describe("Pi docs compliance", () => {
 			scheduleProjectRefresh() {},
 		});
 		state.modelLabel = "openai/gpt-5";
+		state.modelId = "openai/gpt-5";
 		expect(createFooter()?.render(200).join("\n")).toContain("openai/gpt-5 | 0.5%/200k");
 		expect(createFooter()?.render(200).join("\n")).not.toContain("openai/gpt-5 OpenAI");
 		state.providerLabel = "";
 		expect(createFooter()?.render(200).join("\n")).toContain("openai/gpt-5 | 0.5%/200k");
 
 		state.modelLabel = "custom-model";
+		state.modelId = "custom-model";
 		state.providerLabel = "Provider X";
 		installFooter(
 			ctx as never,

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
+	initTheme,
 	ModelSelectorComponent,
 	SettingsSelectorComponent,
 	UserMessageComponent,
@@ -79,11 +80,11 @@ function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 					: editor.viewportIndicators,
 				styles: {
 					...editor.styles,
-					polished: {
-						...editor.styles.polished,
+					opencode: {
+						...editor.styles.opencode,
 						metadataFormat: flatChanged("editorMetadataFormat")
 							? config.editorMetadataFormat
-							: editor.styles.polished.metadataFormat,
+							: editor.styles.opencode.metadataFormat,
 					},
 					minimalist: flatChanged("editorStyles")
 						? { ...editor.styles.minimalist, ...config.editorStyles.minimalist }
@@ -107,7 +108,11 @@ function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 			},
 			footer: {
 				...footer,
-				enabled: flatChanged("features") ? config.features.statusLine : footer.enabled,
+				style: flatChanged("features")
+					? config.features.statusLine
+						? "starship"
+						: "native"
+					: footer.style,
 				colorSource: flatChanged("colorSources")
 					? config.colorSources.starship
 					: footer.colorSource,
@@ -403,7 +408,7 @@ function configWithLowRailStyle(lowRail: boolean): PolishedTuiConfig {
 			...defaultConfig.components,
 			editor: {
 				...defaultConfig.components.editor,
-				style: lowRail ? "polished-copy-friendly" : "polished",
+				style: lowRail ? "opencode-copy-friendly" : "opencode",
 			},
 		},
 	};
@@ -1286,7 +1291,8 @@ describe("Pi docs compliance", () => {
 
 		expect(runner.editorFactory).toBeUndefined();
 		expect(runner.setEditorCalls).toBe(2);
-		expect(runner.footerClears).toBe(1);
+		// A distinct ui wrapper carries no ownership token, so shutdown must not clobber it.
+		expect(runner.footerClears).toBe(0);
 	});
 
 	it("refreshes a stale Zentui editor factory on extension reload instead of adopting old closures", async () => {
@@ -1361,7 +1367,7 @@ describe("Pi docs compliance", () => {
 					editor: { enabled: false },
 					userMessages: { enabled: false },
 					selectorBorders: { enabled: false },
-					footer: { enabled: false },
+					footer: { style: "native" },
 				},
 			}),
 		);
@@ -1627,7 +1633,7 @@ describe("Pi docs compliance", () => {
 				...defaultConfig.components,
 				editor: {
 					...defaultConfig.components.editor,
-					style: "polished-copy-friendly",
+					style: "opencode-copy-friendly",
 				},
 				userMessages: {
 					...defaultConfig.components.userMessages,
@@ -1657,7 +1663,7 @@ describe("Pi docs compliance", () => {
 				...config,
 				components: {
 					...config.components,
-					editor: { ...config.components.editor, style: "polished" },
+					editor: { ...config.components.editor, style: "opencode" },
 					userMessages: { ...config.components.userMessages, style: "labeled" },
 				},
 			};
@@ -1669,12 +1675,12 @@ describe("Pi docs compliance", () => {
 	});
 
 	it.each([
-		["polished", "framed"],
-		["polished", "compact"],
-		["polished", "labeled"],
-		["polished-copy-friendly", "framed"],
-		["polished-copy-friendly", "compact"],
-		["polished-copy-friendly", "labeled"],
+		["opencode", "framed"],
+		["opencode", "compact"],
+		["opencode", "labeled"],
+		["opencode-copy-friendly", "framed"],
+		["opencode-copy-friendly", "compact"],
+		["opencode-copy-friendly", "labeled"],
 		["minimalist", "framed"],
 		["minimalist", "compact"],
 		["minimalist", "labeled"],
@@ -1701,8 +1707,8 @@ describe("Pi docs compliance", () => {
 		const editorRendered = editor.render(80).join("\n");
 		const messageRendered = new UserMessageComponent("message").render(40).join("\n");
 
-		if (editorStyle === "polished") expect(editorRendered).toContain("│");
-		else if (editorStyle === "polished-copy-friendly") expect(editorRendered).not.toContain("│");
+		if (editorStyle === "opencode") expect(editorRendered).toContain("│");
+		else if (editorStyle === "opencode-copy-friendly") expect(editorRendered).not.toContain("│");
 		else expect(editorRendered).toContain("╭");
 		if (messageStyle === "framed") expect(stripPromptMarks(messageRendered)).toContain("────");
 		else if (messageStyle === "compact") {
@@ -1711,7 +1717,7 @@ describe("Pi docs compliance", () => {
 		} else expect(stripPromptMarks(messageRendered)).toContain("User");
 		expect(config.components.editor.style).toBe(editorStyle);
 		expect(config.components.userMessages).toMatchObject({ enabled: true, style: messageStyle });
-		expect(config.components.footer.enabled).toBe(true);
+		expect(config.components.footer.style).toBe("starship");
 		expect(UserMessageComponent.prototype.render).toBe(messageWrapper);
 	});
 
@@ -1816,7 +1822,7 @@ describe("Pi docs compliance", () => {
 		expect(framed).toContain("────");
 
 		config = structuredClone(config);
-		config.components.footer.enabled = false;
+		config.components.footer.style = "hidden";
 		expect(message.render(30).join("\n")).toBe(framed);
 		expect(fg).toHaveBeenCalledTimes(callsAfterFramed);
 
@@ -4065,7 +4071,7 @@ describe("Pi docs compliance", () => {
 
 	it("keeps blank structural metadata rows in the low-rail polished style", () => {
 		const config = configWithLowRailStyle(true);
-		config.components.editor.styles["polished-copy-friendly"].metadataFormat = "($unknown)";
+		config.components.editor.styles["opencode-copy-friendly"].metadataFormat = "($unknown)";
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
@@ -4241,7 +4247,7 @@ describe("Pi docs compliance", () => {
 
 	it("unwraps branded low-rail polished frames without duplicating metadata", () => {
 		const config = configWithLowRailStyle(true);
-		config.components.editor.styles["polished-copy-friendly"].metadataFormat = "copy-meta";
+		config.components.editor.styles["opencode-copy-friendly"].metadataFormat = "copy-meta";
 		const inner = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
@@ -4421,9 +4427,12 @@ describe("Pi docs compliance", () => {
 		const bottom = lines.findLastIndex((line) => /^─+$/.test(stripTestTags(line).trim()));
 		expect(rendered.match(/autocomplete-meta/g)).toHaveLength(1);
 		expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
+		expect(lines.some((line) => stripTestTags(line).includes("├"))).toBe(false);
+		expect(bottom).toBe(lines.length - 4);
 		for (const suggestion of ["suggestion-one", "suggestion-two", "suggestion-three"]) {
 			expect(rendered.match(new RegExp(suggestion, "g"))).toHaveLength(1);
-			expect(lines.findIndex((line) => line.includes(suggestion))).toBeGreaterThan(bottom);
+			const row = lines.findIndex((line) => line.includes(suggestion));
+			expect(row).toBeGreaterThan(bottom);
 		}
 	});
 
@@ -4686,7 +4695,7 @@ describe("Pi docs compliance", () => {
 
 		await command?.handler("status line off", { hasUI: false });
 
-		expect(featureChanges).toEqual([{ enabled: false }]);
+		expect(featureChanges).toEqual([{ style: "native" }]);
 	});
 
 	it("treats removed copy commands as unknown arguments", async () => {
@@ -5223,7 +5232,7 @@ describe("Pi docs compliance", () => {
 						handleInput?: (data: string) => void;
 					};
 					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
-					for (let index = 0; index < 4; index += 1) component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 3; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
@@ -5297,7 +5306,7 @@ describe("Pi docs compliance", () => {
 						() => {},
 					) as { handleInput?: (data: string) => void };
 					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
-					for (let index = 0; index < 7; index += 1) component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 6; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
@@ -6085,5 +6094,155 @@ describe("Pi docs compliance", () => {
 		expect(handler?.({ type: "session_info_changed", name: "release prep" }, ctx)).toBeUndefined();
 		expect(renderRequests).toBe(before + 1);
 		await emit(handlers, "session_shutdown", ctx);
+	});
+});
+
+describe("three-state Footer lifecycle", () => {
+	function createFooterHarness() {
+		let factory: FooterFactory | undefined;
+		let component: ReturnType<FooterFactory> | undefined;
+		const factories: Array<FooterFactory | undefined> = [];
+		const branchSubscriptions = vi.fn(() => () => {});
+		const probeTransitions: unknown[] = [];
+		const tui = { requestRender: vi.fn() };
+		const footerData = {
+			onBranchChange: branchSubscriptions,
+			getExtensionStatuses: () => new Map<string, string>(),
+		};
+		const ui = {
+			theme: makeTheme(),
+			notify() {},
+			setFooter(next: FooterFactory | undefined) {
+				component?.dispose?.();
+				component = undefined;
+				factory = next;
+				factories.push(next);
+				if (next) component = next(tui, makeTheme(), footerData, () => {});
+			},
+			setEditorComponent() {},
+			getEditorComponent: () => undefined,
+			setWidget(key: string, next: unknown) {
+				if (key === "zentui-fixed-editor-probe") probeTransitions.push(next);
+			},
+		};
+		return {
+			ui,
+			factories,
+			branchSubscriptions,
+			probeTransitions,
+			get factory() {
+				return factory;
+			},
+			get component() {
+				return component;
+			},
+		};
+	}
+
+	it("installs Hidden as an owned zero-row component without Starship timers or subscriptions", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ projectRefreshIntervalMs: 0, components: { footer: { style: "hidden" } } }),
+		);
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		const harness = createFooterHarness();
+		const handlers = loadExtension();
+		const ctx = makeContext({ ui: harness.ui });
+		await emit(handlers, "session_start", ctx);
+		expect(harness.component?.render(80)).toEqual([]);
+		expect(harness.branchSubscriptions).not.toHaveBeenCalled();
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("does not replace an unrelated Footer on initial Native reconciliation", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ components: { footer: { style: "native" } } }),
+		);
+		const setFooter = vi.fn();
+		const handlers = loadExtension();
+		const ctx = makeContext({ ui: { theme: makeTheme(), setFooter } });
+		await emit(handlers, "session_start", ctx);
+		expect(setFooter).not.toHaveBeenCalled();
+		await emit(handlers, "session_shutdown", ctx);
+		expect(setFooter).not.toHaveBeenCalled();
+	});
+
+	it("clears ownership after Pi-style external disposal and leaves the replacement on shutdown", async () => {
+		const harness = createFooterHarness();
+		const handlers = loadExtension();
+		const ctx = makeContext({ ui: harness.ui });
+		await emit(handlers, "session_start", ctx);
+		const replacement: FooterFactory = () => ({
+			invalidate() {},
+			render: () => ["third-party"],
+		});
+		harness.ui.setFooter(replacement);
+		expect(harness.component?.render(80)).toEqual(["third-party"]);
+		const callsBeforeShutdown = harness.factories.length;
+		await emit(handlers, "session_shutdown", ctx);
+		expect(harness.factories).toHaveLength(callsBeforeShutdown);
+		expect(harness.factory).toBe(replacement);
+	});
+
+	it("rebinds Footer and reprobes fixed layout across every live style transition", async () => {
+		initTheme(undefined, false);
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ layout: { fixedEditor: { enabled: true } } }),
+		);
+		const commands = new Map<string, unknown>();
+		const harness = createFooterHarness();
+		const handlers = loadExtension({ commands });
+		(
+			harness.ui as typeof harness.ui & {
+				custom: (factory: (...args: unknown[]) => unknown) => Promise<void>;
+			}
+		).custom = async (factory) => {
+			const settings = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
+				handleInput(data: string): void;
+			};
+			for (let index = 0; index < 4; index++) settings.handleInput("\t");
+			settings.handleInput(" ");
+		};
+		const ctx = makeContext({ ui: harness.ui });
+		const chooseFooterStyle = async () => {
+			await (
+				commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+			).handler("", ctx);
+		};
+		await emit(handlers, "session_start", ctx);
+		expect(harness.component?.render(80).length).toBeGreaterThan(0);
+		expect(harness.probeTransitions.map((value) => typeof value)).toEqual([
+			"undefined",
+			"function",
+		]);
+		await chooseFooterStyle();
+		expect(harness.component?.render(80)).toEqual([]);
+		expect(harness.probeTransitions.slice(-2).map((value) => typeof value)).toEqual([
+			"undefined",
+			"function",
+		]);
+		await chooseFooterStyle();
+		expect(harness.factory).toBeUndefined();
+		expect(harness.probeTransitions.slice(-2).map((value) => typeof value)).toEqual([
+			"undefined",
+			"function",
+		]);
+		await chooseFooterStyle();
+		expect(harness.component?.render(80).length).toBeGreaterThan(0);
+		expect(harness.probeTransitions.slice(-2).map((value) => typeof value)).toEqual([
+			"undefined",
+			"function",
+		]);
+		expect(harness.probeTransitions).toHaveLength(8);
+		expect(
+			new Set(harness.probeTransitions.filter((value) => typeof value === "function")).size,
+		).toBe(4);
+		expect(harness.factories).toHaveLength(4);
+		expect(harness.branchSubscriptions).toHaveBeenCalledTimes(2);
+		await emit(handlers, "session_shutdown", ctx);
+		expect(harness.probeTransitions.at(-1)).toBeUndefined();
 	});
 });

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1,4 +1,5 @@
-import { readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import {
@@ -1430,6 +1431,345 @@ describe("Pi docs compliance", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 1)).toBe(true);
 		footer?.dispose?.();
 		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("suppresses footer rows only while minimalist editor output is active", () => {
+		let footerFactory: FooterFactory | undefined;
+		let suppressed = true;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		installFooter(ctx as never, createInitialState(emptyGitStatus()), () => defaultConfig, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+			suppressVisibleOutput: () => suppressed,
+		});
+		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+		expect(footer?.render(80)).toEqual([]);
+		suppressed = false;
+		expect(footer?.render(80).length).toBeGreaterThan(0);
+	});
+
+	it("suppresses the production footer only while the installed minimalist editor decorates", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ editorMode: "minimalist", projectRefreshIntervalMs: 0 }),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		let footerFactory: FooterFactory | undefined;
+		const tui = { requestRender: vi.fn(), terminal: { rows: 24, cols: 80 } };
+		const ui = {
+			theme: makeTheme(),
+			setFooter(factory: FooterFactory | undefined) {
+				footerFactory = factory;
+			},
+			setEditorComponent(factory: unknown) {
+				editorFactory = factory;
+			},
+			getEditorComponent: () => editorFactory,
+		};
+		const ctx = makeContext({ ui });
+
+		await emit(handlers, "session_start", ctx);
+		await new Promise((resolve) => setTimeout(resolve, 20));
+		const editor = (
+			editorFactory as (...args: unknown[]) => {
+				render(width: number): string[];
+				setText(text: string): void;
+			}
+		)(tui as never, { borderColor: (text: string) => text, selectList: {} } as never, {} as never);
+		editor.setText("draft");
+		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+		expect(footer?.render(80).length).toBeGreaterThan(0);
+
+		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
+		expect(footer?.render(80)).toEqual([]);
+		expect(editor.render(4)[0]).not.toContain("╭");
+		expect(footer?.render(80).length).toBeGreaterThan(0);
+		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
+		expect(footer?.render(80)).toEqual([]);
+
+		const nativeEditorPrototype = Object.getPrototypeOf(PolishedEditor.prototype) as {
+			render(width: number): string[];
+		};
+		const nativeRender = vi.spyOn(nativeEditorPrototype, "render").mockImplementation(() => {
+			throw new Error("native render failed");
+		});
+		try {
+			expect(() => editor.render(80)).toThrow("native render failed");
+			expect(footer?.render(80).length).toBeGreaterThan(0);
+		} finally {
+			nativeRender.mockRestore();
+		}
+
+		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
+		expect(footer?.render(80)).toEqual([]);
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+		await emit(handlers, "agent_start", ctx);
+		const thirdPartyFactory = () => ({ render: () => ["third-party"] });
+		ui.setEditorComponent(thirdPartyFactory);
+		expect(footer?.render(80).length).toBeGreaterThan(0);
+		await emit(handlers, "model_select", ctx);
+		expect(clearIntervalSpy).toHaveBeenCalled();
+		clearIntervalSpy.mockRestore();
+
+		footer?.dispose?.();
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("keeps the production footer for unsupported wrapped minimalist output", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ editorMode: "minimalist", projectRefreshIntervalMs: 0 }),
+		);
+		const handlers = loadExtension();
+		const existingFactory = () => ({
+			render: (width: number) => [`third-party-${width}`, "draft", "help"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "draft",
+			setText() {},
+		});
+		let editorFactory: unknown = existingFactory;
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+		});
+		await emit(handlers, "session_start", ctx);
+		const editor = (editorFactory as (...args: unknown[]) => ReturnType<typeof existingFactory>)(
+			{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+		);
+		const footer = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+
+		expect(editor.render(80)).toEqual(["third-party-80", "draft", "help"]);
+		expect(footer?.render(80).length).toBeGreaterThan(0);
+
+		footer?.dispose?.();
+		await emit(handlers, "session_shutdown", ctx);
+	});
+
+	it("forces an initial project refresh for minimalist mode without a status line or polling", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "zentui-minimalist-project-"));
+		mkdirSync(join(cwd, ".git", "objects", "info"), { recursive: true });
+		mkdirSync(join(cwd, ".git", "objects", "pack"), { recursive: true });
+		mkdirSync(join(cwd, ".git", "refs", "heads"), { recursive: true });
+		mkdirSync(join(cwd, ".git", "refs", "tags"), { recursive: true });
+		writeFileSync(join(cwd, ".git", "HEAD"), "ref: refs/heads/minimalist-test\n");
+		writeFileSync(
+			join(cwd, ".git", "config"),
+			"[core]\n\trepositoryformatversion = 0\n\tbare = false\n",
+		);
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				editorMode: "minimalist",
+				projectRefreshIntervalMs: 0,
+				features: { statusLine: false },
+			}),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		const ctx = makeContext({
+			cwd,
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+		});
+		try {
+			await emit(handlers, "session_start", ctx);
+			const editor = (editorFactory as (...args: unknown[]) => { render(width: number): string[] })(
+				{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+				{ borderColor: (text: string) => text, selectList: {} } as never,
+				{} as never,
+			);
+
+			await vi.waitFor(() => {
+				expect(editor.render(120).join("\n")).toContain("minimalist-test");
+			});
+		} finally {
+			await emit(handlers, "session_shutdown", ctx);
+			rmSync(cwd, { recursive: true, force: true });
+		}
+	});
+
+	it("ticks only a decorated minimalist turn and freezes or stops on lifecycle changes", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				editorMode: "minimalist",
+				projectRefreshIntervalMs: 0,
+				features: { statusLine: false },
+			}),
+		);
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		let editorFactory: unknown;
+		const tui = { requestRender: vi.fn(), terminal: { rows: 24, cols: 80 } };
+		const notifications: string[] = [];
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				notify(message: string) {
+					notifications.push(message);
+				},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+		});
+		await emit(handlers, "session_start", ctx);
+		const editor = (
+			editorFactory as (...args: unknown[]) => {
+				render(width: number): string[];
+				setText(text: string): void;
+			}
+		)(tui as never, { borderColor: (text: string) => text, selectList: {} } as never, {} as never);
+		editor.setText("draft");
+		editor.render(80);
+
+		let now = Date.now();
+		vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+		const dateNow = vi.spyOn(Date, "now").mockImplementation(() => now);
+		try {
+			await emit(handlers, "agent_start", ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			now += 2500;
+			vi.advanceTimersByTime(2500);
+			expect(editor.render(80)[0]).toContain("2s");
+
+			await emit(handlers, "agent_end", ctx);
+			expect(vi.getTimerCount()).toBe(0);
+			const frozen = editor.render(80)[0];
+			vi.advanceTimersByTime(5000);
+			expect(editor.render(80)[0]).toBe(frozen);
+
+			await emit(handlers, "agent_start", ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			const command = commands.get("zentui") as {
+				handler(args: string, ctx: unknown): Promise<void>;
+			};
+			await command.handler("editor disable", ctx);
+			expect(notifications).toEqual(["Editor: disabled"]);
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			dateNow.mockRestore();
+			vi.useRealTimers();
+			await emit(handlers, "session_shutdown", ctx);
+		}
+	});
+
+	it("stops minimalist timer and project work after a genuinely late editor takeover", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				editorMode: "minimalist",
+				projectRefreshIntervalMs: 5_000,
+				features: { statusLine: false },
+			}),
+		);
+		const handlers = loadExtension();
+		let editorFactory: unknown;
+		const ui = {
+			theme: makeTheme(),
+			setFooter() {},
+			setEditorComponent(factory: unknown) {
+				editorFactory = factory;
+			},
+			getEditorComponent: () => editorFactory,
+		};
+		const ctx = makeContext({ ui });
+		vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+		try {
+			await emit(handlers, "session_start", ctx);
+			await new Promise((resolve) => setTimeout(resolve, 20));
+			const editor = (
+				editorFactory as (...args: unknown[]) => {
+					render(width: number): string[];
+					setText(text: string): void;
+				}
+			)(
+				{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+				{ borderColor: (text: string) => text, selectList: {} } as never,
+				{} as never,
+			);
+			editor.setText("draft");
+			editor.render(80);
+			await emit(handlers, "agent_start", ctx);
+			expect(vi.getTimerCount()).toBe(2);
+			const thirdPartyFactory = () => ({
+				render: () => ["third-party"],
+				invalidate() {},
+				handleInput() {},
+				getText: () => "",
+				setText() {},
+			});
+			ui.setEditorComponent(thirdPartyFactory);
+			vi.advanceTimersByTime(5_000);
+			expect(editorFactory).toBe(thirdPartyFactory);
+			expect(vi.getTimerCount()).toBe(0);
+
+			await emit(handlers, "agent_start", ctx);
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			await emit(handlers, "session_shutdown", ctx);
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not start turn intervals in polished or non-TUI sessions", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ projectRefreshIntervalMs: 0, features: { statusLine: false } }),
+		);
+		const polishedHandlers = loadExtension();
+		const polishedCtx = makeContext();
+		await emit(polishedHandlers, "session_start", polishedCtx);
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval");
+		await emit(polishedHandlers, "agent_start", polishedCtx);
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+		await emit(polishedHandlers, "session_shutdown", polishedCtx);
+
+		const rpcHandlers = loadExtension();
+		const rpcCtx = makeContext({ hasUI: false, mode: "rpc" });
+		await emit(rpcHandlers, "session_start", rpcCtx);
+		await emit(rpcHandlers, "agent_start", rpcCtx);
+		expect(setIntervalSpy).not.toHaveBeenCalled();
+		await emit(rpcHandlers, "session_shutdown", rpcCtx);
+		setIntervalSpy.mockRestore();
 	});
 
 	it("does not crash when config colors contain Starship modifiers", () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -32,6 +32,7 @@ import {
 	WrappedPolishedEditor as WrappedPolishedEditorProduction,
 } from "../extensions/zentui/ui";
 import { installUserMessageStyle as installUserMessageStyleProduction } from "../extensions/zentui/user-message";
+import { sanitizeUserMessageSourceText } from "../extensions/zentui/user-message-osc";
 
 const isolatedAgentDir = vi.hoisted(() => {
 	const previous = process.env.PI_CODING_AGENT_DIR;
@@ -2577,7 +2578,7 @@ describe("Pi docs compliance", () => {
 	});
 
 	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
-		"strips raw OSC 8 and keeps Markdown links for %s",
+		"strips raw OSC 8 and preserves Pi Markdown rendering for %s",
 		(style) => {
 			const config = structuredClone(defaultConfig);
 			config.components.userMessages.style = style;
@@ -2595,15 +2596,19 @@ describe("Pi docs compliance", () => {
 				source += `${sequence} `;
 			}
 			source += `\x9d8;;https://c1.example\x9cc1-link\x9d8;;\x9c ${preserved[0]} [markdown](https://markdown.example) \x1b]133;Btail`;
+			const cleanSource = sanitizeUserMessageSourceText(source);
+			expect(cleanSource).toContain("[markdown](https://markdown.example)");
 
+			const clean = new UserMessageComponent(cleanSource).render(240).join("\n");
 			const rendered = new UserMessageComponent(source).render(240).join("\n");
+			expect(rendered).toBe(clean);
 			expectSinglePromptZone(rendered);
 			for (const sequence of preserved) expect(rendered).not.toContain(sequence);
 			expect(rendered).toContain("link-0");
 			expect(rendered).toContain("link-1");
 			expect(rendered).toContain("c1-link");
 			expect(rendered).toContain("markdown");
-			expect(rendered).toContain("\x1b]8;;https://markdown.example");
+			expect(rendered).toContain("https://markdown.example");
 			const visible = stripPromptMarks(rendered);
 			expect(visible).not.toContain("\x9d");
 			expect(visible).not.toContain("\x9c");

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -49,11 +49,64 @@ type FooterFactory = (...args: unknown[]) => {
 	dispose?: () => void;
 };
 
+const originalUserMessageRenderDescriptor = Object.getOwnPropertyDescriptor(
+	UserMessageComponent.prototype,
+	"render",
+);
+const originalUserMessageInvalidateDescriptor = Object.getOwnPropertyDescriptor(
+	UserMessageComponent.prototype,
+	"invalidate",
+);
+const originalModelSelectorRenderDescriptor = Object.getOwnPropertyDescriptor(
+	ModelSelectorComponent.prototype,
+	"render",
+);
+const originalSettingsSelectorRenderDescriptor = Object.getOwnPropertyDescriptor(
+	SettingsSelectorComponent.prototype,
+	"render",
+);
 const originalUserMessageRender = UserMessageComponent.prototype.render;
 const originalUserMessageInvalidate = UserMessageComponent.prototype.invalidate;
 const originalModelSelectorRender = ModelSelectorComponent.prototype.render;
 const originalSettingsSelectorRender = SettingsSelectorComponent.prototype.render;
+
+function restoreDescriptor(
+	target: object,
+	property: PropertyKey,
+	descriptor: PropertyDescriptor | undefined,
+): void {
+	if (descriptor) Object.defineProperty(target, property, descriptor);
+	else delete (target as Record<PropertyKey, unknown>)[property];
+}
 const inactiveSessionLifecycle = new SessionLifecycle();
+
+type SettingsCommandDeps = Parameters<typeof registerZentuiSettingsCommand>[1];
+
+const settingsCommandDefaults: SettingsCommandDeps = {
+	sessionLifecycle: inactiveSessionLifecycle,
+	getConfig: () => defaultConfig,
+	setEditorComponent: () => ({ applied: true }),
+	setMinimalist() {},
+	setUserMessagesComponent() {},
+	setSelectorBordersComponent() {},
+	setFooterComponent() {},
+	setFooterSegments() {},
+	setFooterFormat() {},
+	setResponsiveFooter() {},
+	setIconMode() {},
+	setContextStyle() {},
+	setSeparator() {},
+	setPathDisplay() {},
+	setGitBranch() {},
+	setGitCommit() {},
+	setGitMetrics() {},
+	getActiveExtensionStatuses: () => new Map<string, string>(),
+	setExtensionStatusDefaultPlacement() {},
+	setExtensionStatusPlacement() {},
+	setExtensionStatusColorMode() {},
+	setFixedEditor() {},
+	requestRender() {},
+};
 
 function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 	const editor = config.components.editor;
@@ -493,14 +546,26 @@ afterAll(() => {
 
 afterEach(() => {
 	rmSync(join(isolatedAgentDir.path, "zentui.json"), { force: true });
-	UserMessageComponent.prototype.render = originalUserMessageRender;
-	UserMessageComponent.prototype.invalidate = originalUserMessageInvalidate;
+	restoreDescriptor(UserMessageComponent.prototype, "render", originalUserMessageRenderDescriptor);
+	restoreDescriptor(
+		UserMessageComponent.prototype,
+		"invalidate",
+		originalUserMessageInvalidateDescriptor,
+	);
 	delete (UserMessageComponent.prototype as unknown as Record<PropertyKey, unknown>)[
 		ZENTUI_PROTOTYPE_PATCH_REGISTRY
 	];
 
-	ModelSelectorComponent.prototype.render = originalModelSelectorRender;
-	SettingsSelectorComponent.prototype.render = originalSettingsSelectorRender;
+	restoreDescriptor(
+		ModelSelectorComponent.prototype,
+		"render",
+		originalModelSelectorRenderDescriptor,
+	);
+	restoreDescriptor(
+		SettingsSelectorComponent.prototype,
+		"render",
+		originalSettingsSelectorRenderDescriptor,
+	);
 	for (const selectorPrototype of [
 		ModelSelectorComponent.prototype,
 		SettingsSelectorComponent.prototype,
@@ -787,9 +852,12 @@ describe("Pi docs compliance", () => {
 		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
 	});
 
-	it("isolates footer installation failure from editor and prototype surfaces", async () => {
+	it("isolates footer installation failure without clearing a retained predecessor", async () => {
 		const handlers = loadExtension();
 		let editorFactory: unknown;
+		const predecessor = () => ({ render: () => ["third-party"] });
+		let footerFactory: unknown = predecessor;
+		const footerCalls: unknown[] = [];
 		const ctx = makeContext({
 			ui: {
 				theme: makeTheme(),
@@ -798,16 +866,23 @@ describe("Pi docs compliance", () => {
 				},
 				getEditorComponent: () => editorFactory,
 				setFooter(factory: unknown) {
+					footerCalls.push(factory);
 					if (factory) throw new Error("footer unavailable");
+					footerFactory = factory;
 				},
 			},
 		});
 
 		await expect(emit(handlers, "session_start", ctx)).resolves.toBeUndefined();
 		expect(editorFactory).toBeTypeOf("function");
+		expect(footerFactory).toBe(predecessor);
+		expect(footerCalls).toHaveLength(1);
+		expect(footerCalls).not.toContain(undefined);
 		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
 		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
 		await emit(handlers, "session_shutdown", ctx);
+		expect(footerFactory).toBe(predecessor);
+		expect(footerCalls).not.toContain(undefined);
 	});
 
 	it("isolates selector installation failure from editor, messages, and footer", async () => {
@@ -1331,6 +1406,45 @@ describe("Pi docs compliance", () => {
 		expect(editorFactory).toBeTypeOf("function");
 	});
 
+	it("keeps a newer instance installed when the older instance shuts down", async () => {
+		const firstHandlers = loadExtension();
+		let editorFactory: unknown;
+		let footerFactory: unknown;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: unknown) {
+					footerFactory = factory;
+				},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+		});
+
+		await emit(firstHandlers, "session_start", ctx);
+		const secondHandlers = loadExtension();
+		await emit(secondHandlers, "session_start", ctx);
+		const secondEditor = editorFactory;
+		const secondFooter = footerFactory;
+		const secondMessageRender = UserMessageComponent.prototype.render;
+		const secondMessageInvalidate = UserMessageComponent.prototype.invalidate;
+		const secondModelSelector = ModelSelectorComponent.prototype.render;
+		const secondSettingsSelector = SettingsSelectorComponent.prototype.render;
+
+		await emit(firstHandlers, "session_shutdown", ctx);
+		expect(editorFactory).toBe(secondEditor);
+		expect(footerFactory).toBe(secondFooter);
+		expect(UserMessageComponent.prototype.render).toBe(secondMessageRender);
+		expect(UserMessageComponent.prototype.invalidate).toBe(secondMessageInvalidate);
+		expect(ModelSelectorComponent.prototype.render).toBe(secondModelSelector);
+		expect(SettingsSelectorComponent.prototype.render).toBe(secondSettingsSelector);
+		expectSinglePromptZone(new UserMessageComponent("new").render(30).join("\n"));
+
+		await emit(secondHandlers, "session_shutdown", ctx);
+	});
+
 	it("cleans every stale owned surface on an enabled-to-disabled extension reload", async () => {
 		const firstHandlers = loadExtension();
 		const existingFactory = () => ({
@@ -1389,6 +1503,52 @@ describe("Pi docs compliance", () => {
 		expect(SettingsSelectorComponent.prototype.render).toBe(originalSettingsSelectorRender);
 		expect(setEditorCalls).toBe(2);
 		expect(setFooterCalls).toBe(2);
+	});
+
+	it("fails open for explicit unsupported component style IDs", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { enabled: true, style: "future-editor" },
+					userMessages: { enabled: true, style: "future-messages" },
+					selectorBorders: { enabled: true, style: "future-selectors" },
+					footer: { style: "future-footer" },
+				},
+			}),
+		);
+		const handlers = loadExtension();
+		const existingEditor = () => ({ render: () => ["native"] });
+		const existingFooter = () => ({ render: () => ["native"] });
+		let editorFactory: unknown = existingEditor;
+		let footerFactory: unknown = existingFooter;
+		let editorSets = 0;
+		let footerSets = 0;
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setEditorComponent(factory: unknown) {
+					editorSets += 1;
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+				setFooter(factory: unknown) {
+					footerSets += 1;
+					footerFactory = factory;
+				},
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		await new Promise((resolve) => setTimeout(resolve, 1));
+		expect(editorFactory).toBe(existingEditor);
+		expect(footerFactory).toBe(existingFooter);
+		expect(editorSets).toBe(0);
+		expect(footerSets).toBe(0);
+		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+		expect(SettingsSelectorComponent.prototype.render).toBe(originalSettingsSelectorRender);
+		await emit(handlers, "session_shutdown", ctx);
 	});
 
 	it("refreshes a stale wrapped Zentui editor without wrapping the old Zentui wrapper", async () => {
@@ -1975,6 +2135,45 @@ describe("Pi docs compliance", () => {
 		expect(prototype.render).toBe(predecessor);
 	});
 
+	it("removes the temporary own wrapper when the predecessor is inherited", () => {
+		const basePrototype = {
+			render(width: number) {
+				return ["─".repeat(width), "body", "─".repeat(width)];
+			},
+		};
+		const prototype = Object.create(basePrototype) as typeof basePrototype;
+		expect(Object.hasOwn(prototype, "render")).toBe(false);
+
+		const cleanup = patchSelectorBorderStyle(
+			prototype,
+			() => makeTaggedTheme(),
+			() => defaultConfig,
+		);
+		expect(Object.hasOwn(prototype, "render")).toBe(true);
+		cleanup();
+		expect(Object.hasOwn(prototype, "render")).toBe(false);
+		expect(prototype.render).toBe(basePrototype.render);
+	});
+
+	it("restores an own method descriptor exactly", () => {
+		const predecessor = (width: number) => ["─".repeat(width), "body", "─".repeat(width)];
+		const prototype = {} as { render: typeof predecessor };
+		Object.defineProperty(prototype, "render", {
+			value: predecessor,
+			writable: false,
+			enumerable: false,
+			configurable: true,
+		});
+		const descriptor = Object.getOwnPropertyDescriptor(prototype, "render");
+		const cleanup = patchSelectorBorderStyle(
+			prototype,
+			() => makeTaggedTheme(),
+			() => defaultConfig,
+		);
+		cleanup();
+		expect(Object.getOwnPropertyDescriptor(prototype, "render")).toEqual(descriptor);
+	});
+
 	it("does not stack selector wrappers and ignores stale cleanup", () => {
 		const predecessor = vi.fn((width: number) => ["─".repeat(width), "body", "─".repeat(width)]);
 		const prototype = { render: predecessor };
@@ -2114,6 +2313,58 @@ describe("Pi docs compliance", () => {
 		expect(UserMessageComponent.prototype.render).toBe(predecessor);
 	});
 
+	it("sanitizes hostile predecessor output when message text cannot be found", () => {
+		const sgr = "\x1b[31mred\x1b[0m";
+		const open = "\x1b]8;;https://safe.example\x07";
+		const close = "\x1b]8;;\x07";
+		const predecessor = () => [
+			`before ${sgr} ${open}link${close} \x1b]52;c;CLIPBOARD\x07\x1b[2J\x1bPSECRET\x1b\\\x07 after`,
+		];
+		UserMessageComponent.prototype.render = predecessor;
+		const cleanup = installUserMessageStyle(
+			() => makeTaggedTheme(),
+			() => defaultConfig,
+		);
+
+		const rendered = UserMessageComponent.prototype.render.call({ children: [] }, 80).join("\n");
+
+		expect(rendered).toContain(sgr);
+		expect(rendered).toContain(`${open}link${close}`);
+		expect(rendered).toContain("before");
+		expect(rendered).toContain("after");
+		expect(rendered).not.toContain("\x1b]52");
+		expect(rendered).not.toContain("CLIPBOARD");
+		expect(rendered).not.toContain("\x1b[2J");
+		expect(rendered).not.toContain("SECRET");
+		expect(rendered).not.toContain("\x07 after");
+		cleanup();
+	});
+
+	it("strips all predecessor OSC 8 when links are unbalanced across rows", () => {
+		const open = "\x1b]8;;https://safe.example\x07";
+		const close = "\x1b]8;;\x07";
+		const sgr = "\x1b[31mred\x1b[0m";
+		let rows = [`${open}first`, `second ${sgr}`];
+		UserMessageComponent.prototype.render = () => rows;
+		const cleanup = installUserMessageStyle(
+			() => makeTaggedTheme(),
+			() => defaultConfig,
+		);
+
+		const instance = { children: [] };
+		expect(UserMessageComponent.prototype.render.call(instance, 80)).toEqual([
+			"first",
+			`second ${sgr}`,
+		]);
+
+		rows = [`${open}first`, `second${close} ${sgr}`];
+		expect(UserMessageComponent.prototype.render.call(instance, 80)).toEqual([
+			`${open}first`,
+			`second${close} ${sgr}`,
+		]);
+		cleanup();
+	});
+
 	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
 		"preserves exactly one OSC 133 prompt zone for %s messages",
 		(style) => {
@@ -2127,6 +2378,64 @@ describe("Pi docs compliance", () => {
 			const rendered = new UserMessageComponent("hello").render(40).join("\n");
 			expect(rendered.match(/\x1b\]133;A\x07/g)).toHaveLength(1);
 			expect(rendered.match(/\x1b\]133;B\x07\x1b\]133;C\x07/g)).toHaveLength(1);
+		},
+	);
+
+	it("allows only 7-bit OSC 8 from raw user-message controls before adding one prompt zone", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const open = "\x1b]8;;https://example.test\x07";
+		const close = "\x1b]8;;\x07";
+		const hostile = `before \x1b]0;title\x07\x1b]52;c;PAYLOAD\x07\x1b[2J\x1bPSECRET\x1b\\\x9d8;;https://c1.example\x9c${open}link${close} after`;
+		const rendered = new UserMessageComponent(hostile).render(100).join("\n");
+
+		expectSinglePromptZone(rendered);
+		expect(rendered).toContain(`${open}link${close}`);
+		expect(rendered).not.toContain("\x1b]0;");
+		expect(rendered).not.toContain("\x1b]52;");
+		expect(rendered).not.toContain("PAYLOAD");
+		expect(rendered).not.toContain("\x1b[2J");
+		expect(rendered).not.toContain("SECRET");
+		expect(rendered).not.toContain("\x9d");
+	});
+
+	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
+		"preserves row-end OSC 8 without reopening the Markdown-destination exploit for %s",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.userMessages.style = style;
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => config,
+			);
+			const open = "\x1b]8;;https://raw.example\x07";
+			const close = "\x1b]8;;\x07";
+			const clipboard = "\x1b]52;c;c2VjcmV0\x07";
+
+			for (const width of [8, 40]) {
+				const preserved = new UserMessageComponent(`before ${open}LINK${close}\nafter`)
+					.render(width)
+					.join("\n");
+				expectSinglePromptZone(preserved);
+				expect(preserved.split(open)).toHaveLength(2);
+				expect(preserved.split(close)).toHaveLength(2);
+				expect(preserved.indexOf(open)).toBeLessThan(preserved.indexOf(close));
+				expect(preserved).not.toMatch(/[\u200b\u200c\u2060]/);
+
+				const exploit = new UserMessageComponent(
+					`[docs](https://markdown.example/${open}nested${close}) ${clipboard}tail`,
+				)
+					.render(width)
+					.join("\n");
+				expectSinglePromptZone(exploit);
+				expect(exploit).not.toContain(open);
+				expect(exploit).not.toContain(close);
+				expect(exploit).not.toContain("\x1b]52");
+				expect(exploit).not.toContain("c2VjcmV0");
+				expect(exploit).not.toMatch(/[\u200b\u200c\u2060]/);
+			}
 		},
 	);
 
@@ -2261,7 +2570,7 @@ describe("Pi docs compliance", () => {
 	});
 
 	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
-		"preserves mixed 7-bit/C1 OSC 8 through sanitization and Markdown for %s",
+		"preserves 7-bit OSC 8 and strips C1 controls through Markdown for %s",
 		(style) => {
 			const config = structuredClone(defaultConfig);
 			config.components.userMessages.style = style;
@@ -2269,29 +2578,26 @@ describe("Pi docs compliance", () => {
 				() => makeTheme(),
 				() => config,
 			);
-			const starts = ["\x1b]", "\x9d"];
-			const terminators = ["\x07", "\x1b\\", "\x9c"];
 			const preserved: string[] = [];
 			let source = "before \x9d133;Atail ";
-			for (const [index, start] of starts.entries()) {
-				for (const [terminatorIndex, terminator] of terminators.entries()) {
-					const id = `${index}-${terminatorIndex}`;
-					const open = `${start}8;;https://example.com/${id}${terminator}`;
-					const close = `${start}8;;${terminator}`;
-					const sequence = `${open}link-${id}${close}`;
-					preserved.push(sequence);
-					source += `${sequence} `;
-				}
+			for (const [index, terminator] of ["\x07", "\x1b\\"].entries()) {
+				const open = `\x1b]8;;https://example.com/${index}${terminator}`;
+				const close = `\x1b]8;;${terminator}`;
+				const sequence = `${open}link-${index}${close}`;
+				preserved.push(sequence);
+				source += `${sequence} `;
 			}
-			source += `${preserved[0]} [markdown](https://markdown.example) \x1b]133;Btail`;
+			source += `\x9d8;;https://c1.example\x9cc1-link\x9d8;;\x9c ${preserved[0]} [markdown](https://markdown.example) \x1b]133;Btail`;
 
 			const rendered = new UserMessageComponent(source).render(240).join("\n");
 			expectSinglePromptZone(rendered);
 			for (const sequence of preserved) expect(rendered).toContain(sequence);
 			expect(rendered.split(preserved[0])).toHaveLength(3);
+			expect(rendered).toContain("c1-link");
 			expect(rendered).toContain("markdown");
 			const visible = stripPromptMarks(rendered);
-			expect(visible).not.toContain("\x9d133");
+			expect(visible).not.toContain("\x9d");
+			expect(visible).not.toContain("\x9c");
 			expect(visible).not.toContain("\x1b]133");
 		},
 	);
@@ -2316,6 +2622,28 @@ describe("Pi docs compliance", () => {
 		);
 		expect(rendered).toEqual(["native:42"]);
 		expect(rendered.join("\n")).not.toContain("\x1b]133;");
+	});
+
+	it("uses sanitized plain output when styled rendering fails with source OSC", () => {
+		UserMessageComponent.prototype.render = function predecessor() {
+			return [(this as unknown as { text: string }).text];
+		};
+		const failingTheme = {
+			...makeTheme(),
+			fg() {
+				throw new Error("theme failed");
+			},
+		} as unknown as Theme;
+		installUserMessageStyle(
+			() => failingTheme,
+			() => defaultConfig,
+		);
+		const clipboard = "\x1b]52;c;c2VjcmV0\x07";
+		const output = new UserMessageComponent(`before ${clipboard}after`).render(80).join("\n");
+		expect(output).toContain("before after");
+		expect(output).not.toContain("\x1b]52");
+		expect(output).not.toContain("c2VjcmV0");
+		expectSinglePromptZone(output);
 	});
 
 	it("delegates byte-for-byte when message cache-key construction throws", () => {
@@ -4564,10 +4892,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -4610,10 +4937,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -4656,9 +4982,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setEditorComponent(patch) {
 					featureChanges.push(patch as never);
 					return { applied: true };
@@ -4705,9 +5031,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setFooterComponent(patch) {
 					featureChanges.push(patch);
 				},
@@ -4742,6 +5068,7 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setFooterSegments() {},
@@ -4785,9 +5112,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setEditorComponent(patch) {
 					featureChanges.push(patch as never);
 					return { applied: true };
@@ -4833,9 +5160,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setEditorComponent: () => ({
 					applied: false,
 					reason:
@@ -4890,9 +5217,9 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					...settingsCommandDefaults,
 					sessionLifecycle,
 					getConfig: () => defaultConfig,
-					setColorSources() {},
 					setEditorComponent() {
 						doneCallsAtFeatureChange.push(doneCalls);
 						return { applied: true };
@@ -4957,9 +5284,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setUserMessagesComponent(patch) {
 					attemptedPatches.push(patch);
 					throw new Error("config is corrupt");
@@ -5028,9 +5355,9 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					...settingsCommandDefaults,
 					sessionLifecycle,
 					getConfig: () => defaultConfig,
-					setColorSources() {},
 					setEditorComponent() {
 						featureChanges += 1;
 						return { applied: true };
@@ -5098,10 +5425,9 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					...settingsCommandDefaults,
 					sessionLifecycle: inactiveSessionLifecycle,
 					getConfig: () => config,
-					setColorSources() {},
-					setUiFeatures: () => ({ applied: true }),
 					setFooterSegments() {},
 					setFooterFormat() {},
 					setIconMode() {},
@@ -5152,7 +5478,10 @@ describe("Pi docs compliance", () => {
 			true,
 		);
 
-		const terminalLines = await renderSettings(configWithColorSources({ editor: "terminal" }));
+		const selectorTerminalConfig = structuredClone(defaultConfig);
+		selectorTerminalConfig.components.selectorBorders.colorSource = "terminal";
+		const terminalLines = await renderSettings(selectorTerminalConfig);
+		expect(selectorTerminalConfig.components.editor.colorSource).toBe("theme");
 		expect(terminalLines[0]).toContain("\u001b[90m────");
 		expect(terminalLines.at(-1)).toContain("\u001b[90m────");
 		expect(
@@ -5170,10 +5499,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5226,10 +5554,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setResponsiveFooter(patch) {
@@ -5289,10 +5616,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5372,10 +5698,9 @@ describe("Pi docs compliance", () => {
 					},
 				} as never,
 				{
+					...settingsCommandDefaults,
 					sessionLifecycle: inactiveSessionLifecycle,
 					getConfig: () => config,
-					setColorSources() {},
-					setUiFeatures: () => ({ applied: true }),
 					setFooterSegments() {},
 					setFooterFormat() {},
 					setIconMode() {},
@@ -5436,13 +5761,12 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
 				setSelectorBordersComponent(patch) {
 					changes.push(patch);
 				},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5511,13 +5835,12 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => configWithColorSources({ editor: "theme", userMessages: "terminal" }),
-				setColorSources() {},
 				setSelectorBordersComponent(patch) {
 					changes.push(patch);
 				},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5602,10 +5925,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5661,10 +5983,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5725,10 +6046,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5790,10 +6110,9 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5860,13 +6179,12 @@ describe("Pi docs compliance", () => {
 				},
 			} as never,
 			{
+				...settingsCommandDefaults,
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () =>
 					configWithExtensionStatuses({
 						placements: { active: "middle", inactive: "left" },
 					}),
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -5910,6 +6228,73 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("middle");
 		expect(rendered).not.toContain("inactive");
 	});
+	it("sanitizes project-derived metadata in built-in, custom, and compact Footer routes", () => {
+		const hostile = "safe\x1b]52;c;PAYLOAD\x07tail";
+		let footerFactory: FooterFactory | undefined;
+		const ctx = makeContext({
+			cwd: `/tmp/${hostile}`,
+			ui: {
+				theme: makeTheme(),
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+				setEditorComponent() {},
+			},
+		});
+		const state = createInitialState({
+			...emptyGitStatus(),
+			branch: hostile,
+			gitStateLabel: hostile,
+			commit: { oid: hostile, tag: hostile, detached: false },
+		});
+		state.runtime = { name: hostile, symbol: hostile, style: "", version: hostile };
+		state.packageVersion = { ecosystem: "nodejs", version: hostile };
+		const config = structuredClone(defaultConfig);
+		const starship = config.components.footer.styles.starship;
+		starship.format =
+			"$cwd $git_branch $git_state $git_commit $git_tag $runtime $package $package_version";
+		starship.compactFormat = starship.format;
+		starship.responsive = true;
+		starship.gitCommit.onlyDetached = false;
+		starship.gitCommit.showTag = true;
+		starship.segments = {
+			...starship.segments,
+			cwd: true,
+			gitBranch: true,
+			gitStatus: true,
+			gitCommit: true,
+			runtime: true,
+			packageVersion: true,
+			context: false,
+			tokens: false,
+			cost: false,
+		};
+		installFooter(ctx as never, state, () => config, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const component = footerFactory?.({ requestRender() {} }, makeTheme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map<string, string>(),
+		});
+		if (!component) throw new Error("Footer was not installed");
+		const renderSafe = (width: number) => {
+			const rows = component.render(width);
+			const output = rows.join("\n");
+			const plain = output.replaceAll(/\x1b\[[0-9;:]*m/g, "");
+			expect(output).not.toContain("PAYLOAD");
+			expect(plain).not.toMatch(/[\x00-\x1f\x7f-\x9f]/);
+			expect(rows.every((row) => visibleWidth(row) <= width)).toBe(true);
+			return output;
+		};
+
+		expect(renderSafe(500)).toContain("safetail");
+		starship.format = "";
+		expect(renderSafe(500)).toContain("safetail");
+		starship.format = "$cwd $git_branch $runtime $package";
+		expect(renderSafe(24)).toContain("safe");
+	});
+
 	type SessionNameFooterOptions = {
 		name?: string;
 		getSessionName?: () => string | undefined;
@@ -6200,6 +6585,177 @@ describe("three-state Footer lifecycle", () => {
 		expect(setFooter).not.toHaveBeenCalled();
 		await emit(handlers, "session_shutdown", ctx);
 		expect(setFooter).not.toHaveBeenCalled();
+	});
+
+	it("preserves an owned Starship Footer when a live Hidden replacement fails", async () => {
+		initTheme(undefined, false);
+		vi.useFakeTimers();
+		try {
+			writeFileSync(
+				join(isolatedAgentDir.path, "zentui.json"),
+				JSON.stringify({
+					projectRefreshIntervalMs: 0,
+					components: {
+						footer: { style: "starship", styles: { starship: { format: "$time" } } },
+					},
+				}),
+			);
+			const commands = new Map<string, unknown>();
+			let factory: FooterFactory | undefined;
+			let component: ReturnType<FooterFactory> | undefined;
+			let rejectReplacement = false;
+			const tui = { requestRender: vi.fn() };
+			const ui = {
+				theme: makeTheme(),
+				notify() {},
+				setEditorComponent() {},
+				getEditorComponent: () => undefined,
+				setFooter(next: FooterFactory | undefined) {
+					if (rejectReplacement && next !== undefined) throw new Error("replacement unavailable");
+					component?.dispose?.();
+					factory = next;
+					component = next?.(tui, makeTheme(), {
+						onBranchChange: () => () => {},
+						getExtensionStatuses: () => new Map<string, string>(),
+					});
+				},
+				async custom(settingsFactory: (...args: unknown[]) => unknown) {
+					const settings = settingsFactory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
+						handleInput(data: string): void;
+					};
+					for (let index = 0; index < 4; index++) settings.handleInput("\t");
+					settings.handleInput(" ");
+				},
+			};
+			const handlers = loadExtension({ commands });
+			const ctx = makeContext({ ui });
+			await emit(handlers, "session_start", ctx);
+			const predecessorFactory = factory;
+			const predecessorComponent = component;
+			expect(predecessorComponent?.render(80).join("\n")).toBeTruthy();
+
+			rejectReplacement = true;
+			await (
+				commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+			).handler("", ctx);
+			expect(factory).toBe(predecessorFactory);
+			expect(component).toBe(predecessorComponent);
+			const requestsBeforeTick = tui.requestRender.mock.calls.length;
+			vi.advanceTimersByTime(1000);
+			expect(tui.requestRender.mock.calls.length).toBeGreaterThan(requestsBeforeTick);
+
+			rejectReplacement = false;
+			await emit(handlers, "session_shutdown", ctx);
+			expect(factory).toBeUndefined();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("preserves an owned Starship Footer when a live Native transition fails", async () => {
+		initTheme(undefined, false);
+		vi.useFakeTimers();
+		try {
+			writeFileSync(
+				join(isolatedAgentDir.path, "zentui.json"),
+				JSON.stringify({
+					projectRefreshIntervalMs: 0,
+					components: {
+						footer: { style: "starship", styles: { starship: { format: "$time" } } },
+					},
+				}),
+			);
+			const commands = new Map<string, unknown>();
+			let factory: FooterFactory | undefined;
+			let component: ReturnType<FooterFactory> | undefined;
+			let rejectNative = false;
+			const tui = { requestRender: vi.fn() };
+			const ui = {
+				theme: makeTheme(),
+				notify() {},
+				setEditorComponent() {},
+				getEditorComponent: () => undefined,
+				setFooter(next: FooterFactory | undefined) {
+					if (rejectNative && next === undefined) throw new Error("native unavailable");
+					component?.dispose?.();
+					factory = next;
+					component = next?.(tui, makeTheme(), {
+						onBranchChange: () => () => {},
+						getExtensionStatuses: () => new Map<string, string>(),
+					});
+				},
+			};
+			const handlers = loadExtension({ commands });
+			const ctx = makeContext({ ui });
+			await emit(handlers, "session_start", ctx);
+			const predecessorFactory = factory;
+			const predecessorComponent = component;
+
+			rejectNative = true;
+			await (
+				commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+			).handler("footer off", ctx);
+			expect(factory).toBe(predecessorFactory);
+			expect(component).toBe(predecessorComponent);
+			const requestsBeforeTick = tui.requestRender.mock.calls.length;
+			vi.advanceTimersByTime(1000);
+			expect(tui.requestRender.mock.calls.length).toBeGreaterThan(requestsBeforeTick);
+
+			rejectNative = false;
+			await (
+				commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+			).handler("footer off", ctx);
+			expect(factory).toBeUndefined();
+			await emit(handlers, "session_shutdown", ctx);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("preserves an owned Hidden Footer when a live Native transition fails", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ projectRefreshIntervalMs: 0, components: { footer: { style: "hidden" } } }),
+		);
+		const commands = new Map<string, unknown>();
+		let factory: FooterFactory | undefined;
+		let component: ReturnType<FooterFactory> | undefined;
+		let rejectNative = false;
+		const ui = {
+			theme: makeTheme(),
+			notify() {},
+			setEditorComponent() {},
+			getEditorComponent: () => undefined,
+			setFooter(next: FooterFactory | undefined) {
+				if (rejectNative && next === undefined) throw new Error("native unavailable");
+				component?.dispose?.();
+				factory = next;
+				component = next?.({ requestRender() {} }, makeTheme(), {
+					onBranchChange: () => () => {},
+					getExtensionStatuses: () => new Map<string, string>(),
+				});
+			},
+		};
+		const handlers = loadExtension({ commands });
+		const ctx = makeContext({ ui });
+		await emit(handlers, "session_start", ctx);
+		const predecessorFactory = factory;
+		const predecessorComponent = component;
+		expect(predecessorComponent?.render(80)).toEqual([]);
+
+		rejectNative = true;
+		await (
+			commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+		).handler("footer off", ctx);
+		expect(factory).toBe(predecessorFactory);
+		expect(component).toBe(predecessorComponent);
+
+		rejectNative = false;
+		await (
+			commands.get("zentui") as { handler(args: string, ctx: unknown): Promise<void> }
+		).handler("footer off", ctx);
+		expect(factory).toBeUndefined();
+		await emit(handlers, "session_shutdown", ctx);
 	});
 
 	it("clears ownership after Pi-style external disposal and leaves the replacement on shutdown", async () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -78,11 +78,9 @@ function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 					? config.features.viewportIndicators
 					: editor.viewportIndicators,
 				styles: {
+					...editor.styles,
 					polished: {
 						...editor.styles.polished,
-						copyFriendly: flatChanged("features")
-							? config.features.copyFriendly
-							: editor.styles.polished.copyFriendly,
 						metadataFormat: flatChanged("editorMetadataFormat")
 							? config.editorMetadataFormat
 							: editor.styles.polished.metadataFormat,
@@ -98,14 +96,7 @@ function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 				colorSource: flatChanged("colorSources")
 					? config.colorSources.userMessages
 					: messages.colorSource,
-				styles: {
-					framed: {
-						...messages.styles.framed,
-						copyFriendly: flatChanged("features")
-							? config.features.copyFriendly
-							: messages.styles.framed.copyFriendly,
-					},
-				},
+				styles: { ...messages.styles },
 			},
 			selectorBorders: {
 				...selectors,
@@ -323,7 +314,7 @@ function makeStrictTheme(): Theme {
 	} as unknown as Theme;
 }
 
-function makeUi(prefix = "") {
+function _makeUi(prefix = "") {
 	let editorComponent: unknown;
 	let editorText = "";
 	return {
@@ -405,39 +396,28 @@ function configWithExtensionStatuses(
 	};
 }
 
-function configWithFeatures(features: Partial<PolishedTuiConfig["features"]>): PolishedTuiConfig {
-	const merged = { ...defaultConfig.features, ...features };
-	const editor = defaultConfig.components.editor;
-	const messages = defaultConfig.components.userMessages;
+function configWithLowRailStyle(lowRail: boolean): PolishedTuiConfig {
 	return {
 		...defaultConfig,
-		features: merged,
 		components: {
 			...defaultConfig.components,
 			editor: {
-				...editor,
-				enabled: merged.editor,
-				viewportIndicators: merged.viewportIndicators,
-				styles: {
-					...editor.styles,
-					polished: { ...editor.styles.polished, copyFriendly: merged.copyFriendly },
-				},
+				...defaultConfig.components.editor,
+				style: lowRail ? "polished-copy-friendly" : "polished",
 			},
-			userMessages: {
-				...messages,
-				enabled: merged.editor,
-				styles: {
-					framed: { ...messages.styles.framed, copyFriendly: merged.copyFriendly },
-				},
-			},
-			selectorBorders: { ...defaultConfig.components.selectorBorders, enabled: merged.editor },
-			footer: { ...defaultConfig.components.footer, enabled: merged.statusLine },
 		},
 	};
 }
 
 function stripPromptMarks(line: string): string {
 	return line.replaceAll(/\x1b]133;[ABC]\x07/g, "").replaceAll(/\x1b\[[0-9;]*m/g, "");
+}
+
+function expectSinglePromptZone(rendered: string): void {
+	expect(rendered.match(/\x1b\]133;A\x07/g)).toHaveLength(1);
+	expect(rendered.match(/\x1b\]133;B\x07/g)).toHaveLength(1);
+	expect(rendered.match(/\x1b\]133;C\x07/g)).toHaveLength(1);
+	expect(rendered).not.toContain("\x9d133;");
 }
 
 function stripTestTags(line: string): string {
@@ -1572,19 +1552,10 @@ describe("Pi docs compliance", () => {
 		expect(editorFactory).toBe(takeoverFactory);
 	});
 
-	it("persists independent message and copy-friendly commands plus the atomic recipe", async () => {
-		writeFileSync(
-			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({
-				components: {
-					editor: { styles: { polished: { copyFriendly: false } } },
-					userMessages: {
-						enabled: true,
-						styles: { framed: { copyFriendly: true } },
-					},
-				},
-			}),
-		);
+	it("routes removed copy commands through the ordinary usage warning without mutation", async () => {
+		const path = join(isolatedAgentDir.path, "zentui.json");
+		writeFileSync(path, JSON.stringify({ components: { editor: { style: "minimalist" } } }));
+		const before = readFileSync(path, "utf8");
 		const commands = new Map<string, unknown>();
 		const handlers = loadExtension({ commands });
 		const notifications: string[] = [];
@@ -1594,30 +1565,16 @@ describe("Pi docs compliance", () => {
 			handler(args: string, ctx: unknown): Promise<void>;
 		};
 
-		await command.handler("messages disable", ctx);
-		await command.handler("editor-copy-friendly enable", ctx);
-		await command.handler("message-copy-friendly disable", ctx);
-		let persisted = JSON.parse(
-			readFileSync(join(isolatedAgentDir.path, "zentui.json"), "utf8"),
-		) as PolishedTuiConfig;
-		expect(persisted.components.userMessages.enabled).toBe(false);
-		expect(persisted.components.editor.enabled).toBe(true);
-		expect(persisted.components.selectorBorders.enabled).toBe(true);
-		expect(persisted.components.editor.styles.polished.copyFriendly).toBe(true);
-		expect(persisted.components.userMessages.styles.framed.copyFriendly).toBe(false);
-
-		await command.handler("copy-friendly disable", ctx);
-		persisted = JSON.parse(
-			readFileSync(join(isolatedAgentDir.path, "zentui.json"), "utf8"),
-		) as PolishedTuiConfig;
-		expect(persisted.components.editor.styles.polished.copyFriendly).toBe(false);
-		expect(persisted.components.userMessages.styles.framed.copyFriendly).toBe(false);
-		expect(notifications).toEqual([
-			"User messages: disabled",
-			"Editor copy-friendly: enabled",
-			"Message copy-friendly: disabled",
-			"Copy-friendly mode: disabled",
-		]);
+		for (const args of [
+			"copy-friendly disable",
+			"editor-copy-friendly enable",
+			"message-copy-friendly disable",
+		]) {
+			await command.handler(args, ctx);
+		}
+		expect(readFileSync(path, "utf8")).toBe(before);
+		expect(notifications).toHaveLength(3);
+		expect(notifications.every((message) => message.startsWith("Usage: /zentui"))).toBe(true);
 		await emit(handlers, "session_shutdown", ctx);
 	});
 
@@ -1663,24 +1620,18 @@ describe("Pi docs compliance", () => {
 		}
 	});
 
-	it("renders polished-editor and framed-message copy-friendly settings independently", () => {
+	it("renders editor and message style selections independently", () => {
 		let config: PolishedTuiConfig = {
 			...defaultConfig,
 			components: {
 				...defaultConfig.components,
 				editor: {
 					...defaultConfig.components.editor,
-					styles: {
-						...defaultConfig.components.editor.styles,
-						polished: {
-							...defaultConfig.components.editor.styles.polished,
-							copyFriendly: true,
-						},
-					},
+					style: "polished-copy-friendly",
 				},
 				userMessages: {
 					...defaultConfig.components.userMessages,
-					styles: { framed: { copyFriendly: false } },
+					style: "framed",
 				},
 			},
 		};
@@ -1706,27 +1657,62 @@ describe("Pi docs compliance", () => {
 				...config,
 				components: {
 					...config.components,
-					editor: {
-						...config.components.editor,
-						styles: {
-							...config.components.editor.styles,
-							polished: {
-								...config.components.editor.styles.polished,
-								copyFriendly: false,
-							},
-						},
-					},
-					userMessages: {
-						...config.components.userMessages,
-						styles: { framed: { copyFriendly: true } },
-					},
+					editor: { ...config.components.editor, style: "polished" },
+					userMessages: { ...config.components.userMessages, style: "labeled" },
 				},
 			};
 			expect(editor.render(80).join("\n")).toContain("│");
-			expect(new UserMessageComponent("message 2").render(80).join("\n")).not.toContain("│");
+			expect(new UserMessageComponent("message 2").render(80).join("\n")).toContain("User");
 		} finally {
 			cleanup();
 		}
+	});
+
+	it.each([
+		["polished", "framed"],
+		["polished", "compact"],
+		["polished", "labeled"],
+		["polished-copy-friendly", "framed"],
+		["polished-copy-friendly", "compact"],
+		["polished-copy-friendly", "labeled"],
+		["minimalist", "framed"],
+		["minimalist", "compact"],
+		["minimalist", "labeled"],
+	] as const)("composes %s Editor with %s messages independently", (editorStyle, messageStyle) => {
+		const config = structuredClone(defaultConfig);
+		config.components.editor.style = editorStyle;
+		config.components.userMessages.style = messageStyle;
+		installUserMessageStyleProduction(
+			() => makeTheme(),
+			() => config,
+		);
+		const messageWrapper = UserMessageComponent.prototype.render;
+		const editor = new PolishedEditorProduction(
+			{ requestRender() {}, terminal: { rows: 24, cols: 80 } } as never,
+			{ borderColor: (text: string) => text, selectList: {} } as never,
+			{} as never,
+			makeTheme(),
+			() => config,
+			() => ({ modelLabel: "model", providerLabel: "provider" }),
+			() => "off",
+			() => ({ cwd: "/project" }),
+		);
+		editor.setText("draft");
+		const editorRendered = editor.render(80).join("\n");
+		const messageRendered = new UserMessageComponent("message").render(40).join("\n");
+
+		if (editorStyle === "polished") expect(editorRendered).toContain("│");
+		else if (editorStyle === "polished-copy-friendly") expect(editorRendered).not.toContain("│");
+		else expect(editorRendered).toContain("╭");
+		if (messageStyle === "framed") expect(stripPromptMarks(messageRendered)).toContain("────");
+		else if (messageStyle === "compact") {
+			expect(stripPromptMarks(messageRendered)).toContain("│ message");
+			expect(stripPromptMarks(messageRendered)).not.toContain("────");
+		} else expect(stripPromptMarks(messageRendered)).toContain("User");
+		expect(config.components.editor.style).toBe(editorStyle);
+		expect(config.components.userMessages).toMatchObject({ enabled: true, style: messageStyle });
+		expect(config.components.footer.enabled).toBe(true);
+		expect(UserMessageComponent.prototype.render).toBe(messageWrapper);
 	});
 
 	it("renders user messages like the ZentUI prompt box", () => {
@@ -1751,20 +1737,21 @@ describe("Pi docs compliance", () => {
 		expect(rendered).not.toContain("xhigh");
 	});
 
-	it("hides previous user-message rails in copy-friendly mode", () => {
+	it("renders compact user messages without horizontal borders", () => {
+		const config = structuredClone(defaultConfig);
+		config.components.userMessages.style = "compact";
 		installUserMessageStyle(
 			() => makeTaggedTheme(),
-			() => configWithFeatures({ copyFriendly: true }),
+			() => config,
 		);
 
 		const lines = new UserMessageComponent("hello").render(80).map(stripPromptMarks);
 		const rendered = lines.join("\n");
 
-		expect(rendered).not.toContain("│");
-		expect(rendered).not.toContain("❯");
+		expect(rendered).toContain("│");
 		expect(rendered).toContain("hello");
-		expect(stripTestTags(lines[0])).toMatch(/^─+$/);
-		expect(stripTestTags(lines.at(-1) ?? "")).toMatch(/^─+$/);
+		expect(stripTestTags(lines[0])).not.toMatch(/^─+$/);
+		expect(stripTestTags(lines.at(-1) ?? "")).not.toMatch(/^─+$/);
 	});
 
 	it("renders the configured rail glyph on user messages", () => {
@@ -1810,6 +1797,41 @@ describe("Pi docs compliance", () => {
 		renderMessage(79);
 		expect(getChildren).toHaveBeenCalledTimes(1);
 		expect(fg.mock.calls.length).toBeGreaterThan(fgCallsAfterFirstRender);
+	});
+
+	it("restyles cached history when message style or relevant chrome changes", () => {
+		let config = structuredClone(defaultConfig);
+		const fg = vi.fn((color: string, text: string) => `[${color}]${text}`);
+		const theme = { ...makeTaggedTheme(), fg } as unknown as Theme;
+		const wrapperBefore = UserMessageComponent.prototype.render;
+		installUserMessageStyle(
+			() => theme,
+			() => config,
+		);
+		const installedWrapper = UserMessageComponent.prototype.render;
+		const message = new UserMessageComponent("hello");
+
+		const framed = message.render(30).join("\n");
+		const callsAfterFramed = fg.mock.calls.length;
+		expect(framed).toContain("────");
+
+		config = structuredClone(config);
+		config.components.footer.enabled = false;
+		expect(message.render(30).join("\n")).toBe(framed);
+		expect(fg).toHaveBeenCalledTimes(callsAfterFramed);
+
+		config = structuredClone(config);
+		config.components.userMessages.style = "compact";
+		const compact = message.render(30).join("\n");
+		expect(compact).toContain("│");
+		expect(compact).not.toContain("────");
+
+		config = structuredClone(config);
+		config.components.userMessages.style = "labeled";
+		const labeled = message.render(30).join("\n");
+		expect(labeled).toContain("User");
+		expect(UserMessageComponent.prototype.render).toBe(installedWrapper);
+		expect(installedWrapper).not.toBe(wrapperBefore);
 	});
 
 	it("clears cached user-message rendering on invalidate", () => {
@@ -2065,15 +2087,264 @@ describe("Pi docs compliance", () => {
 		expect(UserMessageComponent.prototype.render).toBe(predecessor);
 	});
 
-	it("preserves OSC 133 prompt-zone markers around user-message output", async () => {
-		const handlers = loadExtension();
-		await emit(handlers, "session_start", makeContext({ ui: makeUi() }));
+	it.each(["framed", "compact", "labeled"] as const)(
+		"preserves exactly one OSC 133 prompt zone for %s messages",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.userMessages.style = style;
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => config,
+			);
 
-		const lines = new UserMessageComponent("hello").render(40);
+			const rendered = new UserMessageComponent("hello").render(40).join("\n");
+			expect(rendered.match(/\x1b\]133;A\x07/g)).toHaveLength(1);
+			expect(rendered.match(/\x1b\]133;B\x07\x1b\]133;C\x07/g)).toHaveLength(1);
+		},
+	);
 
-		expect(lines[0].startsWith("\x1b]133;A\x07")).toBe(true);
-		expect(lines.at(-1)).toContain("\x1b]133;B\x07\x1b]133;C\x07");
+	it("removes BEL, ST, and C1-ST terminated OSC 133 zones without removing user text", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const hostile = "before \x1b]133;A\x07middle \x1b]133;B\x1b\\after \x9d133;C\x9c final";
+		const rendered = new UserMessageComponent(hostile).render(80).join("\n");
+
+		expectSinglePromptZone(rendered);
+		expect(rendered).toContain("before middle after  final");
 	});
+
+	it.each([
+		["unterminated ESC OSC", "before \x1b]133;Atail", "before tail", "\x1b]133"],
+		["unterminated C1 OSC", "before \x9d133;Btail", "before tail", "\x9d133"],
+		["partial ESC boundary", "before \x1b]13", "before ", "\x1b]13"],
+		["partial C1 boundary", "before \x9d1", "before ", "\x9d1"],
+		["complete command boundary", "before \x1b]133", "before ", "\x1b]133"],
+	] as const)(
+		"neutralizes %s while preserving trailing text",
+		(_name, hostile, visibleText, hostileFragment) => {
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => defaultConfig,
+			);
+			const rendered = new UserMessageComponent(hostile).render(80).join("\n");
+
+			expectSinglePromptZone(rendered);
+			expect(rendered).toContain(visibleText);
+			expect(stripPromptMarks(rendered)).not.toContain(hostileFragment);
+		},
+	);
+
+	it("neutralizes multiple complete and incomplete OSC 133 sequences", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const hostile = "one \x1b]133;A\x07two \x9d133;B\x9cthree \x1b]133;Cfour";
+		const rendered = new UserMessageComponent(hostile).render(80).join("\n");
+
+		expectSinglePromptZone(rendered);
+		expect(rendered).toContain("one two three four");
+	});
+
+	it.each([
+		["7-bit then C1", "\x1b]9;payload ", "\x9d133;A\x9c", "\x1b]9;"],
+		["C1 then 7-bit", "\x9d9;payload ", "\x1b]133;A\x07", "\x9d9;"],
+	] as const)(
+		"bounds an unterminated unrelated OSC before a nested OSC 133 (%s)",
+		(_name, unrelated, hostile, openIntroducer) => {
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => defaultConfig,
+			);
+			const rendered = new UserMessageComponent(`before ${unrelated}${hostile}after`)
+				.render(80)
+				.join("\n");
+			const visible = stripPromptMarks(rendered);
+
+			expectSinglePromptZone(rendered);
+			expect(visible).toContain("before 9;payload after");
+			expect(visible).not.toContain(openIntroducer);
+			expect(visible).not.toContain(hostile);
+		},
+	);
+
+	it.each([
+		[
+			"C1 then 7-bit",
+			"\x9d133;Btail ",
+			"\x1b]8;;https://example.com\x1b\\",
+			"\x1b]8;;\x1b\\",
+			"\x9d133",
+		],
+		["7-bit", "\x1b]133;Btail ", "\x1b]8;;https://example.com\x1b\\", "\x1b]8;;\x1b\\", "\x1b]133"],
+	] as const)(
+		"preserves a complete OSC 8 after an incomplete OSC 133 (%s)",
+		(_name, hostile, open, close, hostileFragment) => {
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => defaultConfig,
+			);
+			const rendered = new UserMessageComponent(`before ${hostile}${open}link${close} after`)
+				.render(100)
+				.join("\n");
+			const visible = stripPromptMarks(rendered);
+
+			expectSinglePromptZone(rendered);
+			expect(rendered).toContain(`${open}link${close}`);
+			expect(visible).toContain("before tail ");
+			expect(visible).not.toContain(hostileFragment);
+		},
+	);
+
+	it("processes multiple nested OSC boundaries without overconsuming later sequences", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const open = "\x1b]8;;https://example.com\x1b\\";
+		const close = "\x1b]8;;\x1b\\";
+		const hostile = `one \x1b]9;alpha \x9d133;A${open}link${close} two \x1b]133;Btail`;
+		const rendered = new UserMessageComponent(hostile).render(120).join("\n");
+		const visible = stripPromptMarks(rendered);
+
+		expectSinglePromptZone(rendered);
+		expect(rendered).toContain(`${open}link${close}`);
+		expect(visible).toContain("one 9;alpha ");
+		expect(visible).toContain(" two tail");
+		expect(visible).not.toContain("\x1b]9;");
+		expect(visible).not.toContain("\x9d133");
+		expect(visible).not.toContain("\x1b]133");
+	});
+
+	it("preserves unrelated complete OSC 8 sequences byte-for-byte", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const open = "\x1b]8;;https://example.com\x1b\\";
+		const close = "\x1b]8;;\x1b\\";
+		const rendered = new UserMessageComponent(`before ${open}link${close} after`)
+			.render(80)
+			.join("\n");
+
+		expectSinglePromptZone(rendered);
+		expect(rendered).toContain(`${open}link${close}`);
+	});
+
+	it.each(["framed", "compact", "labeled"] as const)(
+		"preserves mixed 7-bit/C1 OSC 8 through sanitization and Markdown for %s",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.userMessages.style = style;
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => config,
+			);
+			const starts = ["\x1b]", "\x9d"];
+			const terminators = ["\x07", "\x1b\\", "\x9c"];
+			const preserved: string[] = [];
+			let source = "before \x9d133;Atail ";
+			for (const [index, start] of starts.entries()) {
+				for (const [terminatorIndex, terminator] of terminators.entries()) {
+					const id = `${index}-${terminatorIndex}`;
+					const open = `${start}8;;https://example.com/${id}${terminator}`;
+					const close = `${start}8;;${terminator}`;
+					const sequence = `${open}link-${id}${close}`;
+					preserved.push(sequence);
+					source += `${sequence} `;
+				}
+			}
+			source += `${preserved[0]} [markdown](https://markdown.example) \x1b]133;Btail`;
+
+			const rendered = new UserMessageComponent(source).render(240).join("\n");
+			expectSinglePromptZone(rendered);
+			for (const sequence of preserved) expect(rendered).toContain(sequence);
+			expect(rendered.split(preserved[0])).toHaveLength(3);
+			expect(rendered).toContain("markdown");
+			const visible = stripPromptMarks(rendered);
+			expect(visible).not.toContain("\x9d133");
+			expect(visible).not.toContain("\x1b]133");
+		},
+	);
+
+	it("delegates byte-for-byte when message theme rendering throws", () => {
+		const predecessor = (width: number) => [`native:${width}`];
+		UserMessageComponent.prototype.render = predecessor;
+		const failingTheme = {
+			...makeTheme(),
+			fg() {
+				throw new Error("theme failed");
+			},
+		} as unknown as Theme;
+		installUserMessageStyle(
+			() => failingTheme,
+			() => defaultConfig,
+		);
+
+		const rendered = UserMessageComponent.prototype.render.call(
+			{ children: [{ text: "hello" }] },
+			42,
+		);
+		expect(rendered).toEqual(["native:42"]);
+		expect(rendered.join("\n")).not.toContain("\x1b]133;");
+	});
+
+	it("delegates byte-for-byte when message cache-key construction throws", () => {
+		const predecessor = (width: number) => [`native:${width}`];
+		UserMessageComponent.prototype.render = predecessor;
+		const config = structuredClone(defaultConfig);
+		Object.defineProperty(config, "components", {
+			get() {
+				throw new Error("cache key failed");
+			},
+		});
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => config,
+		);
+
+		const rendered = UserMessageComponent.prototype.render.call(
+			{ children: [{ text: "hello" }] },
+			42,
+		);
+		expect(rendered).toEqual(["native:42"]);
+		expect(rendered.join("\n")).not.toContain("\x1b]133;");
+	});
+
+	it("keeps zero-width output marker-safe", () => {
+		installUserMessageStyle(
+			() => makeTheme(),
+			() => defaultConfig,
+		);
+		const rendered = new UserMessageComponent("hello").render(0).join("\n");
+		expect(rendered).toBe("\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07");
+	});
+
+	it.each(["theme", "config"] as const)(
+		"fails open byte-for-byte when the %s getter throws",
+		(failure) => {
+			const predecessor = (width: number) => [`fallback:${width}`];
+			UserMessageComponent.prototype.render = predecessor;
+			installUserMessageStyle(
+				() => {
+					if (failure === "theme") throw new Error("theme failed");
+					return makeTheme();
+				},
+				() => {
+					if (failure === "config") throw new Error("config failed");
+					return defaultConfig;
+				},
+			);
+			const lines = UserMessageComponent.prototype.render.call(
+				{ children: [{ text: "hello" }] },
+				42,
+			);
+			expect(lines).toEqual(["fallback:42"]);
+			expect(lines.join("\n")).not.toContain("\x1b]133;");
+		},
+	);
 
 	it("keeps user-message output within the requested render width", async () => {
 		const handlers = loadExtension();
@@ -3654,13 +3925,13 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain("[text]Anthropic");
 	});
 
-	it("hides editor rails in copy-friendly mode", () => {
+	it("hides editor rails in the low-rail polished style", () => {
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
 			{} as never,
 			makeTaggedTheme(),
-			() => configWithFeatures({ copyFriendly: true }),
+			() => configWithLowRailStyle(true),
 			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
 			() => "high",
 		);
@@ -3763,10 +4034,10 @@ describe("Pi docs compliance", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 16)).toBe(true);
 	});
 
-	it("keeps Vim status when long custom metadata collides in rail and copy-friendly modes", () => {
-		for (const copyFriendly of [false, true]) {
+	it("keeps Vim status when long custom metadata collides in both polished modes", () => {
+		for (const lowRail of [false, true]) {
 			const config = {
-				...configWithFeatures({ copyFriendly }),
+				...configWithLowRailStyle(lowRail),
 				editorMetadataFormat: "very-long-custom-metadata-$model-$provider",
 			};
 			const editor = new WrappedPolishedEditor(
@@ -3792,16 +4063,15 @@ describe("Pi docs compliance", () => {
 		}
 	});
 
-	it("keeps blank structural metadata rows in copy-friendly mode", () => {
+	it("keeps blank structural metadata rows in the low-rail polished style", () => {
+		const config = configWithLowRailStyle(true);
+		config.components.editor.styles["polished-copy-friendly"].metadataFormat = "($unknown)";
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
 			{} as never,
 			makeTaggedTheme(),
-			() => ({
-				...configWithFeatures({ copyFriendly: true }),
-				editorMetadataFormat: "($unknown)",
-			}),
+			() => config,
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "off",
 		);
@@ -3812,18 +4082,16 @@ describe("Pi docs compliance", () => {
 		expect(lines.at(-2)).toBe(" ");
 	});
 
-	it("uses custom copy-friendly editor prompt icon and color", () => {
+	it("uses the custom low-rail Editor prompt icon and color", () => {
+		const config = configWithLowRailStyle(true);
+		config.icons = { ...config.icons, editorPrompt: "›" };
+		config.colors = { ...config.colors, editorPrompt: "warning" };
 		const editor = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
 			{} as never,
 			makeTaggedTheme(),
-			() => ({
-				...defaultConfig,
-				icons: { ...defaultConfig.icons, editorPrompt: "›" },
-				colors: { ...defaultConfig.colors, editorPrompt: "warning" },
-				features: { ...defaultConfig.features, copyFriendly: true },
-			}),
+			() => config,
 			() => ({ modelLabel: "claude-sonnet", providerLabel: "Anthropic" }),
 			() => "off",
 		);
@@ -3971,11 +4239,9 @@ describe("Pi docs compliance", () => {
 		expect(lines.filter((line) => /^─+$/.test(stripTestTags(line).trim()))).toHaveLength(2);
 	});
 
-	it("unwraps branded copy-friendly frames without duplicating metadata", () => {
-		const config = {
-			...configWithFeatures({ copyFriendly: true }),
-			editorMetadataFormat: "copy-meta",
-		};
+	it("unwraps branded low-rail polished frames without duplicating metadata", () => {
+		const config = configWithLowRailStyle(true);
+		config.components.editor.styles["polished-copy-friendly"].metadataFormat = "copy-meta";
 		const inner = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,
@@ -4423,9 +4689,8 @@ describe("Pi docs compliance", () => {
 		expect(featureChanges).toEqual([{ enabled: false }]);
 	});
 
-	it("toggles copy-friendly mode from direct Zentui slash-command arguments", async () => {
+	it("treats removed copy commands as unknown arguments", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const featureChanges: boolean[] = [];
 		const notifications: Array<{ message: string; level: string }> = [];
 
 		registerZentuiSettingsCommand(
@@ -4437,10 +4702,6 @@ describe("Pi docs compliance", () => {
 			{
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources() {},
-				setCopyFriendlyRecipe(enabled) {
-					featureChanges.push(enabled);
-				},
 				setFooterSegments() {},
 				setFooterFormat() {},
 				setIconMode() {},
@@ -4465,8 +4726,9 @@ describe("Pi docs compliance", () => {
 			},
 		});
 
-		expect(featureChanges).toEqual([true]);
-		expect(notifications).toEqual([{ message: "Copy-friendly mode: enabled", level: "info" }]);
+		expect(notifications).toHaveLength(1);
+		expect(notifications[0]?.message).toMatch(/^Usage: \/zentui/);
+		expect(notifications[0]?.level).toBe("warning");
 	});
 
 	it("toggles viewport indicators from direct Zentui slash-command arguments", async () => {

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -3140,9 +3140,12 @@ describe("Pi docs compliance", () => {
 				{} as never,
 			);
 
-			await vi.waitFor(() => {
-				expect(editor.render(120).join("\n")).toContain("minimalist-test");
-			});
+			await vi.waitFor(
+				() => {
+					expect(editor.render(120).join("\n")).toContain("minimalist-test");
+				},
+				{ timeout: 3_000 },
+			);
 		} finally {
 			await emit(handlers, "session_shutdown", ctx);
 			rmSync(cwd, { recursive: true, force: true });

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1462,7 +1462,10 @@ describe("Pi docs compliance", () => {
 	it("suppresses the production footer only while the installed minimalist editor decorates", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
+			JSON.stringify({
+				components: { editor: { style: "minimalist" } },
+				projectRefreshIntervalMs: 0,
+			}),
 		);
 		const handlers = loadExtension();
 		let editorFactory: unknown;
@@ -1551,7 +1554,10 @@ describe("Pi docs compliance", () => {
 	it("updates session names through a wrapped minimalist editor", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
+			JSON.stringify({
+				components: { editor: { style: "minimalist" } },
+				projectRefreshIntervalMs: 0,
+			}),
 		);
 		const handlers = loadExtension();
 		const existingEditorFactory = () => ({
@@ -1603,7 +1609,10 @@ describe("Pi docs compliance", () => {
 	it("keeps the production footer for unsupported wrapped minimalist output", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
+			JSON.stringify({
+				components: { editor: { style: "minimalist" } },
+				projectRefreshIntervalMs: 0,
+			}),
 		);
 		const handlers = loadExtension();
 		const existingFactory = () => ({
@@ -1659,7 +1668,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorStyle: "minimalist",
+				components: { editor: { style: "minimalist" } },
 				projectRefreshIntervalMs: 0,
 				features: { statusLine: false },
 			}),
@@ -1698,7 +1707,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorStyle: "minimalist",
+				components: { editor: { style: "minimalist" } },
 				projectRefreshIntervalMs: 0,
 				features: { statusLine: false },
 			}),
@@ -1766,7 +1775,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorStyle: "minimalist",
+				components: { editor: { style: "minimalist" } },
 				projectRefreshIntervalMs: 5_000,
 				features: { statusLine: false },
 			}),

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -2381,7 +2381,7 @@ describe("Pi docs compliance", () => {
 		},
 	);
 
-	it("allows only 7-bit OSC 8 from raw user-message controls before adding one prompt zone", () => {
+	it("strips every raw user-message control before adding one prompt zone", () => {
 		installUserMessageStyle(
 			() => makeTheme(),
 			() => defaultConfig,
@@ -2392,7 +2392,9 @@ describe("Pi docs compliance", () => {
 		const rendered = new UserMessageComponent(hostile).render(100).join("\n");
 
 		expectSinglePromptZone(rendered);
-		expect(rendered).toContain(`${open}link${close}`);
+		expect(rendered).toContain("link");
+		expect(rendered).not.toContain(open);
+		expect(rendered).not.toContain(close);
 		expect(rendered).not.toContain("\x1b]0;");
 		expect(rendered).not.toContain("\x1b]52;");
 		expect(rendered).not.toContain("PAYLOAD");
@@ -2402,7 +2404,7 @@ describe("Pi docs compliance", () => {
 	});
 
 	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
-		"preserves row-end OSC 8 without reopening the Markdown-destination exploit for %s",
+		"strips row-end and Markdown-destination raw OSC 8 for %s",
 		(style) => {
 			const config = structuredClone(defaultConfig);
 			config.components.userMessages.style = style;
@@ -2419,10 +2421,9 @@ describe("Pi docs compliance", () => {
 					.render(width)
 					.join("\n");
 				expectSinglePromptZone(preserved);
-				expect(preserved.split(open)).toHaveLength(2);
-				expect(preserved.split(close)).toHaveLength(2);
-				expect(preserved.indexOf(open)).toBeLessThan(preserved.indexOf(close));
-				expect(preserved).not.toMatch(/[\u200b\u200c\u2060]/);
+				expect(preserved).toContain("LINK");
+				expect(preserved).not.toContain(open);
+				expect(preserved).not.toContain(close);
 
 				const exploit = new UserMessageComponent(
 					`[docs](https://markdown.example/${open}nested${close}) ${clipboard}tail`,
@@ -2516,7 +2517,7 @@ describe("Pi docs compliance", () => {
 		],
 		["7-bit", "\x1b]133;Btail ", "\x1b]8;;https://example.com\x1b\\", "\x1b]8;;\x1b\\", "\x1b]133"],
 	] as const)(
-		"preserves a complete OSC 8 after an incomplete OSC 133 (%s)",
+		"strips complete OSC 8 after an incomplete OSC 133 (%s)",
 		(_name, hostile, open, close, hostileFragment) => {
 			installUserMessageStyle(
 				() => makeTheme(),
@@ -2528,7 +2529,9 @@ describe("Pi docs compliance", () => {
 			const visible = stripPromptMarks(rendered);
 
 			expectSinglePromptZone(rendered);
-			expect(rendered).toContain(`${open}link${close}`);
+			expect(rendered).toContain("link");
+			expect(rendered).not.toContain(open);
+			expect(rendered).not.toContain(close);
 			expect(visible).toContain("before tail ");
 			expect(visible).not.toContain(hostileFragment);
 		},
@@ -2546,7 +2549,9 @@ describe("Pi docs compliance", () => {
 		const visible = stripPromptMarks(rendered);
 
 		expectSinglePromptZone(rendered);
-		expect(rendered).toContain(`${open}link${close}`);
+		expect(rendered).toContain("link");
+		expect(rendered).not.toContain(open);
+		expect(rendered).not.toContain(close);
 		expect(visible).toContain("one 9;alpha ");
 		expect(visible).toContain(" two tail");
 		expect(visible).not.toContain("\x1b]9;");
@@ -2554,7 +2559,7 @@ describe("Pi docs compliance", () => {
 		expect(visible).not.toContain("\x1b]133");
 	});
 
-	it("preserves unrelated complete OSC 8 sequences byte-for-byte", () => {
+	it("strips unrelated complete raw OSC 8 sequences", () => {
 		installUserMessageStyle(
 			() => makeTheme(),
 			() => defaultConfig,
@@ -2566,11 +2571,13 @@ describe("Pi docs compliance", () => {
 			.join("\n");
 
 		expectSinglePromptZone(rendered);
-		expect(rendered).toContain(`${open}link${close}`);
+		expect(rendered).toContain("link");
+		expect(rendered).not.toContain(open);
+		expect(rendered).not.toContain(close);
 	});
 
 	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
-		"preserves 7-bit OSC 8 and strips C1 controls through Markdown for %s",
+		"strips raw OSC 8 and keeps Markdown links for %s",
 		(style) => {
 			const config = structuredClone(defaultConfig);
 			config.components.userMessages.style = style;
@@ -2591,10 +2598,12 @@ describe("Pi docs compliance", () => {
 
 			const rendered = new UserMessageComponent(source).render(240).join("\n");
 			expectSinglePromptZone(rendered);
-			for (const sequence of preserved) expect(rendered).toContain(sequence);
-			expect(rendered.split(preserved[0])).toHaveLength(3);
+			for (const sequence of preserved) expect(rendered).not.toContain(sequence);
+			expect(rendered).toContain("link-0");
+			expect(rendered).toContain("link-1");
 			expect(rendered).toContain("c1-link");
 			expect(rendered).toContain("markdown");
+			expect(rendered).toContain("\x1b]8;;https://markdown.example");
 			const visible = stripPromptMarks(rendered);
 			expect(visible).not.toContain("\x9d");
 			expect(visible).not.toContain("\x9c");
@@ -2639,9 +2648,15 @@ describe("Pi docs compliance", () => {
 			() => defaultConfig,
 		);
 		const clipboard = "\x1b]52;c;c2VjcmV0\x07";
-		const output = new UserMessageComponent(`before ${clipboard}after`).render(80).join("\n");
-		expect(output).toContain("before after");
+		const open = "\x1b]8;;https://raw.example\x07";
+		const close = "\x1b]8;;\x07";
+		const output = new UserMessageComponent(`before ${clipboard}${open}link${close} after`)
+			.render(80)
+			.join("\n");
+		expect(output).toContain("before link after");
 		expect(output).not.toContain("\x1b]52");
+		expect(output).not.toContain(open);
+		expect(output).not.toContain(close);
 		expect(output).not.toContain("c2VjcmV0");
 		expectSinglePromptZone(output);
 	});

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -552,13 +552,13 @@ describe("Pi docs compliance", () => {
 			}),
 		).toEqual(new Set(["cwd"]));
 	});
-	it("installs message and selector surfaces while the editor is canonically disabled", async () => {
+	it("installs enabled copy-friendly framed messages while the editor is disabled", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
 				components: {
 					editor: { enabled: false },
-					userMessages: { enabled: true },
+					userMessages: { enabled: true, style: "framed-copy-friendly" },
 					selectorBorders: { enabled: true },
 					footer: { enabled: false },
 				},
@@ -585,6 +585,10 @@ describe("Pi docs compliance", () => {
 		expect(editorFactory).toBe(existingFactory);
 		expect(footerFactory).toBe("untouched");
 		expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+		const rendered = new UserMessageComponent("message").render(20).join("\n");
+		expectSinglePromptZone(rendered);
+		expect(stripPromptMarks(rendered)).toContain("────────────────────");
+		expect(stripPromptMarks(rendered)).not.toContain("│");
 		expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
 		await emit(handlers, "session_shutdown", ctx);
 	});
@@ -601,6 +605,8 @@ describe("Pi docs compliance", () => {
 				},
 			}),
 		);
+		const predecessor = (width: number) => [`native:${width}`];
+		UserMessageComponent.prototype.render = predecessor;
 		const handlers = loadExtension();
 		let editorFactory: unknown;
 		let footerFactory: unknown;
@@ -620,7 +626,8 @@ describe("Pi docs compliance", () => {
 		await emit(handlers, "session_start", ctx);
 		expect(editorFactory).toBeTypeOf("function");
 		expect(footerFactory).toBeTypeOf("function");
-		expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
+		expect(UserMessageComponent.prototype.render).toBe(predecessor);
+		expect(new UserMessageComponent("message").render(20)).toEqual(["native:20"]);
 		expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
 		await emit(handlers, "session_shutdown", ctx);
 	});
@@ -1676,12 +1683,15 @@ describe("Pi docs compliance", () => {
 
 	it.each([
 		["opencode", "framed"],
+		["opencode", "framed-copy-friendly"],
 		["opencode", "compact"],
 		["opencode", "labeled"],
 		["opencode-copy-friendly", "framed"],
+		["opencode-copy-friendly", "framed-copy-friendly"],
 		["opencode-copy-friendly", "compact"],
 		["opencode-copy-friendly", "labeled"],
 		["minimalist", "framed"],
+		["minimalist", "framed-copy-friendly"],
 		["minimalist", "compact"],
 		["minimalist", "labeled"],
 	] as const)("composes %s Editor with %s messages independently", (editorStyle, messageStyle) => {
@@ -1710,11 +1720,15 @@ describe("Pi docs compliance", () => {
 		if (editorStyle === "opencode") expect(editorRendered).toContain("│");
 		else if (editorStyle === "opencode-copy-friendly") expect(editorRendered).not.toContain("│");
 		else expect(editorRendered).toContain("╭");
-		if (messageStyle === "framed") expect(stripPromptMarks(messageRendered)).toContain("────");
-		else if (messageStyle === "compact") {
-			expect(stripPromptMarks(messageRendered)).toContain("│ message");
-			expect(stripPromptMarks(messageRendered)).not.toContain("────");
-		} else expect(stripPromptMarks(messageRendered)).toContain("User");
+		const plainMessage = stripPromptMarks(messageRendered);
+		if (messageStyle === "framed") expect(plainMessage).toContain("────");
+		else if (messageStyle === "framed-copy-friendly") {
+			expect(plainMessage).toContain("────");
+			expect(plainMessage).not.toContain("│");
+		} else if (messageStyle === "compact") {
+			expect(plainMessage).toContain("│ message");
+			expect(plainMessage).not.toContain("────");
+		} else expect(plainMessage).toContain("User");
 		expect(config.components.editor.style).toBe(editorStyle);
 		expect(config.components.userMessages).toMatchObject({ enabled: true, style: messageStyle });
 		expect(config.components.footer.style).toBe("starship");
@@ -1825,6 +1839,13 @@ describe("Pi docs compliance", () => {
 		config.components.footer.style = "hidden";
 		expect(message.render(30).join("\n")).toBe(framed);
 		expect(fg).toHaveBeenCalledTimes(callsAfterFramed);
+
+		config = structuredClone(config);
+		config.components.userMessages.style = "framed-copy-friendly";
+		const railFree = message.render(30).join("\n");
+		expect(railFree).toContain("────");
+		expect(railFree).not.toContain("│");
+		expect(railFree).not.toBe(framed);
 
 		config = structuredClone(config);
 		config.components.userMessages.style = "compact";
@@ -2093,7 +2114,7 @@ describe("Pi docs compliance", () => {
 		expect(UserMessageComponent.prototype.render).toBe(predecessor);
 	});
 
-	it.each(["framed", "compact", "labeled"] as const)(
+	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
 		"preserves exactly one OSC 133 prompt zone for %s messages",
 		(style) => {
 			const config = structuredClone(defaultConfig);
@@ -2239,7 +2260,7 @@ describe("Pi docs compliance", () => {
 		expect(rendered).toContain(`${open}link${close}`);
 	});
 
-	it.each(["framed", "compact", "labeled"] as const)(
+	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
 		"preserves mixed 7-bit/C1 OSC 8 through sanitization and Markdown for %s",
 		(style) => {
 			const config = structuredClone(defaultConfig);
@@ -2319,14 +2340,19 @@ describe("Pi docs compliance", () => {
 		expect(rendered.join("\n")).not.toContain("\x1b]133;");
 	});
 
-	it("keeps zero-width output marker-safe", () => {
-		installUserMessageStyle(
-			() => makeTheme(),
-			() => defaultConfig,
-		);
-		const rendered = new UserMessageComponent("hello").render(0).join("\n");
-		expect(rendered).toBe("\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07");
-	});
+	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
+		"keeps zero-width %s output marker-safe",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.userMessages.style = style;
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => config,
+			);
+			const rendered = new UserMessageComponent("hello").render(0).join("\n");
+			expect(rendered).toBe("\x1b]133;A\x07\x1b]133;B\x07\x1b]133;C\x07");
+		},
+	);
 
 	it.each(["theme", "config"] as const)(
 		"fails open byte-for-byte when the %s getter throws",
@@ -2352,15 +2378,22 @@ describe("Pi docs compliance", () => {
 		},
 	);
 
-	it("keeps user-message output within the requested render width", async () => {
-		const handlers = loadExtension();
-		await emit(handlers, "session_start", makeContext());
+	it.each(["framed", "framed-copy-friendly", "compact", "labeled"] as const)(
+		"keeps %s user-message output within the requested render width",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.userMessages.style = style;
+			installUserMessageStyle(
+				() => makeTheme(),
+				() => config,
+			);
 
-		const lines = new UserMessageComponent("hello ".repeat(20)).render(12).map(stripPromptMarks);
+			const lines = new UserMessageComponent("hello ".repeat(20)).render(12).map(stripPromptMarks);
 
-		expect(lines.length).toBeGreaterThan(0);
-		expect(lines.every((line) => visibleWidth(line) <= 12)).toBe(true);
-	});
+			expect(lines.length).toBeGreaterThan(0);
+			expect(lines.every((line) => visibleWidth(line) <= 12)).toBe(true);
+		},
+	);
 
 	it("reuses user-message wrappers while stale cleanup leaves the new registration active", () => {
 		const predecessorRender = UserMessageComponent.prototype.render;

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1462,12 +1462,13 @@ describe("Pi docs compliance", () => {
 	it("suppresses the production footer only while the installed minimalist editor decorates", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({ editorMode: "minimalist", projectRefreshIntervalMs: 0 }),
+			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
 		);
 		const handlers = loadExtension();
 		let editorFactory: unknown;
 		let footerFactory: FooterFactory | undefined;
 		const tui = { requestRender: vi.fn(), terminal: { rows: 24, cols: 80 } };
+		let sessionName = "release prep";
 		const ui = {
 			theme: makeTheme(),
 			setFooter(factory: FooterFactory | undefined) {
@@ -1478,7 +1479,13 @@ describe("Pi docs compliance", () => {
 			},
 			getEditorComponent: () => editorFactory,
 		};
-		const ctx = makeContext({ ui });
+		const ctx = makeContext({
+			ui,
+			sessionManager: {
+				getBranch: () => [],
+				getSessionName: () => sessionName,
+			},
+		});
 
 		await emit(handlers, "session_start", ctx);
 		await new Promise((resolve) => setTimeout(resolve, 20));
@@ -1495,8 +1502,19 @@ describe("Pi docs compliance", () => {
 		});
 		expect(footer?.render(80).length).toBeGreaterThan(0);
 
-		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
+		const namedFrame = editor.render(80)[0];
+		expect(namedFrame).toMatch(/^╭.*╮$/);
+		expect(namedFrame).toContain("release prep");
 		expect(footer?.render(80)).toEqual([]);
+		const rendersBeforeRename = tui.requestRender.mock.calls.length;
+		sessionName = "ship it";
+		await handlers.get("session_info_changed")?.[0]?.(
+			{ type: "session_info_changed", name: sessionName },
+			ctx,
+		);
+		expect(tui.requestRender).toHaveBeenCalledTimes(rendersBeforeRename + 1);
+		expect(editor.render(80)[0]).toContain("ship it");
+		expect(editor.render(80)[0]).not.toContain("release prep");
 		expect(editor.render(4)[0]).not.toContain("╭");
 		expect(footer?.render(80).length).toBeGreaterThan(0);
 		expect(editor.render(80)[0]).toMatch(/^╭.*╮$/);
@@ -1530,10 +1548,62 @@ describe("Pi docs compliance", () => {
 		await emit(handlers, "session_shutdown", ctx);
 	});
 
+	it("updates session names through a wrapped minimalist editor", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
+		);
+		const handlers = loadExtension();
+		const existingEditorFactory = () => ({
+			render: (width: number) => ["─".repeat(width), "base editor", "─".repeat(width)],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+		});
+		let editorFactory: unknown = existingEditorFactory;
+		let sessionName = "release prep";
+		const tui = { requestRender: vi.fn(), terminal: { rows: 24, cols: 80 } };
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				setEditorComponent(factory: unknown) {
+					editorFactory = factory;
+				},
+				getEditorComponent: () => editorFactory,
+			},
+			sessionManager: {
+				getBranch: () => [],
+				getSessionName: () => sessionName,
+			},
+		});
+
+		await emit(handlers, "session_start", ctx);
+		expect(editorFactory).not.toBe(existingEditorFactory);
+		const editor = (
+			editorFactory as (...args: unknown[]) => ReturnType<typeof existingEditorFactory>
+		)(tui as never, { borderColor: (text: string) => text, selectList: {} } as never, {} as never);
+		expect(editor.render(80)[0]).toContain("release prep");
+
+		const rendersBeforeRename = tui.requestRender.mock.calls.length;
+		sessionName = "ship it";
+		await handlers.get("session_info_changed")?.[0]?.(
+			{ type: "session_info_changed", name: sessionName },
+			ctx,
+		);
+		expect(tui.requestRender).toHaveBeenCalledTimes(rendersBeforeRename + 1);
+		expect(editor.render(80)[0]).toContain("ship it");
+		expect(editor.render(80)[0]).not.toContain("release prep");
+
+		await emit(handlers, "session_shutdown", ctx);
+		expect(editorFactory).toBe(existingEditorFactory);
+	});
+
 	it("keeps the production footer for unsupported wrapped minimalist output", async () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
-			JSON.stringify({ editorMode: "minimalist", projectRefreshIntervalMs: 0 }),
+			JSON.stringify({ editorStyle: "minimalist", projectRefreshIntervalMs: 0 }),
 		);
 		const handlers = loadExtension();
 		const existingFactory = () => ({
@@ -1589,7 +1659,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorMode: "minimalist",
+				editorStyle: "minimalist",
 				projectRefreshIntervalMs: 0,
 				features: { statusLine: false },
 			}),
@@ -1628,7 +1698,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorMode: "minimalist",
+				editorStyle: "minimalist",
 				projectRefreshIntervalMs: 0,
 				features: { statusLine: false },
 			}),
@@ -1696,7 +1766,7 @@ describe("Pi docs compliance", () => {
 		writeFileSync(
 			join(isolatedAgentDir.path, "zentui.json"),
 			JSON.stringify({
-				editorMode: "minimalist",
+				editorStyle: "minimalist",
 				projectRefreshIntervalMs: 5_000,
 				features: { statusLine: false },
 			}),

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -1005,7 +1005,7 @@ describe("Pi docs compliance", () => {
 		);
 		expect(transferred).toEqual(Array.from({ length: 5 }, () => expanded));
 		expect(transferred).not.toContain(marker);
-		expect(patchPresenceDuringReplacements).toEqual([false, false, true, false, true]);
+		expect(patchPresenceDuringReplacements).toEqual([false, false, true, true, true]);
 	});
 
 	it("keeps the active factory when expanded editor text cannot be read", async () => {
@@ -1505,14 +1505,121 @@ describe("Pi docs compliance", () => {
 			editorFactory = takeoverFactory;
 			await command.handler("editor disable", ctx);
 			expect(editorFactory).toBe(takeoverFactory);
-			// The historical command remains a compatibility recipe that disables all three.
-			expect(UserMessageComponent.prototype.render).toBe(originalUserMessageRender);
-			expect(ModelSelectorComponent.prototype.render).toBe(originalModelSelectorRender);
+			// Editor enablement is component-local; messages and selector borders stay installed.
+			expect(UserMessageComponent.prototype.render).not.toBe(originalUserMessageRender);
+			expect(ModelSelectorComponent.prototype.render).not.toBe(originalModelSelectorRender);
 			await emit(handlers, "session_shutdown", ctx);
 			expect(editorFactory).toBe(takeoverFactory);
 			expect(setEditorCalls).toBe(2);
 		},
 	);
+
+	it("routes fixed-editor aliases through layout without retaking a third-party editor", async () => {
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		const notifications: string[] = [];
+		let editorFactory: unknown;
+		let setEditorCalls = 0;
+		const takeoverFactory = () => ({
+			render: () => ["takeover"],
+			invalidate() {},
+			handleInput() {},
+			getText: () => "",
+			setText() {},
+		});
+		const ctx = makeContext({
+			ui: {
+				theme: makeTheme(),
+				setFooter() {},
+				setEditorComponent(factory: unknown) {
+					setEditorCalls += 1;
+					editorFactory = factory;
+				},
+				getEditorComponent() {
+					return editorFactory;
+				},
+				setWidget() {},
+				notify(message: string) {
+					notifications.push(message);
+				},
+			},
+		});
+		await emit(handlers, "session_start", ctx);
+		expect(setEditorCalls).toBe(1);
+		editorFactory = takeoverFactory;
+		await new Promise((resolve) => setTimeout(resolve, 1));
+
+		const command = commands.get("zentui") as {
+			handler(args: string, ctx: unknown): Promise<void>;
+		};
+		for (const args of ["fixed-editor enable", "fixed_editor disable", "fixed editor toggle"])
+			await command.handler(args, ctx);
+
+		expect(editorFactory).toBe(takeoverFactory);
+		expect(setEditorCalls).toBe(1);
+		expect(notifications).toEqual([
+			"Fixed editor: enabled",
+			"Fixed editor: disabled",
+			"Fixed editor: enabled",
+		]);
+		const persisted = JSON.parse(
+			readFileSync(join(isolatedAgentDir.path, "zentui.json"), "utf8"),
+		) as {
+			layout: { fixedEditor: { enabled: boolean } };
+		};
+		expect(persisted.layout.fixedEditor.enabled).toBe(true);
+		await emit(handlers, "session_shutdown", ctx);
+		expect(editorFactory).toBe(takeoverFactory);
+	});
+
+	it("persists independent message and copy-friendly commands plus the atomic recipe", async () => {
+		writeFileSync(
+			join(isolatedAgentDir.path, "zentui.json"),
+			JSON.stringify({
+				components: {
+					editor: { styles: { polished: { copyFriendly: false } } },
+					userMessages: {
+						enabled: true,
+						styles: { framed: { copyFriendly: true } },
+					},
+				},
+			}),
+		);
+		const commands = new Map<string, unknown>();
+		const handlers = loadExtension({ commands });
+		const notifications: string[] = [];
+		const ctx = makeContext({ ui: { notify: (message: string) => notifications.push(message) } });
+		await emit(handlers, "session_start", ctx);
+		const command = commands.get("zentui") as {
+			handler(args: string, ctx: unknown): Promise<void>;
+		};
+
+		await command.handler("messages disable", ctx);
+		await command.handler("editor-copy-friendly enable", ctx);
+		await command.handler("message-copy-friendly disable", ctx);
+		let persisted = JSON.parse(
+			readFileSync(join(isolatedAgentDir.path, "zentui.json"), "utf8"),
+		) as PolishedTuiConfig;
+		expect(persisted.components.userMessages.enabled).toBe(false);
+		expect(persisted.components.editor.enabled).toBe(true);
+		expect(persisted.components.selectorBorders.enabled).toBe(true);
+		expect(persisted.components.editor.styles.polished.copyFriendly).toBe(true);
+		expect(persisted.components.userMessages.styles.framed.copyFriendly).toBe(false);
+
+		await command.handler("copy-friendly disable", ctx);
+		persisted = JSON.parse(
+			readFileSync(join(isolatedAgentDir.path, "zentui.json"), "utf8"),
+		) as PolishedTuiConfig;
+		expect(persisted.components.editor.styles.polished.copyFriendly).toBe(false);
+		expect(persisted.components.userMessages.styles.framed.copyFriendly).toBe(false);
+		expect(notifications).toEqual([
+			"User messages: disabled",
+			"Editor copy-friendly: enabled",
+			"Message copy-friendly: disabled",
+			"Copy-friendly mode: disabled",
+		]);
+		await emit(handlers, "session_shutdown", ctx);
+	});
 
 	it("does not reconcile an editor after its session shuts down", async () => {
 		vi.useFakeTimers();
@@ -4244,8 +4351,8 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures(patch) {
-					featureChanges.push(patch);
+				setEditorComponent(patch) {
+					featureChanges.push(patch as never);
 					return { applied: true };
 				},
 				setFooterSegments() {},
@@ -4274,14 +4381,14 @@ describe("Pi docs compliance", () => {
 			},
 		});
 
-		expect(featureChanges).toEqual([{ editor: false }]);
+		expect(featureChanges).toEqual([{ enabled: false }]);
 		expect(renderRequests).toBe(1);
 		expect(notifications).toEqual([{ message: "Editor: disabled", level: "info" }]);
 	});
 
 	it("toggles the status line from direct Zentui slash-command arguments", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const featureChanges: Partial<PolishedTuiConfig["features"]>[] = [];
+		const featureChanges: Array<Record<string, unknown>> = [];
 
 		registerZentuiSettingsCommand(
 			{
@@ -4293,9 +4400,8 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures(patch) {
+				setFooterComponent(patch) {
 					featureChanges.push(patch);
-					return { applied: true };
 				},
 				setFooterSegments() {},
 				setFooterFormat() {},
@@ -4314,12 +4420,12 @@ describe("Pi docs compliance", () => {
 
 		await command?.handler("status line off", { hasUI: false });
 
-		expect(featureChanges).toEqual([{ statusLine: false }]);
+		expect(featureChanges).toEqual([{ enabled: false }]);
 	});
 
 	it("toggles copy-friendly mode from direct Zentui slash-command arguments", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const featureChanges: Partial<PolishedTuiConfig["features"]>[] = [];
+		const featureChanges: boolean[] = [];
 		const notifications: Array<{ message: string; level: string }> = [];
 
 		registerZentuiSettingsCommand(
@@ -4332,9 +4438,8 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures(patch) {
-					featureChanges.push(patch);
-					return { applied: true };
+				setCopyFriendlyRecipe(enabled) {
+					featureChanges.push(enabled);
 				},
 				setFooterSegments() {},
 				setFooterFormat() {},
@@ -4360,7 +4465,7 @@ describe("Pi docs compliance", () => {
 			},
 		});
 
-		expect(featureChanges).toEqual([{ copyFriendly: true }]);
+		expect(featureChanges).toEqual([true]);
 		expect(notifications).toEqual([{ message: "Copy-friendly mode: enabled", level: "info" }]);
 	});
 
@@ -4379,8 +4484,8 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures(patch) {
-					featureChanges.push(patch);
+				setEditorComponent(patch) {
+					featureChanges.push(patch as never);
 					return { applied: true };
 				},
 				setFooterSegments() {},
@@ -4427,7 +4532,7 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures: () => ({
+				setEditorComponent: () => ({
 					applied: false,
 					reason:
 						"another extension is currently managing the editor; reload Pi to apply this change",
@@ -4484,7 +4589,7 @@ describe("Pi docs compliance", () => {
 					sessionLifecycle,
 					getConfig: () => defaultConfig,
 					setColorSources() {},
-					setUiFeatures() {
+					setEditorComponent() {
 						doneCallsAtFeatureChange.push(doneCalls);
 						return { applied: true };
 					},
@@ -4539,7 +4644,7 @@ describe("Pi docs compliance", () => {
 
 	it("does not update a settings value when persistence fails", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const attemptedPatches: Partial<PolishedTuiConfig["features"]>[] = [];
+		const attemptedPatches: Array<Record<string, unknown>> = [];
 		const notifications: string[] = [];
 		registerZentuiSettingsCommand(
 			{
@@ -4551,7 +4656,7 @@ describe("Pi docs compliance", () => {
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
 				setColorSources() {},
-				setUiFeatures(patch) {
+				setUserMessagesComponent(patch) {
 					attemptedPatches.push(patch);
 					throw new Error("config is corrupt");
 				},
@@ -4597,7 +4702,7 @@ describe("Pi docs compliance", () => {
 			},
 		});
 
-		expect(attemptedPatches).toEqual([{ statusLine: false }, { statusLine: false }]);
+		expect(attemptedPatches).toEqual([{ enabled: false }, { enabled: false }]);
 		expect(notifications).toEqual([
 			"Could not update Zentui settings: config is corrupt",
 			"Could not update Zentui settings: config is corrupt",
@@ -4622,7 +4727,7 @@ describe("Pi docs compliance", () => {
 					sessionLifecycle,
 					getConfig: () => defaultConfig,
 					setColorSources() {},
-					setUiFeatures() {
+					setEditorComponent() {
 						featureChanges += 1;
 						return { applied: true };
 					},
@@ -4735,9 +4840,8 @@ describe("Pi docs compliance", () => {
 
 		const themeLines = await renderSettings(defaultConfig);
 		expect(themeLines[0]).toContain("[borderMuted]────");
-		for (const section of ["Appearance", "Editor", "Footer", "Segments", "Git", "Extensions"]) {
-			expect(themeLines.join("\n")).toContain(section);
-		}
+		expect(themeLines.join("\n")).toContain("Appearance");
+		expect(themeLines.join("\n")).toContain("(1/8)");
 		expect(themeLines.join("\n")).toContain("Tab/Shift+Tab to switch sections");
 		expect(themeLines.at(-1)).toContain("[borderMuted]────");
 		expect(themeLines.every((line) => visibleWidth(stripTestTags(line)) <= settingsWidth)).toBe(
@@ -4856,9 +4960,8 @@ describe("Pi docs compliance", () => {
 					const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 						handleInput?: (data: string) => void;
 					};
-					component.handleInput?.("\t");
-					component.handleInput?.("\t");
-					component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
@@ -4931,8 +5034,8 @@ describe("Pi docs compliance", () => {
 						{},
 						() => {},
 					) as { handleInput?: (data: string) => void };
-					component.handleInput?.("\x1b[B");
-					component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
+					for (let index = 0; index < 7; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
@@ -4949,13 +5052,15 @@ describe("Pi docs compliance", () => {
 			"Separator: pipe",
 		]);
 		expect(dependencyRenderRequests).toBe(4);
-		expect(tuiRenderRequests).toBe(4);
+		expect(tuiRenderRequests).toBe(8);
 	});
 
 	it("cycles branch length presets and returns custom JSON values to full", async () => {
 		const run = async (maxLength: PolishedTuiConfig["gitBranch"]["maxLength"], presses: number) => {
 			let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
 			const changes: Array<PolishedTuiConfig["gitBranch"]["maxLength"]> = [];
+			const config = structuredClone(defaultConfig);
+			config.components.footer.styles.starship.gitBranch.maxLength = maxLength;
 			registerZentuiSettingsCommand(
 				{
 					registerCommand(_name: string, options: unknown) {
@@ -4964,7 +5069,7 @@ describe("Pi docs compliance", () => {
 				} as never,
 				{
 					sessionLifecycle: inactiveSessionLifecycle,
-					getConfig: () => ({ ...defaultConfig, gitBranch: { maxLength } }),
+					getConfig: () => config,
 					setColorSources() {},
 					setUiFeatures: () => ({ applied: true }),
 					setFooterSegments() {},
@@ -5000,7 +5105,7 @@ describe("Pi docs compliance", () => {
 						const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 							handleInput?: (data: string) => void;
 						};
-						for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
+						for (let index = 0; index < 6; index += 1) component.handleInput?.("\t");
 						component.handleInput?.("\x1b[B");
 						for (let index = 0; index < presses; index += 1) component.handleInput?.(" ");
 					},
@@ -5015,7 +5120,7 @@ describe("Pi docs compliance", () => {
 
 	it("keeps the Zentui settings command open after applying a change", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const changes: Partial<PolishedTuiConfig["colorSources"]>[] = [];
+		const changes: Array<Record<string, unknown>> = [];
 		let dependencyRenderRequests = 0;
 		let tuiRenderRequests = 0;
 		let doneCalls = 0;
@@ -5029,7 +5134,8 @@ describe("Pi docs compliance", () => {
 			{
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => defaultConfig,
-				setColorSources(patch) {
+				setColorSources() {},
+				setSelectorBordersComponent(patch) {
 					changes.push(patch);
 				},
 				setUiFeatures: () => ({ applied: true }),
@@ -5077,20 +5183,21 @@ describe("Pi docs compliance", () => {
 						},
 					) as { handleInput?: (data: string) => void };
 					component.handleInput?.("\x1b[B");
+					component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 				},
 			},
 		});
 
-		expect(changes).toEqual([{ editor: "terminal", userMessages: "terminal" }]);
+		expect(changes).toEqual([{ colorSource: "terminal" }]);
 		expect(dependencyRenderRequests).toBe(1);
 		expect(tuiRenderRequests).toBe(1);
 		expect(doneCalls).toBe(0);
 	});
 
-	it("shows mixed editor/message sources and cycles them together", async () => {
+	it("shows selector color sources independently", async () => {
 		let command: { handler: (args: string, ctx: unknown) => Promise<void> } | undefined;
-		const changes: Partial<PolishedTuiConfig["colorSources"]>[] = [];
+		const changes: Array<Record<string, unknown>> = [];
 		let rendered = "";
 
 		registerZentuiSettingsCommand(
@@ -5102,7 +5209,8 @@ describe("Pi docs compliance", () => {
 			{
 				sessionLifecycle: inactiveSessionLifecycle,
 				getConfig: () => configWithColorSources({ editor: "theme", userMessages: "terminal" }),
-				setColorSources(patch) {
+				setColorSources() {},
+				setSelectorBordersComponent(patch) {
 					changes.push(patch);
 				},
 				setUiFeatures: () => ({ applied: true }),
@@ -5141,21 +5249,39 @@ describe("Pi docs compliance", () => {
 					};
 					rendered = component.render?.(80).join("\n") ?? "";
 					component.handleInput?.("\x1b[B");
+					component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 				},
 			},
 		});
 
-		expect(rendered).toContain("Editor + previous messages");
-		expect(rendered).toContain("mixed");
-		expect(changes).toEqual([{ editor: "theme", userMessages: "theme" }]);
+		expect(rendered).toContain("Selector border colors");
+		expect(rendered).not.toContain("Editor + previous messages");
+		expect(changes).toEqual([{ colorSource: "terminal" }]);
 	});
 
 	function navigateToSettingsSection(
 		component: { handleInput?: (data: string) => void },
-		section: "Appearance" | "Editor" | "Footer" | "Segments" | "Git" | "Extensions",
+		section:
+			| "Appearance"
+			| "Editor"
+			| "User messages"
+			| "Layout"
+			| "Footer"
+			| "Segments"
+			| "Git"
+			| "Extensions",
 	) {
-		const sections = ["Appearance", "Editor", "Footer", "Segments", "Git", "Extensions"];
+		const sections = [
+			"Appearance",
+			"Editor",
+			"User messages",
+			"Layout",
+			"Footer",
+			"Segments",
+			"Git",
+			"Extensions",
+		];
 		for (let index = 0; index < sections.indexOf(section); index += 1) {
 			component.handleInput?.("\t");
 		}
@@ -5416,7 +5542,7 @@ describe("Pi docs compliance", () => {
 
 		expect(placements).toEqual([{ key: "alpha", placement: "off" }]);
 		expect(dependencyRenderRequests).toBe(1);
-		expect(tuiRenderRequests).toBe(6);
+		expect(tuiRenderRequests).toBe(8);
 	});
 
 	it("does not show inactive saved placements in the extension segments tab", async () => {

--- a/test/extension-status.test.ts
+++ b/test/extension-status.test.ts
@@ -9,18 +9,27 @@ import {
 function configWithExtensionStatuses(
 	extensionStatuses: Partial<PolishedTuiConfig["extensionStatuses"]>,
 ): PolishedTuiConfig {
+	const merged = {
+		...defaultConfig.extensionStatuses,
+		...extensionStatuses,
+		placements: {
+			...defaultConfig.extensionStatuses.placements,
+			...(extensionStatuses.placements ?? {}),
+		},
+		colorModes: {
+			...defaultConfig.extensionStatuses.colorModes,
+			...(extensionStatuses.colorModes ?? {}),
+		},
+	};
+	const footer = defaultConfig.components.footer;
 	return {
 		...defaultConfig,
-		extensionStatuses: {
-			...defaultConfig.extensionStatuses,
-			...extensionStatuses,
-			placements: {
-				...defaultConfig.extensionStatuses.placements,
-				...(extensionStatuses.placements ?? {}),
-			},
-			colorModes: {
-				...defaultConfig.extensionStatuses.colorModes,
-				...(extensionStatuses.colorModes ?? {}),
+		extensionStatuses: merged,
+		components: {
+			...defaultConfig.components,
+			footer: {
+				...footer,
+				styles: { starship: { ...footer.styles.starship, extensionStatuses: merged } },
 			},
 		},
 	};

--- a/test/extension-status.test.ts
+++ b/test/extension-status.test.ts
@@ -109,6 +109,56 @@ describe("collectExtensionStatusSegments", () => {
 		expect(segments.left.map((segment) => segment.text)).toEqual(["a", "z"]);
 	});
 
+	it("treats prototype-shaped status keys as opaque strings", () => {
+		const statuses = new Map([
+			["constructor", "constructor"],
+			["toString", "toString"],
+			["__proto__", "proto"],
+		]);
+		const defaults = collectExtensionStatusSegments(statuses, configWithExtensionStatuses({}));
+		expect(defaults.right.map((segment) => segment.key)).toEqual([
+			"__proto__",
+			"constructor",
+			"toString",
+		]);
+
+		const configured = collectExtensionStatusSegments(
+			statuses,
+			configWithExtensionStatuses({
+				placements: Object.fromEntries([
+					["constructor", "left"],
+					["toString", "middle"],
+					["__proto__", "off"],
+				]) as PolishedTuiConfig["extensionStatuses"]["placements"],
+				colorModes: Object.fromEntries([
+					["constructor", "original"],
+					["toString", "original"],
+					["__proto__", "original"],
+				]) as PolishedTuiConfig["extensionStatuses"]["colorModes"],
+			}),
+		);
+		expect(configured.left[0]).toMatchObject({ key: "constructor", colorMode: "original" });
+		expect(configured.middle[0]).toMatchObject({ key: "toString", colorMode: "original" });
+		expect(configured.right).toEqual([]);
+	});
+
+	it("falls back safely after runtime enum mutation", () => {
+		const config = configWithExtensionStatuses({});
+		const mutable = config.components.footer.styles.starship.extensionStatuses as unknown as {
+			defaultPlacement: string;
+			placements: Record<string, string>;
+			colorModes: Record<string, string>;
+		};
+		mutable.defaultPlacement = "center";
+		mutable.placements.alpha = "explode";
+		mutable.colorModes.alpha = "rainbow";
+
+		const segments = collectExtensionStatusSegments(new Map([["alpha", "ok"]]), config);
+		expect(segments.right).toEqual([
+			{ key: "alpha", text: "ok", placement: "right", colorMode: "zentui" },
+		]);
+	});
+
 	it("keeps original ANSI color only for statuses configured as original", () => {
 		const config = configWithExtensionStatuses({
 			colorModes: {

--- a/test/fixed-editor-editor-layout.test.ts
+++ b/test/fixed-editor-editor-layout.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+	FIXED_EDITOR_LAYOUT,
+	type FixedEditorLayoutMetadata,
+	readFixedEditorLayout,
+	validateFixedEditorLayout,
+} from "../extensions/zentui/fixed-editor/editor-layout";
+
+function valid(): FixedEditorLayoutMetadata {
+	return {
+		width: 20,
+		renderedRowCount: 6,
+		editor: {
+			rows: [
+				{ start: 0, end: 3 },
+				{ start: 5, end: 6 },
+			],
+			frame: [
+				{ start: 0, end: 1 },
+				{ start: 5, end: 6 },
+			],
+			content: [{ start: 1, end: 3 }],
+			structuralRows: [0, 5],
+			cursorRow: 1,
+			borderPairs: [{ top: 0, bottom: 5 }],
+		},
+		autocomplete: {
+			rows: { start: 3, end: 5 },
+			structuralRows: [],
+			closureRows: [],
+			borderPairs: [],
+			selection: {
+				known: true,
+				selectedIndex: 1,
+				visibleWindow: { start: 0, end: 2 },
+				itemToOutputRows: [
+					{ itemIndex: 0, outputRow: 3 },
+					{ itemIndex: 1, outputRow: 4 },
+				],
+				selectedRow: 4,
+			},
+		},
+	};
+}
+
+const rows = ["top", "cursor", "body", "one", "two", "bottom"];
+
+describe("fixed editor semantic metadata", () => {
+	it("accepts an exhaustive embedded partition and returns an immutable copy", () => {
+		const metadata = valid();
+		const result = validateFixedEditorLayout(metadata, rows, 20);
+		expect(result).toEqual(metadata);
+		expect(result).not.toBe(metadata);
+		metadata.editor.structuralRows = [2, 5];
+		expect(result?.editor.structuralRows).toEqual([0, 5]);
+	});
+
+	it.each([
+		[
+			"stale width",
+			(m: FixedEditorLayoutMetadata) => {
+				m.width = 19;
+			},
+		],
+		[
+			"stale count",
+			(m: FixedEditorLayoutMetadata) => {
+				m.renderedRowCount = 5;
+			},
+		],
+		[
+			"partition gap",
+			(m: FixedEditorLayoutMetadata) => {
+				m.editor.rows = [
+					{ start: 0, end: 2 },
+					{ start: 5, end: 6 },
+				];
+			},
+		],
+		[
+			"overlap",
+			(m: FixedEditorLayoutMetadata) => {
+				m.editor.rows = [
+					{ start: 0, end: 4 },
+					{ start: 5, end: 6 },
+				];
+			},
+		],
+		[
+			"duplicate row",
+			(m: FixedEditorLayoutMetadata) => {
+				m.editor.structuralRows = [0, 0];
+			},
+		],
+		[
+			"crossing pair",
+			(m: FixedEditorLayoutMetadata) => {
+				m.editor.borderPairs = [
+					{ top: 0, bottom: 5 },
+					{ top: 1, bottom: 2 },
+				];
+			},
+		],
+		[
+			"missing selected mapping",
+			(m: FixedEditorLayoutMetadata) => {
+				if (m.autocomplete?.selection.known)
+					m.autocomplete.selection.itemToOutputRows = [{ itemIndex: 0, outputRow: 3 }];
+			},
+		],
+		[
+			"out of partition",
+			(m: FixedEditorLayoutMetadata) => {
+				if (m.autocomplete?.selection.known)
+					m.autocomplete.selection.itemToOutputRows = [
+						{ itemIndex: 0, outputRow: 1 },
+						{ itemIndex: 1, outputRow: 4 },
+					];
+			},
+		],
+	] as const)("rejects %s", (_name, mutate) => {
+		const metadata = valid();
+		mutate(metadata);
+		expect(validateFixedEditorLayout(metadata, rows, 20)).toBeUndefined();
+	});
+
+	it.each(["separator", "closure", "border", "scroll-info"])(
+		"rejects item mapping to %s rows",
+		(kind) => {
+			const metadata = valid();
+			const auto = metadata.autocomplete;
+			if (!auto) throw new Error("expected autocomplete fixture");
+			auto.rows = { start: 2, end: 6 };
+			metadata.editor.rows = [{ start: 0, end: 2 }];
+			metadata.editor.frame = [{ start: 0, end: 1 }];
+			metadata.editor.content = [{ start: 1, end: 2 }];
+			metadata.editor.structuralRows = [0];
+			metadata.editor.borderPairs = [];
+			const forbidden =
+				kind === "separator" ? 2 : kind === "closure" ? 3 : kind === "border" ? 4 : 5;
+			auto.structuralRows = kind === "separator" || kind === "scroll-info" ? [forbidden] : [];
+			auto.closureRows = kind === "closure" ? [forbidden] : [];
+			auto.borderPairs = kind === "border" ? [{ top: 4, bottom: 5 }] : [];
+			auto.selection = {
+				known: true,
+				selectedIndex: 0,
+				visibleWindow: { start: 0, end: 1 },
+				itemToOutputRows: [{ itemIndex: 0, outputRow: forbidden }],
+				selectedRow: forbidden,
+			};
+			expect(validateFixedEditorLayout(metadata, rows, 20)).toBeUndefined();
+		},
+	);
+
+	it("reads the private provider and fails open", () => {
+		const provider = { [FIXED_EDITOR_LAYOUT]: () => valid() };
+		expect(readFixedEditorLayout(provider, rows, 20)).toEqual(valid());
+		expect(readFixedEditorLayout({}, rows, 20)).toBeUndefined();
+		expect(
+			readFixedEditorLayout(
+				{
+					[FIXED_EDITOR_LAYOUT]: () => {
+						throw new Error("changed");
+					},
+				},
+				rows,
+				20,
+			),
+		).toBeUndefined();
+	});
+
+	it("treats throwing provider access as opaque", () => {
+		const proxy = new Proxy(
+			{},
+			{
+				get(_target, key) {
+					if (key === FIXED_EDITOR_LAYOUT) throw new Error("provider trap");
+					return undefined;
+				},
+			},
+		);
+		const getter = Object.defineProperty({}, FIXED_EDITOR_LAYOUT, {
+			configurable: true,
+			get() {
+				throw new Error("provider getter");
+			},
+		});
+
+		expect(() => readFixedEditorLayout(proxy, rows, 20)).not.toThrow();
+		expect(readFixedEditorLayout(proxy, rows, 20)).toBeUndefined();
+		expect(() => readFixedEditorLayout(getter, rows, 20)).not.toThrow();
+		expect(readFixedEditorLayout(getter, rows, 20)).toBeUndefined();
+	});
+});

--- a/test/fixed-editor-layout.test.ts
+++ b/test/fixed-editor-layout.test.ts
@@ -1,0 +1,242 @@
+import { CURSOR_MARKER } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { renderCluster } from "../extensions/zentui/fixed-editor/cluster";
+import {
+	FIXED_EDITOR_LAYOUT,
+	type FixedEditorLayoutMetadata,
+	validateFixedEditorLayout,
+} from "../extensions/zentui/fixed-editor/editor-layout";
+import { cropAround, planFixedLayout, takeTail } from "../extensions/zentui/fixed-editor/layout";
+
+const metadata: FixedEditorLayoutMetadata = {
+	width: 20,
+	renderedRowCount: 7,
+	editor: {
+		rows: [{ start: 0, end: 5 }],
+		frame: [
+			{ start: 0, end: 1 },
+			{ start: 4, end: 5 },
+		],
+		content: [{ start: 1, end: 4 }],
+		structuralRows: [0, 4],
+		cursorRow: 2,
+		borderPairs: [{ top: 0, bottom: 4 }],
+	},
+	autocomplete: {
+		rows: { start: 5, end: 7 },
+		structuralRows: [],
+		closureRows: [],
+		borderPairs: [],
+		selection: {
+			known: true,
+			selectedIndex: 1,
+			visibleWindow: { start: 0, end: 2 },
+			itemToOutputRows: [
+				{ itemIndex: 0, outputRow: 5 },
+				{ itemIndex: 1, outputRow: 6 },
+			],
+			selectedRow: 6,
+		},
+	},
+};
+
+describe("fixed layout planner", () => {
+	it("treats zero and negative budgets as empty", () => {
+		expect(takeTail([1, 2], 0)).toEqual([]);
+		expect(takeTail([1, 2], -1)).toEqual([]);
+		expect(cropAround([1, 2], 1, 0)).toEqual([]);
+	});
+
+	it("crops contiguously around an anchor", () => {
+		expect(cropAround([0, 1, 2, 3, 4], 2, 3)).toEqual([1, 2, 3]);
+		expect(cropAround([0, 1, 2, 3, 4], 0, 3)).toEqual([0, 1, 2]);
+		expect(cropAround([0, 1, 2, 3, 4], 4, 3)).toEqual([2, 3, 4]);
+	});
+
+	it("suspends with no terminal rows", () => {
+		expect(planFixedLayout({ rawRows: 0, editorRows: [] })).toEqual({
+			mode: "no-terminal-rows",
+			pendingDesiredMode: "fixed",
+		});
+	});
+
+	it("falls back when opaque or semantic minimums do not fit", () => {
+		expect(planFixedLayout({ rawRows: 2, editorRows: ["a", "b"] })).toMatchObject({
+			mode: "normal-flow",
+			reason: "opaque-editor-does-not-fit",
+		});
+		expect(planFixedLayout({ rawRows: 3, editorRows: Array(7).fill("x"), metadata })).toMatchObject(
+			{ mode: "normal-flow", reason: "editor-minimum-does-not-fit" },
+		);
+	});
+
+	it("matches hand-authored allocation and materialization thresholds", () => {
+		const editorRows = [
+			"top",
+			"body-1",
+			`cursor${CURSOR_MARKER}`,
+			"body-3",
+			"bottom",
+			"one",
+			"two",
+		];
+		const expectations = [
+			{ budget: 0, mode: "normal-flow" },
+			{ budget: 1, mode: "normal-flow" },
+			{ budget: 2, mode: "normal-flow" },
+			{
+				budget: 3,
+				editor: [0, 2, 4],
+				auto: [],
+				extras: [0, 0, 0, 0],
+				lines: ["top", "cursor", "bottom"],
+			},
+			{
+				budget: 4,
+				editor: [0, 2, 4],
+				auto: [6],
+				extras: [0, 0, 0, 0],
+				lines: ["top", "cursor", "bottom", "two"],
+			},
+			{
+				budget: 5,
+				editor: [0, 2, 4],
+				auto: [5, 6],
+				extras: [0, 0, 0, 0],
+				lines: ["top", "cursor", "bottom", "one", "two"],
+			},
+			{
+				budget: 6,
+				editor: [0, 2, 4],
+				auto: [5, 6],
+				extras: [1, 0, 0, 0],
+				lines: ["top", "cursor", "bottom", "one", "two", "footer"],
+			},
+			{
+				budget: 7,
+				editor: [0, 2, 4],
+				auto: [5, 6],
+				extras: [1, 1, 0, 0],
+				lines: ["top", "cursor", "bottom", "one", "two", "below", "footer"],
+			},
+			{
+				budget: 8,
+				editor: [0, 2, 4],
+				auto: [5, 6],
+				extras: [1, 1, 1, 0],
+				lines: ["above", "top", "cursor", "bottom", "one", "two", "below", "footer"],
+			},
+			{
+				budget: 9,
+				editor: [0, 2, 4],
+				auto: [5, 6],
+				extras: [1, 1, 1, 1],
+				lines: ["status", "above", "top", "cursor", "bottom", "one", "two", "below", "footer"],
+			},
+			{
+				budget: 10,
+				editor: [0, 1, 2, 4],
+				auto: [5, 6],
+				extras: [1, 1, 1, 1],
+				lines: [
+					"status",
+					"above",
+					"top",
+					"body-1",
+					"cursor",
+					"bottom",
+					"one",
+					"two",
+					"below",
+					"footer",
+				],
+			},
+			{
+				budget: 11,
+				editor: [0, 1, 2, 3, 4],
+				auto: [5, 6],
+				extras: [1, 1, 1, 1],
+				lines: [
+					"status",
+					"above",
+					"top",
+					"body-1",
+					"cursor",
+					"body-3",
+					"bottom",
+					"one",
+					"two",
+					"below",
+					"footer",
+				],
+			},
+		] as const;
+		const capability = (lines: string[]) => {
+			const target = { render: () => lines };
+			return {
+				target,
+				render: target.render,
+				ownDescriptor: Object.getOwnPropertyDescriptor(target, "render"),
+			};
+		};
+		const editorChild = { [FIXED_EDITOR_LAYOUT]: () => metadata };
+		const cluster = {
+			status: capability(["status"]),
+			aboveWidget: capability(["above"]),
+			editor: capability(editorRows),
+			editorChild,
+			belowWidget: capability(["below"]),
+			footer: capability(["footer"]),
+		};
+
+		for (const expected of expectations) {
+			const plan = planFixedLayout({
+				rawRows: expected.budget + 1,
+				editorRows,
+				metadata,
+				statusRows: ["status"],
+				aboveRows: ["above"],
+				belowRows: ["below"],
+				footerRows: ["footer"],
+			});
+			const rendered = renderCluster(cluster, 20, expected.budget + 1);
+			if ("mode" in expected) {
+				expect(plan.mode, `budget ${expected.budget}`).toBe("normal-flow");
+				expect(rendered).toMatchObject({ mode: "normal-flow", lines: [] });
+				continue;
+			}
+			expect(plan).toMatchObject({
+				mode: "fixed",
+				selectedEditorRows: expected.editor,
+				selectedAutocompleteRows: expected.auto,
+				footerBudget: expected.extras[0],
+				belowBudget: expected.extras[1],
+				aboveBudget: expected.extras[2],
+				statusBudget: expected.extras[3],
+			});
+			expect(rendered.lines, `budget ${expected.budget}`).toEqual(expected.lines);
+		}
+	});
+
+	it("always includes validated border-pair endpoints in the editor minimum", () => {
+		const adversarial: FixedEditorLayoutMetadata = {
+			...metadata,
+			autocomplete: undefined,
+			renderedRowCount: 5,
+			editor: { ...metadata.editor, structuralRows: [], borderPairs: [{ top: 0, bottom: 4 }] },
+		};
+		const rows = Array<string>(5).fill("row");
+		expect(validateFixedEditorLayout(adversarial, rows, 20)).toEqual(adversarial);
+		const plan = planFixedLayout({ rawRows: 4, editorRows: rows, metadata: adversarial });
+		expect(plan).toMatchObject({ mode: "fixed", selectedEditorRows: [0, 2, 4] });
+	});
+
+	it("keeps opaque editors intact when they fit", () => {
+		const plan = planFixedLayout({
+			rawRows: 4,
+			editorRows: ["a", "b", "c"],
+			footerRows: ["footer"],
+		});
+		expect(plan).toMatchObject({ mode: "fixed", selectedEditorRows: [0, 1, 2], footerBudget: 0 });
+	});
+});

--- a/test/fixed-editor-pty.test.ts
+++ b/test/fixed-editor-pty.test.ts
@@ -1,8 +1,15 @@
+import { execFileSync } from "node:child_process";
 import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { type CapturedPty, spawnCapturedPty } from "./helpers/pi-pty";
+import {
+	type CapturedPty,
+	probeOwnedProcessGroup,
+	signalOwnedProcessGroup,
+	spawnCapturedPty,
+	terminateWindowsPty,
+} from "./helpers/pi-pty";
 import { OwnedTerminalStateParser } from "./helpers/terminal-state";
 
 const run = process.env.RUN_FIXED_EDITOR_PTY === "1" ? it : it.skip;
@@ -15,14 +22,52 @@ type PtySession = {
 	cleanup?: Promise<void>;
 };
 
+function processExists(pid: number): boolean {
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+		throw error;
+	}
+}
+
+function processGroupExists(pid: number): boolean {
+	try {
+		process.kill(-pid, 0);
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+		throw error;
+	}
+}
+
+function processGroupId(pid: number): number {
+	return Number(
+		execFileSync("ps", ["-o", "pgid=", "-p", String(pid)], { encoding: "utf8" }).trim(),
+	);
+}
+
+function processState(pid: number): string {
+	return execFileSync("ps", ["-o", "stat=", "-p", String(pid)], {
+		encoding: "utf8",
+	}).trim();
+}
+
 let activeSession: PtySession | undefined;
 
 async function cleanupSession(session: PtySession): Promise<void> {
-	session.cleanup ??= (async () => {
-		await session.pty.close();
-		await rm(session.agentDirectory, { recursive: true, force: true });
-		await expect(access(session.agentDirectory)).rejects.toThrow();
-	})();
+	if (!session.cleanup) {
+		const attempt = (async () => {
+			await session.pty.close();
+			await rm(session.agentDirectory, { recursive: true, force: true });
+			await expect(access(session.agentDirectory)).rejects.toThrow();
+		})();
+		session.cleanup = attempt;
+		void attempt.catch(() => {
+			if (session.cleanup === attempt) session.cleanup = undefined;
+		});
+	}
 	await session.cleanup;
 }
 
@@ -66,6 +111,7 @@ async function launch(keyboardMode: "kitty" | "modifyOtherKeys" = "kitty"): Prom
 					PI_OFFLINE: "1",
 					PI_CODING_AGENT_DIR: agentDirectory,
 				},
+				gracefulExitInput: "\x03\x03",
 			},
 		);
 		session = { pty, agentDirectory };
@@ -74,10 +120,15 @@ async function launch(keyboardMode: "kitty" | "modifyOtherKeys" = "kitty"): Prom
 		await pty.waitFor("\x1b[?1002h", 15_000, entered);
 		return pty;
 	} catch (error) {
-		if (session) {
-			await cleanupSession(session);
-		} else {
-			await rm(agentDirectory, { recursive: true, force: true });
+		try {
+			if (session) await cleanupSession(session);
+			else await rm(agentDirectory, { recursive: true, force: true });
+		} catch (cleanupError) {
+			if (error instanceof Error) {
+				error.message += `\nPTY cleanup also failed: ${String(cleanupError)}`;
+				throw error;
+			}
+			throw new AggregateError([error, cleanupError], "PTY launch and cleanup failed");
 		}
 		throw error;
 	}
@@ -163,6 +214,33 @@ async function finishPi(pty: CapturedPty): Promise<void> {
 	await pty.waitForExit(15_000);
 }
 
+describe("PTY cleanup platform helpers", () => {
+	it("uses signal-less node-pty termination on Windows", () => {
+		const argumentCounts: number[] = [];
+		terminateWindowsPty((...args: never[]) => argumentCounts.push(args.length));
+		expect(argumentCounts).toEqual([0]);
+	});
+
+	it("surfaces EPERM immediately when probing or signaling an owned process group", () => {
+		const calls: Array<[number, NodeJS.Signals | 0]> = [];
+		const permissionError = Object.assign(new Error("denied"), { code: "EPERM" });
+		const deny = (pid: number, signal: NodeJS.Signals | 0) => {
+			calls.push([pid, signal]);
+			throw permissionError;
+		};
+		expect(() => probeOwnedProcessGroup(42, deny)).toThrow(
+			"Permission denied inspecting owned PTY process group 42",
+		);
+		expect(() => signalOwnedProcessGroup(42, "SIGTERM", deny)).toThrow(
+			"Permission denied signaling owned PTY process group 42",
+		);
+		expect(calls).toEqual([
+			[-42, 0],
+			[-42, "SIGTERM"],
+		]);
+	});
+});
+
 describe("fixed editor real PTY cleanup", () => {
 	run(
 		"awaits an exact timed-out child exit before removing its agent directory",
@@ -183,12 +261,101 @@ describe("fixed editor real PTY cleanup", () => {
 			const session = { pty, agentDirectory };
 			activeSession = session;
 			await pty.waitFor("ready", 2_000);
-			await expect(pty.waitFor("never", 50)).rejects.toThrow("PTY timeout");
+			await expect(pty.waitForExit(50)).rejects.toThrow("PTY timeout");
 			await cleanupSession(session);
 			expect(pty.hasExited()).toBe(true);
 			await expect(access(agentDirectory)).rejects.toThrow();
 		},
 		5_000,
+	);
+
+	run(
+		"kills an owned PTY group whose leader and child ignore graceful signals",
+		async () => {
+			if (process.platform === "win32") return;
+			const agentDirectory = await mkdtemp(join(tmpdir(), "zentui-pty-group-"));
+			const stubbornChild = [
+				"for (const signal of ['SIGHUP', 'SIGTERM', 'SIGINT']) process.on(signal, () => {});",
+				"if (process.send) process.send('ready');",
+				"setInterval(() => {}, 1000);",
+			].join("");
+			const stubbornLeader = [
+				"const { spawn } = require('node:child_process');",
+				"for (const signal of ['SIGHUP', 'SIGTERM', 'SIGINT']) process.on(signal, () => {});",
+				`const child = spawn(process.execPath, ['-e', ${JSON.stringify(stubbornChild)}], { stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });`,
+				"child.once('message', (message) => { if (message === 'ready') process.stdout.write('ready ' + process.pid + ' ' + child.pid); });",
+				"setInterval(() => {}, 1000);",
+			].join("");
+			const pty = spawnCapturedPty(process.execPath, ["-e", stubbornLeader], {
+				cwd: root,
+				env: Object.fromEntries(
+					Object.entries(process.env).filter(
+						(entry): entry is [string, string] => entry[1] !== undefined,
+					),
+				),
+				gracefulExitInput: "\x03\x03",
+			});
+			const session = { pty, agentDirectory };
+			activeSession = session;
+			await pty.waitFor("ready ", 2_000);
+			const match = pty.output().match(/ready (\d+) (\d+)/);
+			expect(match).not.toBeNull();
+			const leaderPid = Number(match?.[1]);
+			const childPid = Number(match?.[2]);
+			expect(leaderPid).toBe(pty.pty.pid);
+			expect(processGroupId(leaderPid)).toBe(leaderPid);
+			expect(processGroupId(childPid)).toBe(leaderPid);
+			expect(processGroupExists(leaderPid)).toBe(true);
+
+			const firstClose = pty.close();
+			expect(pty.close()).toBe(firstClose);
+			await firstClose;
+			await cleanupSession(session);
+
+			expect(pty.cleanupActions()).toEqual([
+				"write-graceful-exit",
+				"group-SIGCONT",
+				"group-SIGTERM",
+				"group-SIGCONT",
+				"group-SIGKILL",
+			]);
+			expect(processExists(leaderPid)).toBe(false);
+			expect(processExists(childPid)).toBe(false);
+			expect(processGroupExists(leaderPid)).toBe(false);
+		},
+		8_000,
+	);
+
+	run(
+		"cleans an OS-stopped Pi group without a test-body SIGCONT",
+		async () => {
+			if (process.platform === "win32") return;
+			const pty = await launch("kitty");
+			const session = activeSession;
+			expect(session).toBeDefined();
+			const pid = pty.pty.pid;
+			expect(processGroupId(pid)).toBe(pid);
+			process.kill(-pid, "SIGSTOP");
+			expect(
+				await waitUntil(() => {
+					try {
+						return processState(pid).includes("T");
+					} catch {
+						return false;
+					}
+				}, 2_000),
+			).toBe(true);
+			expect(processState(pid)).toContain("T");
+
+			if (session) await cleanupSession(session);
+
+			expect(pty.hasExited()).toBe(true);
+			expect(processExists(pid)).toBe(false);
+			expect(processGroupExists(pid)).toBe(false);
+			expect(pty.cleanupActions()[0]).toBe("write-graceful-exit");
+			expect(pty.cleanupActions()).toContain("group-SIGCONT");
+		},
+		30_000,
 	);
 
 	run.each([
@@ -224,7 +391,7 @@ describe("fixed editor real PTY cleanup", () => {
 		],
 	] as const)(
 		"restores terminal state after %s",
-		async (_name, stop) => {
+		async (name, stop) => {
 			const pty = await launch();
 			const boundary = pty.output().length;
 			await stop(pty);
@@ -233,6 +400,12 @@ describe("fixed editor real PTY cleanup", () => {
 			expect(pty.output().indexOf("\x1b[<u", resetIndex)).toBeGreaterThan(resetIndex);
 			expect(pty.output().indexOf("\x1b[?2004l", resetIndex)).toBeGreaterThan(resetIndex);
 			assertFullTerminalCleanup(pty.output(), "kitty");
+			if (name === "quit") {
+				const session = activeSession;
+				expect(session).toBeDefined();
+				if (session) await cleanupSession(session);
+				expect(pty.cleanupActions()).toEqual([]);
+			}
 		},
 		30_000,
 	);

--- a/test/fixed-editor-pty.test.ts
+++ b/test/fixed-editor-pty.test.ts
@@ -32,7 +32,7 @@ afterEach(async () => {
 	if (session) await cleanupSession(session);
 });
 
-async function launch(): Promise<CapturedPty> {
+async function launch(keyboardMode: "kitty" | "modifyOtherKeys" = "kitty"): Promise<CapturedPty> {
 	const agentDirectory = await mkdtemp(join(tmpdir(), "zentui-pty-"));
 	let session: PtySession | undefined;
 	try {
@@ -55,6 +55,7 @@ async function launch(): Promise<CapturedPty> {
 			],
 			{
 				cwd: root,
+				keyboardMode,
 				env: {
 					...Object.fromEntries(
 						Object.entries(process.env).filter(
@@ -99,6 +100,28 @@ function assertSafeReset(output: string, from: number): number {
 	expect(parser.isSafe()).toBe(true);
 	expect(output.slice(index, index + reset.length)).toBe(reset);
 	return index;
+}
+
+function assertFullTerminalCleanup(
+	output: string,
+	keyboardMode: "kitty" | "modifyOtherKeys",
+): void {
+	const parser = new OwnedTerminalStateParser(
+		{},
+		keyboardMode === "kitty" ? { primary: { kittyFlags: 3, kittyStack: [1] } } : {},
+		keyboardMode === "kitty",
+	);
+	parser.feed(output);
+	expect(parser.keyboardUnderflows).toEqual([]);
+	expect(
+		parser.isSafe(keyboardMode === "kitty" ? { kittyFlags: 3, kittyStack: [1] } : undefined),
+	).toBe(true);
+	expect(parser.screen("primary").bracketedPaste).toBe(false);
+	expect(parser.screen("primary").modifyOtherKeys).toBe(0);
+	expect(parser.screen("alternate").kittyFlags).toBe(0);
+	expect(parser.screen("alternate").kittyStack).toEqual([]);
+	expect(parser.screen("alternate").bracketedPaste).toBe(false);
+	expect(parser.screen("alternate").modifyOtherKeys).toBe(0);
 }
 
 async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
@@ -206,7 +229,10 @@ describe("fixed editor real PTY cleanup", () => {
 			const boundary = pty.output().length;
 			await stop(pty);
 			await finishPi(pty);
-			assertSafeReset(pty.output(), boundary);
+			const resetIndex = assertSafeReset(pty.output(), boundary);
+			expect(pty.output().indexOf("\x1b[<u", resetIndex)).toBeGreaterThan(resetIndex);
+			expect(pty.output().indexOf("\x1b[?2004l", resetIndex)).toBeGreaterThan(resetIndex);
+			assertFullTerminalCleanup(pty.output(), "kitty");
 		},
 		30_000,
 	);
@@ -219,7 +245,59 @@ describe("fixed editor real PTY cleanup", () => {
 			await runCommand(pty, "/zentui fixed-editor disable", reset);
 			const resetIndex = assertSafeReset(pty.output(), boundary);
 			expect(pty.output().slice(resetIndex + reset.length)).not.toContain("\x1b[?1049h");
+			const liveParser = new OwnedTerminalStateParser(
+				{},
+				{
+					primary: { kittyFlags: 3, kittyStack: [1] },
+				},
+			);
+			liveParser.feed(pty.output().slice(0, resetIndex + reset.length));
+			expect(liveParser.state.buffer).toBe("primary");
+			expect(liveParser.screen("primary").kittyFlags).toBe(7);
+			expect(liveParser.screen("primary").bracketedPaste).toBe(true);
+			expect(liveParser.keyboardUnderflows).toEqual([]);
 			await runExitCommand(pty, "/quit");
+			assertFullTerminalCleanup(pty.output(), "kitty");
+		},
+		30_000,
+	);
+
+	run(
+		"exits before suspend cleanup and re-enters after resume",
+		async () => {
+			const pty = await launch("kitty");
+			const boundary = pty.output().length;
+			pty.pty.write("\x1a");
+			const resetIndex = await pty.waitFor(reset, 15_000, boundary);
+			await pty.waitFor("\x1b[?2004l", 15_000, resetIndex);
+			const suspended = new OwnedTerminalStateParser(
+				{},
+				{
+					primary: { kittyFlags: 3, kittyStack: [1] },
+				},
+			);
+			suspended.feed(pty.output().slice(0, pty.output().length));
+			expect(suspended.isSafe({ kittyFlags: 3, kittyStack: [1] })).toBe(true);
+
+			process.kill(pty.pty.pid, "SIGCONT");
+			const reentered = await pty.waitFor("\x1b[?1049h", 15_000, resetIndex + reset.length);
+			await pty.waitFor("\x1b[?1002h", 15_000, reentered);
+			await runExitCommand(pty, "/quit");
+			assertFullTerminalCleanup(pty.output(), "kitty");
+		},
+		35_000,
+	);
+
+	run(
+		"restores modifyOtherKeys fallback on the primary screen",
+		async () => {
+			const pty = await launch("modifyOtherKeys");
+			const boundary = pty.output().length;
+			await runExitCommand(pty, "/quit");
+			const resetIndex = assertSafeReset(pty.output(), boundary);
+			expect(pty.output().indexOf("\x1b[>4;0m", resetIndex)).toBeGreaterThan(resetIndex);
+			expect(pty.output().indexOf("\x1b[?2004l", resetIndex)).toBeGreaterThan(resetIndex);
+			assertFullTerminalCleanup(pty.output(), "modifyOtherKeys");
 		},
 		30_000,
 	);

--- a/test/fixed-editor-pty.test.ts
+++ b/test/fixed-editor-pty.test.ts
@@ -1,0 +1,226 @@
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { type CapturedPty, spawnCapturedPty } from "./helpers/pi-pty";
+import { OwnedTerminalStateParser } from "./helpers/terminal-state";
+
+const run = process.env.RUN_FIXED_EDITOR_PTY === "1" ? it : it.skip;
+const root = resolve(import.meta.dirname, "..");
+const reset =
+	"\x1b[?2026h\x1b[r\x1b[?1002l\x1b[?1006l\x1b[?1000l\x1b[?1007l\x1b[?7h\x1b[?25h\x1b[?1049l\x1b[?2026l";
+type PtySession = {
+	pty: CapturedPty;
+	agentDirectory: string;
+	cleanup?: Promise<void>;
+};
+
+let activeSession: PtySession | undefined;
+
+async function cleanupSession(session: PtySession): Promise<void> {
+	session.cleanup ??= (async () => {
+		await session.pty.close();
+		await rm(session.agentDirectory, { recursive: true, force: true });
+		await expect(access(session.agentDirectory)).rejects.toThrow();
+	})();
+	await session.cleanup;
+}
+
+afterEach(async () => {
+	const session = activeSession;
+	activeSession = undefined;
+	if (session) await cleanupSession(session);
+});
+
+async function launch(): Promise<CapturedPty> {
+	const agentDirectory = await mkdtemp(join(tmpdir(), "zentui-pty-"));
+	let session: PtySession | undefined;
+	try {
+		await mkdir(agentDirectory, { recursive: true });
+		await writeFile(
+			join(agentDirectory, "zentui.json"),
+			JSON.stringify({
+				layout: { fixedEditor: { enabled: true, mouseScroll: true, copyNotice: false } },
+			}),
+		);
+		const pi = join(root, "node_modules/.bin/pi");
+		const pty = spawnCapturedPty(
+			pi,
+			[
+				"--no-extensions",
+				"-e",
+				"./extensions/zentui/index.ts",
+				"--no-session",
+				"--no-context-files",
+			],
+			{
+				cwd: root,
+				env: {
+					...Object.fromEntries(
+						Object.entries(process.env).filter(
+							(entry): entry is [string, string] => entry[1] !== undefined,
+						),
+					),
+					TERM: "xterm-256color",
+					PI_OFFLINE: "1",
+					PI_CODING_AGENT_DIR: agentDirectory,
+				},
+			},
+		);
+		session = { pty, agentDirectory };
+		activeSession = session;
+		const entered = await pty.waitFor("\x1b[?1049h", 15_000);
+		await pty.waitFor("\x1b[?1002h", 15_000, entered);
+		return pty;
+	} catch (error) {
+		if (session) {
+			await cleanupSession(session);
+		} else {
+			await rm(agentDirectory, { recursive: true, force: true });
+		}
+		throw error;
+	}
+}
+
+function assertSafeReset(output: string, from: number): number {
+	const index = output.indexOf(reset, from);
+	expect(index).toBeGreaterThanOrEqual(from);
+	const parser = new OwnedTerminalStateParser({
+		buffer: "alternate",
+		autowrap: false,
+		cursorVisible: false,
+		mouse1000: true,
+		mouse1002: true,
+		mouse1006: true,
+		alternateScroll: true,
+		scrollRegion: { top: 2, bottom: 8 },
+	});
+	parser.feed(output.slice(index, index + reset.length));
+	expect(parser.isSafe()).toBe(true);
+	expect(output.slice(index, index + reset.length)).toBe(reset);
+	return index;
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs: number): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((resolve) => setTimeout(resolve, 20));
+	}
+	return predicate();
+}
+
+async function runCommand(
+	pty: CapturedPty,
+	text: string,
+	acknowledgement: string,
+	timeoutMs = 10_000,
+): Promise<number> {
+	const boundary = pty.output().length;
+	pty.pty.write(`${text}\r`);
+	try {
+		return await pty.waitFor(acknowledgement, 2_000, boundary);
+	} catch {
+		// Pi may use the first Enter to accept the slash-command completion.
+		pty.pty.write("\r");
+		return pty.waitFor(acknowledgement, timeoutMs, boundary);
+	}
+}
+
+async function runExitCommand(pty: CapturedPty, text: string): Promise<void> {
+	pty.pty.write(`${text}\r`);
+	if (!(await waitUntil(() => pty.hasExited(), 2_000))) {
+		// Bounded retry only when the first Enter accepted autocomplete instead of executing.
+		pty.pty.write("\r");
+	}
+	await pty.waitForExit(15_000);
+}
+
+async function finishPi(pty: CapturedPty): Promise<void> {
+	await pty.waitForExit(15_000);
+}
+
+describe("fixed editor real PTY cleanup", () => {
+	run(
+		"awaits an exact timed-out child exit before removing its agent directory",
+		async () => {
+			const agentDirectory = await mkdtemp(join(tmpdir(), "zentui-pty-cleanup-"));
+			const pty = spawnCapturedPty(
+				process.execPath,
+				["-e", "process.stdout.write('ready'); setInterval(() => {}, 1000)"],
+				{
+					cwd: root,
+					env: Object.fromEntries(
+						Object.entries(process.env).filter(
+							(entry): entry is [string, string] => entry[1] !== undefined,
+						),
+					),
+				},
+			);
+			const session = { pty, agentDirectory };
+			activeSession = session;
+			await pty.waitFor("ready", 2_000);
+			await expect(pty.waitFor("never", 50)).rejects.toThrow("PTY timeout");
+			await cleanupSession(session);
+			expect(pty.hasExited()).toBe(true);
+			await expect(access(agentDirectory)).rejects.toThrow();
+		},
+		5_000,
+	);
+
+	run.each([
+		[
+			"quit",
+			async (pty: CapturedPty) => {
+				await runExitCommand(pty, "/quit");
+			},
+		],
+		[
+			"Ctrl+C",
+			async (pty: CapturedPty) => {
+				pty.pty.write("\x03\x03");
+			},
+		],
+		[
+			"Ctrl+D",
+			async (pty: CapturedPty) => {
+				pty.pty.write("\x04");
+			},
+		],
+		[
+			"SIGHUP",
+			async (pty: CapturedPty) => {
+				process.kill(pty.pty.pid, "SIGHUP");
+			},
+		],
+		[
+			"SIGTERM",
+			async (pty: CapturedPty) => {
+				process.kill(pty.pty.pid, "SIGTERM");
+			},
+		],
+	] as const)(
+		"restores terminal state after %s",
+		async (_name, stop) => {
+			const pty = await launch();
+			const boundary = pty.output().length;
+			await stop(pty);
+			await finishPi(pty);
+			assertSafeReset(pty.output(), boundary);
+		},
+		30_000,
+	);
+
+	run(
+		"isolates live-disable reset before later shutdown",
+		async () => {
+			const pty = await launch();
+			const boundary = pty.output().length;
+			await runCommand(pty, "/zentui fixed-editor disable", reset);
+			const resetIndex = assertSafeReset(pty.output(), boundary);
+			expect(pty.output().slice(resetIndex + reset.length)).not.toContain("\x1b[?1049h");
+			await runExitCommand(pty, "/quit");
+		},
+		30_000,
+	);
+});

--- a/test/fixed-editor-terminal-state.test.ts
+++ b/test/fixed-editor-terminal-state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { OwnedTerminalStateParser } from "./helpers/terminal-state";
+
+const unsafe = () =>
+	new OwnedTerminalStateParser({
+		buffer: "alternate",
+		autowrap: false,
+		cursorVisible: false,
+		mouse1000: true,
+		mouse1002: true,
+		mouse1006: true,
+		alternateScroll: true,
+		scrollRegion: { top: 2, bottom: 9 },
+	});
+
+// Literal fixture intentionally independent of production constants.
+const reset =
+	"\x1b[?2026h\x1b[r\x1b[?1002l\x1b[?1006l\x1b[?1000l\x1b[?1007l\x1b[?7h\x1b[?25h\x1b[?1049l\x1b[?2026l";
+
+describe("owned terminal state parser", () => {
+	it("models the canonical teardown from an unsafe state", () => {
+		const parser = unsafe();
+		parser.feed(reset);
+		expect(parser.isSafe()).toBe(true);
+	});
+
+	it("is chunk safe and ignores unrelated output", () => {
+		const parser = unsafe();
+		for (const byte of `noise\x1b[31m${reset}text`) parser.feed(byte);
+		expect(parser.isSafe()).toBe(true);
+	});
+
+	it.each([
+		["scroll region", "\x1b[r"],
+		["mouse 1002", "\x1b[?1002l"],
+		["mouse 1006", "\x1b[?1006l"],
+		["mouse 1000", "\x1b[?1000l"],
+		["alternate scroll", "\x1b[?1007l"],
+		["autowrap", "\x1b[?7h"],
+		["cursor", "\x1b[?25h"],
+		["alternate buffer", "\x1b[?1049l"],
+	])("remains unsafe when %s restoration is omitted", (_name, operation) => {
+		const parser = unsafe();
+		parser.feed(reset.replace(operation, ""));
+		expect(parser.isSafe()).toBe(false);
+	});
+
+	it("records restricted and full scroll regions", () => {
+		const parser = new OwnedTerminalStateParser();
+		parser.feed("\x1b[2;10r");
+		expect(parser.state.scrollRegion).toEqual({ top: 2, bottom: 10 });
+		parser.feed("\x1b[r");
+		expect(parser.state.scrollRegion).toBe("full");
+	});
+});

--- a/test/fixed-editor-terminal-state.test.ts
+++ b/test/fixed-editor-terminal-state.test.ts
@@ -52,4 +52,47 @@ describe("owned terminal state parser", () => {
 		parser.feed("\x1b[r");
 		expect(parser.state.scrollRegion).toBe("full");
 	});
+
+	it("detects a Kitty pop on the wrong screen", () => {
+		const parser = new OwnedTerminalStateParser(
+			{},
+			{
+				primary: { kittyFlags: 3, kittyStack: [1] },
+			},
+		);
+		parser.feed("\x1b[>7u\x1b[?2004h\x1b[?1049h\x1b[<u\x1b[?2004l\x1b[?1049l");
+		expect(parser.screen("primary").kittyFlags).toBe(7);
+		expect(parser.screen("primary").kittyStack).toEqual([1, 3]);
+		expect(parser.screen("primary").bracketedPaste).toBe(true);
+		expect(parser.keyboardUnderflows).toEqual(["alternate"]);
+		expect(parser.isSafe()).toBe(false);
+	});
+
+	it("restores a caller Kitty stack when Pi cleans up on the primary screen", () => {
+		const parser = new OwnedTerminalStateParser(
+			{},
+			{
+				primary: { kittyFlags: 3, kittyStack: [1] },
+			},
+		);
+		parser.feed("\x1b[>7u\x1b[?2004h\x1b[?1049h");
+		parser.feed(reset);
+		parser.feed("\x1b[<u\x1b[?2004l");
+		expect(parser.screen("primary").kittyFlags).toBe(3);
+		expect(parser.screen("primary").kittyStack).toEqual([1]);
+		expect(parser.screen("primary").bracketedPaste).toBe(false);
+		expect(parser.keyboardUnderflows).toEqual([]);
+		expect(parser.isSafe({ kittyFlags: 3, kittyStack: [1] })).toBe(true);
+	});
+
+	it("tracks modifyOtherKeys and bracketed paste per screen incrementally", () => {
+		const parser = new OwnedTerminalStateParser();
+		for (const byte of "\x1b[>4;2m\x1b[?2004h\x1b[?1049h\x1b[>4;0m\x1b[?2004l\x1b[?1049l")
+			parser.feed(byte);
+		expect(parser.screen("primary").modifyOtherKeys).toBe(2);
+		expect(parser.screen("primary").bracketedPaste).toBe(true);
+		expect(parser.screen("alternate").modifyOtherKeys).toBe(0);
+		expect(parser.screen("alternate").bracketedPaste).toBe(false);
+		expect(parser.isSafe()).toBe(false);
+	});
 });

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -42,6 +42,8 @@ function makeValidPiFixture() {
 		},
 	);
 	const terminalWrite = vi.fn();
+	const terminalDrainInput = vi.fn(async (..._args: unknown[]) => "drained");
+	const terminalStop = vi.fn((..._args: unknown[]) => "stopped");
 	const makeRenderable = (label: string) => ({
 		render(width: number) {
 			return [`${label}:${width}`];
@@ -61,6 +63,8 @@ function makeValidPiFixture() {
 		columns: 80,
 		rows: rawRows,
 		write: terminalWrite,
+		drainInput: terminalDrainInput,
+		stop: terminalStop,
 	};
 	Object.defineProperty(terminal, "rows", {
 		configurable: true,
@@ -97,6 +101,8 @@ function makeValidPiFixture() {
 		terminal,
 		cluster: [status, above, editor, below, footer],
 		terminalWrite,
+		terminalDrainInput,
+		terminalStop,
 		rootRender,
 		doRender,
 		requestRender,
@@ -121,6 +127,16 @@ describe("Pi fixed-editor compatibility", () => {
 			"terminal write",
 			(fixture: ReturnType<typeof makeValidPiFixture>) =>
 				Reflect.deleteProperty(fixture.terminal, "write"),
+		],
+		[
+			"terminal drainInput",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.terminal, "drainInput"),
+		],
+		[
+			"terminal stop",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.terminal, "stop"),
 		],
 		[
 			"terminal rows",
@@ -249,6 +265,17 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(inspectPiTui(writeFixture.tui)).toBeUndefined();
 		expect(writeFixture.terminalWrite).not.toHaveBeenCalled();
 
+		for (const key of ["drainInput", "stop"] as const) {
+			const lifecycleFixture = makeValidPiFixture();
+			Object.defineProperty(lifecycleFixture.terminal, key, {
+				value: lifecycleFixture.terminal[key],
+				configurable: true,
+				writable: false,
+			});
+			expect(inspectPiTui(lifecycleFixture.tui)).toBeUndefined();
+			expect(lifecycleFixture.terminalWrite).not.toHaveBeenCalled();
+		}
+
 		const frozenFixture = makeValidPiFixture();
 		Object.freeze(frozenFixture.tui.children[0]);
 		expect(inspectPiTui(frozenFixture.tui)).toBeUndefined();
@@ -263,6 +290,8 @@ describe("Pi fixed-editor compatibility", () => {
 		const render = fixture.tui.render;
 		const doRender = fixture.tui.doRender;
 		const write = fixture.terminal.write;
+		const drainInput = fixture.terminal.drainInput;
+		const stop = fixture.terminal.stop;
 		const rowsDescriptor = Object.getOwnPropertyDescriptor(fixture.terminal, "rows");
 		const clusterDescriptors = fixture.cluster.map((component) =>
 			Object.getOwnPropertyDescriptor(component, "render"),
@@ -277,6 +306,8 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.tui.render).not.toBe(render);
 		expect(fixture.tui.doRender).not.toBe(doRender);
 		expect(fixture.terminal.write).not.toBe(write);
+		expect(fixture.terminal.drainInput).not.toBe(drainInput);
+		expect(fixture.terminal.stop).not.toBe(stop);
 		expect(fixture.cluster.every((component) => component.render(80).length === 0)).toBe(true);
 		expect(fixture.addInputListener).toHaveBeenCalledTimes(1);
 		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
@@ -287,6 +318,8 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.tui.render).toBe(render);
 		expect(fixture.tui.doRender).toBe(doRender);
 		expect(fixture.terminal.write).toBe(write);
+		expect(fixture.terminal.drainInput).toBe(drainInput);
+		expect(fixture.terminal.stop).toBe(stop);
 		expect(Object.getOwnPropertyDescriptor(fixture.terminal, "rows")).toEqual(rowsDescriptor);
 		expect(
 			fixture.cluster.map((component) => Object.getOwnPropertyDescriptor(component, "render")),
@@ -299,6 +332,178 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.requestRender).toHaveBeenCalledTimes(2);
 		expect(fixture.requestRender).toHaveBeenNthCalledWith(1, true);
 		expect(fixture.requestRender).toHaveBeenNthCalledWith(2, true);
+	});
+
+	it("exits the alternate screen before Pi drain and stop cleanup", async () => {
+		const fixture = makeValidPiFixture();
+		let drainReceiver: unknown;
+		let drainArgs: unknown[] = [];
+		let stopReceiver: unknown;
+		let stopArgs: unknown[] = [];
+		const drainResult = Promise.resolve("original-drain");
+		fixture.terminalDrainInput.mockImplementationOnce(function (this: unknown, ...args: unknown[]) {
+			drainReceiver = this;
+			drainArgs = args;
+			expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+			return drainResult;
+		});
+		fixture.terminalStop.mockImplementationOnce(function (this: unknown, ...args: unknown[]) {
+			stopReceiver = this;
+			stopArgs = args;
+			return "original-stop";
+		});
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		const requestsBefore = fixture.requestRender.mock.calls.length;
+
+		const returnedDrain = fixture.terminal.drainInput(250, 10);
+		expect(returnedDrain).toBe(drainResult);
+		await expect(returnedDrain).resolves.toBe("original-drain");
+		expect(drainReceiver).toBe(fixture.terminal);
+		expect(drainArgs).toEqual([250, 10]);
+		expect(fixture.requestRender).toHaveBeenCalledTimes(requestsBefore);
+		const resetWrites = fixture.terminalWrite.mock.calls.filter(
+			([write]) => write === emergencyTerminalReset(),
+		);
+		expect(resetWrites).toHaveLength(1);
+
+		expect(fixture.terminal.stop("suspend")).toBe("original-stop");
+		expect(stopReceiver).toBe(fixture.terminal);
+		expect(stopArgs).toEqual(["suspend"]);
+		expect(
+			fixture.terminalWrite.mock.calls.filter(([write]) => write === emergencyTerminalReset()),
+		).toHaveLength(1);
+
+		fixture.tui.doRender();
+		fixture.tui.doRender();
+		expect(
+			fixture.terminalWrite.mock.calls
+				.slice(-3)
+				.some(([write]) => String(write).includes("\x1b[?1049h")),
+		).toBe(true);
+		compositor.dispose("shutdown");
+	});
+
+	it("prepares once when Pi drain chains into terminal stop", async () => {
+		const fixture = makeValidPiFixture();
+		fixture.terminalDrainInput.mockImplementationOnce(async () => fixture.terminal.stop("nested"));
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: false,
+		}));
+		expect(compositor.install()).toBe(true);
+		await expect(fixture.terminal.drainInput()).resolves.toBe("stopped");
+		expect(fixture.terminalStop).toHaveBeenCalledWith("nested");
+		expect(
+			fixture.terminalWrite.mock.calls.filter(([write]) => write === emergencyTerminalReset()),
+		).toHaveLength(1);
+		compositor.dispose("shutdown");
+	});
+
+	it("always delegates Pi cleanup and retries reset after both reset sinks fail", async () => {
+		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const fallback = vi.fn(() => {
+			throw new Error("fallback failed");
+		});
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: false, copyNotice: false }),
+			undefined,
+			undefined,
+			fallback,
+		);
+		expect(compositor.install()).toBe(true);
+		fixture.terminalWrite.mockImplementation(() => {
+			throw new Error("terminal failed");
+		});
+		await expect(fixture.terminal.drainInput()).resolves.toBe("drained");
+		expect(fixture.terminalDrainInput).toHaveBeenCalledTimes(1);
+		expect(fallback).toHaveBeenCalledWith(emergencyTerminalReset());
+
+		fixture.terminalWrite.mockReset();
+		expect(fixture.terminal.stop()).toBe("stopped");
+		expect(fixture.terminalStop).toHaveBeenCalledTimes(1);
+		expect(fixture.terminalWrite).toHaveBeenCalledWith(emergencyTerminalReset());
+		compositor.dispose("shutdown");
+	});
+
+	it("preserves synchronous Pi stop failures after terminal preparation", () => {
+		const fixture = makeValidPiFixture();
+		fixture.terminalStop.mockImplementationOnce(() => {
+			throw new Error("stop failed");
+		});
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: false,
+		}));
+		expect(compositor.install()).toBe(true);
+		expect(() => fixture.terminal.stop()).toThrow("stop failed");
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+		compositor.dispose("shutdown");
+	});
+
+	it("preserves cleanup rejection and later third-party lifecycle replacements", async () => {
+		const fixture = makeValidPiFixture();
+		const rejection = Promise.reject(new Error("drain rejected"));
+		fixture.terminalDrainInput.mockReturnValueOnce(rejection);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: false,
+		}));
+		expect(compositor.install()).toBe(true);
+		await expect(fixture.terminal.drainInput()).rejects.toThrow("drain rejected");
+		const laterDrain = vi.fn();
+		const laterStop = vi.fn();
+		fixture.terminal.drainInput = laterDrain;
+		fixture.terminal.stop = laterStop;
+		compositor.dispose("shutdown");
+		expect(fixture.terminal.drainInput).toBe(laterDrain);
+		expect(fixture.terminal.stop).toBe(laterStop);
+	});
+
+	it("deletes temporary lifecycle wrappers when Pi methods were inherited", () => {
+		const fixture = makeValidPiFixture();
+		const drainInput = fixture.terminal.drainInput;
+		const stop = fixture.terminal.stop;
+		const prototype = Object.create(Object.getPrototypeOf(fixture.terminal), {
+			drainInput: { configurable: true, writable: true, value: drainInput },
+			stop: { configurable: true, writable: true, value: stop },
+		});
+		Reflect.deleteProperty(fixture.terminal, "drainInput");
+		Reflect.deleteProperty(fixture.terminal, "stop");
+		Object.setPrototypeOf(fixture.terminal, prototype);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: false,
+		}));
+		expect(compositor.install()).toBe(true);
+		expect(Object.hasOwn(fixture.terminal, "drainInput")).toBe(true);
+		expect(Object.hasOwn(fixture.terminal, "stop")).toBe(true);
+		compositor.dispose("shutdown");
+		expect(Object.hasOwn(fixture.terminal, "drainInput")).toBe(false);
+		expect(Object.hasOwn(fixture.terminal, "stop")).toBe(false);
+		expect(fixture.terminal.drainInput).toBe(drainInput);
+		expect(fixture.terminal.stop).toBe(stop);
 	});
 
 	it("rolls back patches when listener registration does not return cleanup", () => {
@@ -316,6 +521,8 @@ describe("Pi fixed-editor compatibility", () => {
 		if (!capabilities) return;
 		const render = fixture.tui.render;
 		const write = fixture.terminal.write;
+		const drainInput = fixture.terminal.drainInput;
+		const stop = fixture.terminal.stop;
 		const compositor = new TerminalSplitCompositor(capabilities, () => ({
 			enabled: true,
 			mouseScroll: false,
@@ -325,6 +532,8 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(compositor.install()).toBe(false);
 		expect(fixture.tui.render).toBe(render);
 		expect(fixture.terminal.write).toBe(write);
+		expect(fixture.terminal.drainInput).toBe(drainInput);
+		expect(fixture.terminal.stop).toBe(stop);
 		expect(fixture.cluster.every((component) => component.render(80).length > 0)).toBe(true);
 		expect(fixture.removeInputListener).toHaveBeenCalledTimes(1);
 		expect(fixture.getInputListener()).toBeUndefined();

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -374,7 +374,13 @@ describe("Pi fixed-editor compatibility", () => {
 		const editor = new WrappedPolishedEditor(
 			base,
 			uiTheme,
-			() => ({ ...defaultConfig, editorBorderColorMode: "adaptive" }),
+			() => ({
+				...defaultConfig,
+				components: {
+					...defaultConfig.components,
+					editor: { ...defaultConfig.components.editor, borderColorMode: "adaptive" },
+				},
+			}),
 			() => ({ modelLabel: "model", providerLabel: "provider" }),
 			() => "high",
 		);

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -2,7 +2,7 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { CURSOR_MARKER, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { defaultConfig } from "../extensions/zentui/config";
-import { capEditorLines, renderCluster } from "../extensions/zentui/fixed-editor/cluster";
+import { renderCluster } from "../extensions/zentui/fixed-editor/cluster";
 import { TerminalSplitCompositor } from "../extensions/zentui/fixed-editor/compositor";
 import {
 	clampScrollOffset,
@@ -17,14 +17,16 @@ import {
 } from "../extensions/zentui/fixed-editor/pi-compat";
 import { highlightSelection, SelectionState } from "../extensions/zentui/fixed-editor/selection";
 import {
+	DISABLE_ALT_SCROLL,
 	DISABLE_MOUSE,
-	ENABLE_ALT_SCROLL,
+	ENABLE_AUTOWRAP,
 	EXIT_ALT_SCREEN,
 	emergencyTerminalReset,
 	RESET_SCROLL_REGION,
 	SHOW_CURSOR,
 } from "../extensions/zentui/fixed-editor/terminal-modes";
 import { WrappedPolishedEditor } from "../extensions/zentui/ui";
+import { OwnedTerminalStateParser } from "./helpers/terminal-state";
 
 function makeValidPiFixture() {
 	let rawRows = 24;
@@ -139,6 +141,11 @@ describe("Pi fixed-editor compatibility", () => {
 			"input listener removal",
 			(fixture: ReturnType<typeof makeValidPiFixture>) =>
 				Reflect.deleteProperty(fixture.tui, "removeInputListener"),
+		],
+		[
+			"forced render",
+			(fixture: ReturnType<typeof makeValidPiFixture>) =>
+				Reflect.deleteProperty(fixture.tui, "requestRender"),
 		],
 		[
 			"children",
@@ -272,10 +279,10 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.terminal.write).not.toBe(write);
 		expect(fixture.cluster.every((component) => component.render(80).length === 0)).toBe(true);
 		expect(fixture.addInputListener).toHaveBeenCalledTimes(1);
-		expect(fixture.terminalWrite).toHaveBeenCalledTimes(1);
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
 
-		compositor.dispose();
-		compositor.dispose();
+		compositor.dispose("live");
+		compositor.dispose("live");
 
 		expect(fixture.tui.render).toBe(render);
 		expect(fixture.tui.doRender).toBe(doRender);
@@ -285,9 +292,13 @@ describe("Pi fixed-editor compatibility", () => {
 			fixture.cluster.map((component) => Object.getOwnPropertyDescriptor(component, "render")),
 		).toEqual(clusterDescriptors);
 		expect(fixture.inputListenerDisposer).toHaveBeenCalledTimes(1);
-		expect(fixture.removeInputListener).not.toHaveBeenCalled();
+		expect(fixture.removeInputListener).toHaveBeenCalledTimes(1);
 		expect(fixture.getInputListener()).toBeUndefined();
-		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(3);
+		// Initial viewport population plus the live-disposal repaint.
+		expect(fixture.requestRender).toHaveBeenCalledTimes(2);
+		expect(fixture.requestRender).toHaveBeenNthCalledWith(1, true);
+		expect(fixture.requestRender).toHaveBeenNthCalledWith(2, true);
 	});
 
 	it("rolls back patches when listener registration does not return cleanup", () => {
@@ -320,8 +331,199 @@ describe("Pi fixed-editor compatibility", () => {
 		expect(fixture.terminalWrite).not.toHaveBeenCalled();
 	});
 
-	it("keeps overlays visible and responds to rows, cursor, and wheel input", () => {
+	it("requests the first repaint and guards writes until it completes", () => {
 		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		expect(fixture.requestRender).toHaveBeenCalledTimes(1);
+		expect(fixture.requestRender).toHaveBeenCalledWith(true);
+		const writesBefore = fixture.terminalWrite.mock.calls.length;
+		fixture.terminal.write("interleaved");
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(writesBefore);
+		fixture.tui.doRender();
+		expect(fixture.doRender).toHaveBeenCalledTimes(1);
+		expect(fixture.terminalWrite.mock.calls.length).toBeGreaterThan(writesBefore);
+		compositor.dispose("shutdown");
+	});
+
+	it("resolves opaque fallback during initial and later attempted fixed transitions", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(10);
+		let editorHeight = 30;
+		Reflect.set(fixture.cluster[2], "render", () =>
+			Array.from({ length: editorHeight }, (_, index) => `opaque-${index}`),
+		);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		const parser = new OwnedTerminalStateParser();
+
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls) parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(true);
+		expect(fixture.terminal.rows).toBe(10);
+		expect(fixture.tui.render(80)).toEqual(fixture.rootRender(80));
+
+		// A fixed transition can become invalid before its forced callback runs.
+		editorHeight = 1;
+		fixture.tui.doRender();
+		editorHeight = 30;
+		const beforeFallback = fixture.terminalWrite.mock.calls.length;
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls.slice(beforeFallback))
+			parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(true);
+		expect(fixture.terminal.rows).toBe(10);
+		expect(fixture.tui.render(80)).toEqual(fixture.rootRender(80));
+
+		// Once the editor fits again, the next transition recovers fixed mode.
+		editorHeight = 1;
+		fixture.tui.doRender();
+		const beforeFixed = fixture.terminalWrite.mock.calls.length;
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls.slice(beforeFixed))
+			parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(false);
+		expect(fixture.terminal.rows).toBeLessThan(10);
+		expect(fixture.tui.render(80).length).toBeLessThan(fixture.rootRender(80).length);
+		compositor.dispose("shutdown");
+	});
+
+	it.each([true, false])(
+		"keeps alternate scroll disabled in initial fixed mode (mouseScroll=%s)",
+		(mouseScroll) => {
+			const fixture = makeValidPiFixture();
+			const capabilities = inspectPiTui(fixture.tui);
+			if (!capabilities) throw new Error("expected valid fixture");
+			const compositor = new TerminalSplitCompositor(capabilities, () => ({
+				enabled: true,
+				mouseScroll,
+				copyNotice: true,
+			}));
+			const parser = new OwnedTerminalStateParser();
+
+			expect(compositor.install()).toBe(true);
+			for (const [write] of fixture.terminalWrite.mock.calls) parser.feed(String(write));
+			expect(parser.state.buffer).toBe("alternate");
+			expect(parser.state.alternateScroll).toBe(false);
+
+			const previousWrites = fixture.terminalWrite.mock.calls.length;
+			fixture.tui.doRender();
+			for (const [write] of fixture.terminalWrite.mock.calls.slice(previousWrites))
+				parser.feed(String(write));
+			expect(parser.state.alternateScroll).toBe(false);
+			expect(parser.state.mouse1002).toBe(mouseScroll);
+			expect(parser.state.mouse1006).toBe(mouseScroll);
+
+			const beforeDispose = fixture.terminalWrite.mock.calls.length;
+			compositor.dispose("shutdown");
+			for (const [write] of fixture.terminalWrite.mock.calls.slice(beforeDispose))
+				parser.feed(String(write));
+			expect(parser.state.alternateScroll).toBe(false);
+			expect(parser.isSafe()).toBe(true);
+		},
+	);
+
+	it("canonically resets when the initial forced repaint request fails", () => {
+		const fixture = makeValidPiFixture();
+		fixture.requestRender.mockImplementation(() => {
+			throw new Error("force render failed");
+		});
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(false);
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+		expect(fixture.tui.render).toBe(fixture.rootRender);
+		expect(fixture.terminal.write).toBe(fixture.terminalWrite);
+	});
+
+	it("canonically resets when the second terminal-entry write fails", () => {
+		const fixture = makeValidPiFixture();
+		fixture.terminalWrite.mockImplementation((_data: string) => {
+			if (fixture.terminalWrite.mock.calls.length === 2) throw new Error("prelude failed");
+		});
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(false);
+		expect(fixture.terminalWrite.mock.calls[0]?.[0]).toContain("\x1b[?1049h");
+		expect(fixture.terminalWrite.mock.calls[1]?.[0]).toContain("\x1b[2J");
+		expect(fixture.terminalWrite.mock.calls[2]?.[0]).toBe(emergencyTerminalReset());
+		expect(fixture.tui.render).toBe(fixture.rootRender);
+		expect(fixture.terminal.write).toBe(fixture.terminalWrite);
+	});
+
+	it("falls back when both terminal entry and captured reset writes fail", () => {
+		const fixture = makeValidPiFixture();
+		fixture.terminalWrite.mockImplementation(() => {
+			throw new Error("writer failed");
+		});
+		const fallback = vi.fn();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: false, copyNotice: true }),
+			undefined,
+			undefined,
+			fallback,
+		);
+		expect(compositor.install()).toBe(false);
+		expect(fallback).toHaveBeenCalledWith(emergencyTerminalReset());
+		expect(fixture.tui.render).toBe(fixture.rootRender);
+	});
+
+	it("routes a live transition prelude failure through disposal", () => {
+		const fixture = makeValidPiFixture();
+		Reflect.set(fixture.cluster[2], "render", () => [
+			"top",
+			`cursor${CURSOR_MARKER}`,
+			"body",
+			"bottom",
+		]);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.setRows(3);
+		fixture.terminalWrite.mockImplementation((data: string) => {
+			if (data.includes("\x1b[2J")) throw new Error("transition prelude failed");
+		});
+		expect(() => fixture.tui.doRender()).toThrow("transition prelude failed");
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+		expect(fixture.tui.render).toBe(fixture.rootRender);
+		expect(fixture.terminal.write).toBe(fixture.terminalWrite);
+		expect(fixture.requestRender).toHaveBeenLastCalledWith(true);
+	});
+
+	it("gives overlays raw rows and recovers fixed rows after they close", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(40);
 		const capabilities = inspectPiTui(fixture.tui);
 		if (!capabilities) throw new Error("expected valid fixture");
 		const compositor = new TerminalSplitCompositor(capabilities, () => ({
@@ -330,14 +532,24 @@ describe("Pi fixed-editor compatibility", () => {
 			copyNotice: true,
 		}));
 		expect(compositor.install()).toBe(true);
+		expect(fixture.requestRender).toHaveBeenCalledWith(true);
+		fixture.tui.doRender();
 		const patchedRender = fixture.tui.render;
-		const narrowRows = fixture.terminal.rows;
-		fixture.setRows(40);
-		expect(fixture.terminal.rows).toBeGreaterThan(narrowRows);
+		expect(fixture.terminal.rows).toBeLessThan(40);
 
 		fixture.tui.overlayStack = [{}];
+		expect(fixture.terminal.rows).toBe(40);
 		expect(patchedRender(80)).toEqual(fixture.rootRender(80));
+		fixture.tui.doRender();
+		fixture.tui.doRender();
+		expect(fixture.terminal.rows).toBe(40);
+
 		fixture.tui.overlayStack = [];
+		expect(fixture.terminal.rows).toBe(40);
+		fixture.tui.doRender();
+		fixture.tui.doRender();
+		expect(fixture.terminal.rows).toBeLessThan(40);
+
 		fixture.setRows(12);
 		patchedRender(80);
 		fixture.terminal.write("update");
@@ -345,7 +557,7 @@ describe("Pi fixed-editor compatibility", () => {
 		fixture.requestRender.mockClear();
 		fixture.getInputListener()?.("\u001b[<64;1;1M");
 		expect(fixture.requestRender).toHaveBeenCalled();
-		compositor.dispose();
+		compositor.dispose("live");
 	});
 
 	it("repaints adaptive polished borders through the fixed-editor cluster without stale color", () => {
@@ -419,7 +631,7 @@ describe("Pi fixed-editor compatibility", () => {
 			expect(paintedRows.every((row) => visibleWidth(row) <= 80)).toBe(true);
 		}
 
-		compositor.dispose();
+		compositor.dispose("live");
 	});
 
 	it("clears the right-click mouse-resume timer on disposal", () => {
@@ -434,16 +646,446 @@ describe("Pi fixed-editor compatibility", () => {
 				copyNotice: true,
 			}));
 			expect(compositor.install()).toBe(true);
+			fixture.tui.doRender();
 			fixture.getInputListener()?.("\u001b[<2;1;1M");
 			expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toContain(DISABLE_MOUSE);
 
-			compositor.dispose();
+			compositor.dispose("live");
 			const writesAfterDispose = fixture.terminalWrite.mock.calls.length;
 			vi.advanceTimersByTime(1_200);
 			expect(fixture.terminalWrite).toHaveBeenCalledTimes(writesAfterDispose);
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("resumes mouse reporting only while fixed mode still owns input", () => {
+		vi.useFakeTimers();
+		try {
+			const fixture = makeValidPiFixture();
+			fixture.setRows(12);
+			const capabilities = inspectPiTui(fixture.tui);
+			if (!capabilities) throw new Error("expected valid fixture");
+			const compositor = new TerminalSplitCompositor(capabilities, () => ({
+				enabled: true,
+				mouseScroll: true,
+				copyNotice: true,
+			}));
+			expect(compositor.install()).toBe(true);
+			fixture.tui.doRender();
+			fixture.getInputListener()?.("\u001b[<2;1;1M");
+			const parser = new OwnedTerminalStateParser({
+				buffer: "alternate",
+				mouse1002: true,
+				mouse1006: true,
+			});
+			parser.feed(String(fixture.terminalWrite.mock.calls.at(-1)?.[0]));
+			expect(parser.state.mouse1002).toBe(false);
+
+			vi.advanceTimersByTime(1_200);
+			parser.feed(String(fixture.terminalWrite.mock.calls.at(-1)?.[0]));
+			expect(parser.state.mouse1002).toBe(true);
+			compositor.dispose("shutdown");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not resume mouse reporting after normal-flow or overlay ownership", () => {
+		vi.useFakeTimers();
+		try {
+			const makeCompositor = () => {
+				const fixture = makeValidPiFixture();
+				fixture.setRows(12);
+				const capabilities = inspectPiTui(fixture.tui);
+				if (!capabilities) throw new Error("expected valid fixture");
+				const compositor = new TerminalSplitCompositor(capabilities, () => ({
+					enabled: true,
+					mouseScroll: true,
+					copyNotice: true,
+				}));
+				expect(compositor.install()).toBe(true);
+				fixture.tui.doRender();
+				return { fixture, compositor };
+			};
+
+			const normal = makeCompositor();
+			normal.fixture.getInputListener()?.("\u001b[<2;1;1M");
+			normal.fixture.setRows(1);
+			normal.fixture.tui.doRender();
+			normal.fixture.tui.doRender();
+			const normalWrites = normal.fixture.terminalWrite.mock.calls.length;
+			vi.advanceTimersByTime(1_200);
+			expect(normal.fixture.terminalWrite).toHaveBeenCalledTimes(normalWrites);
+			normal.compositor.dispose("shutdown");
+
+			const overlay = makeCompositor();
+			overlay.fixture.getInputListener()?.("\u001b[<2;1;1M");
+			overlay.fixture.tui.overlayStack = [{}];
+			const overlayWrites = overlay.fixture.terminalWrite.mock.calls.length;
+			vi.advanceTimersByTime(1_200);
+			expect(overlay.fixture.terminalWrite).toHaveBeenCalledTimes(overlayWrites);
+			overlay.compositor.dispose("shutdown");
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("copies an ordinary in-range selection and reports the selected text once", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(12);
+		const onCopy = vi.fn();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: true, copyNotice: true }),
+			onCopy,
+		);
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.tui.render(80);
+		const listener = fixture.getInputListener();
+
+		expect(listener?.("\u001b[<0;1;1M")).toEqual({ consume: true });
+		expect(listener?.("\u001b[<0;4;1m")).toEqual({ consume: true });
+		expect(onCopy).toHaveBeenCalledOnce();
+		expect(onCopy).toHaveBeenCalledWith("root");
+		expect(fixture.tui.render(80).join("\n")).not.toContain("\u001b[48;5;238m");
+		compositor.dispose("shutdown");
+	});
+
+	it("clears a transcript drag released over the pinned cluster", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(12);
+		const onCopy = vi.fn();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: true, copyNotice: true }),
+			onCopy,
+		);
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.tui.render(80);
+		const listener = fixture.getInputListener();
+		listener?.("\u001b[<0;1;1M");
+		listener?.("\u001b[<32;4;2M");
+		expect(fixture.tui.render(80).join("\n")).toContain("\u001b[48;5;238m");
+
+		fixture.requestRender.mockClear();
+		expect(listener?.("\u001b[<0;4;8m")).toEqual({ consume: true });
+		expect(fixture.requestRender).toHaveBeenCalledTimes(1);
+		expect(fixture.tui.render(80).join("\n")).not.toContain("\u001b[48;5;238m");
+		listener?.("\u001b[<0;4;2m");
+		expect(onCopy).not.toHaveBeenCalled();
+		compositor.dispose("shutdown");
+	});
+
+	it.each([
+		{
+			name: "an overlay",
+			enter: (fixture: ReturnType<typeof makeValidPiFixture>) => {
+				fixture.tui.overlayStack = [{}];
+			},
+			exit: (fixture: ReturnType<typeof makeValidPiFixture>) => {
+				fixture.tui.overlayStack = [];
+			},
+		},
+		{
+			name: "a height fallback",
+			enter: (fixture: ReturnType<typeof makeValidPiFixture>) => fixture.setRows(1),
+			exit: (fixture: ReturnType<typeof makeValidPiFixture>) => fixture.setRows(12),
+		},
+	])("clears an active transcript drag across $name transition and recovery", ({ enter, exit }) => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(12);
+		const onCopy = vi.fn();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: true, copyNotice: true }),
+			onCopy,
+		);
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.tui.render(80);
+		const listener = fixture.getInputListener();
+		listener?.("\u001b[<0;1;1M");
+		listener?.("\u001b[<32;4;2M");
+		expect(fixture.tui.render(80).join("\n")).toContain("\u001b[48;5;238m");
+
+		enter(fixture);
+		fixture.tui.doRender();
+		fixture.tui.doRender();
+		exit(fixture);
+		fixture.tui.doRender();
+		fixture.tui.doRender();
+
+		const recovered = fixture.tui.render(80).join("\n");
+		expect(recovered).not.toContain("\u001b[48;5;238m");
+		fixture.requestRender.mockClear();
+		expect(listener?.("\u001b[<0;4;2m")).toEqual({ consume: true });
+		expect(fixture.requestRender).not.toHaveBeenCalled();
+		expect(onCopy).not.toHaveBeenCalled();
+		expect(fixture.tui.render(80).join("\n")).not.toContain("\u001b[48;5;238m");
+		compositor.dispose("shutdown");
+	});
+
+	it("suspends installation and rendering at zero terminal rows", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(0);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		expect(fixture.terminalWrite).not.toHaveBeenCalled();
+		expect(fixture.requestRender).not.toHaveBeenCalled();
+		fixture.tui.doRender();
+		expect(fixture.doRender).not.toHaveBeenCalled();
+		expect(fixture.terminalWrite).not.toHaveBeenCalled();
+		fixture.setRows(12);
+		fixture.tui.doRender();
+		expect(fixture.requestRender).toHaveBeenCalledWith(true);
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(2);
+		const parser = new OwnedTerminalStateParser();
+		for (const [write] of fixture.terminalWrite.mock.calls) parser.feed(String(write));
+		expect(parser.state.buffer).toBe("alternate");
+		expect(parser.state.alternateScroll).toBe(false);
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls.slice(2)) parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(false);
+		compositor.dispose("shutdown");
+	});
+
+	it("propagates PageUp and PageDown for overlays and when no transcript range exists", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(40);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.tui.render(80);
+		const listener = fixture.getInputListener();
+		expect(listener?.("\x1b[5~")).toBeUndefined();
+		expect(listener?.("\x1b[6~")).toBeUndefined();
+		fixture.tui.overlayStack = [{}];
+		expect(listener?.("\x1b[5~")).toBeUndefined();
+		expect(listener?.("\x1b[6~")).toBeUndefined();
+		compositor.dispose("shutdown");
+	});
+
+	it("consumes PageUp and PageDown at transcript boundaries when a range exists", () => {
+		const fixture = makeValidPiFixture();
+		fixture.setRows(12);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.tui.render(80);
+		const listener = fixture.getInputListener();
+		expect(listener?.("\x1b[6~")).toEqual({ consume: true });
+		expect(listener?.("\x1b[5~")).toEqual({ consume: true });
+		for (let index = 0; index < 20; index++) listener?.("\x1b[5~");
+		expect(listener?.("\x1b[5~")).toEqual({ consume: true });
+		compositor.dispose("shutdown");
+	});
+
+	it("guards bidirectional fixed and normal-flow transitions", () => {
+		const fixture = makeValidPiFixture();
+		Reflect.set(fixture.cluster[2], "render", () => [
+			"top",
+			`cursor${CURSOR_MARKER}`,
+			"body",
+			"bottom",
+		]);
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		// Complete the initial forced fixed-mode render before testing later transitions.
+		fixture.tui.doRender();
+		const parser = new OwnedTerminalStateParser();
+		for (const [write] of fixture.terminalWrite.mock.calls) parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(false);
+		fixture.setRows(3);
+		fixture.terminalWrite.mockClear();
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls) parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(true);
+		expect(String(fixture.terminalWrite.mock.calls[0]?.[0])).toContain("\x1b[2J");
+		expect(String(fixture.terminalWrite.mock.calls[0]?.[0])).not.toContain("\x1b[3J");
+		const writesDuringGuard = fixture.terminalWrite.mock.calls.length;
+		fixture.terminal.write("partial");
+		expect(fixture.terminalWrite).toHaveBeenCalledTimes(writesDuringGuard);
+		fixture.tui.doRender();
+		expect(fixture.tui.render(80)).toEqual(fixture.rootRender(80));
+		fixture.setRows(24);
+		const beforeFixed = fixture.terminalWrite.mock.calls.length;
+		fixture.tui.doRender();
+		for (const [write] of fixture.terminalWrite.mock.calls.slice(beforeFixed))
+			parser.feed(String(write));
+		expect(parser.state.alternateScroll).toBe(false);
+		fixture.tui.doRender();
+		expect(parser.state.alternateScroll).toBe(false);
+		expect(fixture.tui.render(80).length).toBeLessThan(fixture.rootRender(80).length);
+		compositor.dispose("shutdown");
+	});
+
+	it("continues sibling descriptor restoration after an individual failure", () => {
+		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const rootRender = fixture.tui.render;
+		const terminalWrite = fixture.terminal.write;
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: false,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		const status = fixture.cluster[0];
+		const patchedStatus = Object.getOwnPropertyDescriptor(status, "render");
+		Object.defineProperty(status, "render", { ...patchedStatus, configurable: false });
+		compositor.dispose("shutdown");
+		expect(fixture.tui.render).toBe(rootRender);
+		expect(fixture.terminal.write).toBe(terminalWrite);
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+	});
+
+	it.each([
+		["status render", (f: ReturnType<typeof makeValidPiFixture>) => f.cluster[0], "render"],
+		["above render", (f: ReturnType<typeof makeValidPiFixture>) => f.cluster[1], "render"],
+		["editor render", (f: ReturnType<typeof makeValidPiFixture>) => f.cluster[2], "render"],
+		["below render", (f: ReturnType<typeof makeValidPiFixture>) => f.cluster[3], "render"],
+		["footer render", (f: ReturnType<typeof makeValidPiFixture>) => f.cluster[4], "render"],
+		["terminal write", (f: ReturnType<typeof makeValidPiFixture>) => f.terminal, "write"],
+		["root render", (f: ReturnType<typeof makeValidPiFixture>) => f.tui, "render"],
+		["root doRender", (f: ReturnType<typeof makeValidPiFixture>) => f.tui, "doRender"],
+		["terminal rows", (f: ReturnType<typeof makeValidPiFixture>) => f.terminal, "rows"],
+	] as const)(
+		"continues after individual %s descriptor restoration fails",
+		(_name, targetFor, key) => {
+			const fixture = makeValidPiFixture();
+			const capabilities = inspectPiTui(fixture.tui);
+			if (!capabilities) throw new Error("expected valid fixture");
+			const compositor = new TerminalSplitCompositor(capabilities, () => ({
+				enabled: true,
+				mouseScroll: false,
+				copyNotice: true,
+			}));
+			expect(compositor.install()).toBe(true);
+			const target = targetFor(fixture);
+			const descriptor = Object.getOwnPropertyDescriptor(target, key);
+			Object.defineProperty(target, key, { ...descriptor, configurable: false });
+			compositor.dispose("shutdown");
+			expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+			if (key !== "render" || target !== fixture.tui)
+				expect(fixture.tui.render).toBe(fixture.rootRender);
+			if (key !== "write") expect(fixture.terminal.write).toBe(fixture.terminalWrite);
+		},
+	);
+
+	it("isolates timer, disposer, and listener-removal failures from terminal reset", () => {
+		const fixture = makeValidPiFixture();
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(capabilities, () => ({
+			enabled: true,
+			mouseScroll: true,
+			copyNotice: true,
+		}));
+		expect(compositor.install()).toBe(true);
+		fixture.tui.doRender();
+		fixture.getInputListener()?.("\u001b[<2;1;1M");
+		fixture.inputListenerDisposer.mockImplementationOnce(() => {
+			throw new Error("disposer failed");
+		});
+		fixture.removeInputListener.mockImplementationOnce(() => {
+			throw new Error("removal failed");
+		});
+		const clear = vi.spyOn(globalThis, "clearTimeout").mockImplementation((() => {
+			throw new Error("timer failed");
+		}) as typeof clearTimeout);
+		try {
+			compositor.dispose("shutdown");
+		} finally {
+			clear.mockRestore();
+		}
+		expect(fixture.inputListenerDisposer).toHaveBeenCalled();
+		expect(fixture.removeInputListener).toHaveBeenCalled();
+		expect(fixture.terminalWrite.mock.calls.at(-1)?.[0]).toBe(emergencyTerminalReset());
+		expect(fixture.tui.render).toBe(fixture.rootRender);
+	});
+
+	it("uses the default stdout fallback when the captured reset writer fails", () => {
+		const fixture = makeValidPiFixture();
+		let failReset = false;
+		fixture.terminalWrite.mockImplementation((data: string) => {
+			if (failReset && data === emergencyTerminalReset()) throw new Error("writer closed");
+		});
+		const stdout = vi
+			.spyOn(process.stdout, "write")
+			.mockImplementation((() => true) as typeof process.stdout.write);
+		try {
+			const capabilities = inspectPiTui(fixture.tui);
+			if (!capabilities) throw new Error("expected valid fixture");
+			const compositor = new TerminalSplitCompositor(capabilities, () => ({
+				enabled: true,
+				mouseScroll: false,
+				copyNotice: true,
+			}));
+			expect(compositor.install()).toBe(true);
+			failReset = true;
+			compositor.dispose("shutdown");
+			expect(stdout).toHaveBeenCalledWith(emergencyTerminalReset());
+		} finally {
+			stdout.mockRestore();
+		}
+	});
+
+	it("uses the canonical reset fallback and never repaints on shutdown", () => {
+		const fixture = makeValidPiFixture();
+		const fallback = vi.fn();
+		let failReset = false;
+		fixture.terminalWrite.mockImplementation((data: string) => {
+			if (failReset && data === emergencyTerminalReset()) throw new Error("writer closed");
+		});
+		const capabilities = inspectPiTui(fixture.tui);
+		if (!capabilities) throw new Error("expected valid fixture");
+		const compositor = new TerminalSplitCompositor(
+			capabilities,
+			() => ({ enabled: true, mouseScroll: true, copyNotice: true }),
+			undefined,
+			undefined,
+			fallback,
+		);
+		expect(compositor.install()).toBe(true);
+		const requestsBefore = fixture.requestRender.mock.calls.length;
+		failReset = true;
+		compositor.dispose("shutdown");
+		expect(fallback).toHaveBeenCalledWith(emergencyTerminalReset());
+		expect(fixture.requestRender).toHaveBeenCalledTimes(requestsBefore);
 	});
 });
 
@@ -563,8 +1205,10 @@ describe("terminal-modes", () => {
 			expect(reset).toContain(EXIT_ALT_SCREEN);
 			expect(reset).toContain(DISABLE_MOUSE);
 			expect(reset).toContain(RESET_SCROLL_REGION);
-			expect(reset).toContain(ENABLE_ALT_SCROLL);
+			expect(reset).toContain(DISABLE_ALT_SCROLL);
+			expect(reset).toContain(ENABLE_AUTOWRAP);
 			expect(reset).toContain(SHOW_CURSOR);
+			expect(reset.indexOf(ENABLE_AUTOWRAP)).toBeLessThan(reset.indexOf(EXIT_ALT_SCREEN));
 		});
 	});
 });
@@ -617,28 +1261,6 @@ describe("cluster", () => {
 		});
 	});
 
-	describe("capEditorLines", () => {
-		it("keeps last N lines when no cursor marker", () => {
-			const lines = Array.from({ length: 10 }, (_, i) => `line ${i}`);
-			const result = capEditorLines(lines, 5);
-			expect(result).toHaveLength(5);
-			expect(result[0]).toBe("line 5");
-		});
-
-		it("centers window on cursor row", () => {
-			const lines = Array.from({ length: 20 }, (_, i) => `line ${i}`);
-			lines[15] = `line 15${CURSOR_MARKER}`;
-			const result = capEditorLines(lines, 5);
-			expect(result).toHaveLength(5);
-			expect(result[4]).toContain("line 15");
-		});
-
-		it("returns all lines when under max", () => {
-			const lines = ["a", "b", "c"];
-			expect(capEditorLines(lines, 5)).toBe(lines);
-		});
-	});
-
 	describe("renderCluster", () => {
 		it("renders and concatenates all cluster components", () => {
 			const cluster = {
@@ -665,18 +1287,31 @@ describe("cluster", () => {
 			expect(result.lines[0]).toBe("helloworld");
 		});
 
-		it("caps editor lines when total exceeds maxHeight", () => {
+		it("selects normal flow rather than cropping an oversized opaque editor", () => {
 			const manyLines = Array.from({ length: 30 }, (_, i) => `ed-${i}`);
+			const throwingEditor = new Proxy(
+				{},
+				{
+					get() {
+						throw new Error("opaque provider trap");
+					},
+				},
+			);
 			const cluster = {
 				status: null,
 				aboveWidget: null,
 				editor: makeCapability(manyLines),
+				editorChild: throwingEditor,
 				belowWidget: null,
 				footer: null,
 			};
-			// maxHeight = 10, maxRows = 9, so editor gets max 9 lines
+			expect(() => renderCluster(cluster, 80, 10)).not.toThrow();
 			const result = renderCluster(cluster, 80, 10);
-			expect(result.lines.length).toBeLessThanOrEqual(9);
+			expect(result).toMatchObject({
+				mode: "normal-flow",
+				lines: [],
+				plan: { mode: "normal-flow", reason: "opaque-editor-does-not-fit" },
+			});
 		});
 
 		it("preserves internal blank lines (low-rail polished padding)", () => {

--- a/test/fixed-editor.test.ts
+++ b/test/fixed-editor.test.ts
@@ -679,9 +679,9 @@ describe("cluster", () => {
 			expect(result.lines.length).toBeLessThanOrEqual(9);
 		});
 
-		it("preserves internal blank lines (copy-friendly editor padding)", () => {
-			// In copy-friendly mode the editor renders truly empty strings as
-			// padding: [border, "", text, "", meta, border]. These must survive.
+		it("preserves internal blank lines (low-rail polished padding)", () => {
+			// The low-rail polished editor renders truly empty strings as padding:
+			// [border, "", text, "", meta, border]. These must survive.
 			const editorFrame = ["border", "", "input text", "", "model provider", "border"];
 			const cluster = {
 				status: null,

--- a/test/helpers/pi-pty.ts
+++ b/test/helpers/pi-pty.ts
@@ -1,0 +1,93 @@
+import { chmodSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { type IPty, spawn } from "node-pty";
+
+export type CapturedPty = {
+	pty: IPty;
+	output: () => string;
+	waitFor: (needle: string, timeoutMs?: number, from?: number) => Promise<number>;
+	waitForExit: (timeoutMs?: number) => Promise<void>;
+	hasExited: () => boolean;
+	close: (timeoutMs?: number) => Promise<void>;
+};
+
+export function spawnCapturedPty(
+	file: string,
+	args: string[],
+	options: { cwd: string; env: Record<string, string> },
+): CapturedPty {
+	if (process.platform !== "win32") {
+		try {
+			const entry = createRequire(import.meta.url).resolve("node-pty");
+			const root = dirname(dirname(entry));
+			chmodSync(
+				join(root, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+				0o755,
+			);
+		} catch {
+			// Source builds do not use the prebuilt spawn helper.
+		}
+	}
+	let data = "";
+	const terminal = spawn(file, args, {
+		name: "xterm-256color",
+		cols: 100,
+		rows: 30,
+		cwd: options.cwd,
+		env: options.env,
+	});
+	terminal.onData((chunk) => {
+		data += chunk;
+	});
+	let exited = false;
+	let exitDescription = "";
+	terminal.onExit(({ exitCode, signal }) => {
+		exited = true;
+		exitDescription = `exitCode=${exitCode}, signal=${signal}`;
+	});
+	const diagnostics = () =>
+		`pid=${terminal.pid}${exitDescription ? `, ${exitDescription}` : ""}\n${data.slice(-4000)}`;
+	const waitFor = async (needle: string, timeoutMs = 12_000, from = 0): Promise<number> => {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			const index = data.indexOf(needle, from);
+			if (index >= 0) return index;
+			if (exited)
+				throw new Error(
+					`PTY exited before ${JSON.stringify(needle)} was observed\n${diagnostics()}`,
+				);
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		}
+		throw new Error(`PTY timeout waiting for ${JSON.stringify(needle)}\n${diagnostics()}`);
+	};
+	const waitForExit = async (timeoutMs = 12_000): Promise<void> => {
+		const deadline = Date.now() + timeoutMs;
+		while (!exited && Date.now() < deadline)
+			await new Promise((resolve) => setTimeout(resolve, 20));
+		if (!exited) throw new Error(`PTY timeout waiting for exit\n${diagnostics()}`);
+	};
+	let closePromise: Promise<void> | undefined;
+	const close = (timeoutMs = 5_000): Promise<void> => {
+		closePromise ??= (async () => {
+			if (!exited) {
+				try {
+					terminal.kill();
+				} catch (error) {
+					if (!exited)
+						throw new Error(`PTY termination failed: ${String(error)}\n${diagnostics()}`);
+				}
+			}
+			await waitForExit(timeoutMs);
+		})();
+		return closePromise;
+	};
+	return {
+		pty: terminal,
+		output: () => data,
+		waitFor,
+		waitForExit,
+		hasExited: () => exited,
+		close,
+	};
+}

--- a/test/helpers/pi-pty.ts
+++ b/test/helpers/pi-pty.ts
@@ -15,7 +15,11 @@ export type CapturedPty = {
 export function spawnCapturedPty(
 	file: string,
 	args: string[],
-	options: { cwd: string; env: Record<string, string> },
+	options: {
+		cwd: string;
+		env: Record<string, string>;
+		keyboardMode?: "kitty" | "modifyOtherKeys";
+	},
 ): CapturedPty {
 	if (process.platform !== "win32") {
 		try {
@@ -37,8 +41,27 @@ export function spawnCapturedPty(
 		cwd: options.cwd,
 		env: options.env,
 	});
+	let emulatorPending = "";
 	terminal.onData((chunk) => {
 		data += chunk;
+		if (!options.keyboardMode) return;
+		emulatorPending += chunk;
+		while (true) {
+			const kittyQuery = emulatorPending.indexOf("\x1b[?u");
+			const attributesQuery = emulatorPending.indexOf("\x1b[c");
+			const indexes = [kittyQuery, attributesQuery].filter((index) => index >= 0);
+			if (indexes.length === 0) break;
+			const index = Math.min(...indexes);
+			if (index === kittyQuery) {
+				emulatorPending = emulatorPending.slice(index + "\x1b[?u".length);
+				if (options.keyboardMode === "kitty") terminal.write("\x1b[?7u");
+			} else {
+				emulatorPending = emulatorPending.slice(index + "\x1b[c".length);
+				terminal.write("\x1b[?1;2c");
+			}
+		}
+		const lastEscape = emulatorPending.lastIndexOf("\x1b");
+		emulatorPending = lastEscape >= 0 ? emulatorPending.slice(lastEscape) : "";
 	});
 	let exited = false;
 	let exitDescription = "";

--- a/test/helpers/pi-pty.ts
+++ b/test/helpers/pi-pty.ts
@@ -3,13 +3,61 @@ import { createRequire } from "node:module";
 import { dirname, join } from "node:path";
 import { type IPty, spawn } from "node-pty";
 
+type ProcessGroupSignal = (pid: number, signal: NodeJS.Signals | 0) => void;
+
+export function probeOwnedProcessGroup(
+	pid: number,
+	signalProcess: ProcessGroupSignal = process.kill,
+): boolean {
+	if (!Number.isSafeInteger(pid) || pid <= 1)
+		throw new Error(`Refusing to inspect unsafe PTY process group ${pid}`);
+	try {
+		signalProcess(-pid, 0);
+		return true;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return false;
+		if (code === "EPERM")
+			throw new Error(`Permission denied inspecting owned PTY process group ${pid}`, {
+				cause: error,
+			});
+		throw error;
+	}
+}
+
+export function signalOwnedProcessGroup(
+	pid: number,
+	signal: NodeJS.Signals,
+	signalProcess: ProcessGroupSignal = process.kill,
+): boolean {
+	if (!Number.isSafeInteger(pid) || pid <= 1)
+		throw new Error(`Refusing to signal unsafe PTY process group ${pid}`);
+	try {
+		signalProcess(-pid, signal);
+		return true;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		if (code === "ESRCH") return false;
+		if (code === "EPERM")
+			throw new Error(`Permission denied signaling owned PTY process group ${pid}`, {
+				cause: error,
+			});
+		throw error;
+	}
+}
+
+export function terminateWindowsPty(kill: () => void): void {
+	kill();
+}
+
 export type CapturedPty = {
 	pty: IPty;
 	output: () => string;
 	waitFor: (needle: string, timeoutMs?: number, from?: number) => Promise<number>;
 	waitForExit: (timeoutMs?: number) => Promise<void>;
 	hasExited: () => boolean;
-	close: (timeoutMs?: number) => Promise<void>;
+	cleanupActions: () => readonly string[];
+	close: () => Promise<void>;
 };
 
 export function spawnCapturedPty(
@@ -19,6 +67,7 @@ export function spawnCapturedPty(
 		cwd: string;
 		env: Record<string, string>;
 		keyboardMode?: "kitty" | "modifyOtherKeys";
+		gracefulExitInput?: string;
 	},
 ): CapturedPty {
 	if (process.platform !== "win32") {
@@ -65,9 +114,14 @@ export function spawnCapturedPty(
 	});
 	let exited = false;
 	let exitDescription = "";
+	let resolveExactExit!: () => void;
+	const exactExit = new Promise<void>((resolve) => {
+		resolveExactExit = resolve;
+	});
 	terminal.onExit(({ exitCode, signal }) => {
 		exited = true;
 		exitDescription = `exitCode=${exitCode}, signal=${signal}`;
+		resolveExactExit();
 	});
 	const diagnostics = () =>
 		`pid=${terminal.pid}${exitDescription ? `, ${exitDescription}` : ""}\n${data.slice(-4000)}`;
@@ -84,26 +138,90 @@ export function spawnCapturedPty(
 		}
 		throw new Error(`PTY timeout waiting for ${JSON.stringify(needle)}\n${diagnostics()}`);
 	};
+	const delay = (timeoutMs: number) =>
+		new Promise<void>((resolve) => setTimeout(resolve, timeoutMs));
 	const waitForExit = async (timeoutMs = 12_000): Promise<void> => {
+		if (exited) return;
+		const completed = await Promise.race([
+			exactExit.then(() => true),
+			delay(timeoutMs).then(() => false),
+		]);
+		if (!completed) throw new Error(`PTY timeout waiting for exit\n${diagnostics()}`);
+	};
+	const cleanupActions: string[] = [];
+	const pid = terminal.pid;
+	const ownedGroupExists = (): boolean => {
+		if (process.platform === "win32") return false;
+		try {
+			return probeOwnedProcessGroup(pid);
+		} catch (error) {
+			throw new Error(`PTY process-group inspection failed: ${String(error)}\n${diagnostics()}`, {
+				cause: error,
+			});
+		}
+	};
+	const signalOwnedGroup = (signal: NodeJS.Signals): boolean => {
+		try {
+			const signaled = signalOwnedProcessGroup(pid, signal);
+			if (signaled) cleanupActions.push(`group-${signal}`);
+			return signaled;
+		} catch (error) {
+			throw new Error(`PTY process-group ${signal} failed: ${String(error)}\n${diagnostics()}`, {
+				cause: error,
+			});
+		}
+	};
+	const waitForOwnedTreeExit = async (timeoutMs: number): Promise<boolean> => {
 		const deadline = Date.now() + timeoutMs;
-		while (!exited && Date.now() < deadline)
-			await new Promise((resolve) => setTimeout(resolve, 20));
-		if (!exited) throw new Error(`PTY timeout waiting for exit\n${diagnostics()}`);
+		while (Date.now() < deadline) {
+			if (exited && !ownedGroupExists()) return true;
+			if (exited) await delay(20);
+			else await Promise.race([exactExit, delay(20)]);
+		}
+		return exited && !ownedGroupExists();
+	};
+	// forkpty makes pid the owned session/process-group leader. Deliberately detached
+	// descendants are outside this group; Pi's TERM handler gets time to clean those.
+	const closeUnix = async (): Promise<void> => {
+		if (!Number.isSafeInteger(pid) || pid <= 1)
+			throw new Error(`Refusing to clean unsafe PTY process group ${pid}\n${diagnostics()}`);
+		if (exited && !ownedGroupExists()) return;
+		if (options.gracefulExitInput && !exited) {
+			terminal.write(options.gracefulExitInput);
+			cleanupActions.push("write-graceful-exit");
+		}
+		if (ownedGroupExists()) signalOwnedGroup("SIGCONT");
+		if (await waitForOwnedTreeExit(300)) return;
+		if (ownedGroupExists()) signalOwnedGroup("SIGTERM");
+		if (await waitForOwnedTreeExit(700)) return;
+		if (ownedGroupExists()) {
+			signalOwnedGroup("SIGCONT");
+			signalOwnedGroup("SIGKILL");
+		}
+		await waitForExit(2_000);
+		if (!(await waitForOwnedTreeExit(2_000)))
+			throw new Error(`PTY process group survived cleanup\n${diagnostics()}`);
+	};
+	const closeWindows = async (): Promise<void> => {
+		if (exited) return;
+		if (options.gracefulExitInput) {
+			terminal.write(options.gracefulExitInput);
+			cleanupActions.push("write-graceful-exit");
+			if (await Promise.race([exactExit.then(() => true), delay(300).then(() => false)])) return;
+		}
+		terminateWindowsPty(() => terminal.kill());
+		cleanupActions.push("pid-kill");
+		await waitForExit(2_000);
 	};
 	let closePromise: Promise<void> | undefined;
-	const close = (timeoutMs = 5_000): Promise<void> => {
-		closePromise ??= (async () => {
-			if (!exited) {
-				try {
-					terminal.kill();
-				} catch (error) {
-					if (!exited)
-						throw new Error(`PTY termination failed: ${String(error)}\n${diagnostics()}`);
-				}
-			}
-			await waitForExit(timeoutMs);
-		})();
-		return closePromise;
+	const close = (): Promise<void> => {
+		if (closePromise) return closePromise;
+		const attempt = process.platform === "win32" ? closeWindows() : closeUnix();
+		closePromise = attempt;
+		void attempt.catch(() => {
+			if (closePromise === attempt) closePromise = undefined;
+		});
+		return attempt;
 	};
 	return {
 		pty: terminal,
@@ -111,6 +229,7 @@ export function spawnCapturedPty(
 		waitFor,
 		waitForExit,
 		hasExited: () => exited,
+		cleanupActions: () => [...cleanupActions],
 		close,
 	};
 }

--- a/test/helpers/terminal-state.ts
+++ b/test/helpers/terminal-state.ts
@@ -1,5 +1,6 @@
-export type OwnedTerminalState = {
-	buffer: "primary" | "alternate";
+export type TerminalScreen = "primary" | "alternate";
+
+type VisualTerminalState = {
 	autowrap: boolean;
 	cursorVisible: boolean;
 	mouse1000: boolean;
@@ -9,70 +10,170 @@ export type OwnedTerminalState = {
 	scrollRegion: "full" | { top: number; bottom: number };
 };
 
+type KeyboardTerminalState = {
+	bracketedPaste: boolean;
+	modifyOtherKeys: 0 | 2;
+	kittyFlags: number;
+	kittyStack: number[];
+};
+
+export type ScreenTerminalState = VisualTerminalState & KeyboardTerminalState;
+
+export type OwnedTerminalState = ScreenTerminalState & {
+	buffer: TerminalScreen;
+};
+
+function defaultVisualState(): VisualTerminalState {
+	return {
+		autowrap: true,
+		cursorVisible: true,
+		mouse1000: false,
+		mouse1002: false,
+		mouse1006: false,
+		alternateScroll: false,
+		scrollRegion: "full",
+	};
+}
+
+function defaultKeyboardState(
+	initial: Partial<KeyboardTerminalState> | undefined,
+): KeyboardTerminalState {
+	return {
+		bracketedPaste: initial?.bracketedPaste ?? false,
+		modifyOtherKeys: initial?.modifyOtherKeys ?? 0,
+		kittyFlags: initial?.kittyFlags ?? 0,
+		kittyStack: [...(initial?.kittyStack ?? [])],
+	};
+}
+
 export class OwnedTerminalStateParser {
-	readonly state: OwnedTerminalState;
+	private activeScreen: TerminalScreen;
+	private readonly visual: VisualTerminalState;
+	private readonly keyboard: Record<TerminalScreen, KeyboardTerminalState>;
 	private pending = "";
 	readonly operations: string[] = [];
+	readonly keyboardUnderflows: TerminalScreen[] = [];
 
-	constructor(initial: Partial<OwnedTerminalState> = {}) {
-		this.state = {
-			buffer: "primary",
-			autowrap: true,
-			cursorVisible: true,
-			mouse1000: false,
-			mouse1002: false,
-			mouse1006: false,
-			alternateScroll: false,
-			scrollRegion: "full",
-			...initial,
+	constructor(
+		initial: Partial<OwnedTerminalState> = {},
+		screens: Partial<Record<TerminalScreen, Partial<ScreenTerminalState>>> = {},
+		private readonly kittySupported = true,
+	) {
+		this.activeScreen = initial.buffer ?? "primary";
+		this.visual = { ...defaultVisualState(), ...initial };
+		this.keyboard = {
+			primary: defaultKeyboardState(screens.primary),
+			alternate: defaultKeyboardState(screens.alternate),
+		};
+		const active = this.keyboard[this.activeScreen];
+		if (initial.bracketedPaste !== undefined) active.bracketedPaste = initial.bracketedPaste;
+		if (initial.modifyOtherKeys !== undefined) active.modifyOtherKeys = initial.modifyOtherKeys;
+		if (initial.kittyFlags !== undefined) active.kittyFlags = initial.kittyFlags;
+		if (initial.kittyStack !== undefined) active.kittyStack = [...initial.kittyStack];
+	}
+
+	get state(): OwnedTerminalState {
+		return { buffer: this.activeScreen, ...this.screen(this.activeScreen) };
+	}
+
+	screen(screen: TerminalScreen): ScreenTerminalState {
+		return {
+			...this.visual,
+			...this.keyboard[screen],
+			kittyStack: [...this.keyboard[screen].kittyStack],
 		};
 	}
 
 	feed(chunk: string): void {
 		this.pending += chunk;
 		let cursor = 0;
-		const pattern = /\x1b\[([?]?)([0-9;]*)([hlr])/g;
+		const pattern = /\x1b\[([?=><]?)([0-9;:]*)([A-Za-z])/g;
 		for (let match = pattern.exec(this.pending); match; match = pattern.exec(this.pending)) {
 			cursor = pattern.lastIndex;
-			const privateMode = match[1] === "?";
+			const prefix = match[1] ?? "";
 			const args = match[2] ?? "";
-			const final = match[3];
+			const final = match[3] ?? "";
 			const sequence = match[0];
-			if (final === "r" && !privateMode) {
+			const keyboard = this.keyboard[this.activeScreen];
+
+			if (prefix === ">" && final === "u") {
+				if (!this.kittySupported) continue;
+				const flags = Number(args || "0");
+				if (Number.isFinite(flags)) {
+					keyboard.kittyStack.push(keyboard.kittyFlags);
+					keyboard.kittyFlags = flags;
+					this.operations.push(sequence);
+				}
+				continue;
+			}
+			if (prefix === "<" && final === "u") {
+				if (!this.kittySupported) continue;
+				const count = Math.max(1, Number(args || "1"));
+				for (let index = 0; index < count; index++) {
+					const previous = keyboard.kittyStack.pop();
+					if (previous === undefined) {
+						this.keyboardUnderflows.push(this.activeScreen);
+						keyboard.kittyFlags = 0;
+					} else {
+						keyboard.kittyFlags = previous;
+					}
+				}
+				this.operations.push(sequence);
+				continue;
+			}
+			if (prefix === "=" && final === "u") {
+				if (!this.kittySupported) continue;
+				const flags = Number(args.split(";")[0] || "0");
+				if (Number.isFinite(flags)) keyboard.kittyFlags = flags;
+				this.operations.push(sequence);
+				continue;
+			}
+			if (prefix === ">" && final === "m") {
+				const [resource, level] = args.split(";").map(Number);
+				if (resource === 4 && (level === 0 || level === 2)) {
+					keyboard.modifyOtherKeys = level;
+					this.operations.push(sequence);
+				}
+				continue;
+			}
+			if (final === "r" && prefix === "") {
 				const parts = args ? args.split(";").map(Number) : [];
 				const top = parts[0];
 				const bottom = parts[1];
-				this.state.scrollRegion =
+				this.visual.scrollRegion =
 					parts.length === 2 && Number.isFinite(top) && Number.isFinite(bottom)
 						? { top: top ?? 0, bottom: bottom ?? 0 }
 						: "full";
 				this.operations.push(sequence);
 				continue;
 			}
-			if (!privateMode || (final !== "h" && final !== "l")) continue;
+			if (prefix !== "?" || (final !== "h" && final !== "l")) continue;
 			const enabled = final === "h";
 			for (const code of args.split(";")) {
 				switch (code) {
 					case "1049":
-						this.state.buffer = enabled ? "alternate" : "primary";
+						this.activeScreen = enabled ? "alternate" : "primary";
 						break;
 					case "7":
-						this.state.autowrap = enabled;
+						this.visual.autowrap = enabled;
 						break;
 					case "25":
-						this.state.cursorVisible = enabled;
+						this.visual.cursorVisible = enabled;
 						break;
 					case "1000":
-						this.state.mouse1000 = enabled;
+						this.visual.mouse1000 = enabled;
 						break;
 					case "1002":
-						this.state.mouse1002 = enabled;
+						this.visual.mouse1002 = enabled;
 						break;
 					case "1006":
-						this.state.mouse1006 = enabled;
+						this.visual.mouse1006 = enabled;
 						break;
 					case "1007":
-						this.state.alternateScroll = enabled;
+						this.visual.alternateScroll = enabled;
+						break;
+					case "2004":
+						this.keyboard[this.activeScreen].bracketedPaste = enabled;
 						break;
 					default:
 						continue;
@@ -86,16 +187,24 @@ export class OwnedTerminalStateParser {
 		if (this.pending.length > 64) this.pending = this.pending.slice(-64);
 	}
 
-	isSafe(): boolean {
+	isSafe(keyboardBaseline: { kittyFlags?: number; kittyStack?: readonly number[] } = {}): boolean {
+		const primary = this.keyboard.primary;
+		const expectedStack = keyboardBaseline.kittyStack ?? [];
 		return (
-			this.state.buffer === "primary" &&
-			this.state.autowrap &&
-			this.state.cursorVisible &&
-			!this.state.mouse1000 &&
-			!this.state.mouse1002 &&
-			!this.state.mouse1006 &&
-			!this.state.alternateScroll &&
-			this.state.scrollRegion === "full"
+			this.activeScreen === "primary" &&
+			this.visual.autowrap &&
+			this.visual.cursorVisible &&
+			!this.visual.mouse1000 &&
+			!this.visual.mouse1002 &&
+			!this.visual.mouse1006 &&
+			!this.visual.alternateScroll &&
+			!primary.bracketedPaste &&
+			primary.modifyOtherKeys === 0 &&
+			primary.kittyFlags === (keyboardBaseline.kittyFlags ?? 0) &&
+			primary.kittyStack.length === expectedStack.length &&
+			primary.kittyStack.every((value, index) => value === expectedStack[index]) &&
+			this.visual.scrollRegion === "full" &&
+			this.keyboardUnderflows.length === 0
 		);
 	}
 }

--- a/test/helpers/terminal-state.ts
+++ b/test/helpers/terminal-state.ts
@@ -1,0 +1,101 @@
+export type OwnedTerminalState = {
+	buffer: "primary" | "alternate";
+	autowrap: boolean;
+	cursorVisible: boolean;
+	mouse1000: boolean;
+	mouse1002: boolean;
+	mouse1006: boolean;
+	alternateScroll: boolean;
+	scrollRegion: "full" | { top: number; bottom: number };
+};
+
+export class OwnedTerminalStateParser {
+	readonly state: OwnedTerminalState;
+	private pending = "";
+	readonly operations: string[] = [];
+
+	constructor(initial: Partial<OwnedTerminalState> = {}) {
+		this.state = {
+			buffer: "primary",
+			autowrap: true,
+			cursorVisible: true,
+			mouse1000: false,
+			mouse1002: false,
+			mouse1006: false,
+			alternateScroll: false,
+			scrollRegion: "full",
+			...initial,
+		};
+	}
+
+	feed(chunk: string): void {
+		this.pending += chunk;
+		let cursor = 0;
+		const pattern = /\x1b\[([?]?)([0-9;]*)([hlr])/g;
+		for (let match = pattern.exec(this.pending); match; match = pattern.exec(this.pending)) {
+			cursor = pattern.lastIndex;
+			const privateMode = match[1] === "?";
+			const args = match[2] ?? "";
+			const final = match[3];
+			const sequence = match[0];
+			if (final === "r" && !privateMode) {
+				const parts = args ? args.split(";").map(Number) : [];
+				const top = parts[0];
+				const bottom = parts[1];
+				this.state.scrollRegion =
+					parts.length === 2 && Number.isFinite(top) && Number.isFinite(bottom)
+						? { top: top ?? 0, bottom: bottom ?? 0 }
+						: "full";
+				this.operations.push(sequence);
+				continue;
+			}
+			if (!privateMode || (final !== "h" && final !== "l")) continue;
+			const enabled = final === "h";
+			for (const code of args.split(";")) {
+				switch (code) {
+					case "1049":
+						this.state.buffer = enabled ? "alternate" : "primary";
+						break;
+					case "7":
+						this.state.autowrap = enabled;
+						break;
+					case "25":
+						this.state.cursorVisible = enabled;
+						break;
+					case "1000":
+						this.state.mouse1000 = enabled;
+						break;
+					case "1002":
+						this.state.mouse1002 = enabled;
+						break;
+					case "1006":
+						this.state.mouse1006 = enabled;
+						break;
+					case "1007":
+						this.state.alternateScroll = enabled;
+						break;
+					default:
+						continue;
+				}
+				this.operations.push(`\x1b[?${code}${final}`);
+			}
+		}
+		const lastEscape = this.pending.lastIndexOf("\x1b");
+		this.pending =
+			lastEscape >= cursor ? this.pending.slice(lastEscape) : this.pending.slice(cursor);
+		if (this.pending.length > 64) this.pending = this.pending.slice(-64);
+	}
+
+	isSafe(): boolean {
+		return (
+			this.state.buffer === "primary" &&
+			this.state.autowrap &&
+			this.state.cursorVisible &&
+			!this.state.mouse1000 &&
+			!this.state.mouse1002 &&
+			!this.state.mouse1006 &&
+			!this.state.alternateScroll &&
+			this.state.scrollRegion === "full"
+		);
+	}
+}

--- a/test/live-context-integration.test.ts
+++ b/test/live-context-integration.test.ts
@@ -16,17 +16,23 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 
 vi.mock("../extensions/zentui/git", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/git")>();
-	return { ...actual, readGitStatus: async () => actual.emptyGitStatus() };
+	return {
+		...actual,
+		readGitStatus: async () => ({ kind: "ok" as const, status: actual.emptyGitStatus() }),
+	};
 });
 
 vi.mock("../extensions/zentui/runtime", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/runtime")>();
-	return { ...actual, readRuntimeInfo: async () => undefined };
+	return { ...actual, readRuntimeInfo: async () => ({ kind: "ok" as const, runtime: undefined }) };
 });
 
 vi.mock("../extensions/zentui/package-version", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/package-version")>();
-	return { ...actual, readPackageVersionResult: async () => undefined };
+	return {
+		...actual,
+		readPackageVersionResult: async () => ({ kind: "ok" as const, result: null }),
+	};
 });
 
 import zentui from "../extensions/zentui/index";

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -1,0 +1,215 @@
+import { homedir } from "node:os";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import {
+	formatElapsedDuration,
+	renderMinimalistFrame,
+} from "../extensions/zentui/minimalist-editor";
+
+function theme(): Theme {
+	return {
+		fg(_color: string, text: string) {
+			return text;
+		},
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+		inverse: (text: string) => text,
+	} as Theme;
+}
+
+function config(overrides: Partial<PolishedTuiConfig> = {}): PolishedTuiConfig {
+	return { ...defaultConfig, editorMode: "minimalist", ...overrides };
+}
+
+function render(width = 80, inputText = "draft") {
+	return renderMinimalistFrame({
+		width,
+		editorLines: ["draft"],
+		autocompleteLines: ["suggestion"],
+		inputText,
+		metadata: {
+			cwd: `${homedir()}/project`,
+			branch: "feature/minimalist",
+			dirty: true,
+			ahead: 2,
+			behind: 1,
+			costLabel: "$0.123",
+			modelLabel: "model-x",
+			thinkingLevel: "high",
+			contextPercent: 42.4,
+			agentDurationMs: 12_500,
+			agentActive: true,
+		},
+		uiTheme: theme(),
+		config: config(),
+	});
+}
+
+describe("minimalist editor frame", () => {
+	it("renders metadata with symmetric breathing room and framed autocomplete", () => {
+		const lines = render();
+		expect(lines[0]).toContain("12s");
+		expect(lines[0]).toContain("$0.123 – model-x – high – 42%");
+		expect(lines[0]).toMatch(/^╭.*╮$/);
+		expect(lines[1]).toMatch(/^│\s+│$/);
+		expect(lines[2]).toMatch(/^│ draft\s+│$/);
+		expect(lines[3]).toMatch(/^│\s+│$/);
+		expect(lines[4]).toMatch(/^├─+┤$/);
+		expect(lines[5]).toContain("suggestion");
+		expect(lines.at(-1)).toContain("feature/minimalist * ↑2 ↓1");
+		expect(lines.at(-1)).toContain("project");
+		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+	});
+
+	it("shows visual shell markers without changing editor text", () => {
+		expect(render(80, "  !pwd")[0]).toContain("$ · 12s");
+		expect(render(80, "  !!pwd")[0]).toContain("$ · 12s");
+		expect(render(80, "draft")[0]).not.toContain("$ · 12s");
+		expect(render(80, "  !pwd")[2]).toContain("draft");
+	});
+
+	it("formats active and completed elapsed durations", () => {
+		expect(formatElapsedDuration(-1)).toBe("0s");
+		expect(formatElapsedDuration(65_999)).toBe("1m 5s");
+		expect(formatElapsedDuration(3_661_000)).toBe("1h 1m");
+	});
+
+	it.each([5, 6, 8, 12, 20, 40, 80])("keeps every decorated row within %i columns", (width) => {
+		const lines = render(width);
+		expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+		expect(lines[0]).toMatch(/^╭.*╮$/);
+		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+	});
+
+	it("fits long Git and cwd labels with the shared balanced border rule", () => {
+		const lines = renderMinimalistFrame({
+			width: 32,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: {
+				cwd: "/a/very/long/project/path/that/does/not/fit",
+				branch: "feature/a-very-long-branch-name-that-does-not-fit",
+				dirty: true,
+			},
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(lines.every((line) => visibleWidth(line) <= 32)).toBe(true);
+		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+		expect(lines.at(-1)).toContain("…");
+	});
+
+	it("renders Unicode and ANSI content without overflowing", () => {
+		const lines = renderMinimalistFrame({
+			width: 18,
+			editorLines: ["界 e\u0301 👩‍💻 \x1b[31mred\x1b[0m"],
+			inputText: "界",
+			metadata: {
+				cwd: "/tmp/界-project",
+				branch: "feature/👩‍💻-e\u0301-long",
+				modelLabel: "模型-👩‍💻",
+				contextPercent: 99,
+			},
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(lines.every((line) => visibleWidth(line) <= 18)).toBe(true);
+		expect(lines.join("\n")).toContain("界");
+	});
+
+	it("renders compact, project-relative, and full minimalist paths", () => {
+		const pathLine = (pathDisplay: "compact" | "project" | "full", projectRoot?: string) =>
+			renderMinimalistFrame({
+				width: 80,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: `${homedir()}/workspace/repo/src/lib`, projectRoot },
+				uiTheme: theme(),
+				config: config({
+					minimalist: { ...defaultConfig.minimalist, pathDisplay },
+				}),
+			}).at(-1) ?? "";
+
+		expect(pathLine("compact")).toContain("lib");
+		expect(pathLine("project", `${homedir()}/workspace/repo`)).toContain("repo/src/lib");
+		expect(pathLine("project")).toContain("~/workspace/repo/src/lib");
+		expect(pathLine("full")).toContain("~/workspace/repo/src/lib");
+	});
+
+	it("supports focused visibility controls", () => {
+		const lines = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: {
+				cwd: "/tmp/project",
+				branch: "main",
+				costLabel: "$1.000",
+				agentDurationMs: 5000,
+				contextPercent: 11,
+			},
+			uiTheme: theme(),
+			config: config({
+				minimalist: {
+					...defaultConfig.minimalist,
+					showTimer: false,
+					showCost: false,
+					showGit: false,
+				},
+			}),
+		});
+		const rendered = lines.join("\n");
+		expect(rendered).not.toContain("5s");
+		expect(rendered).not.toContain("$1.000");
+		expect(rendered).not.toContain("main");
+		expect(rendered).toContain("11%");
+	});
+
+	it("renders percent, percent-total, and gauge context forms", () => {
+		const contextLine = (
+			contextFormat: "percent" | "percent-total",
+			contextGauge: boolean,
+			contextWindow?: number,
+			width = 80,
+		) =>
+			renderMinimalistFrame({
+				width,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: "/tmp", contextPercent: 11, contextWindow },
+				uiTheme: theme(),
+				config: config({
+					minimalist: { ...defaultConfig.minimalist, contextFormat, contextGauge },
+				}),
+			})[0] ?? "";
+
+		expect(contextLine("percent", false, 372_000)).toContain("11%");
+		expect(contextLine("percent", false, 372_000)).not.toContain("372k");
+		expect(contextLine("percent-total", false, 372_000)).toContain("11%/372k");
+		expect(contextLine("percent-total", false)).toContain("11%");
+		expect(contextLine("percent-total", false)).not.toContain("/");
+		expect(contextLine("percent-total", true, 372_000)).toContain("[█░░░░] 11%/372k");
+		const narrow = contextLine("percent-total", true, 372_000, 16);
+		expect(narrow).toContain("11%/372k");
+		expect(narrow).not.toContain("[");
+		expect(visibleWidth(narrow)).toBeLessThanOrEqual(16);
+	});
+
+	it("uses the adaptive border callback when configured", () => {
+		const lines = renderMinimalistFrame({
+			width: 20,
+			editorLines: ["draft"],
+			inputText: "!pwd",
+			metadata: { cwd: "/tmp" },
+			uiTheme: theme(),
+			config: config({ editorBorderColorMode: "adaptive" }),
+			borderColor: (text) => `\x1b[36m${text}\x1b[0m`,
+		});
+		expect(lines.join("\n")).toContain("\x1b[36m");
+		expect(lines.every((line) => visibleWidth(line) <= 20)).toBe(true);
+	});
+});

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -25,11 +25,12 @@ function config(overrides: Partial<PolishedTuiConfig> = {}): PolishedTuiConfig {
 	return { ...defaultConfig, editorMode: "minimalist", ...overrides };
 }
 
-function render(width = 80, inputText = "draft") {
+function render(width = 80, inputText = "draft", viewport?: { above?: string; below?: string }) {
 	return renderMinimalistFrame({
 		width,
 		editorLines: ["draft"],
 		autocompleteLines: ["suggestion"],
+		viewport,
 		inputText,
 		metadata: {
 			cwd: `${homedir()}/project`,
@@ -61,6 +62,38 @@ describe("minimalist editor frame", () => {
 		expect(lines.at(-1)).toContain("feature/minimalist * ↑2 ↓1");
 		expect(lines.at(-1)).toContain("project");
 		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+	});
+
+	it("puts complete viewport counts first on their matching borders", () => {
+		const lines = render(80, "draft", { above: "7", below: "11" });
+		expect(lines[0]).toMatch(/^╭─ ↑ 7 more · 12s/);
+		expect(lines.at(-1)).toMatch(/^╰─ ↓ 11 more · feature\/minimalist \* ↑2 ↓1/);
+	});
+
+	it.each([
+		[{ above: "7" }, "↑ 7 more", "↓"],
+		[{ below: "11" }, "↓ 11 more", "↑"],
+	] as const)("supports one-sided viewport counts", (viewport, present, absent) => {
+		const borders = [render(80, "draft", viewport)[0], render(80, "draft", viewport).at(-1)].join(
+			"\n",
+		);
+		expect(borders).toContain(present);
+		expect(borders).not.toContain(`${absent} `);
+	});
+
+	it("omits viewport counts atomically when they do not fit", () => {
+		const lines = renderMinimalistFrame({
+			width: 18,
+			editorLines: ["draft"],
+			viewport: { above: "123456789", below: "987654321" },
+			inputText: "draft",
+			metadata: { cwd: "" },
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(lines[0]).not.toContain("more");
+		expect(lines.at(-1)).not.toContain("more");
+		expect(lines.every((line) => visibleWidth(line) <= 18)).toBe(true);
 	});
 
 	it("shows visual shell markers without changing editor text", () => {

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -3,10 +3,13 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import { installFooter } from "../extensions/zentui/footer";
+import { emptyGitStatus } from "../extensions/zentui/git";
 import {
 	formatElapsedDuration,
 	renderMinimalistFrame,
 } from "../extensions/zentui/minimalist-editor";
+import { createInitialState } from "../extensions/zentui/state";
 
 function theme(): Theme {
 	return {
@@ -22,7 +25,27 @@ function theme(): Theme {
 }
 
 function config(overrides: Partial<PolishedTuiConfig> = {}): PolishedTuiConfig {
-	return { ...defaultConfig, editorStyle: "minimalist", ...overrides };
+	const editor = defaultConfig.components.editor;
+	return {
+		...defaultConfig,
+		...overrides,
+		components: {
+			...defaultConfig.components,
+			editor: {
+				...editor,
+				style: "minimalist",
+				borderColorMode: overrides.editorBorderColorMode ?? editor.borderColorMode,
+				colorSource: overrides.colorSources?.editor ?? editor.colorSource,
+				styles: {
+					...editor.styles,
+					minimalist: {
+						...editor.styles.minimalist,
+						...overrides.editorStyles?.minimalist,
+					},
+				},
+			},
+		},
+	};
 }
 
 function render(width = 80, inputText = "draft", viewport?: { above?: string; below?: string }) {
@@ -287,6 +310,94 @@ describe("minimalist editor frame", () => {
 		expect(narrow).toContain("11%/372k");
 		expect(narrow).not.toContain("[");
 		expect(visibleWidth(narrow)).toBeLessThanOrEqual(16);
+	});
+
+	it("uses minimalist-owned context thresholds independently of footer thresholds", () => {
+		const base = config();
+		const divergent = {
+			...base,
+			colors: {
+				...base.colors,
+				contextNormal: "bright-black",
+				contextWarning: "yellow",
+				contextError: "red",
+			},
+			components: {
+				...base.components,
+				editor: {
+					...base.components.editor,
+					colorSource: "terminal" as const,
+					styles: {
+						...base.components.editor.styles,
+						minimalist: {
+							...base.components.editor.styles.minimalist,
+							contextThresholds: { warning: 40, error: 60 },
+						},
+					},
+				},
+				footer: {
+					...base.components.footer,
+					colorSource: "terminal" as const,
+					styles: {
+						starship: {
+							...base.components.footer.styles.starship,
+							format: "$context",
+							responsive: false,
+							contextThresholds: { warning: 70, error: 90 },
+						},
+					},
+				},
+			},
+		};
+		const taggedTheme = {
+			...theme(),
+			fg(color: string, text: string) {
+				return `[${color}]${text}`;
+			},
+		} as Theme;
+		const rendered = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "/tmp", contextPercent: 50 },
+			uiTheme: taggedTheme,
+			config: divergent,
+		}).join("\n");
+		expect(rendered).toContain("\x1b[33m50%\x1b[0m");
+		expect(rendered).not.toContain("\x1b[90m50%\x1b[0m");
+
+		let footerFactory:
+			| ((
+					tui: { requestRender(): void },
+					theme: Theme,
+					data: {
+						onBranchChange(callback: () => void): () => void;
+						getExtensionStatuses(): Map<string, string>;
+					},
+			  ) => { render(width: number): string[] })
+			| undefined;
+		const footerContext = {
+			cwd: "/tmp",
+			model: { contextWindow: 100_000 },
+			getContextUsage: () => ({ percent: 50, tokens: 50_000, contextWindow: 100_000 }),
+			sessionManager: { getSessionName: () => undefined },
+			ui: {
+				setFooter(factory: typeof footerFactory) {
+					footerFactory = factory;
+				},
+			},
+		};
+		installFooter(footerContext as never, createInitialState(emptyGitStatus()), () => divergent, {
+			setRequestRender() {},
+			scheduleProjectRefresh() {},
+		});
+		const footer = footerFactory?.({ requestRender() {} }, taggedTheme, {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map(),
+		});
+		const footerRendered = footer?.render(80).join("\n") ?? "";
+		expect(footerRendered).toContain("\x1b[90m50.0%/100k\x1b[0m");
+		expect(footerRendered).not.toContain("\x1b[33m50.0%/100k\x1b[0m");
 	});
 
 	it("uses the adaptive border callback when configured", () => {

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -22,7 +22,7 @@ function theme(): Theme {
 }
 
 function config(overrides: Partial<PolishedTuiConfig> = {}): PolishedTuiConfig {
-	return { ...defaultConfig, editorMode: "minimalist", ...overrides };
+	return { ...defaultConfig, editorStyle: "minimalist", ...overrides };
 }
 
 function render(width = 80, inputText = "draft", viewport?: { above?: string; below?: string }) {
@@ -42,6 +42,7 @@ function render(width = 80, inputText = "draft", viewport?: { above?: string; be
 			modelLabel: "model-x",
 			thinkingLevel: "high",
 			contextPercent: 42.4,
+			sessionName: "release prep",
 			agentDurationMs: 12_500,
 			agentActive: true,
 		},
@@ -53,7 +54,7 @@ function render(width = 80, inputText = "draft", viewport?: { above?: string; be
 describe("minimalist editor frame", () => {
 	it("renders metadata and framed autocomplete", () => {
 		const lines = render();
-		expect(lines[0]).toContain("12s");
+		expect(lines[0]).toContain("12s · release prep");
 		expect(lines[0]).toContain("$0.123 – model-x – high – 42%");
 		expect(lines[0]).toMatch(/^╭.*╮$/);
 		expect(lines[1]).toMatch(/^│ draft\s+│$/);
@@ -66,7 +67,7 @@ describe("minimalist editor frame", () => {
 
 	it("puts complete viewport counts first on their matching borders", () => {
 		const lines = render(80, "draft", { above: "7", below: "11" });
-		expect(lines[0]).toMatch(/^╭─ ↑ 7 more · 12s/);
+		expect(lines[0]).toMatch(/^╭─ ↑ 7 more · 12s · release prep/);
 		expect(lines.at(-1)).toMatch(/^╰─ ↓ 11 more · feature\/minimalist \* ↑2 ↓1/);
 	});
 
@@ -101,6 +102,54 @@ describe("minimalist editor frame", () => {
 		expect(render(80, "  !!pwd")[0]).toContain("$ · 12s");
 		expect(render(80, "draft")[0]).not.toContain("$ · 12s");
 		expect(render(80, "  !pwd")[1]).toContain("draft");
+	});
+
+	it("shows the explicit session name after the timer and omits it when disabled", () => {
+		const enabled = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "/tmp", agentDurationMs: 12_000, sessionName: "release\nprep" },
+			uiTheme: theme(),
+			config: config(),
+		})[0];
+		expect(enabled).toContain("12s · release prep");
+
+		const disabled = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "/tmp", agentDurationMs: 12_000, sessionName: "release prep" },
+			uiTheme: theme(),
+			config: config({
+				editorStyles: {
+					minimalist: {
+						...defaultConfig.editorStyles.minimalist,
+						showSessionName: false,
+					},
+				},
+			}),
+		})[0];
+		expect(disabled).not.toContain("release prep");
+	});
+
+	it("drops a long session name before viewport and operational indicators", () => {
+		const top = renderMinimalistFrame({
+			width: 34,
+			editorLines: ["draft"],
+			viewport: { above: "7" },
+			inputText: "!pwd",
+			metadata: {
+				cwd: "/tmp",
+				agentDurationMs: 12_000,
+				sessionName: "a very long session name that cannot fit",
+			},
+			uiTheme: theme(),
+			config: config(),
+		})[0];
+		expect(top).toContain("↑ 7 more · $ · 12s");
+		expect(top).not.toContain("session");
+		expect(visibleWidth(top)).toBeLessThanOrEqual(34);
 	});
 
 	it("formats active and completed elapsed durations", () => {
@@ -161,7 +210,9 @@ describe("minimalist editor frame", () => {
 				metadata: { cwd: `${homedir()}/workspace/repo/src/lib`, projectRoot },
 				uiTheme: theme(),
 				config: config({
-					minimalist: { ...defaultConfig.minimalist, pathDisplay },
+					editorStyles: {
+						minimalist: { ...defaultConfig.editorStyles.minimalist, pathDisplay },
+					},
 				}),
 			}).at(-1) ?? "";
 
@@ -185,11 +236,13 @@ describe("minimalist editor frame", () => {
 			},
 			uiTheme: theme(),
 			config: config({
-				minimalist: {
-					...defaultConfig.minimalist,
-					showTimer: false,
-					showCost: false,
-					showGit: false,
+				editorStyles: {
+					minimalist: {
+						...defaultConfig.editorStyles.minimalist,
+						showTimer: false,
+						showCost: false,
+						showGit: false,
+					},
 				},
 			}),
 		});
@@ -214,7 +267,13 @@ describe("minimalist editor frame", () => {
 				metadata: { cwd: "/tmp", contextPercent: 11, contextWindow },
 				uiTheme: theme(),
 				config: config({
-					minimalist: { ...defaultConfig.minimalist, contextFormat, contextGauge },
+					editorStyles: {
+						minimalist: {
+							...defaultConfig.editorStyles.minimalist,
+							contextFormat,
+							contextGauge,
+						},
+					},
 				}),
 			})[0] ?? "";
 

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -50,16 +50,14 @@ function render(width = 80, inputText = "draft") {
 }
 
 describe("minimalist editor frame", () => {
-	it("renders metadata with symmetric breathing room and framed autocomplete", () => {
+	it("renders metadata and framed autocomplete", () => {
 		const lines = render();
 		expect(lines[0]).toContain("12s");
 		expect(lines[0]).toContain("$0.123 – model-x – high – 42%");
 		expect(lines[0]).toMatch(/^╭.*╮$/);
-		expect(lines[1]).toMatch(/^│\s+│$/);
-		expect(lines[2]).toMatch(/^│ draft\s+│$/);
-		expect(lines[3]).toMatch(/^│\s+│$/);
-		expect(lines[4]).toMatch(/^├─+┤$/);
-		expect(lines[5]).toContain("suggestion");
+		expect(lines[1]).toMatch(/^│ draft\s+│$/);
+		expect(lines[2]).toMatch(/^├─+┤$/);
+		expect(lines[3]).toContain("suggestion");
 		expect(lines.at(-1)).toContain("feature/minimalist * ↑2 ↓1");
 		expect(lines.at(-1)).toContain("project");
 		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
@@ -69,7 +67,7 @@ describe("minimalist editor frame", () => {
 		expect(render(80, "  !pwd")[0]).toContain("$ · 12s");
 		expect(render(80, "  !!pwd")[0]).toContain("$ · 12s");
 		expect(render(80, "draft")[0]).not.toContain("$ · 12s");
-		expect(render(80, "  !pwd")[2]).toContain("draft");
+		expect(render(80, "  !pwd")[1]).toContain("draft");
 	});
 
 	it("formats active and completed elapsed durations", () => {

--- a/test/package-version.test.ts
+++ b/test/package-version.test.ts
@@ -53,6 +53,13 @@ describe("readPackageVersion", () => {
 		expect(readPackageVersion(cwd)).toBeNull();
 	});
 
+	it("rejects terminal controls in a JSON-decoded package version", () => {
+		const cwd = makeProject({
+			"package.json": JSON.stringify({ version: "1.2.3\x1b]52;c;c2VjcmV0\x07" }),
+		});
+		expect(readPackageVersion(cwd)).toBeNull();
+	});
+
 	it("parses deno.json and deno.jsonc", () => {
 		const denoJson = makeProject({ "deno.json": JSON.stringify({ version: "0.1.0" }) });
 		const denoJsonc = makeProject({
@@ -296,6 +303,19 @@ describe("cleanVersion", () => {
 	});
 
 	it.each(["", "   ", "not a version", "1.2.3 with spaces", "{1.2.3}"])("rejects %j", (input) => {
+		expect(cleanVersion(input)).toBeUndefined();
+	});
+
+	it.each([
+		"1.2.3\x07",
+		"1.2.3\x1b",
+		"1.2.3\x7f",
+		"1.2.3\x9d",
+		"1.2.3\x9c",
+		"1.2.3\x1b[31m",
+		"1.2.3\n",
+		"1.2.3\t",
+	])("rejects terminal control input %j", (input) => {
 		expect(cleanVersion(input)).toBeUndefined();
 	});
 });

--- a/test/project-refresh.test.ts
+++ b/test/project-refresh.test.ts
@@ -61,7 +61,7 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(1);
-		expect(refresh).toHaveBeenLastCalledWith("initial");
+		expect(refresh).toHaveBeenLastCalledWith("initial", expect.anything());
 		expect(afterRefresh).toHaveBeenCalledTimes(1);
 
 		scheduler.schedule("first-pending");
@@ -78,7 +78,7 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(refresh).toHaveBeenLastCalledWith("latest-pending");
+		expect(refresh).toHaveBeenLastCalledWith("latest-pending", expect.anything());
 		expect(afterRefresh).toHaveBeenCalledTimes(2);
 	});
 
@@ -111,7 +111,7 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(refresh).toHaveBeenLastCalledWith("pending");
+		expect(refresh).toHaveBeenLastCalledWith("pending", expect.anything());
 	});
 
 	it("preserves force intent while a refresh is in flight", async () => {
@@ -137,7 +137,7 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(refresh).toHaveBeenLastCalledWith("dependency-change");
+		expect(refresh).toHaveBeenLastCalledWith("dependency-change", expect.anything());
 		expect(afterRefresh).toHaveBeenCalledTimes(2);
 
 		scheduler.schedule("ordinary-follow-up");
@@ -151,7 +151,7 @@ describe("createProjectRefreshScheduler", () => {
 		vi.advanceTimersByTime(1);
 		await flushPromises();
 		expect(refresh).toHaveBeenCalledTimes(3);
-		expect(refresh).toHaveBeenLastCalledWith("ordinary-follow-up");
+		expect(refresh).toHaveBeenLastCalledWith("ordinary-follow-up", expect.anything());
 	});
 
 	it("supports forced refreshes for initial status reads", async () => {
@@ -166,7 +166,7 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(refresh).toHaveBeenLastCalledWith("forced");
+		expect(refresh).toHaveBeenLastCalledWith("forced", expect.anything());
 	});
 
 	it("recovers from failed refreshes", async () => {
@@ -184,7 +184,67 @@ describe("createProjectRefreshScheduler", () => {
 		await flushPromises();
 
 		expect(refresh).toHaveBeenCalledTimes(2);
-		expect(refresh).toHaveBeenLastCalledWith("next");
+		expect(refresh).toHaveBeenLastCalledWith("next", expect.anything());
 		expect(afterRefresh).toHaveBeenCalledTimes(2);
+	});
+
+	it("invalidates an active run before starting a dependency replacement", async () => {
+		const resolvers = new Map<string, () => void>();
+		const applied: string[] = [];
+		const refresh = vi.fn(
+			(target: string, run: { isCurrent: () => boolean }) =>
+				new Promise<void>((resolve) => {
+					resolvers.set(target, () => {
+						if (run.isCurrent()) applied.push(target);
+						resolve();
+					});
+				}),
+		);
+		const afterRefresh = vi.fn();
+		const scheduler = createProjectRefreshScheduler(refresh, afterRefresh, 0);
+
+		scheduler.schedule("old");
+		scheduler.invalidate();
+		scheduler.schedule("replacement", { force: true });
+		expect(refresh).toHaveBeenCalledTimes(2);
+
+		resolvers.get("old")?.();
+		await flushPromises();
+		expect(applied).toEqual([]);
+		expect(afterRefresh).not.toHaveBeenCalled();
+
+		resolvers.get("replacement")?.();
+		await flushPromises();
+		expect(applied).toEqual(["replacement"]);
+		expect(afterRefresh).toHaveBeenCalledTimes(1);
+	});
+
+	it("makes stopped runs stale when a restarted run finishes first", async () => {
+		const resolvers = new Map<string, () => void>();
+		const applied: string[] = [];
+		const refresh = vi.fn(
+			(target: string, run: { isCurrent: () => boolean }) =>
+				new Promise<void>((resolve) => {
+					resolvers.set(target, () => {
+						if (run.isCurrent()) applied.push(target);
+						resolve();
+					});
+				}),
+		);
+		const afterRefresh = vi.fn();
+		const scheduler = createProjectRefreshScheduler(refresh, afterRefresh, 0);
+
+		scheduler.schedule("old");
+		scheduler.stop();
+		scheduler.schedule("new");
+		expect(refresh).toHaveBeenCalledTimes(2);
+
+		resolvers.get("new")?.();
+		await flushPromises();
+		resolvers.get("old")?.();
+		await flushPromises();
+
+		expect(applied).toEqual(["new"]);
+		expect(afterRefresh).toHaveBeenCalledTimes(1);
 	});
 });

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -318,7 +318,7 @@ beforeEach(() => {
 			editor: { ...defaultConfig.components.editor, enabled: false },
 			footer: {
 				...footer,
-				enabled: true,
+				style: "starship",
 				styles: {
 					starship: {
 						...footer.styles.starship,
@@ -369,7 +369,7 @@ describe("responsive footer dependency reconciliation", () => {
 				handleInput?: (data: string) => void;
 			};
 			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
-			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 3; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();
@@ -464,7 +464,7 @@ describe("responsive footer dependency reconciliation", () => {
 				handleInput?: (data: string) => void;
 			};
 			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
-			for (let index = 0; index < 5; index++) component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -43,6 +43,17 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 			};
 			return mocks.config;
 		},
+		saveFooterComponentPatch(patch: Record<string, unknown>) {
+			const footer = mocks.config.components.footer;
+			mocks.config = {
+				...mocks.config,
+				components: {
+					...mocks.config.components,
+					footer: { ...footer, ...patch },
+				},
+			};
+			return mocks.config;
+		},
 		saveStarshipFooterStylePatch(patch: Record<string, unknown>) {
 			const footer = mocks.config.components.footer;
 			const starship = footer.styles.starship;
@@ -197,7 +208,10 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 
 vi.mock("../extensions/zentui/git", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/git")>();
-	mocks.readGitStatus.mockImplementation(async () => actual.emptyGitStatus());
+	mocks.readGitStatus.mockImplementation(async () => ({
+		kind: "ok" as const,
+		status: actual.emptyGitStatus(),
+	}));
 	return { ...actual, readGitStatus: mocks.readGitStatus };
 });
 vi.mock("../extensions/zentui/runtime", () => ({ readRuntimeInfo: mocks.readRuntimeInfo }));
@@ -291,6 +305,8 @@ function createContext(custom?: (factory: (...args: unknown[]) => unknown) => Pr
 		},
 		ui: {
 			theme,
+			getEditorText: () => "",
+			setEditorText() {},
 			setFooter(factory: unknown) {
 				footerFactory = factory;
 			},
@@ -335,8 +351,8 @@ beforeEach(() => {
 		compactFooterFormat: "$package",
 	};
 	mocks.readGitStatus.mockClear();
-	mocks.readRuntimeInfo.mockReset().mockResolvedValue(undefined);
-	mocks.readPackageVersionResult.mockReset().mockResolvedValue(undefined);
+	mocks.readRuntimeInfo.mockReset().mockResolvedValue({ kind: "ok", runtime: undefined });
+	mocks.readPackageVersionResult.mockReset().mockResolvedValue({ kind: "ok", result: null });
 	mocks.syncState.mockClear();
 });
 
@@ -352,6 +368,7 @@ describe("responsive footer dependency reconciliation", () => {
 		await emit(handlers, "session_start", ctx);
 		await settleProjectRefresh();
 		expect(mocks.readPackageVersionResult).not.toHaveBeenCalled();
+		expect(mocks.readRuntimeInfo).not.toHaveBeenCalled();
 
 		const gitReads = mocks.readGitStatus.mock.calls.length;
 		await command.handler('format "$directory"', ctx);
@@ -361,6 +378,230 @@ describe("responsive footer dependency reconciliation", () => {
 		await command.handler('format "$package"', ctx);
 		await settleProjectRefresh();
 		expect(mocks.readPackageVersionResult).toHaveBeenCalledOnce();
+	});
+
+	it("clears package state when its reference deactivates before a failed re-enable", async () => {
+		updateStarship({ format: "$package", responsive: false });
+		mocks.readPackageVersionResult.mockResolvedValueOnce({
+			kind: "ok",
+			result: { ecosystem: "nodejs", version: "1.2.3" },
+		});
+		const { handlers, command } = loadExtension();
+		const ctx = createContext();
+		await emit(handlers, "session_start", ctx);
+		await settleProjectRefresh();
+		const state = mocks.syncState.mock.calls[0]?.[0] as {
+			packageVersion?: { ecosystem: string; version: string };
+		};
+		expect(state.packageVersion).toEqual({ ecosystem: "nodejs", version: "1.2.3" });
+
+		await command.handler('format "$cwd"', ctx);
+		await settleProjectRefresh();
+		expect(state.packageVersion).toBeUndefined();
+
+		mocks.readPackageVersionResult.mockResolvedValue({ kind: "error" });
+		await command.handler('format "$package"', ctx);
+		await settleProjectRefresh();
+		expect(mocks.readPackageVersionResult).toHaveBeenCalledTimes(2);
+		expect(state.packageVersion).toBeUndefined();
+	});
+
+	it("invalidates an in-flight package read across remove and failed re-enable", async () => {
+		updateStarship({ format: "$package", responsive: false });
+		let resolveObsoleteRead:
+			| ((value: { kind: "ok"; result: { ecosystem: string; version: string } }) => void)
+			| undefined;
+		mocks.readPackageVersionResult
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveObsoleteRead = resolve;
+					}),
+			)
+			.mockResolvedValueOnce({ kind: "error" });
+		const { handlers, command } = loadExtension();
+		const ctx = createContext();
+		await emit(handlers, "session_start", ctx);
+		await settleProjectRefresh();
+		expect(mocks.readPackageVersionResult).toHaveBeenCalledOnce();
+
+		const state = mocks.syncState.mock.calls[0]?.[0] as {
+			packageVersion?: { ecosystem: string; version: string };
+		};
+		await command.handler('format "$cwd"', ctx);
+		await settleProjectRefresh();
+		expect(state.packageVersion).toBeUndefined();
+
+		await command.handler('format "$package"', ctx);
+		await settleProjectRefresh();
+		expect(mocks.readPackageVersionResult).toHaveBeenCalledTimes(2);
+		expect(state.packageVersion).toBeUndefined();
+
+		resolveObsoleteRead?.({
+			kind: "ok",
+			result: { ecosystem: "nodejs", version: "9.9.9-obsolete" },
+		});
+		await settleProjectRefresh();
+		expect(state.packageVersion).toBeUndefined();
+	});
+
+	it("replaces in-flight Footer probes across live styles while Minimalist keeps refresh active", async () => {
+		const editor = mocks.config.components.editor;
+		updateStarship({ format: "$package $runtime", responsive: false });
+		mocks.config = {
+			...mocks.config,
+			components: {
+				...mocks.config.components,
+				editor: {
+					...editor,
+					enabled: true,
+					style: "minimalist",
+					styles: {
+						...editor.styles,
+						minimalist: { ...editor.styles.minimalist, showGit: true },
+					},
+				},
+			},
+		};
+		let resolveObsoletePackage:
+			| ((value: { kind: "ok"; result: { ecosystem: string; version: string } }) => void)
+			| undefined;
+		let resolveObsoleteRuntime:
+			| ((value: {
+					kind: "ok";
+					runtime: { name: string; symbol: string; style: string; version: string };
+			  }) => void)
+			| undefined;
+		mocks.readPackageVersionResult
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveObsoletePackage = resolve;
+					}),
+			)
+			.mockResolvedValueOnce({ kind: "error" });
+		mocks.readRuntimeInfo
+			.mockImplementationOnce(
+				() =>
+					new Promise((resolve) => {
+						resolveObsoleteRuntime = resolve;
+					}),
+			)
+			.mockResolvedValueOnce({ kind: "error" });
+		const { handlers, command } = loadExtension();
+		const ctx = createContext();
+		await emit(handlers, "session_start", ctx);
+		await settleProjectRefresh();
+		expect(mocks.readPackageVersionResult).toHaveBeenCalledOnce();
+		expect(mocks.readRuntimeInfo).toHaveBeenCalledOnce();
+
+		const state = mocks.syncState.mock.calls[0]?.[0] as {
+			packageVersion?: { ecosystem: string; version: string };
+			runtime?: { name: string; version?: string };
+		};
+		await command.handler("footer off", ctx);
+		await settleProjectRefresh();
+		expect(state.packageVersion).toBeUndefined();
+		expect(state.runtime).toBeUndefined();
+
+		await command.handler("footer on", ctx);
+		await settleProjectRefresh();
+		expect(mocks.readPackageVersionResult).toHaveBeenCalledTimes(2);
+		expect(mocks.readRuntimeInfo).toHaveBeenCalledTimes(2);
+		expect(state.packageVersion).toBeUndefined();
+		expect(state.runtime).toBeUndefined();
+
+		resolveObsoletePackage?.({
+			kind: "ok",
+			result: { ecosystem: "nodejs", version: "9.9.9-obsolete" },
+		});
+		resolveObsoleteRuntime?.({
+			kind: "ok",
+			runtime: {
+				name: "Obsolete",
+				symbol: "O",
+				style: "bold red",
+				version: "9.9.9-obsolete",
+			},
+		});
+		await settleProjectRefresh();
+		expect(state.packageVersion).toBeUndefined();
+		expect(state.runtime).toBeUndefined();
+
+		const footerFactory = ctx.footerFactory as
+			| ((
+					tui: { requestRender(): void },
+					theme: Theme,
+					data: {
+						onBranchChange(callback: () => void): () => void;
+						getExtensionStatuses(): Map<string, string>;
+					},
+			  ) => { render(width: number): string[] })
+			| undefined;
+		const rendered =
+			footerFactory?.({ requestRender() {} }, makeTheme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			})
+				.render(120)
+				.join("\n") ?? "";
+		expect(rendered).not.toContain("9.9.9-obsolete");
+		expect(rendered).not.toContain("Obsolete");
+	});
+
+	it("probes runtime only while a custom Footer format references it", async () => {
+		const { handlers, command } = loadExtension();
+		const ctx = createContext();
+		await emit(handlers, "session_start", ctx);
+		await settleProjectRefresh();
+		expect(mocks.readRuntimeInfo).not.toHaveBeenCalled();
+
+		await command.handler('format "$runtime"', ctx);
+		await settleProjectRefresh();
+		expect(mocks.readRuntimeInfo).toHaveBeenCalledOnce();
+
+		await command.handler('format "$cwd"', ctx);
+		await settleProjectRefresh();
+		expect(mocks.readRuntimeInfo).toHaveBeenCalledOnce();
+	});
+
+	it("counts the enabled built-in runtime segment as an active reference", async () => {
+		updateStarship({
+			format: "",
+			responsive: false,
+			segments: { ...mocks.config.components.footer.styles.starship.segments, runtime: true },
+		});
+		const { handlers } = loadExtension();
+		await emit(handlers, "session_start", createContext());
+		await settleProjectRefresh();
+		expect(mocks.readRuntimeInfo).toHaveBeenCalledOnce();
+	});
+
+	it("skips runtime and package probes for Minimalist-only project refreshes", async () => {
+		const editor = mocks.config.components.editor;
+		const footer = mocks.config.components.footer;
+		mocks.config = {
+			...mocks.config,
+			components: {
+				...mocks.config.components,
+				editor: {
+					...editor,
+					enabled: true,
+					style: "minimalist",
+					styles: {
+						...editor.styles,
+						minimalist: { ...editor.styles.minimalist, showGit: true },
+					},
+				},
+				footer: { ...footer, style: "native" },
+			},
+		};
+		const { handlers } = loadExtension();
+		await emit(handlers, "session_start", createContext());
+		await settleProjectRefresh();
+		expect(mocks.readGitStatus).toHaveBeenCalledOnce();
+		expect(mocks.readRuntimeInfo).not.toHaveBeenCalled();
+		expect(mocks.readPackageVersionResult).not.toHaveBeenCalled();
 	});
 
 	it("refreshes compact-only probes immediately when responsiveness is enabled", async () => {

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -30,6 +30,54 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 		...actual,
 		ensureConfigExists: () => {},
 		loadConfig: () => mocks.config,
+		saveEditorComponentPatch(patch: Record<string, unknown>) {
+			mocks.config = {
+				...mocks.config,
+				components: {
+					...mocks.config.components,
+					editor: { ...mocks.config.components.editor, ...patch },
+				},
+				...(patch.modelLabel === undefined
+					? {}
+					: { editorModelLabel: patch.modelLabel as "id" | "name" }),
+			};
+			return mocks.config;
+		},
+		saveStarshipFooterStylePatch(patch: Record<string, unknown>) {
+			const footer = mocks.config.components.footer;
+			const starship = footer.styles.starship;
+			const nextStarship = {
+				...starship,
+				...patch,
+				...(patch.segments
+					? { segments: { ...starship.segments, ...(patch.segments as object) } }
+					: {}),
+				...(patch.gitCommit
+					? { gitCommit: { ...starship.gitCommit, ...(patch.gitCommit as object) } }
+					: {}),
+				...(patch.gitMetrics
+					? { gitMetrics: { ...starship.gitMetrics, ...(patch.gitMetrics as object) } }
+					: {}),
+			};
+			mocks.config = {
+				...mocks.config,
+				...(patch.format === undefined ? {} : { footerFormat: patch.format as string }),
+				...(patch.responsive === undefined
+					? {}
+					: { responsiveFooter: patch.responsive as boolean }),
+				...(patch.compactMaxLines === undefined
+					? {}
+					: { compactFooterMaxLines: patch.compactMaxLines as 1 | 2 | 3 | "unlimited" }),
+				...(patch.segments === undefined ? {} : { footerSegments: nextStarship.segments }),
+				...(patch.gitCommit === undefined ? {} : { gitCommit: nextStarship.gitCommit }),
+				...(patch.gitMetrics === undefined ? {} : { gitMetrics: nextStarship.gitMetrics }),
+				components: {
+					...mocks.config.components,
+					footer: { ...footer, styles: { starship: nextStarship } },
+				},
+			};
+			return mocks.config;
+		},
 		saveEditorModelLabel(value: "id" | "name") {
 			mocks.config = {
 				...mocks.config,
@@ -320,9 +368,8 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			component.handleInput?.("\t");
-			component.handleInput?.("\t");
-			component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();
@@ -353,7 +400,7 @@ describe("responsive footer dependency reconciliation", () => {
 		const before = mocks.syncState.mock.calls.length;
 		await command.handler("", ctx);
 		expect(mocks.config.components.editor.modelLabel).toBe("name");
-		expect(mocks.config.components.footer.modelLabel).toBe("name");
+		expect(mocks.config.components.footer.modelLabel).toBe("id");
 		expect(mocks.syncState).toHaveBeenCalledTimes(before + 1);
 	});
 
@@ -365,7 +412,7 @@ describe("responsive footer dependency reconciliation", () => {
 				render(width: number): string[];
 				handleInput(data: string): void;
 			};
-			for (let index = 0; index < 4; index++) component.handleInput("\t");
+			for (let index = 0; index < 6; index++) component.handleInput("\t");
 			const label = target === "showTag" ? "Show exact-match tag" : "Ignore submodules";
 			for (let attempts = 0; attempts < 12; attempts++) {
 				if (component.render(140).some((line) => line.includes(`> ${label}`))) break;
@@ -396,9 +443,7 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			component.handleInput?.("\t");
-			component.handleInput?.("\t");
-			component.handleInput?.("\t");
+			for (let index = 0; index < 5; index++) component.handleInput?.("\t");
 			for (let index = 0; index < 11; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
@@ -418,10 +463,8 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			component.handleInput?.("\t");
-			component.handleInput?.("\t");
-			component.handleInput?.("\x1b[B");
-			component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
+			for (let index = 0; index < 5; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -31,35 +31,116 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 		ensureConfigExists: () => {},
 		loadConfig: () => mocks.config,
 		saveEditorModelLabel(value: "id" | "name") {
-			mocks.config = { ...mocks.config, editorModelLabel: value };
+			mocks.config = {
+				...mocks.config,
+				editorModelLabel: value,
+				components: {
+					...mocks.config.components,
+					editor: { ...mocks.config.components.editor, modelLabel: value },
+					footer: { ...mocks.config.components.footer, modelLabel: value },
+				},
+			};
 			return mocks.config;
 		},
 		saveFooterFormatPatch(value: string) {
-			mocks.config = { ...mocks.config, footerFormat: value };
+			const footer = mocks.config.components.footer;
+			mocks.config = {
+				...mocks.config,
+				footerFormat: value,
+				components: {
+					...mocks.config.components,
+					footer: {
+						...footer,
+						styles: { starship: { ...footer.styles.starship, format: value } },
+					},
+				},
+			};
 			return mocks.config;
 		},
 		saveFooterSegmentsPatch(patch: Record<string, boolean>) {
+			const footer = mocks.config.components.footer;
 			mocks.config = {
 				...mocks.config,
 				footerSegments: { ...mocks.config.footerSegments, ...patch },
+				components: {
+					...mocks.config.components,
+					footer: {
+						...footer,
+						styles: {
+							starship: {
+								...footer.styles.starship,
+								segments: { ...footer.styles.starship.segments, ...patch },
+							},
+						},
+					},
+				},
 			};
 			return mocks.config;
 		},
 		saveResponsiveFooterPatch(patch: Record<string, unknown>) {
-			mocks.config = { ...mocks.config, ...patch };
+			const footer = mocks.config.components.footer;
+			mocks.config = {
+				...mocks.config,
+				...patch,
+				components: {
+					...mocks.config.components,
+					footer: {
+						...footer,
+						styles: {
+							starship: {
+								...footer.styles.starship,
+								...(patch.responsiveFooter === undefined
+									? {}
+									: { responsive: patch.responsiveFooter as boolean }),
+								...(patch.compactFooterMaxLines === undefined
+									? {}
+									: {
+											compactMaxLines: patch.compactFooterMaxLines as 1 | 2 | 3 | "unlimited",
+										}),
+							},
+						},
+					},
+				},
+			};
 			return mocks.config;
 		},
 		saveGitCommitPatch(patch: Record<string, boolean>) {
+			const footer = mocks.config.components.footer;
 			mocks.config = {
 				...mocks.config,
 				gitCommit: { ...mocks.config.gitCommit, ...patch },
+				components: {
+					...mocks.config.components,
+					footer: {
+						...footer,
+						styles: {
+							starship: {
+								...footer.styles.starship,
+								gitCommit: { ...footer.styles.starship.gitCommit, ...patch },
+							},
+						},
+					},
+				},
 			};
 			return mocks.config;
 		},
 		saveGitMetricsPatch(patch: Record<string, boolean>) {
+			const footer = mocks.config.components.footer;
 			mocks.config = {
 				...mocks.config,
 				gitMetrics: { ...mocks.config.gitMetrics, ...patch },
+				components: {
+					...mocks.config.components,
+					footer: {
+						...footer,
+						styles: {
+							starship: {
+								...footer.styles.starship,
+								gitMetrics: { ...footer.styles.starship.gitMetrics, ...patch },
+							},
+						},
+					},
+				},
 			};
 			return mocks.config;
 		},
@@ -129,6 +210,22 @@ async function settleProjectRefresh() {
 	for (let index = 0; index < 8; index++) await Promise.resolve();
 }
 
+function updateStarship(
+	patch: Partial<PolishedTuiConfig["components"]["footer"]["styles"]["starship"]>,
+) {
+	const footer = mocks.config.components.footer;
+	mocks.config = {
+		...mocks.config,
+		components: {
+			...mocks.config.components,
+			footer: {
+				...footer,
+				styles: { starship: { ...footer.styles.starship, ...patch } },
+			},
+		},
+	};
+}
+
 function createContext(custom?: (factory: (...args: unknown[]) => unknown) => Promise<void>) {
 	let footerFactory: unknown;
 	let editorFactory: unknown;
@@ -164,9 +261,26 @@ function createContext(custom?: (factory: (...args: unknown[]) => unknown) => Pr
 
 beforeEach(() => {
 	vi.useFakeTimers();
+	const footer = defaultConfig.components.footer;
 	mocks.config = {
 		...defaultConfig,
 		features: { ...defaultConfig.features, editor: false, statusLine: true },
+		components: {
+			...defaultConfig.components,
+			editor: { ...defaultConfig.components.editor, enabled: false },
+			footer: {
+				...footer,
+				enabled: true,
+				styles: {
+					starship: {
+						...footer.styles.starship,
+						format: "$cwd",
+						responsive: false,
+						compactFormat: "$package",
+					},
+				},
+			},
+		},
 		projectRefreshIntervalMs: 0,
 		footerFormat: "$cwd",
 		responsiveFooter: false,
@@ -238,17 +352,13 @@ describe("responsive footer dependency reconciliation", () => {
 		await emit(handlers, "session_start", ctx);
 		const before = mocks.syncState.mock.calls.length;
 		await command.handler("", ctx);
-		expect(mocks.config.editorModelLabel).toBe("name");
+		expect(mocks.config.components.editor.modelLabel).toBe("name");
+		expect(mocks.config.components.footer.modelLabel).toBe("name");
 		expect(mocks.syncState).toHaveBeenCalledTimes(before + 1);
-		expect(mocks.syncState.mock.calls.at(-1)?.[3]).toBe("name");
 	});
 
 	it("forces Git refreshes for exact-tag and submodule probe changes", async () => {
-		mocks.config = {
-			...mocks.config,
-			footerFormat: "$git_commit $git_metrics",
-			responsiveFooter: false,
-		};
+		updateStarship({ format: "$git_commit $git_metrics", responsive: false });
 		let target: "showTag" | "ignoreSubmodules" = "showTag";
 		const ctx = createContext(async (factory) => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
@@ -281,7 +391,7 @@ describe("responsive footer dependency reconciliation", () => {
 	});
 
 	it("refreshes probes activated by built-in segment settings", async () => {
-		mocks.config = { ...mocks.config, footerFormat: "", compactFooterFormat: "$cwd" };
+		updateStarship({ format: "", compactFormat: "$cwd" });
 		const ctx = createContext(async (factory) => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
@@ -303,7 +413,7 @@ describe("responsive footer dependency reconciliation", () => {
 	});
 
 	it("does not refresh when only the compact row limit changes", async () => {
-		mocks.config = { ...mocks.config, responsiveFooter: true };
+		updateStarship({ responsive: true });
 		const ctx = createContext(async (factory) => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;

--- a/test/session-lifecycle.test.ts
+++ b/test/session-lifecycle.test.ts
@@ -64,7 +64,10 @@ describe("fixed-editor probe lifecycle", () => {
 			ctx as never,
 			() => ({
 				...defaultConfig,
-				fixedEditor: { ...defaultConfig.fixedEditor, enabled: true },
+				layout: {
+					...defaultConfig.layout,
+					fixedEditor: { ...defaultConfig.layout.fixedEditor, enabled: true },
+				},
 			}),
 			lifecycle,
 		);
@@ -114,7 +117,10 @@ describe("fixed-editor probe lifecycle", () => {
 			ctx as never,
 			() => ({
 				...defaultConfig,
-				fixedEditor: { ...defaultConfig.fixedEditor, enabled: true },
+				layout: {
+					...defaultConfig.layout,
+					fixedEditor: { ...defaultConfig.layout.fixedEditor, enabled: true },
+				},
 			}),
 			lifecycle,
 		);

--- a/test/session-lifecycle.test.ts
+++ b/test/session-lifecycle.test.ts
@@ -4,7 +4,7 @@ import { disposeFixedEditor, installFixedEditorProbe } from "../extensions/zentu
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 
 afterEach(() => {
-	disposeFixedEditor();
+	disposeFixedEditor("shutdown");
 	vi.useRealTimers();
 	vi.restoreAllMocks();
 });
@@ -127,7 +127,7 @@ describe("fixed-editor probe lifecycle", () => {
 		const component = widgetFactory?.({ terminal: { write: terminalWrite } });
 		component?.render();
 
-		disposeFixedEditor();
+		disposeFixedEditor("live");
 		await Promise.resolve();
 		await Promise.resolve();
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -466,11 +466,18 @@ describe("component-oriented /zentui settings", () => {
 		expect(focusedRow(component)).toContain("Framed");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Message style");
+		expect(focusedRow(component)).toContain("Framed (copy-friendly)");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Message style");
 		expect(focusedRow(component)).toContain("Compact");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Message style");
 		expect(focusedRow(component)).toContain("Labeled");
-		expect(harness.calls.messages).toEqual([{ style: "compact" }, { style: "labeled" }]);
+		expect(harness.calls.messages).toEqual([
+			{ style: "framed-copy-friendly" },
+			{ style: "compact" },
+			{ style: "labeled" },
+		]);
 	});
 
 	it("restores fixed-editor focus after conditional rows rebuild", async () => {

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -54,7 +54,9 @@ describe("bounded /zentui settings", () => {
 	it("orders the six sections and applies all six new controls from effective config", async () => {
 		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
 		const config = cloneConfig();
+		const editorModes: string[] = [];
 		const editorLabels: string[] = [];
+		const minimalistPatches: Array<Record<string, unknown>> = [];
 		const commitPatches: Array<Record<string, boolean>> = [];
 		const metricsPatches: Array<Record<string, boolean>> = [];
 		const defaultPlacements: ExtensionStatusPlacement[] = [];
@@ -79,6 +81,14 @@ describe("bounded /zentui settings", () => {
 				setSeparator() {},
 				setPathDisplay() {},
 				setGitBranch() {},
+				setEditorMode(value) {
+					editorModes.push(value);
+					config.editorMode = value;
+				},
+				setMinimalist(patch) {
+					minimalistPatches.push(patch);
+					Object.assign(config.minimalist, patch);
+				},
 				setEditorModelLabel(value) {
 					editorLabels.push(value);
 					config.editorModelLabel = value;
@@ -122,6 +132,19 @@ describe("bounded /zentui settings", () => {
 					firstRender = component.render(160).join("\n");
 
 					goToSection(component, "Editor");
+					selectLabel(component, "Editor mode");
+					component.handleInput(" ");
+					for (const label of [
+						"Minimalist path",
+						"Minimalist context text",
+						"Minimalist context gauge",
+						"Minimalist timer",
+						"Minimalist cost",
+						"Minimalist Git",
+					]) {
+						selectLabel(component, label);
+						component.handleInput(" ");
+					}
 					selectLabel(component, "Editor model label");
 					component.handleInput(" ");
 
@@ -148,11 +171,20 @@ describe("bounded /zentui settings", () => {
 			expect(index).toBeGreaterThan(lastIndex);
 			lastIndex = index;
 		}
+		expect(editorModes).toEqual(["minimalist"]);
 		expect(editorLabels).toEqual(["name"]);
+		expect(minimalistPatches).toEqual([
+			{ pathDisplay: "project" },
+			{ contextFormat: "percent-total" },
+			{ contextGauge: true },
+			{ showTimer: false },
+			{ showCost: false },
+			{ showGit: false },
+		]);
 		expect(commitPatches).toEqual([{ onlyDetached: false }, { showTag: false }]);
 		expect(metricsPatches).toEqual([{ onlyNonzero: false }, { ignoreSubmodules: true }]);
 		expect(defaultPlacements).toEqual(["off"]);
-		expect(requestRender).toHaveBeenCalledTimes(6);
+		expect(requestRender).toHaveBeenCalledTimes(13);
 	});
 
 	it("cycles editor border color mode live and reopens with the persisted value", async () => {

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -497,8 +497,11 @@ describe("component-oriented /zentui settings", () => {
 		const harness = createHarness();
 		await harness.command().handler("", harness.ctx);
 		const component = harness.component();
+		expect(component.render(160)[0]).not.toContain("\x1b[90m");
 		selectLabel(component, "Selector border colors");
 		component.handleInput(" ");
+		expect(component.render(160)[0]).toContain("\x1b[90m");
+		expect(harness.config.components.editor.colorSource).toBe("theme");
 		goToSection(component, "Editor");
 		selectLabel(component, "Editor colors");
 		component.handleInput(" ");

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1,20 +1,33 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	defaultConfig,
+	type EditorComponentConfig,
 	type ExtensionStatusPlacement,
+	type FooterComponentConfig,
 	type PolishedTuiConfig,
+	type SelectorBordersComponentConfig,
+	type UserMessagesComponentConfig,
 } from "../extensions/zentui/config";
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-command";
 
-type Component = {
-	render(width: number): string[];
-	handleInput(data: string): void;
+type Component = { render(width: number): string[]; handleInput(data: string): void };
+type Command = {
+	handler(args: string, ctx: unknown): Promise<void>;
+	getArgumentCompletions(prefix: string): Array<{ value: string }> | null;
 };
-
-const sectionNames = ["Appearance", "Editor", "Footer", "Segments", "Git", "Extensions"] as const;
+const sectionNames = [
+	"Appearance",
+	"Editor",
+	"User messages",
+	"Layout",
+	"Footer",
+	"Segments",
+	"Git",
+	"Extensions",
+] as const;
 type SectionName = (typeof sectionNames)[number];
 
 function theme(): Theme {
@@ -27,395 +40,242 @@ function theme(): Theme {
 		getThinkingBorderColor: () => (text: string) => text,
 	} as unknown as Theme;
 }
-
 function cloneConfig(): PolishedTuiConfig {
 	return structuredClone(defaultConfig);
 }
-
 function goToSection(component: Component, section: SectionName): void {
 	for (let index = 0; index < sectionNames.indexOf(section); index += 1)
 		component.handleInput("\t");
 }
-
 function selectLabel(component: Component, label: string): void {
-	for (let attempts = 0; attempts < 30; attempts += 1) {
-		if (component.render(120).some((line) => line.includes(`> ${label}`))) return;
+	for (let index = 0; index < 40; index += 1) {
+		if (component.render(160).some((line) => line.includes(`> ${label}`))) return;
 		component.handleInput("\x1b[B");
 	}
-	throw new Error(`Could not select settings row: ${label}`);
+	throw new Error(`Could not select ${label}`);
 }
-
-function renderedValue(component: Component, label: string): string {
+function row(component: Component, label: string): string {
 	selectLabel(component, label);
-	return component.render(120).find((line) => line.includes(`> ${label}`)) ?? "";
+	return component.render(160).find((line) => line.includes(`> ${label}`)) ?? "";
+}
+function focusedRow(component: Component): string {
+	return component.render(200).find((line) => line.includes("> ")) ?? "";
+}
+function expectFocusOrder(component: Component, labels: readonly string[]): void {
+	const first = focusedRow(component);
+	for (const [index, label] of labels.entries()) {
+		expect(focusedRow(component)).toContain(`> ${label}`);
+		if (index < labels.length - 1) component.handleInput("\x1b[B");
+	}
+	component.handleInput("\x1b[B");
+	expect(focusedRow(component)).toBe(first);
 }
 
-describe("bounded /zentui settings", () => {
-	it("shows active editor-style controls in the Editor section", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const editorStyles: string[] = [];
-		const editorLabels: string[] = [];
-		const minimalistPatches: Array<Record<string, unknown>> = [];
-		const commitPatches: Array<Record<string, boolean>> = [];
-		const metricsPatches: Array<Record<string, boolean>> = [];
-		const defaultPlacements: ExtensionStatusPlacement[] = [];
-		const requestRender = vi.fn();
-		let firstRender = "";
-		let polishedEditorRender = "";
-		let polishedAgainRender = "";
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				setEditorStyle(value) {
-					editorStyles.push(value);
-					config.editorStyle = value;
-				},
-				setMinimalist(patch) {
-					minimalistPatches.push(patch);
-					Object.assign(config.editorStyles.minimalist, patch);
-				},
-				setEditorModelLabel(value) {
-					editorLabels.push(value);
-					config.editorModelLabel = value;
-				},
-				setGitCommit(patch) {
-					commitPatches.push(patch as Record<string, boolean>);
-					Object.assign(config.gitCommit, patch);
-				},
-				setGitMetrics(patch) {
-					metricsPatches.push(patch as Record<string, boolean>);
-					Object.assign(config.gitMetrics, patch);
-				},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusDefaultPlacement(placement) {
-					defaultPlacements.push(placement);
-					config.extensionStatuses.defaultPlacement = placement;
-				},
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender,
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
+function createHarness(config = cloneConfig(), overrides: Record<string, unknown> = {}) {
+	let command: Command | undefined;
+	let component: Component | undefined;
+	const notifications: string[] = [];
+	let doneCalls = 0;
+	const calls = {
+		editor: [] as Partial<EditorComponentConfig>[],
+		messages: [] as Partial<UserMessagesComponentConfig>[],
+		selectors: [] as Partial<SelectorBordersComponentConfig>[],
+		footer: [] as Partial<FooterComponentConfig>[],
+		polished: [] as Array<Record<string, unknown>>,
+		minimalist: [] as Array<Record<string, unknown>>,
+		framed: [] as Array<Record<string, unknown>>,
+		fixed: [] as Array<Record<string, unknown>>,
+		segments: [] as Array<Record<string, boolean>>,
+		gitCommit: [] as Array<Record<string, boolean>>,
+		gitMetrics: [] as Array<Record<string, boolean>>,
+		extensionDefaultPlacement: [] as ExtensionStatusPlacement[],
+		recipe: [] as boolean[],
+	};
+	const deps = {
+		sessionLifecycle: new SessionLifecycle(),
+		getConfig: () => config,
+		setEditorComponent(patch: Partial<EditorComponentConfig>) {
+			calls.editor.push(patch);
+			Object.assign(config.components.editor, patch);
+			return { applied: true };
+		},
+		setPolishedEditorStyle(patch: Record<string, unknown>) {
+			calls.polished.push(patch);
+			Object.assign(config.components.editor.styles.polished, patch);
+		},
+		setMinimalist(patch: Record<string, unknown>) {
+			calls.minimalist.push(patch);
+			Object.assign(config.components.editor.styles.minimalist, patch);
+		},
+		setUserMessagesComponent(patch: Partial<UserMessagesComponentConfig>) {
+			calls.messages.push(patch);
+			Object.assign(config.components.userMessages, patch);
+		},
+		setFramedUserMessagesStyle(patch: Record<string, unknown>) {
+			calls.framed.push(patch);
+			Object.assign(config.components.userMessages.styles.framed, patch);
+		},
+		setSelectorBordersComponent(patch: Partial<SelectorBordersComponentConfig>) {
+			calls.selectors.push(patch);
+			Object.assign(config.components.selectorBorders, patch);
+		},
+		setFooterComponent(patch: Partial<FooterComponentConfig>) {
+			calls.footer.push(patch);
+			Object.assign(config.components.footer, patch);
+		},
+		setCopyFriendlyRecipe(enabled: boolean) {
+			calls.recipe.push(enabled);
+			config.components.editor.styles.polished.copyFriendly = enabled;
+			config.components.userMessages.styles.framed.copyFriendly = enabled;
+		},
+		setFooterSegments(patch: Record<string, boolean>) {
+			calls.segments.push(patch);
+			Object.assign(config.components.footer.styles.starship.segments, patch);
+		},
+		setFooterFormat() {},
+		setResponsiveFooter() {},
+		setIconMode() {},
+		setContextStyle() {},
+		setSeparator() {},
+		setPathDisplay() {},
+		setGitBranch() {},
+		setGitCommit(patch: Record<string, boolean>) {
+			calls.gitCommit.push(patch);
+			Object.assign(config.components.footer.styles.starship.gitCommit, patch);
+		},
+		setGitMetrics(patch: Record<string, boolean>) {
+			calls.gitMetrics.push(patch);
+			Object.assign(config.components.footer.styles.starship.gitMetrics, patch);
+		},
+		getActiveExtensionStatuses: () => new Map(),
+		setExtensionStatusDefaultPlacement(placement: ExtensionStatusPlacement) {
+			calls.extensionDefaultPlacement.push(placement);
+			config.components.footer.styles.starship.extensionStatuses.defaultPlacement = placement;
+		},
+		setExtensionStatusPlacement() {},
+		setExtensionStatusColorMode() {},
+		setFixedEditor(patch: Record<string, unknown>) {
+			calls.fixed.push(patch);
+			Object.assign(config.layout.fixedEditor, patch);
+		},
+		requestRender() {},
+		settingsListTheme: {
+			label: (text: string) => text,
+			value: (text: string) => text,
+			description: (text: string) => text,
+			cursor: "> ",
+			hint: (text: string) => text,
+		},
+		...overrides,
+	};
+	registerZentuiSettingsCommand(
+		{
+			registerCommand(_name: string, value: unknown) {
+				command = value as Command;
 			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			cwd: process.cwd(),
-			ui: {
-				theme: theme(),
-				notify() {},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					firstRender = component.render(160).join("\n");
-
-					goToSection(component, "Editor");
-					polishedEditorRender = component.render(160).join("\n");
-					selectLabel(component, "Editor style");
-					component.handleInput(" ");
-					for (const label of [
-						"Path",
-						"Context text",
-						"Context gauge",
-						"Session name",
-						"Timer",
-						"Cost",
-						"Git",
-					]) {
-						selectLabel(component, label);
-						component.handleInput(" ");
-					}
-					selectLabel(component, "Editor model label");
-					component.handleInput(" ");
-					selectLabel(component, "Editor style");
-					component.handleInput(" ");
-					polishedAgainRender = component.render(160).join("\n");
-
-					for (let index = 0; index < 3; index += 1) component.handleInput("\t");
-					selectLabel(component, "Commit only on detached HEAD");
-					component.handleInput(" ");
-					selectLabel(component, "Show exact-match tag");
-					component.handleInput(" ");
-					selectLabel(component, "Hide zero metrics");
-					component.handleInput(" ");
-					selectLabel(component, "Ignore submodules");
-					component.handleInput(" ");
-
-					component.handleInput("\t");
-					selectLabel(component, "Default placement");
-					component.handleInput(" ");
-				},
+		} as never,
+		deps as never,
+	);
+	const ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd: process.cwd(),
+		ui: {
+			theme: theme(),
+			notify(message: string) {
+				notifications.push(message);
 			},
-		});
+			async custom(factory: (...args: unknown[]) => unknown) {
+				component = factory({ requestRender() {} }, theme(), {}, () => {
+					doneCalls += 1;
+				}) as Component;
+			},
+		},
+	};
+	return {
+		config,
+		command: () => {
+			if (!command) throw new Error("Command was not registered");
+			return command;
+		},
+		component: () => {
+			if (!component) throw new Error("Settings component was not opened");
+			return component;
+		},
+		ctx,
+		calls,
+		notifications,
+		doneCalls: () => doneCalls,
+	};
+}
 
-		let lastIndex = -1;
-		for (const section of sectionNames) {
-			const index = firstRender.indexOf(section);
-			expect(index).toBeGreaterThan(lastIndex);
-			lastIndex = index;
+describe("component-oriented /zentui settings", () => {
+	it("uses the exact eight-section order in wide and narrow navigation", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		const wide = component.render(200).join("\n");
+		let previous = -1;
+		for (const name of sectionNames) {
+			const index = wide.indexOf(name);
+			expect(index).toBeGreaterThan(previous);
+			previous = index;
 		}
-		expect(polishedEditorRender).toContain("Editor style");
-		expect(polishedEditorRender).not.toContain("Context gauge");
-		expect(polishedEditorRender).not.toContain("Session name");
-		expect(polishedAgainRender).not.toContain("Context gauge");
-		expect(polishedAgainRender).not.toContain("Session name");
-		expect(editorStyles).toEqual(["minimalist", "polished"]);
-		expect(editorLabels).toEqual(["name"]);
-		expect(minimalistPatches).toEqual([
-			{ pathDisplay: "project" },
-			{ contextFormat: "percent-total" },
-			{ contextGauge: true },
-			{ showSessionName: false },
-			{ showTimer: false },
-			{ showCost: false },
-			{ showGit: false },
+		for (const [index, name] of sectionNames.entries()) {
+			const lines = component.render(40);
+			expect(lines[1]).toContain(name);
+			expect(lines[1]).toContain(`(${index + 1}/8)`);
+			expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+			component.handleInput("\t");
+		}
+	});
+
+	it("uses exact component-owned row sets and ordering", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		expectFocusOrder(component, [
+			"Selector borders",
+			"Selector border style",
+			"Selector border colors",
+			"Icon mode",
 		]);
-		expect(commitPatches).toEqual([{ onlyDetached: false }, { showTag: false }]);
-		expect(metricsPatches).toEqual([{ onlyNonzero: false }, { ignoreSubmodules: true }]);
-		expect(defaultPlacements).toEqual(["off"]);
-		expect(requestRender).toHaveBeenCalledTimes(15);
-	});
 
-	it("cycles editor border color mode live and reopens with the persisted value", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const values: string[] = [];
-		const rows: string[] = [];
-		const notifications: string[] = [];
-		const requestRender = vi.fn();
-		const tuiRequestRender = vi.fn();
-		let liveTuiRenderCalls = 0;
-		let closeCalls = 0;
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				setEditorBorderColorMode(value) {
-					values.push(value);
-					config.editorBorderColorMode = value;
-				},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender,
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		let invocation = 0;
-		const ctx = {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify(message: string) {
-					notifications.push(message);
-				},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					invocation += 1;
-					const component = factory({ requestRender: tuiRequestRender }, theme(), {}, () => {
-						closeCalls += 1;
-					}) as Component;
-					goToSection(component, "Editor");
-					rows.push(renderedValue(component, "Editor border color"));
-					if (invocation === 1) {
-						tuiRequestRender.mockClear();
-						component.handleInput(" ");
-						liveTuiRenderCalls = tuiRequestRender.mock.calls.length;
-						rows.push(renderedValue(component, "Editor border color"));
-					}
-				},
-			},
-		};
-
-		await command?.handler("", ctx);
-		await command?.handler("", ctx);
-
-		expect(values).toEqual(["adaptive"]);
-		expect(config.editorBorderColorMode).toBe("adaptive");
-		expect(rows[0]).toContain("static");
-		expect(rows[1]).toContain("adaptive");
-		expect(rows[2]).toContain("adaptive");
-		expect(requestRender).toHaveBeenCalledTimes(1);
-		expect(liveTuiRenderCalls).toBe(1);
-		expect(notifications).toEqual(["Editor border color: adaptive"]);
-		expect(closeCalls).toBe(0);
-	});
-
-	it("keeps editor border color unchanged when persistence fails", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const rows: string[] = [];
-		const notifications: Array<{ message: string; level: string }> = [];
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				setEditorBorderColorMode() {
-					throw new Error("config is read-only");
-				},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify(message: string, level: string) {
-					notifications.push({ message, level });
-				},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					goToSection(component, "Editor");
-					rows.push(renderedValue(component, "Editor border color"));
-					component.handleInput(" ");
-					rows.push(renderedValue(component, "Editor border color"));
-				},
-			},
-		});
-
-		expect(config.editorBorderColorMode).toBe("static");
-		expect(rows.every((row) => row.includes("static") && !row.includes("adaptive"))).toBe(true);
-		expect(notifications).toEqual([
-			{ message: "Could not update Zentui settings: config is read-only", level: "error" },
+		goToSection(component, "Editor");
+		expectFocusOrder(component, [
+			"Editor",
+			"Editor style",
+			"Editor colors",
+			"Editor model label",
+			"Editor border color",
+			"Editor viewport indicators",
+			"Copy-friendly",
 		]);
-	});
 
-	it("keeps every active section visible and every line width-safe at 40 columns", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify() {},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					for (const [index, section] of sectionNames.entries()) {
-						const lines = component.render(40);
-						expect(lines[1]).toContain(section);
-						expect(lines[1]).toContain(`(${index + 1}/6)`);
-						expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
-						component.handleInput("\t");
-					}
-				},
-			},
-		});
-	});
-
-	it("uses the documented non-Git segment navigation order", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const expectedLabels = [
+		component.handleInput("\t");
+		expectFocusOrder(component, [
+			"User messages",
+			"Message style",
+			"Message colors",
+			"Copy-friendly",
+		]);
+		component.handleInput("\t");
+		expectFocusOrder(component, ["Fixed editor (experimental)"]);
+		component.handleInput("\t");
+		expectFocusOrder(component, [
+			"Footer",
+			"Footer style",
+			"Footer colors",
+			"Footer model label",
+			"Responsive footer",
+			"Compact footer rows",
+			"Context style",
+			"Separator",
+			"Path display",
+			"Path depth",
+		]);
+		component.handleInput("\t");
+		expectFocusOrder(component, [
 			"Current directory",
 			"Session name",
 			"Runtime",
@@ -428,373 +288,321 @@ describe("bounded /zentui settings", () => {
 			"Current time",
 			"OS icon",
 			"Package version",
-		];
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify() {},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					goToSection(component, "Segments");
-					for (const label of expectedLabels) {
-						expect(component.render(120).some((line) => line.includes(`> ${label}`))).toBe(true);
-						component.handleInput("\x1b[B");
-					}
-				},
-			},
-		});
-	});
-
-	it("reopens changed controls with their effective current values", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const rows: string[] = [];
-		let invocation = 0;
-		let closeCalls = 0;
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				setEditorModelLabel(value) {
-					config.editorModelLabel = value;
-				},
-				setGitMetrics(patch) {
-					Object.assign(config.gitMetrics, patch);
-				},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		const ctx = {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify() {},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					invocation += 1;
-					const component = factory({ requestRender() {} }, theme(), {}, () => {
-						closeCalls += 1;
-					}) as Component;
-					goToSection(component, "Editor");
-					if (invocation === 1) {
-						selectLabel(component, "Editor model label");
-						component.handleInput(" ");
-						for (let index = 0; index < 3; index += 1) component.handleInput("\t");
-						selectLabel(component, "Ignore submodules");
-						component.handleInput(" ");
-						component.handleInput("\x1b");
-						return;
-					}
-
-					rows.push(renderedValue(component, "Editor model label"));
-					for (let index = 0; index < 3; index += 1) component.handleInput("\t");
-					rows.push(renderedValue(component, "Ignore submodules"));
-					component.handleInput("\x1b");
-				},
-			},
-		};
-
-		await command?.handler("", ctx);
-		await command?.handler("", ctx);
-
-		expect(invocation).toBe(2);
-		expect(closeCalls).toBe(2);
-		expect(rows[0]).toContain("name");
-		expect(rows[1]).toContain("enabled");
-	});
-
-	it("toggles model info, persists each change, and reopens with the effective value", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
-		const config = cloneConfig();
-		const patches: Array<Record<string, boolean>> = [];
-		const rows: string[] = [];
-		let invocation = 0;
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments(patch) {
-					patches.push(patch as Record<string, boolean>);
-					Object.assign(config.footerSegments, patch);
-				},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		const ctx = {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify() {},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					invocation += 1;
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					goToSection(component, "Segments");
-					selectLabel(component, "Model info");
-					if (invocation === 1) {
-						rows.push(renderedValue(component, "Model info"));
-						component.handleInput(" ");
-						rows.push(renderedValue(component, "Model info"));
-						component.handleInput(" ");
-						rows.push(renderedValue(component, "Model info"));
-						component.handleInput(" ");
-					}
-					rows.push(renderedValue(component, "Model info"));
-					component.handleInput("\x1b");
-				},
-			},
-		};
-
-		await command?.handler("", ctx);
-		await command?.handler("", ctx);
-
-		expect(patches).toEqual([{ modelInfo: true }, { modelInfo: false }, { modelInfo: true }]);
-		expect(config.footerSegments.modelInfo).toBe(true);
-		expect(rows).toEqual([
-			expect.stringContaining("disabled"),
-			expect.stringContaining("enabled"),
-			expect.stringContaining("disabled"),
-			expect.stringContaining("enabled"),
-			expect.stringContaining("enabled"),
 		]);
+		component.handleInput("\t");
+		expectFocusOrder(component, [
+			"Git branch",
+			"Branch length",
+			"Git status",
+			"Git counts",
+			"Git commit",
+			"Commit only on detached HEAD",
+			"Show exact-match tag",
+			"Git line metrics",
+			"Hide zero metrics",
+			"Ignore submodules",
+		]);
+		component.handleInput("\t");
+		expectFocusOrder(component, ["Default placement", "No active statuses"]);
 	});
 
-	it("rolls back the model-info control when persistence fails", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+	it("shows exact minimalist and enabled-layout rows while components are disabled", async () => {
 		const config = cloneConfig();
-		const patches: Array<Record<string, boolean>> = [];
-		const rows: string[] = [];
-		const notifications: Array<{ message: string; level: string }> = [];
-
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments(patch) {
-					patches.push(patch as Record<string, boolean>);
-					throw new Error("config is read-only");
-				},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify(message: string, level: string) {
-					notifications.push({ message, level });
-				},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					goToSection(component, "Segments");
-					selectLabel(component, "Model info");
-					rows.push(renderedValue(component, "Model info"));
-					component.handleInput(" ");
-					rows.push(renderedValue(component, "Model info"));
-				},
-			},
-		});
-
-		expect(patches).toEqual([{ modelInfo: true }]);
-		expect(config.footerSegments.modelInfo).toBe(false);
-		expect(rows).toEqual([
-			expect.stringContaining("disabled"),
-			expect.stringContaining("disabled"),
+		config.components.editor.enabled = false;
+		config.components.editor.style = "minimalist";
+		config.components.userMessages.enabled = false;
+		config.layout.fixedEditor.enabled = true;
+		const harness = createHarness(config);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		expectFocusOrder(component, [
+			"Editor",
+			"Editor style",
+			"Editor colors",
+			"Editor model label",
+			"Editor border color",
+			"Editor viewport indicators",
+			"Path",
+			"Context text",
+			"Context gauge",
+			"Session name",
+			"Timer",
+			"Cost",
+			"Git",
 		]);
-		expect(notifications).toEqual([
-			{ message: "Could not update Zentui settings: config is read-only", level: "error" },
+		component.handleInput("\t");
+		expectFocusOrder(component, [
+			"User messages",
+			"Message style",
+			"Message colors",
+			"Copy-friendly",
 		]);
+		component.handleInput("\t");
+		expectFocusOrder(component, ["Fixed editor (experimental)", "Mouse scroll", "Copy notice"]);
 	});
 
-	it("keeps a new control unchanged when persistence fails", async () => {
-		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
+	it("routes every minimalist, Git option, and default-placement action", async () => {
 		const config = cloneConfig();
-		const attemptedValues: string[] = [];
-		const notifications: Array<{ message: string; level: string }> = [];
-		const rows: string[] = [];
+		config.components.editor.style = "minimalist";
+		const harness = createHarness(config);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
 
-		registerZentuiSettingsCommand(
-			{
-				registerCommand(_name: string, options: unknown) {
-					command = options as typeof command;
-				},
-			} as never,
-			{
-				sessionLifecycle: new SessionLifecycle(),
-				getConfig: () => config,
-				setColorSources() {},
-				setUiFeatures: () => ({ applied: true }),
-				setFooterSegments() {},
-				setFooterFormat() {},
-				setIconMode() {},
-				setContextStyle() {},
-				setSeparator() {},
-				setPathDisplay() {},
-				setGitBranch() {},
-				setEditorModelLabel(value) {
-					attemptedValues.push(value);
-					throw new Error("config is read-only");
-				},
-				getActiveExtensionStatuses: () => new Map(),
-				setExtensionStatusPlacement() {},
-				setExtensionStatusColorMode() {},
-				setFixedEditor() {},
-				requestRender() {},
-				settingsListTheme: {
-					label: (text) => text,
-					value: (text) => text,
-					description: (text) => text,
-					cursor: "> ",
-					hint: (text) => text,
-				},
-			},
-		);
-
-		await command?.handler("", {
-			hasUI: true,
-			mode: "tui",
-			ui: {
-				theme: theme(),
-				notify(message: string, level: string) {
-					notifications.push({ message, level });
-				},
-				async custom(factory: (...args: unknown[]) => unknown) {
-					const component = factory({ requestRender() {} }, theme(), {}, () => {}) as Component;
-					goToSection(component, "Editor");
-					rows.push(renderedValue(component, "Editor model label"));
-					component.handleInput(" ");
-					rows.push(renderedValue(component, "Editor model label"));
-				},
-			},
-		});
-
-		expect(attemptedValues).toEqual(["name"]);
-		expect(config.editorModelLabel).toBe("id");
-		expect(rows).toHaveLength(2);
-		for (const row of rows) {
-			expect(row).toContain("id");
-			expect(row).not.toContain("name");
+		for (const [label, value] of [
+			["Path", "project"],
+			["Context text", "percent-total"],
+			["Context gauge", "enabled"],
+			["Session name", "disabled"],
+			["Timer", "disabled"],
+			["Cost", "disabled"],
+			["Git", "disabled"],
+		] as const) {
+			selectLabel(component, label);
+			component.handleInput(" ");
+			expect(focusedRow(component)).toContain(`> ${label}`);
+			expect(focusedRow(component)).toContain(value);
 		}
-		expect(notifications).toEqual([
-			{
-				message: "Could not update Zentui settings: config is read-only",
-				level: "error",
-			},
+		expect(harness.calls.minimalist).toEqual([
+			{ pathDisplay: "project" },
+			{ contextFormat: "percent-total" },
+			{ contextGauge: true },
+			{ showSessionName: false },
+			{ showTimer: false },
+			{ showCost: false },
+			{ showGit: false },
 		]);
+
+		for (let index = 0; index < 5; index += 1) component.handleInput("\t");
+		for (const [label, value] of [
+			["Commit only on detached HEAD", "disabled"],
+			["Show exact-match tag", "disabled"],
+			["Hide zero metrics", "disabled"],
+			["Ignore submodules", "enabled"],
+		] as const) {
+			selectLabel(component, label);
+			component.handleInput(" ");
+			expect(focusedRow(component)).toContain(`> ${label}`);
+			expect(focusedRow(component)).toContain(value);
+		}
+		expect(harness.calls.gitCommit).toEqual([{ onlyDetached: false }, { showTag: false }]);
+		expect(harness.calls.gitMetrics).toEqual([{ onlyNonzero: false }, { ignoreSubmodules: true }]);
+
+		component.handleInput("\t");
+		selectLabel(component, "Default placement");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Default placement");
+		expect(focusedRow(component)).toContain("off");
+		expect(harness.calls.extensionDefaultPlacement).toEqual(["off"]);
+		expect(config.components.footer.styles.starship.extensionStatuses.defaultPlacement).toBe("off");
+	});
+
+	it("restores editor-style focus by ID after dynamic rebuild", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Editor style");
+		expect(focusedRow(component)).toContain("minimalist");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Editor style");
+		expect(focusedRow(component)).toContain("polished");
+		expect(harness.calls.editor).toEqual([{ style: "minimalist" }, { style: "polished" }]);
+	});
+
+	it("restores fixed-editor focus after conditional rows rebuild", async () => {
+		const harness = createHarness();
+		await harness.command().handler("layout", harness.ctx);
+		const component = harness.component();
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Fixed editor (experimental)");
+		expect(focusedRow(component)).toContain("enabled");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Fixed editor (experimental)");
+		expect(focusedRow(component)).toContain("disabled");
+		expect(harness.calls.fixed).toEqual([{ enabled: true }, { enabled: false }]);
+	});
+
+	it("routes color and model rows to separate component dependencies", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		selectLabel(component, "Selector border colors");
+		component.handleInput(" ");
+		goToSection(component, "Editor");
+		selectLabel(component, "Editor colors");
+		component.handleInput(" ");
+		selectLabel(component, "Editor model label");
+		component.handleInput(" ");
+		component.handleInput("\t");
+		selectLabel(component, "Message colors");
+		component.handleInput(" ");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		selectLabel(component, "Footer colors");
+		component.handleInput(" ");
+		selectLabel(component, "Footer model label");
+		component.handleInput(" ");
+		expect(harness.calls.selectors).toEqual([{ colorSource: "terminal" }]);
+		expect(harness.calls.editor).toEqual([{ colorSource: "terminal" }, { modelLabel: "name" }]);
+		expect(harness.calls.messages).toEqual([{ colorSource: "terminal" }]);
+		expect(harness.calls.footer).toEqual([{ colorSource: "terminal" }, { modelLabel: "name" }]);
+	});
+
+	it("rebuilds failed persistence with effective values and attempted-row focus", async () => {
+		const config = cloneConfig();
+		const harness = createHarness(config, {
+			setEditorComponent() {
+				throw new Error("read-only");
+			},
+		});
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Editor model label");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Editor model label");
+		expect(focusedRow(component)).toContain("id");
+		expect(focusedRow(component)).not.toContain("name");
+		expect(harness.notifications).toEqual(["Could not update Zentui settings: read-only"]);
+	});
+
+	it("parses component direct operations and keeps the atomic recipe separate", async () => {
+		const harness = createHarness();
+		for (const command of [
+			"editor disable",
+			"messages disable",
+			"editor-copy-friendly enable",
+			"message-copy-friendly disable",
+			"copy-friendly enable",
+		])
+			await harness.command().handler(command, harness.ctx);
+		expect(harness.calls.editor).toContainEqual({ enabled: false });
+		expect(harness.calls.messages).toContainEqual({ enabled: false });
+		expect(harness.calls.polished).toEqual([{ copyFriendly: true }]);
+		expect(harness.calls.framed).toEqual([{ copyFriendly: false }]);
+		expect(harness.calls.recipe).toEqual([true]);
+		expect(harness.config.components.editor.styles.polished.copyFriendly).toBe(true);
+		expect(harness.config.components.userMessages.styles.framed.copyFriendly).toBe(true);
+		const values =
+			harness
+				.command()
+				.getArgumentCompletions("")
+				?.map((item) => item.value) ?? [];
+		expect(values).toEqual(
+			expect.arrayContaining([
+				"messages toggle",
+				"editor-copy-friendly toggle",
+				"message-copy-friendly toggle",
+			]),
+		);
+	});
+
+	it.each([
+		["fixed-editor", "enable", true],
+		["fixed-editor", "disable", false],
+		["fixed-editor", "toggle", true],
+		["fixed_editor", "enable", true],
+		["fixed_editor", "disable", false],
+		["fixed_editor", "toggle", true],
+		["fixed editor", "enable", true],
+		["fixed editor", "disable", false],
+		["fixed editor", "toggle", true],
+	] as const)("routes %s %s only to layout", async (alias, action, enabled) => {
+		const harness = createHarness();
+		await harness.command().handler(`${alias} ${action}`, harness.ctx);
+		expect(harness.calls.fixed).toEqual([{ enabled }]);
+		expect(harness.calls.editor).toEqual([]);
+		expect(harness.config.components.editor.enabled).toBe(true);
+		expect(harness.config.layout.fixedEditor.enabled).toBe(enabled);
+		expect(harness.notifications).toEqual([`Fixed editor: ${enabled ? "enabled" : "disabled"}`]);
+	});
+
+	it("persists and reopens editor-border and model/segment controls", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		let component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Editor border color");
+		component.handleInput(" ");
+		selectLabel(component, "Editor model label");
+		component.handleInput(" ");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		selectLabel(component, "Ignore submodules");
+		component.handleInput(" ");
+		component.handleInput("\x1b[Z");
+		selectLabel(component, "Model info");
+		component.handleInput(" ");
+		component.handleInput("\x1b");
+		expect(harness.doneCalls()).toBe(1);
+
+		await harness.command().handler("", harness.ctx);
+		component = harness.component();
+		goToSection(component, "Editor");
+		expect(row(component, "Editor border color")).toContain("adaptive");
+		expect(row(component, "Editor model label")).toContain("name");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		expect(row(component, "Ignore submodules")).toContain("enabled");
+		component.handleInput("\x1b[Z");
+		expect(row(component, "Model info")).toContain("enabled");
+		expect(harness.calls.editor).toEqual([{ borderColorMode: "adaptive" }, { modelLabel: "name" }]);
+		expect(harness.calls.gitMetrics).toEqual([{ ignoreSubmodules: true }]);
+		expect(harness.calls.segments).toEqual([{ modelInfo: true }]);
+		component.handleInput("\x1b");
+		expect(harness.doneCalls()).toBe(2);
+	});
+
+	it("rolls back editor-border and model-info rows when persistence fails", async () => {
+		const config = cloneConfig();
+		const harness = createHarness(config, {
+			setEditorComponent() {
+				throw new Error("read-only editor");
+			},
+			setFooterSegments() {
+				throw new Error("read-only segments");
+			},
+		});
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Editor border color");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Editor border color");
+		expect(focusedRow(component)).toContain("static");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		component.handleInput("\t");
+		selectLabel(component, "Model info");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Model info");
+		expect(focusedRow(component)).toContain("disabled");
+		expect(config.components.editor.borderColorMode).toBe("static");
+		expect(config.components.footer.styles.starship.segments.modelInfo).toBe(false);
+		expect(harness.notifications).toEqual([
+			"Could not update Zentui settings: read-only editor",
+			"Could not update Zentui settings: read-only segments",
+		]);
+	});
+
+	it.each([
+		["messages", "User messages"],
+		["user-messages", "User messages"],
+		["layout", "Layout"],
+	])("opens %s directly in %s", async (argument, section) => {
+		const harness = createHarness();
+		await harness.command().handler(argument, harness.ctx);
+		expect(harness.component().render(40)[1]).toContain(section);
 	});
 });

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -242,7 +242,6 @@ describe("component-oriented /zentui settings", () => {
 		expectFocusOrder(component, ["Fixed editor (experimental)"]);
 		component.handleInput("\t");
 		expectFocusOrder(component, [
-			"Footer",
 			"Footer style",
 			"Footer colors",
 			"Footer model label",
@@ -283,6 +282,75 @@ describe("component-oriented /zentui settings", () => {
 		]);
 		component.handleInput("\t");
 		expectFocusOrder(component, ["Default placement", "No active statuses"]);
+	});
+
+	it.each(["native", "hidden"] as const)(
+		"shows only Footer style for %s while retaining Starship preconfiguration sections",
+		async (style) => {
+			const config = cloneConfig();
+			config.components.footer.style = style;
+			const harness = createHarness(config);
+			await harness.command().handler("", harness.ctx);
+			const component = harness.component();
+			goToSection(component, "Footer");
+			expectFocusOrder(component, ["Footer style"]);
+			component.handleInput("\t");
+			expectFocusOrder(component, [
+				"Current directory",
+				"Session name",
+				"Runtime",
+				"Model info",
+				"Context usage",
+				"Token counts",
+				"Session cost",
+				"Session duration",
+				"Username@host",
+				"Current time",
+				"OS icon",
+				"Package version",
+			]);
+			component.handleInput("\t");
+			expect(row(component, "Git branch")).toContain("enabled");
+			component.handleInput("\t");
+			expect(row(component, "Default placement")).toContain("right");
+		},
+	);
+
+	it("keeps Footer-style focus through Native, Starship, and Hidden rebuilds", async () => {
+		const config = cloneConfig();
+		config.components.footer.style = "native";
+		const harness = createHarness(config);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Footer");
+		for (const expected of ["Starship", "Hidden", "Native"]) {
+			component.handleInput(" ");
+			expect(focusedRow(component)).toContain("> Footer style");
+			expect(focusedRow(component)).toContain(expected);
+		}
+		expect(harness.calls.footer).toEqual([
+			{ style: "starship" },
+			{ style: "hidden" },
+			{ style: "native" },
+		]);
+	});
+
+	it("restores Footer-style focus and effective rows after persistence failure", async () => {
+		const config = cloneConfig();
+		config.components.footer.style = "native";
+		const harness = createHarness(config, {
+			setFooterComponent() {
+				throw new Error("read-only footer");
+			},
+		});
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Footer");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Footer style");
+		expect(focusedRow(component)).toContain("Native");
+		expectFocusOrder(component, ["Footer style"]);
+		expect(harness.notifications).toEqual(["Could not update Zentui settings: read-only footer"]);
 	});
 
 	it("shows exact minimalist and enabled-layout rows while components are disabled", async () => {
@@ -380,12 +448,12 @@ describe("component-oriented /zentui settings", () => {
 		selectLabel(component, "Editor style");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Editor style");
-		expect(focusedRow(component)).toContain("Polished (copy-friendly)");
+		expect(focusedRow(component)).toContain("Opencode (copy-friendly)");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Editor style");
 		expect(focusedRow(component)).toContain("Minimalist");
 		expect(harness.calls.editor).toEqual([
-			{ style: "polished-copy-friendly" },
+			{ style: "opencode-copy-friendly" },
 			{ style: "minimalist" },
 		]);
 	});

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -81,9 +81,7 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		messages: [] as Partial<UserMessagesComponentConfig>[],
 		selectors: [] as Partial<SelectorBordersComponentConfig>[],
 		footer: [] as Partial<FooterComponentConfig>[],
-		polished: [] as Array<Record<string, unknown>>,
 		minimalist: [] as Array<Record<string, unknown>>,
-		framed: [] as Array<Record<string, unknown>>,
 		fixed: [] as Array<Record<string, unknown>>,
 		segments: [] as Array<Record<string, boolean>>,
 		gitCommit: [] as Array<Record<string, boolean>>,
@@ -99,10 +97,6 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 			Object.assign(config.components.editor, patch);
 			return { applied: true };
 		},
-		setPolishedEditorStyle(patch: Record<string, unknown>) {
-			calls.polished.push(patch);
-			Object.assign(config.components.editor.styles.polished, patch);
-		},
 		setMinimalist(patch: Record<string, unknown>) {
 			calls.minimalist.push(patch);
 			Object.assign(config.components.editor.styles.minimalist, patch);
@@ -111,10 +105,6 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 			calls.messages.push(patch);
 			Object.assign(config.components.userMessages, patch);
 		},
-		setFramedUserMessagesStyle(patch: Record<string, unknown>) {
-			calls.framed.push(patch);
-			Object.assign(config.components.userMessages.styles.framed, patch);
-		},
 		setSelectorBordersComponent(patch: Partial<SelectorBordersComponentConfig>) {
 			calls.selectors.push(patch);
 			Object.assign(config.components.selectorBorders, patch);
@@ -122,11 +112,6 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		setFooterComponent(patch: Partial<FooterComponentConfig>) {
 			calls.footer.push(patch);
 			Object.assign(config.components.footer, patch);
-		},
-		setCopyFriendlyRecipe(enabled: boolean) {
-			calls.recipe.push(enabled);
-			config.components.editor.styles.polished.copyFriendly = enabled;
-			config.components.userMessages.styles.framed.copyFriendly = enabled;
 		},
 		setFooterSegments(patch: Record<string, boolean>) {
 			calls.segments.push(patch);
@@ -249,16 +234,10 @@ describe("component-oriented /zentui settings", () => {
 			"Editor model label",
 			"Editor border color",
 			"Editor viewport indicators",
-			"Copy-friendly",
 		]);
 
 		component.handleInput("\t");
-		expectFocusOrder(component, [
-			"User messages",
-			"Message style",
-			"Message colors",
-			"Copy-friendly",
-		]);
+		expectFocusOrder(component, ["User messages", "Message style", "Message colors"]);
 		component.handleInput("\t");
 		expectFocusOrder(component, ["Fixed editor (experimental)"]);
 		component.handleInput("\t");
@@ -332,12 +311,7 @@ describe("component-oriented /zentui settings", () => {
 			"Git",
 		]);
 		component.handleInput("\t");
-		expectFocusOrder(component, [
-			"User messages",
-			"Message style",
-			"Message colors",
-			"Copy-friendly",
-		]);
+		expectFocusOrder(component, ["User messages", "Message style", "Message colors"]);
 		component.handleInput("\t");
 		expectFocusOrder(component, ["Fixed editor (experimental)", "Mouse scroll", "Copy notice"]);
 	});
@@ -406,11 +380,29 @@ describe("component-oriented /zentui settings", () => {
 		selectLabel(component, "Editor style");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Editor style");
-		expect(focusedRow(component)).toContain("minimalist");
+		expect(focusedRow(component)).toContain("Polished (copy-friendly)");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Editor style");
-		expect(focusedRow(component)).toContain("polished");
-		expect(harness.calls.editor).toEqual([{ style: "minimalist" }, { style: "polished" }]);
+		expect(focusedRow(component)).toContain("Minimalist");
+		expect(harness.calls.editor).toEqual([
+			{ style: "polished-copy-friendly" },
+			{ style: "minimalist" },
+		]);
+	});
+
+	it("shows friendly message style labels and restores focus after rebuild", async () => {
+		const harness = createHarness();
+		await harness.command().handler("messages", harness.ctx);
+		const component = harness.component();
+		selectLabel(component, "Message style");
+		expect(focusedRow(component)).toContain("Framed");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Message style");
+		expect(focusedRow(component)).toContain("Compact");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Message style");
+		expect(focusedRow(component)).toContain("Labeled");
+		expect(harness.calls.messages).toEqual([{ style: "compact" }, { style: "labeled" }]);
 	});
 
 	it("restores fixed-editor focus after conditional rows rebuild", async () => {
@@ -470,35 +462,28 @@ describe("component-oriented /zentui settings", () => {
 		expect(harness.notifications).toEqual(["Could not update Zentui settings: read-only"]);
 	});
 
-	it("parses component direct operations and keeps the atomic recipe separate", async () => {
+	it("parses component direct operations and rejects removed copy commands", async () => {
 		const harness = createHarness();
+		for (const command of ["editor disable", "messages disable"]) {
+			await harness.command().handler(command, harness.ctx);
+		}
 		for (const command of [
-			"editor disable",
-			"messages disable",
 			"editor-copy-friendly enable",
 			"message-copy-friendly disable",
 			"copy-friendly enable",
-		])
+		]) {
 			await harness.command().handler(command, harness.ctx);
-		expect(harness.calls.editor).toContainEqual({ enabled: false });
-		expect(harness.calls.messages).toContainEqual({ enabled: false });
-		expect(harness.calls.polished).toEqual([{ copyFriendly: true }]);
-		expect(harness.calls.framed).toEqual([{ copyFriendly: false }]);
-		expect(harness.calls.recipe).toEqual([true]);
-		expect(harness.config.components.editor.styles.polished.copyFriendly).toBe(true);
-		expect(harness.config.components.userMessages.styles.framed.copyFriendly).toBe(true);
+		}
+		expect(harness.calls.editor).toEqual([{ enabled: false }]);
+		expect(harness.calls.messages).toEqual([{ enabled: false }]);
+		expect(harness.notifications.filter((message) => message.startsWith("Usage:"))).toHaveLength(3);
 		const values =
 			harness
 				.command()
 				.getArgumentCompletions("")
 				?.map((item) => item.value) ?? [];
-		expect(values).toEqual(
-			expect.arrayContaining([
-				"messages toggle",
-				"editor-copy-friendly toggle",
-				"message-copy-friendly toggle",
-			]),
-		);
+		expect(values).toContain("messages toggle");
+		expect(values.some((value) => value.includes("copy-friendly"))).toBe(false);
 	});
 
 	it.each([

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -51,10 +51,10 @@ function renderedValue(component: Component, label: string): string {
 }
 
 describe("bounded /zentui settings", () => {
-	it("orders the six sections and applies all six new controls from effective config", async () => {
+	it("shows active editor-style controls in the Editor section", async () => {
 		let command: { handler(args: string, ctx: unknown): Promise<void> } | undefined;
 		const config = cloneConfig();
-		const editorModes: string[] = [];
+		const editorStyles: string[] = [];
 		const editorLabels: string[] = [];
 		const minimalistPatches: Array<Record<string, unknown>> = [];
 		const commitPatches: Array<Record<string, boolean>> = [];
@@ -62,6 +62,8 @@ describe("bounded /zentui settings", () => {
 		const defaultPlacements: ExtensionStatusPlacement[] = [];
 		const requestRender = vi.fn();
 		let firstRender = "";
+		let polishedEditorRender = "";
+		let polishedAgainRender = "";
 
 		registerZentuiSettingsCommand(
 			{
@@ -81,13 +83,13 @@ describe("bounded /zentui settings", () => {
 				setSeparator() {},
 				setPathDisplay() {},
 				setGitBranch() {},
-				setEditorMode(value) {
-					editorModes.push(value);
-					config.editorMode = value;
+				setEditorStyle(value) {
+					editorStyles.push(value);
+					config.editorStyle = value;
 				},
 				setMinimalist(patch) {
 					minimalistPatches.push(patch);
-					Object.assign(config.minimalist, patch);
+					Object.assign(config.editorStyles.minimalist, patch);
 				},
 				setEditorModelLabel(value) {
 					editorLabels.push(value);
@@ -132,21 +134,26 @@ describe("bounded /zentui settings", () => {
 					firstRender = component.render(160).join("\n");
 
 					goToSection(component, "Editor");
-					selectLabel(component, "Editor mode");
+					polishedEditorRender = component.render(160).join("\n");
+					selectLabel(component, "Editor style");
 					component.handleInput(" ");
 					for (const label of [
-						"Minimalist path",
-						"Minimalist context text",
-						"Minimalist context gauge",
-						"Minimalist timer",
-						"Minimalist cost",
-						"Minimalist Git",
+						"Path",
+						"Context text",
+						"Context gauge",
+						"Session name",
+						"Timer",
+						"Cost",
+						"Git",
 					]) {
 						selectLabel(component, label);
 						component.handleInput(" ");
 					}
 					selectLabel(component, "Editor model label");
 					component.handleInput(" ");
+					selectLabel(component, "Editor style");
+					component.handleInput(" ");
+					polishedAgainRender = component.render(160).join("\n");
 
 					for (let index = 0; index < 3; index += 1) component.handleInput("\t");
 					selectLabel(component, "Commit only on detached HEAD");
@@ -171,12 +178,18 @@ describe("bounded /zentui settings", () => {
 			expect(index).toBeGreaterThan(lastIndex);
 			lastIndex = index;
 		}
-		expect(editorModes).toEqual(["minimalist"]);
+		expect(polishedEditorRender).toContain("Editor style");
+		expect(polishedEditorRender).not.toContain("Context gauge");
+		expect(polishedEditorRender).not.toContain("Session name");
+		expect(polishedAgainRender).not.toContain("Context gauge");
+		expect(polishedAgainRender).not.toContain("Session name");
+		expect(editorStyles).toEqual(["minimalist", "polished"]);
 		expect(editorLabels).toEqual(["name"]);
 		expect(minimalistPatches).toEqual([
 			{ pathDisplay: "project" },
 			{ contextFormat: "percent-total" },
 			{ contextGauge: true },
+			{ showSessionName: false },
 			{ showTimer: false },
 			{ showCost: false },
 			{ showGit: false },
@@ -184,7 +197,7 @@ describe("bounded /zentui settings", () => {
 		expect(commitPatches).toEqual([{ onlyDetached: false }, { showTag: false }]);
 		expect(metricsPatches).toEqual([{ onlyNonzero: false }, { ignoreSubmodules: true }]);
 		expect(defaultPlacements).toEqual(["off"]);
-		expect(requestRender).toHaveBeenCalledTimes(13);
+		expect(requestRender).toHaveBeenCalledTimes(15);
 	});
 
 	it("cycles editor border color mode live and reopens with the persisted value", async () => {

--- a/test/state.test.ts
+++ b/test/state.test.ts
@@ -1,7 +1,7 @@
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { emptyGitStatus } from "../extensions/zentui/git";
-import { createInitialState, syncState } from "../extensions/zentui/state";
+import { createInitialState, modelLabelFor, syncState } from "../extensions/zentui/state";
 
 function makeCtx(model: unknown) {
 	return {
@@ -14,34 +14,31 @@ function makeCtx(model: unknown) {
 const model = { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" };
 
 describe("syncState model label", () => {
-	it("shows the model id when the label source is 'id' and retains raw model fields", () => {
+	it("retains raw model fields and formats independent label sources", () => {
 		const state = createInitialState(emptyGitStatus());
-		syncState(state, makeCtx(model), "", "id");
-		expect(state.modelLabel).toBe("gpt-5.6-terra");
+		syncState(state, makeCtx(model), "");
 		expect(state.modelId).toBe("gpt-5.6-terra");
 		expect(state.modelName).toBe("GPT-5.6 Terra");
-	});
-
-	it("shows the model name when the label source is 'name'", () => {
-		const state = createInitialState(emptyGitStatus());
-		syncState(state, makeCtx(model), "", "name");
-		expect(state.modelLabel).toBe("GPT-5.6 Terra");
-	});
-
-	it("falls back to the id when the name is empty without changing the raw name", () => {
-		const state = createInitialState(emptyGitStatus());
-		syncState(state, makeCtx({ ...model, name: "" }), "", "name");
 		expect(state.modelLabel).toBe("gpt-5.6-terra");
-		expect(state.modelId).toBe("gpt-5.6-terra");
+		expect(modelLabelFor(state, "id")).toBe("gpt-5.6-terra");
+		expect(modelLabelFor(state, "name")).toBe("GPT-5.6 Terra");
+	});
+
+	it("falls back to the id when the name is empty", () => {
+		const state = createInitialState(emptyGitStatus());
+		syncState(state, makeCtx({ ...model, name: "" }), "");
+		expect(modelLabelFor(state, "name")).toBe("gpt-5.6-terra");
 		expect(state.modelName).toBe("");
 	});
 
 	it("shows no-model when there is no active model and clears raw fields", () => {
 		const state = createInitialState(emptyGitStatus());
-		syncState(state, makeCtx(undefined), "", "name");
-		expect(state.modelLabel).toBe("no-model");
+		syncState(state, makeCtx(undefined), "");
+		expect(modelLabelFor(state, "name")).toBe("no-model");
+		expect(modelLabelFor(state, "id")).toBe("no-model");
 		expect(state.modelId).toBe("");
 		expect(state.modelName).toBe("");
+		expect(state.modelLabel).toBe("no-model");
 	});
 
 	it("stores cache atoms and clears optional markers on later synchronization", () => {
@@ -64,7 +61,7 @@ describe("syncState model label", () => {
 		};
 		const state = createInitialState(emptyGitStatus());
 
-		syncState(state, ctx as never, "", "id", {
+		syncState(state, ctx as never, "", {
 			subscription: true,
 			autoCompaction: true,
 		});
@@ -76,7 +73,7 @@ describe("syncState model label", () => {
 		});
 		expect(state.tokenLabel).not.toContain("R1.2k");
 
-		syncState(state, makeCtx(model), "", "id", {});
+		syncState(state, makeCtx(model), "", {});
 		expect(state).toMatchObject({
 			cacheReadLabel: "",
 			cacheWriteLabel: "",

--- a/test/telemetry-lifecycle-integration.test.ts
+++ b/test/telemetry-lifecycle-integration.test.ts
@@ -247,7 +247,6 @@ describe("telemetry lifecycle integration", () => {
 		await emit(handlers, "session_start", first.ctx);
 		const firstFooter = first.createFooter();
 		expect(rendered(firstFooter)).toMatch(/\(sub\).*\(auto\)|\(auto\).*\(sub\)/);
-		firstFooter.dispose?.();
 		await emit(handlers, "session_shutdown", first.ctx);
 		expect(() => first.createFooter()).toThrow("footer was not installed");
 

--- a/test/telemetry-lifecycle-integration.test.ts
+++ b/test/telemetry-lifecycle-integration.test.ts
@@ -57,11 +57,16 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 
 vi.mock("../extensions/zentui/git", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/git")>();
-	return { ...actual, readGitStatus: async () => actual.emptyGitStatus() };
+	return {
+		...actual,
+		readGitStatus: async () => ({ kind: "ok" as const, status: actual.emptyGitStatus() }),
+	};
 });
-vi.mock("../extensions/zentui/runtime", () => ({ readRuntimeInfo: async () => undefined }));
+vi.mock("../extensions/zentui/runtime", () => ({
+	readRuntimeInfo: async () => ({ kind: "ok" as const, runtime: undefined }),
+}));
 vi.mock("../extensions/zentui/package-version", () => ({
-	readPackageVersionResult: async () => undefined,
+	readPackageVersionResult: async () => ({ kind: "ok" as const, result: null }),
 }));
 
 import zentui from "../extensions/zentui/index";

--- a/test/telemetry-lifecycle-integration.test.ts
+++ b/test/telemetry-lifecycle-integration.test.ts
@@ -31,12 +31,27 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 	return {
 		...actual,
 		ensureConfigExists: () => {},
-		loadConfig: () => ({
-			...actual.defaultConfig,
-			projectRefreshIntervalMs: 0,
-			features: { ...actual.defaultConfig.features, editor: false, statusLine: true },
-			footerSegments: { ...actual.defaultConfig.footerSegments, modelInfo: true },
-		}),
+		loadConfig: () => {
+			const footer = actual.defaultConfig.components.footer;
+			return {
+				...actual.defaultConfig,
+				projectRefreshIntervalMs: 0,
+				components: {
+					...actual.defaultConfig.components,
+					editor: { ...actual.defaultConfig.components.editor, enabled: false },
+					footer: {
+						...footer,
+						enabled: true,
+						styles: {
+							starship: {
+								...footer.styles.starship,
+								segments: { ...footer.styles.starship.segments, modelInfo: true },
+							},
+						},
+					},
+				},
+			};
+		},
 	};
 });
 

--- a/test/user-message-osc.test.ts
+++ b/test/user-message-osc.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+import {
+	isValidUserMessageOsc8Payload,
+	sanitizeRenderedUserMessageLines,
+	sanitizeRenderedUserMessageText,
+	sanitizeUserMessageOscText,
+	stripUserMessageOscText,
+} from "../extensions/zentui/user-message-osc";
+
+const safeTerminators = ["\x07", "\x1b\\"];
+
+describe("sanitizeUserMessageOscText", () => {
+	it.each(safeTerminators)("preserves structurally valid 7-bit OSC 8 byte-for-byte (%j)", (end) => {
+		const open = `\x1b]8;id=docs;https://example.test/a${end}`;
+		const close = `\x1b]8;;${end}`;
+		const source = `before ${open}link${close} after`;
+		expect(sanitizeUserMessageOscText(source)).toBe(source);
+	});
+
+	it("preserves a balanced link spanning source rows", () => {
+		const open = "\x1b]8;;https://example.test\x07";
+		const close = "\x1b]8;;\x07";
+		const source = `${open}first\nsecond${close}`;
+		expect(sanitizeUserMessageOscText(source)).toBe(source);
+	});
+
+	it.each([
+		["unmatched open", "\x1b]8;;https://example.test\x07before link after", "before link after"],
+		["stray close", "before\x1b]8;;\x07 after", "before after"],
+		[
+			"nested open",
+			"\x1b]8;;https://first.test\x07first \x1b]8;;https://second.test\x07second\x1b]8;;\x07",
+			"first second",
+		],
+	] as const)(
+		"strips every OSC 8 control for an unbalanced %s stream",
+		(_name, source, visible) => {
+			const output = sanitizeUserMessageOscText(source);
+			expect(output).toBe(visible);
+			expect(output).not.toContain("\x1b]8;");
+		},
+	);
+
+	it.each([
+		["C1 introducer and terminator", "\x9d", "\x9c"],
+		["C1 introducer with BEL", "\x9d", "\x07"],
+		["7-bit introducer with C1 terminator", "\x1b]", "\x9c"],
+	] as const)("strips unsupported %s OSC 8 controls", (_name, start, end) => {
+		const open = `${start}8;;https://example.test${end}`;
+		const close = `${start}8;;${end}`;
+		expect(sanitizeUserMessageOscText(`before ${open}link${close} after`)).toBe(
+			"before link after",
+		);
+	});
+
+	it.each(["0;title", "2;title", "52;c;c2VjcmV0", "133;A", "9;text", "hello"])(
+		"removes complete non-OSC-8 command %j and its payload",
+		(payload) => {
+			expect(sanitizeUserMessageOscText(`before\x1b]${payload}\x07after`)).toBe("beforeafter");
+			expect(sanitizeUserMessageOscText(`before\x9d${payload}\x9cafter`)).toBe("beforeafter");
+		},
+	);
+
+	it.each([
+		"8",
+		"8;params",
+		"88;;https://example.test",
+		"8;badparam;https://example.test",
+		"8;bad key=value;https://example.test",
+		"8;;https://example.test/has space",
+		"8;id=x;",
+	])("removes malformed OSC 8 payload %j", (payload) => {
+		expect(sanitizeUserMessageOscText(`left\x1b]${payload}\x07right`)).toBe("leftright");
+	});
+
+	it("neutralizes unterminated and nested OSC without consuming later visible text", () => {
+		expect(sanitizeUserMessageOscText("left\x1b]133;A;visible")).toBe("leftvisible");
+		expect(sanitizeUserMessageOscText("left\x1b]2;title\x1b]8;;https://safe.test\x07right")).toBe(
+			"left2;titleright",
+		);
+	});
+
+	it("can remove valid OSC 8 as a fail-closed rendering fallback", () => {
+		const open = "\x1b]8;;https://safe.test\x07";
+		const close = "\x1b]8;;\x07";
+		expect(stripUserMessageOscText(`before ${open}link${close} after`)).toBe("before link after");
+	});
+
+	it.each([
+		["7-bit CSI", "a\x1b[2Jb", "ab"],
+		["C1 CSI", "a\x9b2Jb", "ab"],
+		["7-bit DCS", "a\x1bPpayload\x1b\\b", "ab"],
+		["C1 DCS", "a\x90payload\x9cb", "ab"],
+		["7-bit SOS", "a\x1bXpayload\x1b\\b", "ab"],
+		["C1 SOS", "a\x98payload\x9cb", "ab"],
+		["7-bit PM", "a\x1b^payload\x1b\\b", "ab"],
+		["C1 PM", "a\x9epayload\x9cb", "ab"],
+		["7-bit APC", "a\x1b_payload\x1b\\b", "ab"],
+		["C1 APC", "a\x9fpayload\x9cb", "ab"],
+		["BEL", "a\x07b", "ab"],
+		["C0", "a\x01b", "ab"],
+		["DEL", "a\x7fb", "ab"],
+		["standalone C1", "a\x85b", "ab"],
+		["generic escape", "a\x1b(0b", "ab"],
+	] as const)("removes %s terminal controls", (_name, source, expected) => {
+		expect(sanitizeUserMessageOscText(source)).toBe(expected);
+	});
+
+	it("preserves Markdown-safe structural whitespace", () => {
+		expect(sanitizeUserMessageOscText("a\tb\nc")).toBe("a\tb\nc");
+	});
+});
+
+describe("sanitizeRenderedUserMessageText", () => {
+	it("preserves only SGR and structurally valid 7-bit OSC 8", () => {
+		const sgr = "\x1b[38;5;202mstyled\x1b[0m";
+		const open = "\x1b]8;;https://safe.example\x1b\\";
+		const close = "\x1b]8;;\x1b\\";
+		const source = `before ${sgr} ${open}link${close} \x1b]52;c;CLIP\x07\x1b[2J\x1bPSECRET\x1b\\\x07 after`;
+		const sanitized = sanitizeRenderedUserMessageText(source);
+		expect(sanitized).toContain(sgr);
+		expect(sanitized).toContain(`${open}link${close}`);
+		expect(sanitized).toContain("before");
+		expect(sanitized).toContain("after");
+		expect(sanitized).not.toContain("CLIP");
+		expect(sanitized).not.toContain("SECRET");
+		expect(sanitized).not.toContain("\x1b[2J");
+		expect(sanitized).not.toContain("\x07 after");
+	});
+
+	it("balances predecessor hyperlinks across rendered rows", () => {
+		const open = "\x1b]8;;https://safe.example\x07";
+		const close = "\x1b]8;;\x07";
+		const sgr = "\x1b[31mred\x1b[0m";
+		expect(sanitizeRenderedUserMessageLines([`${open}first`, `second${close} ${sgr}`])).toEqual([
+			`${open}first`,
+			`second${close} ${sgr}`,
+		]);
+		expect(sanitizeRenderedUserMessageLines([`${open}first`, `second ${sgr}`])).toEqual([
+			"first",
+			`second ${sgr}`,
+		]);
+		expect(sanitizeRenderedUserMessageLines(["first", `second\x1b]8;;\x07 ${sgr}`])).toEqual([
+			"first",
+			`second ${sgr}`,
+		]);
+	});
+});
+
+describe("isValidUserMessageOsc8Payload", () => {
+	it("accepts parameter entries and custom URI schemes", () => {
+		expect(isValidUserMessageOsc8Payload("8;id=x:foo=bar;custom:target")).toBe(true);
+	});
+
+	it.each(["8;id=x;bad\nuri", "8;i\x1bd=x;https://x", "8;id=x;https://x\x9c"])(
+		"rejects controls in params and URIs",
+		(payload) => {
+			expect(isValidUserMessageOsc8Payload(payload)).toBe(false);
+		},
+	);
+});

--- a/test/user-message-osc.test.ts
+++ b/test/user-message-osc.test.ts
@@ -3,25 +3,24 @@ import {
 	isValidUserMessageOsc8Payload,
 	sanitizeRenderedUserMessageLines,
 	sanitizeRenderedUserMessageText,
-	sanitizeUserMessageOscText,
-	stripUserMessageOscText,
+	sanitizeUserMessageSourceText,
 } from "../extensions/zentui/user-message-osc";
 
 const safeTerminators = ["\x07", "\x1b\\"];
 
-describe("sanitizeUserMessageOscText", () => {
-	it.each(safeTerminators)("preserves structurally valid 7-bit OSC 8 byte-for-byte (%j)", (end) => {
+describe("sanitizeUserMessageSourceText", () => {
+	it.each(safeTerminators)("strips structurally valid 7-bit OSC 8 controls (%j)", (end) => {
 		const open = `\x1b]8;id=docs;https://example.test/a${end}`;
 		const close = `\x1b]8;;${end}`;
-		const source = `before ${open}link${close} after`;
-		expect(sanitizeUserMessageOscText(source)).toBe(source);
+		expect(sanitizeUserMessageSourceText(`before ${open}link${close} after`)).toBe(
+			"before link after",
+		);
 	});
 
-	it("preserves a balanced link spanning source rows", () => {
+	it("strips a balanced link spanning source rows while preserving text", () => {
 		const open = "\x1b]8;;https://example.test\x07";
 		const close = "\x1b]8;;\x07";
-		const source = `${open}first\nsecond${close}`;
-		expect(sanitizeUserMessageOscText(source)).toBe(source);
+		expect(sanitizeUserMessageSourceText(`${open}first\nsecond${close}`)).toBe("first\nsecond");
 	});
 
 	it.each([
@@ -35,7 +34,7 @@ describe("sanitizeUserMessageOscText", () => {
 	] as const)(
 		"strips every OSC 8 control for an unbalanced %s stream",
 		(_name, source, visible) => {
-			const output = sanitizeUserMessageOscText(source);
+			const output = sanitizeUserMessageSourceText(source);
 			expect(output).toBe(visible);
 			expect(output).not.toContain("\x1b]8;");
 		},
@@ -48,7 +47,7 @@ describe("sanitizeUserMessageOscText", () => {
 	] as const)("strips unsupported %s OSC 8 controls", (_name, start, end) => {
 		const open = `${start}8;;https://example.test${end}`;
 		const close = `${start}8;;${end}`;
-		expect(sanitizeUserMessageOscText(`before ${open}link${close} after`)).toBe(
+		expect(sanitizeUserMessageSourceText(`before ${open}link${close} after`)).toBe(
 			"before link after",
 		);
 	});
@@ -56,8 +55,8 @@ describe("sanitizeUserMessageOscText", () => {
 	it.each(["0;title", "2;title", "52;c;c2VjcmV0", "133;A", "9;text", "hello"])(
 		"removes complete non-OSC-8 command %j and its payload",
 		(payload) => {
-			expect(sanitizeUserMessageOscText(`before\x1b]${payload}\x07after`)).toBe("beforeafter");
-			expect(sanitizeUserMessageOscText(`before\x9d${payload}\x9cafter`)).toBe("beforeafter");
+			expect(sanitizeUserMessageSourceText(`before\x1b]${payload}\x07after`)).toBe("beforeafter");
+			expect(sanitizeUserMessageSourceText(`before\x9d${payload}\x9cafter`)).toBe("beforeafter");
 		},
 	);
 
@@ -70,20 +69,14 @@ describe("sanitizeUserMessageOscText", () => {
 		"8;;https://example.test/has space",
 		"8;id=x;",
 	])("removes malformed OSC 8 payload %j", (payload) => {
-		expect(sanitizeUserMessageOscText(`left\x1b]${payload}\x07right`)).toBe("leftright");
+		expect(sanitizeUserMessageSourceText(`left\x1b]${payload}\x07right`)).toBe("leftright");
 	});
 
 	it("neutralizes unterminated and nested OSC without consuming later visible text", () => {
-		expect(sanitizeUserMessageOscText("left\x1b]133;A;visible")).toBe("leftvisible");
-		expect(sanitizeUserMessageOscText("left\x1b]2;title\x1b]8;;https://safe.test\x07right")).toBe(
-			"left2;titleright",
-		);
-	});
-
-	it("can remove valid OSC 8 as a fail-closed rendering fallback", () => {
-		const open = "\x1b]8;;https://safe.test\x07";
-		const close = "\x1b]8;;\x07";
-		expect(stripUserMessageOscText(`before ${open}link${close} after`)).toBe("before link after");
+		expect(sanitizeUserMessageSourceText("left\x1b]133;A;visible")).toBe("leftvisible");
+		expect(
+			sanitizeUserMessageSourceText("left\x1b]2;title\x1b]8;;https://safe.test\x07right"),
+		).toBe("left2;titleright");
 	});
 
 	it.each([
@@ -103,11 +96,21 @@ describe("sanitizeUserMessageOscText", () => {
 		["standalone C1", "a\x85b", "ab"],
 		["generic escape", "a\x1b(0b", "ab"],
 	] as const)("removes %s terminal controls", (_name, source, expected) => {
-		expect(sanitizeUserMessageOscText(source)).toBe(expected);
+		expect(sanitizeUserMessageSourceText(source)).toBe(expected);
 	});
 
 	it("preserves Markdown-safe structural whitespace", () => {
-		expect(sanitizeUserMessageOscText("a\tb\nc")).toBe("a\tb\nc");
+		expect(sanitizeUserMessageSourceText("a\tb\nc")).toBe("a\tb\nc");
+	});
+
+	it("strips many raw links in one linear source pass", () => {
+		const open = "\x1b]8;;https://example.test\x07";
+		const close = "\x1b]8;;\x07";
+		const source = Array.from({ length: 20_000 }, (_, index) => `${open}${index}${close}`).join(
+			" ",
+		);
+		const expected = Array.from({ length: 20_000 }, (_, index) => String(index)).join(" ");
+		expect(sanitizeUserMessageSourceText(source)).toBe(expected);
 	});
 });
 

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -137,116 +137,76 @@ describe("pure user-message styles", () => {
 		}
 	});
 
-	it("preserves complete 7-bit OSC 8 controls byte-for-byte", () => {
+	it("strips every raw OSC 8 control while preserving visible text", () => {
+		const pairs = [
+			["\x1b]8;;https://example.com\x07", "\x1b]8;;\x07"],
+			["\x1b]8;;https://example.com\x1b\\", "\x1b]8;;\x1b\\"],
+			["\x9d8;;https://example.com\x9c", "\x9d8;;\x9c"],
+		] as const;
 		for (const style of userMessageStyles) {
-			for (const terminator of ["\x07", "\x1b\\"]) {
-				const open = `\x1b]8;;https://example.com${terminator}`;
-				const close = `\x1b]8;;${terminator}`;
-				const output = render(style, `${open}raw${close}`, 80).join("\n");
-				expect(output.split(open)).toHaveLength(2);
-				expect(output.split(close)).toHaveLength(2);
-				expect(output).toContain(`${open}raw${close}`);
+			for (const [open, close] of pairs) {
+				const output = render(style, `before ${open}VISIBLE${close}\nafter`, 80).join("\n");
+				expect(output).not.toContain(open);
+				expect(output).not.toContain(close);
+				expect(plain(output).replaceAll(/[^\p{L}]/gu, "")).toContain("beforeVISIBLEafter");
 			}
 		}
 	});
 
-	it("preserves a balanced OSC 8 close immediately before a non-final Markdown row", () => {
-		const open = "\x1b]8;;https://example.com\x07";
+	it("strips raw OSC 8 independently of Markdown source context", () => {
+		const open = "\x1b]8;;https://raw.example\x07";
 		const close = "\x1b]8;;\x07";
-		const source = `before ${open}LINK${close}\nafter`;
+		const contexts = [
+			`${open}VISIBLE${close}`,
+			`[docs](https://markdown.example/${open}VISIBLE${close})`,
+			`![image](https://markdown.example/${open}VISIBLE${close})`,
+			`\` ${open}VISIBLE${close} \``,
+			`\`\`foo \`\`\` bar \` ${open}VISIBLE${close} \`\``,
+			`~~~\n${open}VISIBLE${close}\n~~~`,
+			`[foo\nbar]: ${open}VISIBLE${close}\n\n[foo bar]`,
+			`<https://markdown.example/${open}VISIBLE${close}>`,
+			`See,https://markdown.example/a_(b)/${open}VISIBLE${close}!`,
+			`[broken](https://markdown.example/${open}VISIBLE${close}`,
+			`（https://markdown.example/${open}VISIBLE${close}）`,
+		];
 		for (const style of userMessageStyles) {
-			for (let width = 1; width <= 40; width += 1) {
-				const output = render(style, source, width).join("\n");
-				if (style === "framed" && width <= 2) {
-					expect(output).not.toContain("LINK");
-					expect(output).not.toContain(open);
-					expect(output).not.toContain(close);
-					continue;
-				}
-				expect(output.split(open)).toHaveLength(2);
-				expect(output.split(close)).toHaveLength(2);
-				expect(output.indexOf(open)).toBeLessThan(output.indexOf(close));
-				const visible = output.replace(open, "").replace(close, "");
-				expect(plain(visible).replaceAll(/[^\p{L}]/gu, "")).toContain("beforeLINKafter");
-				expect(output).not.toMatch(/[\u200b\u200c\u2060]/);
+			for (const source of contexts) {
+				const output = render(style, `${source} TAIL`, 160).join("\n");
+				expect(output).not.toContain(open);
+				expect(output).not.toContain(close);
+				expect(output).toContain("TAIL");
 			}
+		}
+	});
+
+	it("keeps Markdown-generated links clickable after raw-source sanitization", () => {
+		const markdown = "[docs](https://markdown.example) <https://autolink.example>";
+		const hostile = "\x1b]52;c;c2VjcmV0\x07";
+		for (const style of userMessageStyles) {
+			const clean = render(style, markdown, 160).join("\n");
+			const mixed = render(style, `${hostile}${markdown}`, 160).join("\n");
+			expect(mixed).toBe(clean);
+			expect(mixed).toContain("\x1b]8;;https://markdown.example");
+			expect(mixed).toContain("\x1b]8;;https://autolink.example");
+			expect(mixed).not.toContain("\x1b]52");
+			expect(mixed).not.toContain("c2VjcmV0");
 		}
 	});
 
 	it.each([
 		["unmatched open", "\x1b]8;;https://example.com\x07raw"],
 		["stray close", "raw\x1b]8;;\x07"],
+		["C1 unmatched open", "\x9d8;;https://example.com\x9craw"],
 		[
 			"nested open",
 			"\x1b]8;;https://first.example\x07one \x1b]8;;https://second.example\x07two\x1b]8;;\x07",
 		],
-	] as const)("fails closed for %s OSC 8 streams", (_name, source) => {
+	] as const)("strips raw %s OSC 8 streams", (_name, source) => {
 		for (const style of userMessageStyles) {
 			const output = render(style, source, 80).join("\n");
 			expect(output).not.toContain("\x1b]8;");
-			expect(output).toMatch(/raw|one/);
-		}
-	});
-
-	it("strips C1 OSC 8 instead of exposing controls unsupported by fixed selection", () => {
-		const open = "\x9d8;;https://example.com\x9c";
-		const close = "\x9d8;;\x9c";
-		for (const style of userMessageStyles) {
-			const output = render(style, `${open}raw${close}`, 80).join("\n");
-			expect(output).toContain("raw");
 			expect(output).not.toContain("\x9d");
-			expect(output).not.toContain("\x9c");
-		}
-	});
-
-	it("preserves duplicate and mixed OSC 8 ordering alongside Markdown links", () => {
-		const firstOpen = "\x1b]8;;https://first.example\x07";
-		const firstClose = "\x1b]8;;\x1b\\";
-		const secondOpen = "\x1b]8;;https://second.example\x1b\\";
-		const secondClose = "\x1b]8;;\x07";
-		const text = `${firstOpen}one${firstClose} ${secondOpen}two${secondClose} ${firstOpen}three${firstClose} [markdown](https://markdown.example)`;
-		for (const style of userMessageStyles) {
-			const output = render(style, text, 160).join("\n");
-			expect(output.split(`${firstOpen}one${firstClose}`)).toHaveLength(2);
-			expect(output.split(`${secondOpen}two${secondClose}`)).toHaveLength(2);
-			expect(output.split(`${firstOpen}three${firstClose}`)).toHaveLength(2);
-			expect(output.indexOf(`${firstOpen}one${firstClose}`)).toBeLessThan(
-				output.indexOf(`${secondOpen}two${secondClose}`),
-			);
-			expect(output.indexOf(`${secondOpen}two${secondClose}`)).toBeLessThan(
-				output.indexOf(`${firstOpen}three${firstClose}`),
-			);
-			expect(output).toContain("markdown");
-		}
-	});
-
-	it("removes hostile raw OSC before Markdown while preserving Markdown links", () => {
-		const markdown = "[docs](https://markdown.example)";
-		const hostile = "\x1b]52;c;c2VjcmV0\x07";
-		for (const style of userMessageStyles) {
-			const clean = render(style, markdown, 120).join("\n");
-			const mixed = render(style, `${hostile}${markdown}`, 120).join("\n");
-			expect(mixed).toBe(clean);
-			expect(mixed).not.toContain("\x1b]52");
-			expect(mixed).not.toContain("c2VjcmV0");
-			expect(mixed).toContain("docs");
-		}
-	});
-
-	it("fails closed when Markdown duplicates an OSC 8 shield across wrapped lines", () => {
-		const open = "\x1b]8;;https://raw.example\x07";
-		const close = "\x1b]8;;\x07";
-		const clipboard = "\x1b]52;c;c2VjcmV0\x07";
-		const source = `[docs](https://markdown.example/${open}nested${close}) ${clipboard}tail`;
-		for (const style of userMessageStyles) {
-			for (const width of [...Array.from({ length: 40 }, (_, index) => index + 1), 160]) {
-				const output = render(style, source, width).join("\n");
-				expect(output).not.toMatch(/[\u200b\u200c\u2060]/);
-				expect(output).not.toContain("\x1b]52");
-				expect(output).not.toContain("c2VjcmV0");
-				expect(output).not.toContain(open);
-				expect(output).not.toContain(close);
-			}
+			expect(output).toMatch(/raw|one/);
 		}
 	});
 

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
@@ -6,6 +7,10 @@ import {
 	type PolishedTuiConfig,
 	type UserMessageStyle,
 } from "../extensions/zentui/config";
+import {
+	sanitizeRenderedUserMessageText,
+	sanitizeUserMessageSourceText,
+} from "../extensions/zentui/user-message-osc";
 import {
 	renderUserMessageStyle,
 	userMessageStyleCacheKey,
@@ -179,15 +184,18 @@ describe("pure user-message styles", () => {
 		}
 	});
 
-	it("keeps Markdown-generated links clickable after raw-source sanitization", () => {
+	it("preserves Pi Markdown link rendering after raw-source sanitization", () => {
 		const markdown = "[docs](https://markdown.example) <https://autolink.example>";
 		const hostile = "\x1b]52;c;c2VjcmV0\x07";
+		expect(sanitizeUserMessageSourceText(markdown)).toBe(markdown);
 		for (const style of userMessageStyles) {
 			const clean = render(style, markdown, 160).join("\n");
 			const mixed = render(style, `${hostile}${markdown}`, 160).join("\n");
 			expect(mixed).toBe(clean);
-			expect(mixed).toContain("\x1b]8;;https://markdown.example");
-			expect(mixed).toContain("\x1b]8;;https://autolink.example");
+			expect(stripVTControlCharacters(mixed)).toContain("docs");
+			expect(mixed).toContain("https://markdown.example");
+			expect(mixed).toContain("https://autolink.example");
+			if (clean.includes("\x1b]8;")) expect(sanitizeRenderedUserMessageText(clean)).toBe(clean);
 			expect(mixed).not.toContain("\x1b]52");
 			expect(mixed).not.toContain("c2VjcmV0");
 		}

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -137,35 +137,79 @@ describe("pure user-message styles", () => {
 		}
 	});
 
-	it("preserves complete 7-bit and C1 OSC 8 controls byte-for-byte", () => {
-		const starts = ["\x1b]", "\x9d"];
-		const terminators = ["\x07", "\x1b\\", "\x9c"];
+	it("preserves complete 7-bit OSC 8 controls byte-for-byte", () => {
 		for (const style of userMessageStyles) {
-			for (const start of starts) {
-				for (const terminator of terminators) {
-					const open = `${start}8;;https://example.com${terminator}`;
-					const close = `${start}8;;${terminator}`;
-					const output = render(style, `${open}raw${close}`, 80).join("\n");
-					expect(output.split(open)).toHaveLength(2);
-					expect(output.split(close)).toHaveLength(2);
-					expect(output).toContain(`${open}raw${close}`);
-				}
+			for (const terminator of ["\x07", "\x1b\\"]) {
+				const open = `\x1b]8;;https://example.com${terminator}`;
+				const close = `\x1b]8;;${terminator}`;
+				const output = render(style, `${open}raw${close}`, 80).join("\n");
+				expect(output.split(open)).toHaveLength(2);
+				expect(output.split(close)).toHaveLength(2);
+				expect(output).toContain(`${open}raw${close}`);
 			}
+		}
+	});
+
+	it("preserves a balanced OSC 8 close immediately before a non-final Markdown row", () => {
+		const open = "\x1b]8;;https://example.com\x07";
+		const close = "\x1b]8;;\x07";
+		const source = `before ${open}LINK${close}\nafter`;
+		for (const style of userMessageStyles) {
+			for (let width = 1; width <= 40; width += 1) {
+				const output = render(style, source, width).join("\n");
+				if (style === "framed" && width <= 2) {
+					expect(output).not.toContain("LINK");
+					expect(output).not.toContain(open);
+					expect(output).not.toContain(close);
+					continue;
+				}
+				expect(output.split(open)).toHaveLength(2);
+				expect(output.split(close)).toHaveLength(2);
+				expect(output.indexOf(open)).toBeLessThan(output.indexOf(close));
+				const visible = output.replace(open, "").replace(close, "");
+				expect(plain(visible).replaceAll(/[^\p{L}]/gu, "")).toContain("beforeLINKafter");
+				expect(output).not.toMatch(/[\u200b\u200c\u2060]/);
+			}
+		}
+	});
+
+	it.each([
+		["unmatched open", "\x1b]8;;https://example.com\x07raw"],
+		["stray close", "raw\x1b]8;;\x07"],
+		[
+			"nested open",
+			"\x1b]8;;https://first.example\x07one \x1b]8;;https://second.example\x07two\x1b]8;;\x07",
+		],
+	] as const)("fails closed for %s OSC 8 streams", (_name, source) => {
+		for (const style of userMessageStyles) {
+			const output = render(style, source, 80).join("\n");
+			expect(output).not.toContain("\x1b]8;");
+			expect(output).toMatch(/raw|one/);
+		}
+	});
+
+	it("strips C1 OSC 8 instead of exposing controls unsupported by fixed selection", () => {
+		const open = "\x9d8;;https://example.com\x9c";
+		const close = "\x9d8;;\x9c";
+		for (const style of userMessageStyles) {
+			const output = render(style, `${open}raw${close}`, 80).join("\n");
+			expect(output).toContain("raw");
+			expect(output).not.toContain("\x9d");
+			expect(output).not.toContain("\x9c");
 		}
 	});
 
 	it("preserves duplicate and mixed OSC 8 ordering alongside Markdown links", () => {
 		const firstOpen = "\x1b]8;;https://first.example\x07";
-		const firstClose = "\x1b]8;;\x07";
-		const secondOpen = "\x9d8;;https://second.example\x9c";
-		const secondClose = "\x9d8;;\x9c";
+		const firstClose = "\x1b]8;;\x1b\\";
+		const secondOpen = "\x1b]8;;https://second.example\x1b\\";
+		const secondClose = "\x1b]8;;\x07";
 		const text = `${firstOpen}one${firstClose} ${secondOpen}two${secondClose} ${firstOpen}three${firstClose} [markdown](https://markdown.example)`;
 		for (const style of userMessageStyles) {
 			const output = render(style, text, 160).join("\n");
-			expect(output.split(firstOpen)).toHaveLength(3);
-			expect(output.split(firstClose)).toHaveLength(3);
-			expect(output.split(secondOpen)).toHaveLength(2);
-			expect(output.split(secondClose)).toHaveLength(2);
+			expect(output.split(`${firstOpen}one${firstClose}`)).toHaveLength(2);
+			expect(output.split(`${secondOpen}two${secondClose}`)).toHaveLength(2);
+			expect(output.split(`${firstOpen}three${firstClose}`)).toHaveLength(2);
 			expect(output.indexOf(`${firstOpen}one${firstClose}`)).toBeLessThan(
 				output.indexOf(`${secondOpen}two${secondClose}`),
 			);
@@ -173,6 +217,57 @@ describe("pure user-message styles", () => {
 				output.indexOf(`${firstOpen}three${firstClose}`),
 			);
 			expect(output).toContain("markdown");
+		}
+	});
+
+	it("removes hostile raw OSC before Markdown while preserving Markdown links", () => {
+		const markdown = "[docs](https://markdown.example)";
+		const hostile = "\x1b]52;c;c2VjcmV0\x07";
+		for (const style of userMessageStyles) {
+			const clean = render(style, markdown, 120).join("\n");
+			const mixed = render(style, `${hostile}${markdown}`, 120).join("\n");
+			expect(mixed).toBe(clean);
+			expect(mixed).not.toContain("\x1b]52");
+			expect(mixed).not.toContain("c2VjcmV0");
+			expect(mixed).toContain("docs");
+		}
+	});
+
+	it("fails closed when Markdown duplicates an OSC 8 shield across wrapped lines", () => {
+		const open = "\x1b]8;;https://raw.example\x07";
+		const close = "\x1b]8;;\x07";
+		const clipboard = "\x1b]52;c;c2VjcmV0\x07";
+		const source = `[docs](https://markdown.example/${open}nested${close}) ${clipboard}tail`;
+		for (const style of userMessageStyles) {
+			for (const width of [...Array.from({ length: 40 }, (_, index) => index + 1), 160]) {
+				const output = render(style, source, width).join("\n");
+				expect(output).not.toMatch(/[\u200b\u200c\u2060]/);
+				expect(output).not.toContain("\x1b]52");
+				expect(output).not.toContain("c2VjcmV0");
+				expect(output).not.toContain(open);
+				expect(output).not.toContain(close);
+			}
+		}
+	});
+
+	it("removes raw non-OSC terminal controls before Markdown", () => {
+		const hostile = [
+			"\x1b[2J",
+			"\x9b2J",
+			"\x1bPsecret\x1b\\",
+			"\x90secret\x9c",
+			"\x1bXsecret\x1b\\",
+			"\x1b^secret\x1b\\",
+			"\x1b_secret\x1b\\",
+			"\x07",
+			"\x01",
+			"\x7f",
+		].join("");
+		for (const style of userMessageStyles) {
+			const output = render(style, `before${hostile}after`, 80).join("\n");
+			expect(output).toContain("beforeafter");
+			expect(output).not.toMatch(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/);
+			expect(output).not.toContain("secret");
 		}
 	});
 

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -180,7 +180,8 @@ describe("pure user-message styles", () => {
 			const base = config(style);
 			const key = userMessageStyleCacheKey(base);
 			const unrelated = structuredClone(base);
-			unrelated.components.footer.enabled = !unrelated.components.footer.enabled;
+			unrelated.components.footer.style =
+				unrelated.components.footer.style === "hidden" ? "native" : "hidden";
 			unrelated.layout.fixedEditor.enabled = !unrelated.layout.fixedEditor.enabled;
 			expect(userMessageStyleCacheKey(unrelated)).toBe(key);
 

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -11,6 +11,8 @@ import {
 	userMessageStyleCacheKey,
 } from "../extensions/zentui/user-message-styles";
 
+const userMessageStyles = ["framed", "framed-copy-friendly", "compact", "labeled"] as const;
+
 function config(style: UserMessageStyle): PolishedTuiConfig {
 	const value = structuredClone(defaultConfig);
 	value.components.userMessages.style = style;
@@ -46,6 +48,25 @@ describe("pure user-message styles", () => {
 		]);
 	});
 
+	it("preserves exact copy-friendly framed chrome and Markdown padding", () => {
+		expect(render("framed-copy-friendly", "Hello", 12)).toEqual([
+			"────────────",
+			"",
+			"Hello       ",
+			"",
+			"────────────",
+		]);
+	});
+
+	it("keeps copy-friendly ANSI and wide-Unicode body rows padded within width", () => {
+		for (let width = 2; width <= 24; width += 1) {
+			const lines = render("framed-copy-friendly", "界🙂 \x1b[31mwide\x1b[0m", width, ansiTheme());
+			const body = lines.slice(2, -2);
+			expect(body.length).toBeGreaterThan(0);
+			expect(body.every((line) => visibleWidth(line) === width)).toBe(true);
+		}
+	});
+
 	it("renders compact multiline and blank Markdown rows with an unpadded rail", () => {
 		const lines = render("compact", "First\n\nFinal", 16);
 		expect(lines).toEqual(["│ First", "│ ", "│ Final"]);
@@ -62,7 +83,7 @@ describe("pure user-message styles", () => {
 	});
 
 	it("preserves Markdown rendering across all styles", () => {
-		for (const style of ["framed", "compact", "labeled"] as const) {
+		for (const style of userMessageStyles) {
 			const output = plain(
 				render(style, "**bold**\n\n- item\n\n> quote\n\n```ts\ncode\n```", 40).join("\n"),
 			);
@@ -95,7 +116,7 @@ describe("pure user-message styles", () => {
 	});
 
 	it("returns a marker-safe row at non-positive widths and clamps ANSI/wide Unicode", () => {
-		for (const style of ["framed", "compact", "labeled"] as const) {
+		for (const style of userMessageStyles) {
 			expect(render(style, "hello", 0)).toEqual([""]);
 			for (let width = 1; width <= 24; width += 1) {
 				const lines = render(style, "界🙂 \x1b[31mwide\x1b[0m", width, ansiTheme());
@@ -111,13 +132,15 @@ describe("pure user-message styles", () => {
 				throw new Error("theme failed");
 			},
 		} as unknown as Theme;
-		expect(() => render("framed", "hello", 20, failingTheme)).toThrow("theme failed");
+		for (const style of userMessageStyles) {
+			expect(() => render(style, "hello", 20, failingTheme)).toThrow("theme failed");
+		}
 	});
 
 	it("preserves complete 7-bit and C1 OSC 8 controls byte-for-byte", () => {
 		const starts = ["\x1b]", "\x9d"];
 		const terminators = ["\x07", "\x1b\\", "\x9c"];
-		for (const style of ["framed", "compact", "labeled"] as const) {
+		for (const style of userMessageStyles) {
 			for (const start of starts) {
 				for (const terminator of terminators) {
 					const open = `${start}8;;https://example.com${terminator}`;
@@ -137,7 +160,7 @@ describe("pure user-message styles", () => {
 		const secondOpen = "\x9d8;;https://second.example\x9c";
 		const secondClose = "\x9d8;;\x9c";
 		const text = `${firstOpen}one${firstClose} ${secondOpen}two${secondClose} ${firstOpen}three${firstClose} [markdown](https://markdown.example)`;
-		for (const style of ["framed", "compact", "labeled"] as const) {
+		for (const style of userMessageStyles) {
 			const output = render(style, text, 160).join("\n");
 			expect(output.split(firstOpen)).toHaveLength(3);
 			expect(output.split(firstClose)).toHaveLength(3);
@@ -176,7 +199,7 @@ describe("pure user-message styles", () => {
 	});
 
 	it("uses only style-relevant cache-key inputs", () => {
-		for (const style of ["framed", "compact", "labeled"] as const) {
+		for (const style of userMessageStyles) {
 			const base = config(style);
 			const key = userMessageStyleCacheKey(base);
 			const unrelated = structuredClone(base);
@@ -187,7 +210,7 @@ describe("pure user-message styles", () => {
 
 			const accent = structuredClone(base);
 			accent.colors.editorAccent = "red";
-			expect(userMessageStyleCacheKey(accent)).not.toBe(key);
+			expect(userMessageStyleCacheKey(accent) === key).toBe(style === "framed-copy-friendly");
 
 			const border = structuredClone(base);
 			border.colors.editorBorder = "blue";
@@ -195,7 +218,13 @@ describe("pure user-message styles", () => {
 
 			const rail = structuredClone(base);
 			rail.icons.rail = "┃";
-			expect(userMessageStyleCacheKey(rail) === key).toBe(style === "labeled");
+			expect(userMessageStyleCacheKey(rail) === key).toBe(
+				style === "labeled" || style === "framed-copy-friendly",
+			);
 		}
+
+		expect(userMessageStyleCacheKey(config("framed-copy-friendly"))).not.toBe(
+			userMessageStyleCacheKey(config("framed")),
+		);
 	});
 });

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -1,0 +1,200 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+	defaultConfig,
+	type PolishedTuiConfig,
+	type UserMessageStyle,
+} from "../extensions/zentui/config";
+import {
+	renderUserMessageStyle,
+	userMessageStyleCacheKey,
+} from "../extensions/zentui/user-message-styles";
+
+function config(style: UserMessageStyle): PolishedTuiConfig {
+	const value = structuredClone(defaultConfig);
+	value.components.userMessages.style = style;
+	return value;
+}
+
+function render(style: UserMessageStyle, text: string, width: number, theme?: Theme): string[] {
+	return renderUserMessageStyle({ text, width, theme, config: config(style) });
+}
+
+function plain(value: string): string {
+	return value.replaceAll(/\x1b\[[0-?]*[ -/]*[@-~]/g, "");
+}
+
+function ansiTheme(): Theme {
+	return {
+		fg: (_color: string, text: string) => `\x1b[34m${text}\x1b[0m`,
+		bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+	} as Theme;
+}
+
+describe("pure user-message styles", () => {
+	it("preserves exact framed chrome and padding", () => {
+		expect(render("framed", "Hello", 12)).toEqual([
+			"────────────",
+			"│           ",
+			"│ Hello     ",
+			"│           ",
+			"────────────",
+		]);
+	});
+
+	it("renders compact multiline and blank Markdown rows with an unpadded rail", () => {
+		const lines = render("compact", "First\n\nFinal", 16);
+		expect(lines).toEqual(["│ First", "│ ", "│ Final"]);
+		expect(lines.every((line) => !line.endsWith("  "))).toBe(true);
+	});
+
+	it("renders a fixed User label and no extra body padding", () => {
+		expect(render("labeled", "Hello\nContinued", 20)).toEqual([
+			"╭─ User ───────────╮",
+			"│ Hello            │",
+			"│ Continued        │",
+			"╰──────────────────╯",
+		]);
+	});
+
+	it("preserves Markdown rendering across all styles", () => {
+		for (const style of ["framed", "compact", "labeled"] as const) {
+			const output = plain(
+				render(style, "**bold**\n\n- item\n\n> quote\n\n```ts\ncode\n```", 40).join("\n"),
+			);
+			expect(output).toContain("bold");
+			expect(output).toContain("item");
+			expect(output).toContain("quote");
+			expect(output).toContain("code");
+			expect(output).not.toContain("**bold**");
+		}
+	});
+
+	it("degrades atomically at compact and labeled narrow thresholds", () => {
+		expect(render("compact", "界a", 2)).toEqual(["界", "a"]);
+		expect(render("compact", "abc", 3)[0]).toBe("│ a");
+		for (const width of [3, 4, 5, 6, 7, 8]) {
+			const lines = render("labeled", "abc", width);
+			const body = lines.slice(1, -1);
+			expect(lines[0]).toMatch(/^╭─*╮$/);
+			expect(lines.at(-1)).toMatch(/^╰─*╯$/);
+			expect(lines.join("\n")).not.toContain("User");
+			expect(lines.every((line) => visibleWidth(line) === width)).toBe(true);
+			expect(body.every((line) => line.startsWith("│") && line.endsWith("│"))).toBe(true);
+			expect(body.map((line) => line.slice(1, -1).trim()).join("")).toContain("abc");
+		}
+		for (const width of [1, 2]) {
+			const joined = render("labeled", "abc", width).join("\n");
+			expect(joined).not.toMatch(/[╭╮╰╯│]/);
+		}
+		expect(render("labeled", "abc", 9)[0]).toBe("╭─ User ╮");
+	});
+
+	it("returns a marker-safe row at non-positive widths and clamps ANSI/wide Unicode", () => {
+		for (const style of ["framed", "compact", "labeled"] as const) {
+			expect(render(style, "hello", 0)).toEqual([""]);
+			for (let width = 1; width <= 24; width += 1) {
+				const lines = render(style, "界🙂 \x1b[31mwide\x1b[0m", width, ansiTheme());
+				expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+			}
+		}
+	});
+
+	it("throws rendering failures for the shared adapter to handle", () => {
+		const failingTheme = {
+			...ansiTheme(),
+			fg() {
+				throw new Error("theme failed");
+			},
+		} as unknown as Theme;
+		expect(() => render("framed", "hello", 20, failingTheme)).toThrow("theme failed");
+	});
+
+	it("preserves complete 7-bit and C1 OSC 8 controls byte-for-byte", () => {
+		const starts = ["\x1b]", "\x9d"];
+		const terminators = ["\x07", "\x1b\\", "\x9c"];
+		for (const style of ["framed", "compact", "labeled"] as const) {
+			for (const start of starts) {
+				for (const terminator of terminators) {
+					const open = `${start}8;;https://example.com${terminator}`;
+					const close = `${start}8;;${terminator}`;
+					const output = render(style, `${open}raw${close}`, 80).join("\n");
+					expect(output.split(open)).toHaveLength(2);
+					expect(output.split(close)).toHaveLength(2);
+					expect(output).toContain(`${open}raw${close}`);
+				}
+			}
+		}
+	});
+
+	it("preserves duplicate and mixed OSC 8 ordering alongside Markdown links", () => {
+		const firstOpen = "\x1b]8;;https://first.example\x07";
+		const firstClose = "\x1b]8;;\x07";
+		const secondOpen = "\x9d8;;https://second.example\x9c";
+		const secondClose = "\x9d8;;\x9c";
+		const text = `${firstOpen}one${firstClose} ${secondOpen}two${secondClose} ${firstOpen}three${firstClose} [markdown](https://markdown.example)`;
+		for (const style of ["framed", "compact", "labeled"] as const) {
+			const output = render(style, text, 160).join("\n");
+			expect(output.split(firstOpen)).toHaveLength(3);
+			expect(output.split(firstClose)).toHaveLength(3);
+			expect(output.split(secondOpen)).toHaveLength(2);
+			expect(output.split(secondClose)).toHaveLength(2);
+			expect(output.indexOf(`${firstOpen}one${firstClose}`)).toBeLessThan(
+				output.indexOf(`${secondOpen}two${secondClose}`),
+			);
+			expect(output.indexOf(`${secondOpen}two${secondClose}`)).toBeLessThan(
+				output.indexOf(`${firstOpen}three${firstClose}`),
+			);
+			expect(output).toContain("markdown");
+		}
+	});
+
+	it("supports theme and terminal color sources", () => {
+		const themed = config("labeled");
+		const themeLines = renderUserMessageStyle({
+			text: "hello",
+			width: 20,
+			theme: ansiTheme(),
+			config: themed,
+		});
+		expect(themeLines.join("\n")).toContain("\x1b[");
+
+		const terminal = config("compact");
+		terminal.components.userMessages.colorSource = "terminal";
+		terminal.colors.editorAccent = "fg:202";
+		const terminalLines = renderUserMessageStyle({
+			text: "hello",
+			width: 20,
+			theme: ansiTheme(),
+			config: terminal,
+		});
+		expect(terminalLines.join("\n")).toContain("\x1b[");
+	});
+
+	it("uses only style-relevant cache-key inputs", () => {
+		for (const style of ["framed", "compact", "labeled"] as const) {
+			const base = config(style);
+			const key = userMessageStyleCacheKey(base);
+			const unrelated = structuredClone(base);
+			unrelated.components.footer.enabled = !unrelated.components.footer.enabled;
+			unrelated.layout.fixedEditor.enabled = !unrelated.layout.fixedEditor.enabled;
+			expect(userMessageStyleCacheKey(unrelated)).toBe(key);
+
+			const accent = structuredClone(base);
+			accent.colors.editorAccent = "red";
+			expect(userMessageStyleCacheKey(accent)).not.toBe(key);
+
+			const border = structuredClone(base);
+			border.colors.editorBorder = "blue";
+			expect(userMessageStyleCacheKey(border) === key).toBe(style === "compact");
+
+			const rail = structuredClone(base);
+			rail.icons.rail = "┃";
+			expect(userMessageStyleCacheKey(rail) === key).toBe(style === "labeled");
+		}
+	});
+});

--- a/test/user-message-styles.test.ts
+++ b/test/user-message-styles.test.ts
@@ -48,11 +48,11 @@ describe("pure user-message styles", () => {
 		]);
 	});
 
-	it("preserves exact copy-friendly framed chrome and Markdown padding", () => {
+	it("adds one leading space to copy-friendly framed message text", () => {
 		expect(render("framed-copy-friendly", "Hello", 12)).toEqual([
 			"────────────",
 			"",
-			"Hello       ",
+			" Hello      ",
 			"",
 			"────────────",
 		]);


### PR DESCRIPTION
## Summary

- make Editor, previous User-message, selector-border, and Footer rendering independently configurable through canonical component settings and the reorganized eight-section `/zentui` UI
- add Opencode, Opencode copy-friendly, and Minimalist Editor styles; Framed, Framed copy-friendly, Compact, and Labeled User-message styles; and Native, Starship, and Hidden Footer modes
- preserve legacy configuration during migration, retain unknown future keys/style IDs, fail open to Pi-native behavior when a style is unsupported, and keep third-party surface ownership conservative
- harden user-message terminal-control handling, including stripping all raw source controls before Markdown while preserving Pi’s platform-native Markdown rendering
- harden project metadata rendering, async refresh generations, prototype cleanup, and live UI reload ownership
- stabilize fixed-editor terminal restoration and constrained-height rendering, including deterministic layout priorities, normal-flow fallback, boundary key ownership, overlay/resize transitions, and graceful cleanup paths
- add an Ubuntu compatibility matrix for Pi 0.80.3, 0.82.1, and 0.83.0 with real PTY cleanup coverage

Closes #55
Closes #67

## Screenshots / recordings

![Fixed-editor startup, overlay, narrow-height, resize recovery, and live-disable transitions](https://gist.githubusercontent.com/lmilojevicc/44d924d6bae63d316e736089b2008e02/raw/fixed-editor-transitions-clean.gif)

The GIF is rendered from genuine `tmux capture-pane -e` output from the final branch. Frames show initial fixed repaint, wide and narrow settings overlays, constrained height, fixed-layout recovery after growth, and live disable. Startup diagnostics were excluded by cropping to the bottom TUI viewport; source rows were not edited.

[Still image](https://gist.githubusercontent.com/lmilojevicc/44d924d6bae63d316e736089b2008e02/raw/fixed-editor-final-clean.png) · [capture manifest](https://gist.github.com/lmilojevicc/44d924d6bae63d316e736089b2008e02)

## Testing

- [x] `npm run verify` — 955 passed, 11 intentionally PTY-gated tests skipped
- [x] `npm run pack:check` — 41 expected package files, version 0.16.0
- [x] Manual Pi test via `npm run pi:dev` (required for UI behavior changes)
- [x] Added or updated tests where practical

Additional validation:

- `npm run fmt` and `npm run fmt:check`
- `RUN_FIXED_EDITOR_PTY=1 npm run test:fixed-editor` — 247 passed
- repeated PTY cleanup runs covering live disable, `/quit`, Ctrl+C, Ctrl+D, SIGHUP, SIGTERM, suspend/resume, OS-stopped Pi, and signal-resistant same-group children
- PTY fixture cleanup confirms exact child exit and process-group disappearance before removing temporary agent directories
- isolated local compatibility runs for Pi 0.80.3, 0.82.1, and 0.83.0
- [Ubuntu/Node 24 CI](https://github.com/lmilojevicc/pi-zentui/actions/runs/30777140877): verify plus all three exact Pi compatibility/PT​​Y jobs passed
- manual Pi coverage at 120×36, 40×20, 40×12, and 40×6: all Editor/User-message/Footer styles, native fallbacks, all eight `/zentui` sections, independent color sources, autocomplete framing, fixed-editor scrolling, overlay rendering, constrained height, resize recovery, Footer transitions, and live disable
- `git diff --check`, YAML parse, package-content scan, and runtime dependency audit

Manual retesting in the affected terminal confirmed arrow keys work normally after both `/quit` and Ctrl+C. Exact reporter-environment replication and Termux-specific resize testing remain platform follow-up evidence; automated screen-aware PTY tests and the Ubuntu matrix cover the owned terminal modes and graceful signal paths.

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [x] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in focused modules.
- [x] Used a conventional commit-style PR title (e.g. `feat: add ...`, `fix: handle ...`).
