### PR TITLE
chore: release v0.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.16.0",
+			"version": "0.17.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.16.0",
+	"version": "0.17.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

- bump `pi-zentui` from 0.16.0 to 0.17.0
- release composable Editor, User-message, selector-border, and Footer styles
- include the Minimalist editor and hardened fixed-editor lifecycle, terminal restoration, and PTY cleanup

## Validation

- `npm run fmt`
- `npm run verify` — 31 files passed, 955 tests passed, 11 PTY-gated tests skipped
- `npm run pack:check` — 41 files, 118.2 kB packed / 496.1 kB unpacked
- `git diff --check`
- Node 24.13.0, matching the CI major version

After merge, tag `v0.17.0` will trigger the established npm publish and GitHub release workflow.
