### PR TITLE
feat: add configurable working line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pi-version: ["0.80.3", "0.82.1", "0.83.0"]
+        pi-version: ["0.80.5", "0.82.1", "0.83.0"]
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ A Starship-inspired statusline and Opencode-style TUI for [Pi](https://pi.dev).
 
 ## What is this?
 
-Zentui styles three major Pi surfaces independently:
+Zentui styles four major Pi surfaces independently:
 
 - **Editor** — selectable opencode, low-rail opencode, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
 - **User messages** — selectable framed, framed copy-friendly, compact, and labeled transcript messages
+- **Working line** — optional ownership and styling of Pi's complete in-progress row
 - **[Starship](https://starship.rs/) footer** — current directory, Git, runtime, context, tokens, cost, and other configurable segments
 
-Editor, User messages, and selector borders use an `enabled` field. Footer uses one `style`: `native`, `starship`, or `hidden`. **Appearance** contains selector-border and icon settings.
+Editor, User messages, Working line, and selector borders use independent `enabled` fields. Footer uses one `style`: `native`, `starship`, or `hidden`. **Appearance** contains selector-border and icon settings.
 
 ## Features
 
@@ -80,6 +81,21 @@ User-message previews:
 <h4 align="center"><code>labeled</code></h4>
 
 ![Zentui Labeled user-message style in a rounded frame with the label User.](./assets/screenshots/user-message-labeled.png)
+
+### Working line
+
+When enabled, the optional Working line always owns and stylizes Pi's complete working-row message and indicator. It provides five fixed-width spinner presets: Braille Orbit, Star Bloom, ASCII Pinwheel, Claude-inspired, and three-cell Pulse. **Custom messages** defaults on and selects once per model turn from an editable, materialized 16-message list. Turning it off keeps the row owned and displays styled, animated `Working…` without random selection. An empty or invalid custom list safely uses the same fallback. The row can show the latest active **Tool**, interaction-wide **Elapsed** time, cumulative wall-clock **Thinking** time, and whole-interaction **Tokens**. Committed totals stay exact and provider-reported across tool loops, automatic retries, compaction retries, and queued continuations. During the current response, live output uses the native `↓N` convention whether it comes from provider usage or an estimate used while provider usage is unavailable or stale. Authoritative final usage always reconciles the response atomically; input is never estimated. Messages and tool labels are sanitized and width-bounded.
+
+When Pi has fully settled and will not continue automatically, the default-on **Turn summary** appends a persistent, context-free transcript row such as ` Turn took 56s · thought for 10s · ↑7.1k ↓779`. Thought is cumulative wall-clock time from Pi's public thinking stream; overlapping blocks count once and zero is omitted. Output usage already includes reasoning tokens, so reasoning is not added separately. The summary always includes both token totals—even when live Tokens or Thinking is hidden or both totals are zero—and can be opted out of without affecting historical summaries. Turn summaries use the fixed Working-line high style and are inactive while the overall Working line is disabled.
+
+Spinner glyph motion is always active. Classic and KITT move color across the message and segments by default; **Animate spinner color** optionally includes spinner cells and their separator in that sweep. Static colors the complete row uniformly and ignores text speed and spinner-color participation without changing their saved values. Content fits the 77-cell indicator payload while reserving the complete Tokens label first, then Message, Thought, Elapsed, and Tool allocation, and preserves the visual **Message · Tool · Elapsed · Thought · Tokens** order and complete 80-column Loader-row contract. Active thought appears immediately as `thinking 0s` and updates once per second; completed positive thought appears as `thought for Ns`. Rebuilds preserve the displayed spinner and visible color-sweep position. Pi's working-row APIs are global and unkeyed, so another extension may win by writing last.
+
+| Setting | Default | Presets | Applies to |
+| --- | ---: | --- | --- |
+| `spinnerIntervalMs` | 100 ms | Fast 60 / Normal 100 / Slow 160 / Custom | Spinner glyph motion |
+| `textIntervalMs` | 60 ms | Fast 40 / Normal 60 / Slow 100 / Custom | Classic/KITT color motion |
+
+Both speeds accept safe integers from `30` through `1000` ms. Static ignores text speed without changing it. Classic/KITT combine both cadences through one Pi Loader interval; exact cycles are used within the 1024-frame/512-KiB limits. Pathological custom pairs use a bounded evenly distributed schedule: cycle totals round by at most half a spinner glyph cycle and half a text step, spinner wrap remains continuous, and text phase may reset once per bounded fallback array cycle. Legacy `intervalMs` is accepted only as migration input for `spinnerIntervalMs` when the canonical field is absent.
 
 ### Git Status Icons
 
@@ -174,19 +190,20 @@ pi install git:github.com/lmilojevicc/pi-zentui
 
 User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or invalid known values fall back to Zentui defaults, unknown keys are ignored at runtime, and `/zentui` can patch color-source settings, UI feature toggles, built-in footer segment visibility, and active third-party status placements.
 
-The interactive `/zentui` menu is split into exactly seven component-oriented sections, in this order. Use `Tab` and `Shift+Tab` to switch sections:
+The interactive `/zentui` menu is split into exactly eight component-oriented sections, in this order. Use `Tab` and `Shift+Tab` to switch sections:
 
 1. **Appearance** — selector-border enablement, style, and colors; icon mode.
 2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
 3. **User messages** — message enablement, `framed | framed-copy-friendly | compact | labeled` style selection (including **Framed (copy-friendly)**), and colors.
-4. **Footer** — `Native | Starship | Hidden` style selection. Starship additionally shows colors, model label, responsive layout, separator, context style, and path display.
-5. **Segments** — visibility toggles for non-Git Starship segments.
-6. **Git** — Starship Git segment and probe controls.
-7. **Extensions** — Starship extension-status placement and color controls for active keys.
+4. **Working line** — ownership, settled Turn summary, spinner and text speeds, optional spinner-color motion, text animation, color source, custom-message toggle and editable list, Tool/Elapsed/Thinking/Tokens toggles, and preview.
+5. **Footer** — `Native | Starship | Hidden` style selection. Starship additionally shows colors, model label, responsive layout, separator, context style, and path display.
+6. **Segments** — visibility toggles for non-Git Starship segments.
+7. **Git** — Starship Git segment and probe controls.
+8. **Extensions** — Starship extension-status placement and color controls for active keys.
 
-Editor and User messages retain independent enablement and style configuration. Footer's single style selects Pi's built-in Footer (`Native`), Zentui's Starship Footer, or an owned zero-row Footer (`Hidden`). Color and model-label rows update only their owning component.
+Editor, User messages, and Working line retain independent configuration. Footer's single style selects Pi's built-in Footer (`Native`), Zentui's Starship Footer, or an owned zero-row Footer (`Hidden`). Color and model-label rows update only their owning component.
 
-Starship-specific Footer rows are shown only while Starship is selected. The **Segments**, **Git**, and **Extensions** sections remain available for preconfiguration under every Footer style. Free-form values such as custom formats, Opencode metadata format, raw colors/styles, numeric values outside the shown presets, and inactive extension keys remain JSON-only.
+Starship-specific Footer rows are shown only while Starship is selected. The **Segments**, **Git**, and **Extensions** sections remain available for preconfiguration under every Footer style. Free-form values such as custom formats, Opencode metadata format, raw colors/styles, and inactive extension keys remain JSON-only; Working-line speed accepts validated custom milliseconds in `/zentui`.
 
 Useful slash-command shortcuts:
 
@@ -202,6 +219,7 @@ Useful slash-command shortcuts:
 /zentui statusline toggle
 /zentui messages
 /zentui user-messages
+/zentui working-line
 /zentui viewport-indicators enable
 /zentui viewport-indicators disable
 /zentui viewport-indicators toggle
@@ -255,6 +273,31 @@ Default config values — copy this and change any value you want:
 				"framed-copy-friendly": {},
 				"compact": {},
 				"labeled": {}
+			}
+		},
+		"workingLine": {
+			"enabled": false,
+			"turnSummary": true,
+			"spinner": "star-bloom",
+			"spinnerIntervalMs": 100,
+			"animateSpinnerColor": false,
+			"textIntervalMs": 60,
+			"textAnimation": "classic",
+			"colorSource": "theme",
+			"messages": {
+				"custom": true,
+				"values": [
+					"Sautéing…", "Cooking…", "Ionizing…", "Zigzagging…",
+					"Razzle-dazzling…", "Photosynthesizing…", "Nucleating…", "Brewing…",
+					"Combobulating…", "Boogieing…", "Befuddling…", "Alchemizing…",
+					"Conjuring…", "Baking…", "Simmering…", "Blanching…"
+				]
+			},
+			"segments": {
+				"tool": true,
+				"elapsed": true,
+				"thought": true,
+				"tokens": true
 			}
 		},
 		"selectorBorders": {
@@ -384,6 +427,8 @@ Default config values — copy this and change any value you want:
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
 - `components.editor`: owns editor enablement, `opencode | opencode-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
 - `components.userMessages`: owns message enablement, `framed | framed-copy-friendly | compact | labeled` style selection, and color source. `framed-copy-friendly` remains Zentui-rendered; disabling the component delegates to Pi's native renderer.
+- `components.workingLine`: `enabled` is the sole ownership switch. While enabled, Zentui owns both the Working-row message and indicator and renders the full row. It configures `braille | star-bloom | pinwheel | claude-inspired | pulse`, independent spinner/text speeds, optional Classic/KITT spinner-color participation, `classic | kitt | disabled` text animation, color source, the default-on `messages.custom` toggle and editable 16-value list, plus Tool/Elapsed/Thinking/Tokens segments. Thinking only controls the live row; measurement and final summaries continue while it is hidden. Custom-off and empty-list fallback both render owned `Working…`; Static keeps glyph motion but ignores text speed and spinner-color participation.
+- Optional `colors.workingLineLow`, `colors.workingLineMid`, and `colors.workingLineHigh` override its palette. Without overrides, theme mode uses `dim`, `muted`, and `bold accent`; terminal mode uses `bright-black`, `cyan`, and `bold cyan`.
 - `components.selectorBorders`: owns selector-border enablement, the fixed `zentui` style, and its color source.
 - `components.footer`: owns `native | starship | hidden` style selection, Footer color source, Footer model label, and every Starship option under `styles.starship` (formats, segments, context thresholds, path, Git, and extension statuses). Native restores Pi's built-in Footer; Hidden installs an empty component with zero rows.
 - Editor and Footer `modelLabel` values are independent and have separate controls in the **Editor** and **Footer** sections.
@@ -546,7 +591,7 @@ Pi 0.84 introduces a native fullscreen TUI with a sticky editor and Footer plus 
 }
 ```
 
-You can also select fullscreen from Pi's `/settings` UI or start Pi with `--tui-mode fullscreen`. Zentui does not enable fullscreen automatically: Pi owns terminal layout, scrolling, and sticky placement, while Zentui supplies the configured editor and Footer components. Pi 0.80.3–0.83 remain supported for Zentui styling, without native sticky placement.
+You can also select fullscreen from Pi's `/settings` UI or start Pi with `--tui-mode fullscreen`. Zentui does not enable fullscreen automatically: Pi owns terminal layout, scrolling, and sticky placement, while Zentui supplies the configured editor and Footer components. Pi 0.80.5–0.83 remain supported for Zentui styling, without native sticky placement.
 
 ## Acknowledgments
 
@@ -554,7 +599,7 @@ The minimalist frame's information hierarchy was inspired by [VinhLe1410/pi-cust
 
 ## Requirements
 
-- [Pi](https://pi.dev) coding agent 0.80.3 or newer
+- [Pi](https://pi.dev) coding agent 0.80.5 or newer
 - A [Nerd Font](https://www.nerdfonts.com/) for icons (or set `icons.mode` to `"ascii"`)
 
 ## Development

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -25,6 +25,8 @@ import {
 	resolveConfiguredIcons,
 } from "./icons";
 import { isSupportedColorSpec } from "./style";
+import { normalizeWorkingLineMessages } from "./working-line";
+import { PI_WORKING_LINE_MESSAGES } from "./working-line-messages";
 
 export type ColorSpec = string;
 export type ColorSource = "theme" | "terminal";
@@ -37,6 +39,13 @@ export type EditorStyle = "opencode" | "opencode-copy-friendly" | "minimalist";
 export type UserMessageStyle = "framed" | "framed-copy-friendly" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
 export type FooterStyle = "native" | "starship" | "hidden";
+export type WorkingLineSpinner =
+	| "braille"
+	| "star-bloom"
+	| "pinwheel"
+	| "claude-inspired"
+	| "pulse";
+export type WorkingLineTextAnimation = "classic" | "kitt" | "disabled";
 export type ComponentStyleOwner = "editor" | "userMessages" | "selectorBorders" | "footer";
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
@@ -185,9 +194,56 @@ export type FooterComponentConfig = {
 	};
 };
 
+export type WorkingLineMessagesConfig = {
+	custom: boolean;
+	values: string[];
+};
+
+export type WorkingLineSegmentsConfig = {
+	tool: boolean;
+	elapsed: boolean;
+	thought: boolean;
+	tokens: boolean;
+};
+
+export const DEFAULT_WORKING_LINE_SPINNER_INTERVAL_MS = 100;
+export const DEFAULT_WORKING_LINE_TEXT_INTERVAL_MS = 60;
+export const MIN_WORKING_LINE_INTERVAL_MS = 30;
+export const MAX_WORKING_LINE_INTERVAL_MS = 1000;
+
+export function isValidWorkingLineIntervalMs(value: unknown): value is number {
+	return (
+		typeof value === "number" &&
+		Number.isSafeInteger(value) &&
+		value >= MIN_WORKING_LINE_INTERVAL_MS &&
+		value <= MAX_WORKING_LINE_INTERVAL_MS
+	);
+}
+
+export type WorkingLineComponentConfig = {
+	enabled: boolean;
+	turnSummary: boolean;
+	spinner: WorkingLineSpinner;
+	spinnerIntervalMs: number;
+	animateSpinnerColor: boolean;
+	textIntervalMs: number;
+	textAnimation: WorkingLineTextAnimation;
+	colorSource: ColorSource;
+	messages: WorkingLineMessagesConfig;
+	segments: WorkingLineSegmentsConfig;
+};
+
+export type WorkingLineComponentPatch = Partial<
+	Omit<WorkingLineComponentConfig, "messages" | "segments">
+> & {
+	messages?: Partial<WorkingLineMessagesConfig>;
+	segments?: Partial<WorkingLineSegmentsConfig>;
+};
+
 export type ComponentsConfig = {
 	editor: EditorComponentConfig;
 	userMessages: UserMessagesComponentConfig;
+	workingLine: WorkingLineComponentConfig;
 	selectorBorders: SelectorBordersComponentConfig;
 	footer: FooterComponentConfig;
 };
@@ -266,6 +322,9 @@ export type PolishedTuiColors = {
 	editorThinkingMedium?: ColorSpec;
 	editorThinkingHigh?: ColorSpec;
 	editorThinkingXhigh?: ColorSpec;
+	workingLineLow?: ColorSpec;
+	workingLineMid?: ColorSpec;
+	workingLineHigh?: ColorSpec;
 };
 
 /**
@@ -412,6 +471,18 @@ const defaultComponents: ComponentsConfig = {
 		style: "framed",
 		colorSource: "theme",
 		styles: { framed: {}, "framed-copy-friendly": {}, compact: {}, labeled: {} },
+	},
+	workingLine: {
+		enabled: false,
+		turnSummary: true,
+		spinner: "star-bloom",
+		spinnerIntervalMs: DEFAULT_WORKING_LINE_SPINNER_INTERVAL_MS,
+		animateSpinnerColor: false,
+		textIntervalMs: DEFAULT_WORKING_LINE_TEXT_INTERVAL_MS,
+		textAnimation: "classic",
+		colorSource: "theme",
+		messages: { custom: true, values: [...PI_WORKING_LINE_MESSAGES] },
+		segments: { tool: true, elapsed: true, thought: true, tokens: true },
 	},
 	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 	footer: {
@@ -646,6 +717,9 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		editorThinkingMedium: colorValue(record, "editorThinkingMedium"),
 		editorThinkingHigh: colorValue(record, "editorThinkingHigh"),
 		editorThinkingXhigh: colorValue(record, "editorThinkingXhigh"),
+		workingLineLow: colorValue(record, "workingLineLow"),
+		workingLineMid: colorValue(record, "workingLineMid"),
+		workingLineHigh: colorValue(record, "workingLineHigh"),
 	});
 }
 
@@ -1038,6 +1112,28 @@ function resolveUserMessagesSelection(
 	};
 }
 
+function resolveWorkingLineMessages(messages: ConfigRecord): WorkingLineMessagesConfig {
+	const preset = () => [...PI_WORKING_LINE_MESSAGES];
+	const hasCanonicalCustom = hasOwn(messages, "custom");
+	const custom = hasCanonicalCustom
+		? parseBoolean(messages.custom, true)
+		: messages.mode !== "native";
+	if (hasCanonicalCustom) {
+		return {
+			custom,
+			values: hasOwn(messages, "values") ? normalizeWorkingLineMessages(messages.values) : preset(),
+		};
+	}
+	const legacyValues = normalizeWorkingLineMessages(messages.values);
+	if (messages.mode === "append") {
+		return { custom, values: normalizeWorkingLineMessages([...preset(), ...legacyValues]) };
+	}
+	if (messages.mode === "replace" || messages.mode === "native") {
+		return { custom, values: legacyValues.length > 0 ? legacyValues : preset() };
+	}
+	return { custom, values: hasOwn(messages, "values") ? legacyValues : preset() };
+}
+
 function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const components = recordValue(config.components);
 	const editor = recordValue(components.editor);
@@ -1050,6 +1146,9 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const userMessages = recordValue(components.userMessages);
 	const userMessageStyles = recordValue(userMessages.styles);
 	const framed = recordValue(userMessageStyles.framed);
+	const workingLine = recordValue(components.workingLine);
+	const workingLineMessages = recordValue(workingLine.messages);
+	const workingLineSegments = recordValue(workingLine.segments);
 	const selectorBorders = recordValue(components.selectorBorders);
 	const footer = recordValue(components.footer);
 	const footerStyles = recordValue(footer.styles);
@@ -1145,6 +1244,56 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 				"framed-copy-friendly": {},
 				compact: {},
 				labeled: {},
+			},
+		},
+		workingLine: {
+			enabled: parseBoolean(workingLine.enabled, defaultComponents.workingLine.enabled),
+			turnSummary: parseBoolean(workingLine.turnSummary, defaultComponents.workingLine.turnSummary),
+			spinner:
+				workingLine.spinner === "braille" ||
+				workingLine.spinner === "star-bloom" ||
+				workingLine.spinner === "pinwheel" ||
+				workingLine.spinner === "claude-inspired" ||
+				workingLine.spinner === "pulse"
+					? workingLine.spinner
+					: defaultComponents.workingLine.spinner,
+			spinnerIntervalMs: isValidWorkingLineIntervalMs(
+				resolvedValue(workingLine, "spinnerIntervalMs", workingLine, "intervalMs"),
+			)
+				? (resolvedValue(workingLine, "spinnerIntervalMs", workingLine, "intervalMs") as number)
+				: defaultComponents.workingLine.spinnerIntervalMs,
+			animateSpinnerColor: parseBoolean(
+				workingLine.animateSpinnerColor,
+				defaultComponents.workingLine.animateSpinnerColor,
+			),
+			textIntervalMs: isValidWorkingLineIntervalMs(workingLine.textIntervalMs)
+				? workingLine.textIntervalMs
+				: defaultComponents.workingLine.textIntervalMs,
+			textAnimation:
+				workingLine.textAnimation === "classic" ||
+				workingLine.textAnimation === "kitt" ||
+				workingLine.textAnimation === "disabled"
+					? workingLine.textAnimation
+					: defaultComponents.workingLine.textAnimation,
+			colorSource: parseColorSource(
+				workingLine.colorSource,
+				defaultComponents.workingLine.colorSource,
+			),
+			messages: resolveWorkingLineMessages(workingLineMessages),
+			segments: {
+				tool: parseBoolean(workingLineSegments.tool, defaultComponents.workingLine.segments.tool),
+				elapsed: parseBoolean(
+					workingLineSegments.elapsed,
+					defaultComponents.workingLine.segments.elapsed,
+				),
+				thought: parseBoolean(
+					workingLineSegments.thought,
+					defaultComponents.workingLine.segments.thought,
+				),
+				tokens: parseBoolean(
+					workingLineSegments.tokens,
+					defaultComponents.workingLine.segments.tokens,
+				),
 			},
 		},
 		selectorBorders: {
@@ -1511,6 +1660,44 @@ export function saveUserMessagesComponentPatch(
 		path,
 		patch.style !== undefined ? deleteLegacyMessageCopyFriendly : undefined,
 		patch.style !== undefined ? "userMessages" : undefined,
+	);
+}
+
+export function saveWorkingLineComponentPatch(
+	patch: WorkingLineComponentPatch,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation(
+		(components) => {
+			const component = components.workingLine;
+			if (patch.enabled !== undefined) component.enabled = patch.enabled;
+			if (patch.turnSummary !== undefined) component.turnSummary = patch.turnSummary;
+			if (patch.spinner !== undefined) component.spinner = patch.spinner;
+			if (patch.spinnerIntervalMs !== undefined)
+				component.spinnerIntervalMs = patch.spinnerIntervalMs;
+			if (patch.animateSpinnerColor !== undefined)
+				component.animateSpinnerColor = patch.animateSpinnerColor;
+			if (patch.textIntervalMs !== undefined) component.textIntervalMs = patch.textIntervalMs;
+			if (patch.textAnimation !== undefined) component.textAnimation = patch.textAnimation;
+			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
+			if (patch.messages?.custom !== undefined) component.messages.custom = patch.messages.custom;
+			if (patch.messages?.values !== undefined) {
+				component.messages.values = normalizeWorkingLineMessages([...patch.messages.values]);
+			}
+			if (patch.segments?.tool !== undefined) component.segments.tool = patch.segments.tool;
+			if (patch.segments?.elapsed !== undefined)
+				component.segments.elapsed = patch.segments.elapsed;
+			if (patch.segments?.thought !== undefined)
+				component.segments.thought = patch.segments.thought;
+			if (patch.segments?.tokens !== undefined) component.segments.tokens = patch.segments.tokens;
+		},
+		path,
+		(record) => {
+			const workingLine = recordValue(recordValue(record.components).workingLine);
+			delete workingLine.intervalMs;
+			const messages = recordValue(workingLine.messages);
+			delete messages.mode;
+		},
 	);
 }
 

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -123,6 +123,17 @@ export function formatCount(value: number): string {
 	return `${Math.round(value / 1_000_000)}M`;
 }
 
+/** Human-readable whole-second duration used by settled and minimalist turn UI. */
+export function formatElapsedDuration(durationMs: number): string {
+	const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
+}
+
 export function formatProviderLabel(provider: string | undefined): string {
 	if (!provider) return "Unknown";
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -37,7 +37,9 @@ import {
 	saveSelectorBordersComponentPatch,
 	saveStarshipFooterStylePatch,
 	saveUserMessagesComponentPatch,
+	saveWorkingLineComponentPatch,
 	type UserMessagesComponentConfig,
+	type WorkingLineComponentPatch,
 	type ZentuiConfig,
 } from "./config";
 import {
@@ -48,6 +50,11 @@ import { installFooter, installHiddenFooter } from "./footer";
 import { collectFooterFormatReferences, parseFooterFormat } from "./footer-format";
 import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
+import {
+	InteractionMetricsTracker,
+	renderTurnSummaryEntry,
+	TURN_SUMMARY_ENTRY_TYPE,
+} from "./interaction-summary";
 import { LiveContextController } from "./live-context";
 import { readPackageVersionResult } from "./package-version";
 import {
@@ -66,6 +73,11 @@ import { createInitialState, type FooterState, modelLabelFor, syncState } from "
 import { resolveFooterTelemetry } from "./telemetry";
 import { PolishedEditor, WrappedPolishedEditor } from "./ui";
 import { installUserMessageStyle, removeUserMessageStyle } from "./user-message";
+import {
+	AgentDurationClock,
+	snapshotWorkingLineHighStyle,
+	WorkingLineController,
+} from "./working-line";
 
 const ZENTUI_EDITOR_FACTORY = Symbol.for("pi-zentui.editor-factory");
 const ZENTUI_EDITOR_BASE_FACTORY = Symbol.for("pi-zentui.editor-base-factory");
@@ -164,6 +176,20 @@ export default function (pi: ExtensionAPI) {
 	const editorOwnerToken = Symbol("zentui-editor-owner");
 
 	let currentConfig: PolishedTuiConfig = loadConfig();
+	// Keep the capability guard defensive for hosts with incomplete extension APIs.
+	if (typeof pi.registerEntryRenderer === "function") {
+		pi.registerEntryRenderer(TURN_SUMMARY_ENTRY_TYPE, (entry, options, theme) =>
+			renderTurnSummaryEntry(
+				entry,
+				{
+					...options,
+					colorSource: currentConfig.components.workingLine.colorSource,
+					workingLineHigh: currentConfig.colors.workingLineHigh,
+				},
+				theme,
+			),
+		);
+	}
 	let activeTheme: Theme | undefined;
 	let requestFooterRender: (() => void) | undefined;
 	let requestEditorRender: (() => void) | undefined;
@@ -180,15 +206,16 @@ export default function (pi: ExtensionAPI) {
 	let installedEditorFactory: EditorFactory | undefined;
 	let wrappedEditorFactory: EditorFactory | undefined;
 	let stopSessionTimer: () => void = () => {};
-	let stopAgentTimer: () => void = () => {};
-	let agentTimerRunning = false;
+	let stopMinimalistDurationUpdates: () => void = () => {};
+	let minimalistDurationUpdatesActive = false;
 	let minimalistDecorationActive = false;
 	let sessionTimerRequirements = "";
 	let lastDurationLabel = "";
 	let lastProjectCwd: string | undefined;
 	let requestedProjectCwd: string | undefined;
-	let agentStartedAt: number | undefined;
-	let agentDurationMs: number | undefined;
+	const agentDurationClock = new AgentDurationClock();
+	const interactionMetrics = new InteractionMetricsTracker();
+	let agentRunActive = false;
 	let minimalistProjectRoot: string | undefined;
 	let projectRefreshActive = false;
 	let activeTuiContext: ExtensionContext | undefined;
@@ -236,6 +263,14 @@ export default function (pi: ExtensionAPI) {
 	const liveContext = new LiveContextController(sessionLifecycle, refresh);
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
+	const workingLine = new WorkingLineController(
+		getCurrentConfig,
+		() => activeTheme as Theme,
+		agentDurationClock,
+		Math.random,
+		Date.now,
+		() => interactionMetrics.currentThought(),
+	);
 	const getContextWindow = (ctx: ExtensionContext): number | undefined =>
 		ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow;
 	const getContextPercent = (ctx: ExtensionContext): number | undefined => {
@@ -246,8 +281,7 @@ export default function (pi: ExtensionAPI) {
 			? (live.tokens / contextWindow) * 100
 			: (usage?.percent ?? undefined);
 	};
-	const getAgentDurationMs = () =>
-		agentStartedAt === undefined ? agentDurationMs : Math.max(0, Date.now() - agentStartedAt);
+	const getAgentDurationMs = () => agentDurationClock.elapsedMs();
 	const getThinkingLevel = () =>
 		sessionLifecycle.isCurrent() ? pi.getThinkingLevel() : ("off" as const);
 	const syncFooterState = (ctx: ExtensionContext) =>
@@ -420,31 +454,29 @@ export default function (pi: ExtensionAPI) {
 	const reconcileAgentTimer = () => {
 		const needed =
 			sessionLifecycle.isCurrent() &&
-			agentStartedAt !== undefined &&
+			agentRunActive &&
+			agentDurationClock.isActive() &&
 			minimalistDecorationActive &&
 			effectiveEditorEnabled() &&
 			ownsInstalledEditorFactory() &&
 			currentConfig.components.editor.style === "minimalist" &&
 			currentConfig.components.editor.styles.minimalist.showTimer;
 		if (!needed) {
-			stopAgentTimer();
+			stopMinimalistDurationUpdates();
+			stopMinimalistDurationUpdates = () => {};
+			minimalistDurationUpdatesActive = false;
 			return;
 		}
-		if (agentTimerRunning) return;
-		const timer = setInterval(() => {
+		if (minimalistDurationUpdatesActive) return;
+		minimalistDurationUpdatesActive = true;
+		stopMinimalistDurationUpdates = agentDurationClock.subscribe(() => {
 			const ctx = activeTuiContext;
 			if (ctx && editorInstalled && !ownsInstalledEditorFactory()) {
 				reconcileObservedEditorOwnership(ctx);
 			}
 			reconcileAgentTimer();
-			if (agentTimerRunning) refresh();
-		}, 1000);
-		agentTimerRunning = true;
-		stopAgentTimer = () => {
-			clearInterval(timer);
-			agentTimerRunning = false;
-			stopAgentTimer = () => {};
-		};
+			if (minimalistDurationUpdatesActive) refresh();
+		});
 	};
 
 	const setMinimalistDecorationActive = (active: boolean) => {
@@ -454,28 +486,33 @@ export default function (pi: ExtensionAPI) {
 		reconcileAgentTimer();
 	};
 
-	const startAgentTurn = () => {
-		stopAgentTimer();
-		agentStartedAt = Date.now();
-		agentDurationMs = 0;
+	const startAgentTurn = (interactionStarted: boolean) => {
+		agentRunActive = true;
+		if (interactionStarted) agentDurationClock.start();
 		reconcileAgentTimer();
 		refresh();
 	};
 
-	const finishAgentTurn = () => {
-		if (agentStartedAt !== undefined) {
-			agentDurationMs = Math.max(0, Date.now() - agentStartedAt);
-		}
-		agentStartedAt = undefined;
+	const pauseAgentRun = () => {
+		agentRunActive = false;
+		reconcileAgentTimer();
+		refresh();
+	};
+
+	const settleAgentTurn = (nextStartedAt?: number) => {
+		agentRunActive = nextStartedAt !== undefined;
+		if (nextStartedAt === undefined) agentDurationClock.finish();
+		else agentDurationClock.start(nextStartedAt);
 		reconcileAgentTimer();
 		refresh();
 	};
 
 	const resetAgentTimer = () => {
-		stopAgentTimer();
-		agentTimerRunning = false;
-		agentStartedAt = undefined;
-		agentDurationMs = undefined;
+		stopMinimalistDurationUpdates();
+		stopMinimalistDurationUpdates = () => {};
+		minimalistDurationUpdatesActive = false;
+		agentRunActive = false;
+		agentDurationClock.reset();
 	};
 
 	const sameReferences = (left: Set<string>, right: Set<string>) =>
@@ -637,7 +674,7 @@ export default function (pi: ExtensionAPI) {
 					contextWindow: getContextWindow(ctx),
 					sessionName: ctx.sessionManager.getSessionName() ?? "",
 					agentDurationMs: getAgentDurationMs(),
-					agentActive: agentStartedAt !== undefined,
+					agentActive: agentRunActive,
 				}),
 				setMinimalistDecorationActive,
 			);
@@ -680,7 +717,7 @@ export default function (pi: ExtensionAPI) {
 					contextWindow: getContextWindow(ctx),
 					sessionName: ctx.sessionManager.getSessionName() ?? "",
 					agentDurationMs: getAgentDurationMs(),
-					agentActive: agentStartedAt !== undefined,
+					agentActive: agentRunActive,
 				}),
 				setMinimalistDecorationActive,
 			);
@@ -1055,6 +1092,7 @@ export default function (pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		sessionLifecycle.start();
 		liveContext.clear();
+		interactionMetrics.shutdown();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		resetAgentTimer();
@@ -1062,6 +1100,7 @@ export default function (pi: ExtensionAPI) {
 		requestedProjectCwd = undefined;
 		minimalistProjectRoot = undefined;
 		installUi(ctx);
+		workingLine.startSession(ctx);
 		scheduleEditorReconciliation(ctx);
 	});
 
@@ -1096,6 +1135,10 @@ export default function (pi: ExtensionAPI) {
 			currentConfig = saveUserMessagesComponentPatch(patch);
 			if (patch.enabled !== undefined || patch.style !== undefined) reconcileUserMessages();
 			refresh();
+		},
+		setWorkingLineComponent(patch: WorkingLineComponentPatch, ctx: ExtensionContext) {
+			currentConfig = saveWorkingLineComponentPatch(patch);
+			return workingLine.reconcile(ctx);
 		},
 		setSelectorBordersComponent(
 			patch: Partial<SelectorBordersComponentConfig>,
@@ -1181,6 +1224,8 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_shutdown", async (_event, ctx) => {
 		liveContext.clear();
+		interactionMetrics.shutdown();
+		workingLine.dispose(ctx);
 		cleanupUi(ctx);
 	});
 
@@ -1191,12 +1236,22 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("agent_start", (event, ctx) => {
 		liveContext.clear();
-		startAgentTurn();
+		const { interactionStarted } = interactionMetrics.agentStart();
+		startAgentTurn(interactionStarted);
+		workingLine.startAgent(ctx);
 		syncInteractiveState(event, ctx);
+	});
+	pi.on("turn_start", (_event, ctx) => {
+		interactionMetrics.turnStart();
+		workingLine.startTurn(ctx);
 	});
 	pi.on("agent_end", (event, ctx) => {
 		liveContext.clear();
-		finishAgentTurn();
+		const displayTokens = interactionMetrics.currentDisplayTokens();
+		interactionMetrics.agentEnd();
+		pauseAgentRun();
+		workingLine.finishAgent(ctx);
+		workingLine.updateMetrics(displayTokens, interactionMetrics.currentThought(), ctx);
 		// Reconcile once more after Pi has persisted the assistant message.
 		syncInteractiveAndProjectStateWithUsage(event, ctx);
 	});
@@ -1206,13 +1261,26 @@ export default function (pi: ExtensionAPI) {
 	});
 	pi.on("thinking_level_select", syncInteractiveState);
 	pi.on("session_info_changed", syncInteractiveState);
-	pi.on("message_update", (event) => {
+	pi.on("message_update", (event, ctx) => {
 		liveContext.update(event.message);
+		const metrics = interactionMetrics.messageUpdate(
+			event.message,
+			"assistantMessageEvent" in event ? event.assistantMessageEvent : undefined,
+		);
+		if (metrics.usageChanged || metrics.thoughtChanged) {
+			workingLine.updateMetrics(metrics.displayTokens, interactionMetrics.currentThought(), ctx);
+		}
 	});
 	pi.on("message_end", (event, ctx) => {
+		const result = interactionMetrics.messageEnd(event.message);
+		if (result.status === "accepted") {
+			workingLine.updateMetrics(result.displayTokens, interactionMetrics.currentThought(), ctx);
+		}
 		// Pi notifies extensions before persisting a successful message, so retain its live
-		// context until agent_end; failed messages clear immediately instead of showing stale usage.
+		// context until agent_end; accepted failed messages clear immediately instead of showing
+		// stale usage. Rejected and duplicate finals are not authoritative.
 		if (
+			result.status === "accepted" &&
 			event.message.role === "assistant" &&
 			(event.message.stopReason === "error" || event.message.stopReason === "aborted")
 		) {
@@ -1220,11 +1288,33 @@ export default function (pi: ExtensionAPI) {
 		}
 		syncInteractiveAndProjectStateWithUsage(event, ctx);
 	});
+	pi.on("agent_settled", (_event, ctx) => {
+		const settled = interactionMetrics.settle(ctx.isIdle());
+		if (!settled) return;
+		settleAgentTurn(settled.nextStartedAt);
+		workingLine.settle(settled.nextTokens, settled.nextThought, ctx);
+		const config = currentConfig.components.workingLine;
+		if (config.enabled && config.turnSummary) {
+			try {
+				pi.appendEntry(TURN_SUMMARY_ENTRY_TYPE, {
+					version: 3,
+					...settled.summary,
+					stylePrefix: snapshotWorkingLineHighStyle(ctx.ui.theme, config, currentConfig.colors),
+				});
+			} catch {
+				// A transcript persistence failure must not break settlement cleanup.
+			}
+		}
+	});
 	pi.on("tool_execution_start", (event, ctx) => {
 		liveContext.clear();
+		workingLine.startTool(event.toolCallId, event.toolName, ctx);
 		syncInteractiveState(event, ctx);
 	});
-	pi.on("tool_execution_end", syncInteractiveAndProjectState);
+	pi.on("tool_execution_end", (event, ctx) => {
+		workingLine.finishTool(event.toolCallId, ctx);
+		syncInteractiveAndProjectState(event, ctx);
+	});
 	pi.on("session_compact", (event, ctx) => {
 		liveContext.clear();
 		syncInteractiveAndProjectStateWithUsage(event, ctx);

--- a/extensions/zentui/interaction-summary.ts
+++ b/extensions/zentui/interaction-summary.ts
@@ -1,0 +1,1049 @@
+import type { AssistantMessage, AssistantMessageEvent } from "@earendil-works/pi-ai";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import type { ColorSource, ColorSpec } from "./config";
+import { formatCount, formatElapsedDuration } from "./format";
+import { isSafeSgrStylePrefix } from "./style";
+import { renderWorkingLineHigh } from "./working-line";
+
+export const TURN_SUMMARY_ENTRY_TYPE = "zentui-turn-summary";
+const TURN_SUMMARY_VERSION = 3;
+const SGR_RESET = "\x1b[0m";
+
+export type InteractionTokens = Readonly<{ input: number; output: number }>;
+export type LiveTokenDisplay = Readonly<{
+	input: number;
+	output: number;
+	outputApproximate: boolean;
+}>;
+export type ThoughtSnapshot = Readonly<{ durationMs: number; active: boolean }>;
+
+type SummaryBase = {
+	durationMs: number;
+	input: number;
+	output: number;
+};
+
+export type TurnSummaryDataV1 = SummaryBase & { version: 1 };
+export type TurnSummaryDataV2 = SummaryBase & { version: 2; stylePrefix: string };
+export type TurnSummaryDataV3 = SummaryBase & {
+	version: 3;
+	thoughtDurationMs: number;
+	stylePrefix: string;
+};
+export type TurnSummaryData = TurnSummaryDataV1 | TurnSummaryDataV2 | TurnSummaryDataV3;
+export type TurnSummaryMetrics = SummaryBase & { thoughtDurationMs: number };
+
+type Interval = { start: number; end: number };
+type TaggedInterval = Interval & { sources: number[] };
+type ThoughtCoverage = { intervals: TaggedInterval[]; incomplete: boolean };
+type ThoughtBlock = { startedAt?: number; closed: boolean };
+
+type ContentBlock = {
+	acceptedLength: number;
+	codePoints: number;
+	pendingHighSurrogate: boolean;
+	headHash: number;
+	headUnits: number;
+	tail: string;
+	frozen: boolean;
+};
+
+type ResponseState = {
+	ordinal: number;
+	authorized: boolean;
+	responseIdKey?: string;
+	snapshot: InteractionTokens;
+	hasSnapshot: boolean;
+	thoughtBlocks: Map<number, ThoughtBlock>;
+	contentBlocks: Map<string, ContentBlock>;
+	generatedCodePoints: number;
+	outputAnchor: number;
+	outputAnchorCodePoints: number;
+	liveOutputFloor: number;
+	lastDisplay?: LiveTokenDisplay;
+	estimateIncomplete: boolean;
+	estimateEnabled: boolean;
+};
+
+type RunState = {
+	ordinal: number;
+	startedAt: number;
+	ended: boolean;
+	committed: InteractionTokens;
+	responseOrdinal: number;
+	response?: ResponseState;
+	committedResponseIds: Set<string>;
+	lastClosedResponseId?: string;
+	lastClosedDisplay?: LiveTokenDisplay;
+	responseLessClosed: boolean;
+};
+
+type InteractionState = {
+	startedAt: number;
+	runOrdinal: number;
+	runs: RunState[];
+	activeRun?: RunState;
+	foldedCommitted: InteractionTokens;
+	thoughtCoverage: ThoughtCoverage;
+};
+
+export type MetricsUpdateResult = {
+	displayTokens?: LiveTokenDisplay;
+	usageChanged: boolean;
+	thoughtChanged: boolean;
+};
+
+export type MessageEndResult =
+	| {
+			status: "accepted";
+			tokens: InteractionTokens;
+			displayTokens: LiveTokenDisplay;
+			source: "final" | "last-snapshot" | "no-snapshot";
+	  }
+	| { status: "duplicate" }
+	| { status: "rejected" };
+
+export type SettlementResult = {
+	summary: TurnSummaryMetrics;
+	nextStartedAt?: number;
+	nextTokens?: LiveTokenDisplay;
+	nextThought?: ThoughtSnapshot;
+};
+
+export type InteractionMetricsDiagnostics = Readonly<{
+	runs: number;
+	responseIds: number;
+	activeResponses: number;
+	contentBlocks: number;
+	thoughtBlocks: number;
+	thoughtIntervals: number;
+	maxContentTailUnits: number;
+	retainedContentUnits: number;
+	estimateIncomplete: boolean;
+}>;
+
+const MAX_CONTENT_BLOCKS = 128;
+const MAX_CONTENT_INDEX = 65_535;
+const MAX_DELTA_UNITS = 65_536;
+const MAX_SNAPSHOT_UNITS = 1_048_576;
+const MAX_GENERATED_CODE_POINTS = 4_194_304;
+const MAX_ESTIMATED_RESPONSES = 128;
+const MAX_RUNS = 32;
+const MAX_RESPONSE_IDS = 256;
+const MAX_RESPONSE_ID_UNITS = 128;
+const MAX_THOUGHT_INTERVALS = 256;
+const HEAD_UNITS = 64;
+const TAIL_UNITS = 64;
+const HASH_OFFSET = 0x811c9dc5;
+
+function isNonnegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function safeAdd(left: number, right: number): number {
+	return Math.min(Number.MAX_SAFE_INTEGER, left + right);
+}
+
+function estimatedTokens(codePoints: number): number {
+	return Math.min(Number.MAX_SAFE_INTEGER, Math.ceil(codePoints / 4));
+}
+
+function addTokens(left: InteractionTokens, right: InteractionTokens): InteractionTokens {
+	return { input: safeAdd(left.input, right.input), output: safeAdd(left.output, right.output) };
+}
+
+type InteractionMessage = { role?: string; usage?: unknown; responseId?: unknown };
+
+export function parseAssistantMessageTokens(
+	message: InteractionMessage,
+): InteractionTokens | undefined {
+	if (message.role !== "assistant") return undefined;
+	const usage = (message as unknown as AssistantMessage).usage;
+	return isNonnegativeSafeInteger(usage?.input) && isNonnegativeSafeInteger(usage?.output)
+		? { input: usage.input, output: usage.output }
+		: undefined;
+}
+
+function responseIdKey(message: InteractionMessage): string | undefined {
+	if (typeof message.responseId !== "string") return undefined;
+	const value = message.responseId;
+	if (value.length > MAX_RESPONSE_ID_UNITS) return undefined;
+	const normalized = value.trim();
+	return normalized.length > 0 ? normalized : undefined;
+}
+
+function safeTime(value: number): number {
+	if (!Number.isFinite(value)) return value > 0 ? Number.MAX_SAFE_INTEGER : 0;
+	return Math.min(Number.MAX_SAFE_INTEGER, Math.max(0, Math.floor(value)));
+}
+
+function durationMs(startedAt: number, now: number): number {
+	const elapsed = Math.floor(now - startedAt);
+	if (Number.isNaN(elapsed) || elapsed <= 0) return 0;
+	return Math.min(Number.MAX_SAFE_INTEGER, elapsed);
+}
+
+function unionIntervals(intervals: readonly Interval[]): Interval[] {
+	const sorted = intervals
+		.filter(({ start, end }) => end > start)
+		.map(({ start, end }) => ({ start: safeTime(start), end: safeTime(end) }))
+		.filter(({ start, end }) => end > start)
+		.sort((left, right) => left.start - right.start || left.end - right.end);
+	const union: Interval[] = [];
+	for (const interval of sorted) {
+		const previous = union.at(-1);
+		if (!previous || interval.start > previous.end) union.push({ ...interval });
+		else previous.end = Math.max(previous.end, interval.end);
+	}
+	return union;
+}
+
+function intervalDuration(intervals: readonly Interval[]): number {
+	return unionIntervals(intervals).reduce(
+		(total, interval) => safeAdd(total, interval.end - interval.start),
+		0,
+	);
+}
+
+function sameSources(left: readonly number[], right: readonly number[]): boolean {
+	return left.length === right.length && left.every((source, index) => source === right[index]);
+}
+
+function normalizeTaggedIntervals(intervals: readonly TaggedInterval[]): TaggedInterval[] {
+	const sanitized = intervals
+		.map(({ start, end, sources }) => ({
+			start: safeTime(start),
+			end: safeTime(end),
+			sources: [...new Set(sources)].sort((left, right) => left - right),
+		}))
+		.filter(({ start, end, sources }) => end > start && sources.length > 0);
+	const boundaries = [...new Set(sanitized.flatMap(({ start, end }) => [start, end]))].sort(
+		(left, right) => left - right,
+	);
+	const result: TaggedInterval[] = [];
+	for (let index = 0; index + 1 < boundaries.length; index++) {
+		const start = boundaries[index];
+		const end = boundaries[index + 1];
+		if (start === undefined || end === undefined || end <= start) continue;
+		const sources = [
+			...new Set(
+				sanitized
+					.filter((interval) => interval.start < end && interval.end > start)
+					.flatMap((interval) => interval.sources),
+			),
+		].sort((left, right) => left - right);
+		if (sources.length === 0) continue;
+		const previous = result.at(-1);
+		if (previous && previous.end === start && sameSources(previous.sources, sources)) {
+			previous.end = end;
+		} else result.push({ start, end, sources });
+	}
+	return result;
+}
+
+function addThoughtInterval(
+	coverage: ThoughtCoverage,
+	interval: Interval,
+	source: number,
+): boolean {
+	if (coverage.incomplete) return false;
+	const candidate = normalizeTaggedIntervals([
+		...coverage.intervals,
+		{ ...interval, sources: [source] },
+	]);
+	if (candidate.length > MAX_THOUGHT_INTERVALS) {
+		coverage.incomplete = true;
+		return false;
+	}
+	coverage.intervals = candidate;
+	return true;
+}
+
+export function subtractThoughtIntervalsWithinCap(
+	source: readonly Interval[],
+	removed: readonly Interval[],
+): { intervals: Interval[]; incomplete: boolean } {
+	let result = unionIntervals(source);
+	for (const cut of unionIntervals(removed)) {
+		result = result.flatMap((part) => {
+			if (cut.end <= part.start || cut.start >= part.end) return [part];
+			return [
+				...(cut.start > part.start ? [{ start: part.start, end: cut.start }] : []),
+				...(cut.end < part.end ? [{ start: cut.end, end: part.end }] : []),
+			];
+		});
+	}
+	return {
+		intervals: result.slice(0, MAX_THOUGHT_INTERVALS),
+		incomplete: result.length > MAX_THOUGHT_INTERVALS,
+	};
+}
+
+function cappedTaggedDifference(
+	source: readonly TaggedInterval[],
+	removed: readonly Interval[],
+): { intervals: TaggedInterval[]; incomplete: boolean } {
+	let incomplete = false;
+	const fragments = source.flatMap((interval) => {
+		const difference = subtractThoughtIntervalsWithinCap([interval], removed);
+		incomplete ||= difference.incomplete;
+		return difference.intervals.map((fragment) => ({
+			...fragment,
+			sources: interval.sources,
+		}));
+	});
+	const normalized = normalizeTaggedIntervals(fragments);
+	return {
+		intervals: normalized.slice(0, MAX_THOUGHT_INTERVALS),
+		incomplete: incomplete || normalized.length > MAX_THOUGHT_INTERVALS,
+	};
+}
+
+function hashUnits(value: string, start: number, end: number, seed = HASH_OFFSET): number {
+	let hash = seed;
+	for (let index = start; index < end; index++)
+		hash = Math.imul(hash ^ value.charCodeAt(index), 0x01000193) >>> 0;
+	return hash;
+}
+
+function appendCodePoints(
+	value: string,
+	pendingHighSurrogate: boolean,
+): { codePoints: number; pendingHighSurrogate: boolean } {
+	let codePoints = 0;
+	let index = 0;
+	if (pendingHighSurrogate) {
+		if (value.length === 0) return { codePoints, pendingHighSurrogate };
+		const first = value.charCodeAt(0);
+		codePoints++;
+		if (first >= 0xdc00 && first <= 0xdfff) index = 1;
+	}
+	for (; index < value.length; index++) {
+		const unit = value.charCodeAt(index);
+		if (unit >= 0xd800 && unit <= 0xdbff) {
+			if (index + 1 === value.length) return { codePoints, pendingHighSurrogate: true };
+			const next = value.charCodeAt(index + 1);
+			codePoints++;
+			if (next >= 0xdc00 && next <= 0xdfff) index++;
+		} else codePoints++;
+	}
+	return { codePoints, pendingHighSurrogate: false };
+}
+
+function contentFingerprintMatches(block: ContentBlock, snapshot: string): boolean {
+	if (block.headUnits > snapshot.length) return false;
+	if (hashUnits(snapshot, 0, block.headUnits) !== block.headHash) return false;
+	const tailStart = block.acceptedLength - block.tail.length;
+	return snapshot.slice(tailStart, block.acceptedLength) === block.tail;
+}
+
+type ValidatedEvent = {
+	type: "text_delta" | "thinking_delta" | "toolcall_delta" | "thinking_start" | "thinking_end";
+	contentIndex: number;
+	delta?: string;
+	cumulative?: string;
+	oversizedDelta: boolean;
+	oversizedSnapshot: boolean;
+};
+
+function validateEvent(
+	event: AssistantMessageEvent | undefined,
+): ValidatedEvent | undefined | false {
+	if (!event) return undefined;
+	if (
+		event.type !== "text_delta" &&
+		event.type !== "thinking_delta" &&
+		event.type !== "toolcall_delta" &&
+		event.type !== "thinking_start" &&
+		event.type !== "thinking_end"
+	)
+		return undefined;
+	const record = event as unknown as Record<string, unknown>;
+	if (
+		!Number.isSafeInteger(record.contentIndex) ||
+		(record.contentIndex as number) < 0 ||
+		(record.contentIndex as number) > MAX_CONTENT_INDEX
+	)
+		return false;
+	const partial = record.partial;
+	if (!partial || typeof partial !== "object" || Array.isArray(partial)) return false;
+	const content = (partial as Record<string, unknown>).content;
+	if (!Array.isArray(content)) return false;
+	const contentIndex = record.contentIndex as number;
+	const isDelta =
+		event.type === "text_delta" ||
+		event.type === "thinking_delta" ||
+		event.type === "toolcall_delta";
+	if (isDelta && typeof record.delta !== "string") return false;
+	const expectedType =
+		event.type === "text_delta"
+			? "text"
+			: event.type === "toolcall_delta"
+				? "toolCall"
+				: "thinking";
+	let cumulative: string | undefined;
+	if (event.type === "toolcall_delta" && !(contentIndex in content)) return false;
+	if (contentIndex in content) {
+		const item = content[contentIndex];
+		if (!item || typeof item !== "object" || Array.isArray(item)) return false;
+		const itemRecord = item as Record<string, unknown>;
+		if (itemRecord.type !== expectedType) return false;
+		if (expectedType === "toolCall") {
+			if (
+				typeof itemRecord.id !== "string" ||
+				typeof itemRecord.name !== "string" ||
+				!itemRecord.arguments ||
+				typeof itemRecord.arguments !== "object" ||
+				Array.isArray(itemRecord.arguments)
+			)
+				return false;
+		} else {
+			const field = expectedType === "text" ? "text" : "thinking";
+			if (typeof itemRecord[field] !== "string") return false;
+			cumulative = itemRecord[field] as string;
+		}
+	}
+	const delta = isDelta ? (record.delta as string) : undefined;
+	return {
+		type: event.type,
+		contentIndex,
+		delta,
+		cumulative,
+		oversizedDelta: (delta?.length ?? 0) > MAX_DELTA_UNITS,
+		oversizedSnapshot: (cumulative?.length ?? 0) > MAX_SNAPSHOT_UNITS,
+	};
+}
+
+/** Owns provider-usage snapshots and thought-time partitioning for one settled interaction. */
+export class InteractionMetricsTracker {
+	private interaction?: InteractionState;
+
+	constructor(private readonly now: () => number = Date.now) {}
+
+	agentStart(now = this.now()): { interactionStarted: boolean } {
+		const at = safeTime(now);
+		const interactionStarted = this.interaction === undefined;
+		if (!this.interaction) {
+			this.interaction = {
+				startedAt: at,
+				runOrdinal: 0,
+				runs: [],
+				foldedCommitted: { input: 0, output: 0 },
+				thoughtCoverage: { intervals: [], incomplete: false },
+			};
+		}
+		const previous = this.interaction.activeRun;
+		if (previous && !previous.ended) {
+			if (previous.response) {
+				this.commitSnapshot(previous, previous.response);
+				this.closeResponse(previous, previous.response, at);
+			}
+			previous.ended = true;
+		}
+		this.makeRunCapacity(this.interaction);
+		const ordinal = safeAdd(this.interaction.runOrdinal, 1);
+		this.interaction.runOrdinal = ordinal;
+		const run: RunState = {
+			ordinal,
+			startedAt: at,
+			ended: false,
+			committed: { input: 0, output: 0 },
+			responseOrdinal: 0,
+			committedResponseIds: new Set(),
+			responseLessClosed: false,
+		};
+		this.interaction.runs.push(run);
+		this.interaction.activeRun = run;
+		return { interactionStarted };
+	}
+
+	turnStart(now = this.now()): void {
+		const run = this.activeRun();
+		if (!run) return;
+		if (run.response) {
+			this.commitSnapshot(run, run.response);
+			this.closeResponse(run, run.response, now);
+		}
+		this.openResponse(run);
+	}
+
+	messageUpdate(
+		message: InteractionMessage,
+		event?: AssistantMessageEvent,
+		now = this.now(),
+	): MetricsUpdateResult {
+		const unchanged: MetricsUpdateResult = {
+			displayTokens: this.currentDisplayTokens(),
+			usageChanged: false,
+			thoughtChanged: false,
+		};
+		const run = this.activeRun();
+		if (!run || message.role !== "assistant") return unchanged;
+		const validated = validateEvent(event);
+		if (validated === false) return unchanged;
+		const tokens = parseAssistantMessageTokens(message);
+		if (!tokens && !validated) return unchanged;
+		const response = this.responseForUpdate(run, message);
+		if (!response) return unchanged;
+		let thoughtChanged = false;
+		let contentChanged = false;
+		if (validated) {
+			if (validated.type.startsWith("thinking"))
+				thoughtChanged = this.applyThoughtEvent(run, response, validated, now);
+			if (
+				validated.type === "text_delta" ||
+				validated.type === "thinking_delta" ||
+				validated.type === "toolcall_delta"
+			)
+				contentChanged = this.applyContentEvent(response, validated);
+		}
+		const usageChanged = tokens ? this.applyLiveUsage(response, tokens) : false;
+		const display = this.liveDisplay(response);
+		const displayChanged = !this.sameDisplay(response.lastDisplay, display);
+		response.lastDisplay = display;
+		return {
+			displayTokens: display,
+			usageChanged: usageChanged || contentChanged || displayChanged,
+			thoughtChanged,
+		};
+	}
+
+	messageEnd(message: InteractionMessage, now = this.now()): MessageEndResult {
+		const run = this.activeRun();
+		if (!run || message.role !== "assistant") return { status: "rejected" };
+		const tokens = parseAssistantMessageTokens(message);
+		const key = responseIdKey(message);
+		const response = run.response;
+		if (!response?.authorized) return { status: "rejected" };
+		if (key && this.isDuplicateId(run, key)) return { status: "duplicate" };
+		if (response.responseIdKey && key && response.responseIdKey !== key)
+			return { status: "rejected" };
+		if (!response.responseIdKey && key) response.responseIdKey = key;
+		const preCloseDisplay = this.liveDisplay(response);
+		let source: "final" | "last-snapshot" | "no-snapshot";
+		if (tokens) {
+			response.snapshot = tokens;
+			response.hasSnapshot = true;
+			source = "final";
+		} else source = response.hasSnapshot ? "last-snapshot" : "no-snapshot";
+		this.commitSnapshot(run, response);
+		const committed = this.totalTokens();
+		const preserveEstimate = source !== "final" && response.lastDisplay?.outputApproximate === true;
+		const displayTokens = preserveEstimate
+			? { ...preCloseDisplay, outputApproximate: true }
+			: { ...committed, outputApproximate: false };
+		run.lastClosedDisplay = preserveEstimate ? displayTokens : undefined;
+		this.closeResponse(run, response, now);
+		return { status: "accepted", tokens: committed, displayTokens, source };
+	}
+
+	agentEnd(now = this.now()): void {
+		const interaction = this.interaction;
+		const run = interaction?.activeRun;
+		if (!interaction || !run) return;
+		if (run.response) {
+			this.commitSnapshot(run, run.response);
+			this.closeResponse(run, run.response, now);
+		}
+		run.ended = true;
+		interaction.activeRun = undefined;
+	}
+
+	currentTokens(): InteractionTokens | undefined {
+		return this.interaction ? this.totalTokens() : undefined;
+	}
+
+	currentDisplayTokens(): LiveTokenDisplay | undefined {
+		if (!this.interaction) return undefined;
+		const run = this.interaction.activeRun;
+		if (run?.response) return this.liveDisplay(run.response);
+		return run?.lastClosedDisplay ?? { ...this.totalTokens(), outputApproximate: false };
+	}
+
+	currentThought(now = this.now()): ThoughtSnapshot | undefined {
+		if (!this.interaction) return undefined;
+		return this.thoughtSnapshot(this.interaction, now);
+	}
+
+	settle(idle: boolean, now = this.now()): SettlementResult | undefined {
+		const interaction = this.interaction;
+		if (!interaction) return undefined;
+		const at = safeTime(now);
+		const splitIndex = idle
+			? interaction.runs.length
+			: interaction.runs.findIndex((run) => !run.ended);
+		const settledCount = splitIndex < 0 ? interaction.runs.length : splitIndex;
+		const hasFolded =
+			interaction.foldedCommitted.input > 0 ||
+			interaction.foldedCommitted.output > 0 ||
+			interaction.thoughtCoverage.intervals.some((interval) => interval.sources.includes(0));
+		if (settledCount === 0 && !hasFolded) return undefined;
+		const settledRuns = interaction.runs.slice(0, settledCount);
+		for (const run of interaction.runs) this.retainOpenThought(run, at);
+		for (const run of settledRuns) {
+			if (run.response) this.closeResponse(run, run.response, at);
+		}
+		const settledSources = new Set([0, ...settledRuns.map((run) => run.ordinal)]);
+		const settledIntervals = interaction.thoughtCoverage.intervals.filter((interval) =>
+			interval.sources.some((source) => settledSources.has(source)),
+		);
+		let tokens = interaction.foldedCommitted;
+		for (const run of settledRuns) tokens = addTokens(tokens, this.runTokens(run));
+		const summary: TurnSummaryMetrics = {
+			durationMs: durationMs(interaction.startedAt, now),
+			thoughtDurationMs: intervalDuration(settledIntervals),
+			input: tokens.input,
+			output: tokens.output,
+		};
+		const remaining = interaction.runs.slice(settledCount);
+		if (remaining.length === 0) {
+			this.interaction = undefined;
+			return { summary };
+		}
+		const remainingSources = new Set(remaining.map((run) => run.ordinal));
+		const remainingCoverage = interaction.thoughtCoverage.intervals
+			.map((interval) => ({
+				...interval,
+				sources: interval.sources.filter((source) => remainingSources.has(source)),
+			}))
+			.filter((interval) => interval.sources.length > 0);
+		const difference = cappedTaggedDifference(remainingCoverage, settledIntervals);
+		for (const run of remaining) {
+			for (const block of run.response?.thoughtBlocks.values() ?? []) {
+				if (block.startedAt !== undefined && !block.closed) block.startedAt = at;
+			}
+		}
+		const nextStartedAt = remaining[0]?.startedAt ?? at;
+		this.interaction = {
+			startedAt: nextStartedAt,
+			runOrdinal: interaction.runOrdinal,
+			runs: remaining,
+			activeRun: remaining.find((run) => !run.ended),
+			foldedCommitted: { input: 0, output: 0 },
+			thoughtCoverage: {
+				intervals: difference.intervals,
+				incomplete: interaction.thoughtCoverage.incomplete || difference.incomplete,
+			},
+		};
+		return {
+			summary,
+			nextStartedAt,
+			nextTokens: this.currentDisplayTokens(),
+			nextThought: this.currentThought(at),
+		};
+	}
+
+	shutdown(): void {
+		this.interaction = undefined;
+	}
+
+	diagnostics(): InteractionMetricsDiagnostics {
+		const interaction = this.interaction;
+		const responses =
+			interaction?.runs.flatMap((run) => (run.response ? [run.response] : [])) ?? [];
+		const blocks = responses.flatMap((response) => [...response.contentBlocks.values()]);
+		return {
+			runs: interaction?.runs.length ?? 0,
+			responseIds:
+				interaction?.runs.reduce((total, run) => total + run.committedResponseIds.size, 0) ?? 0,
+			activeResponses: responses.length,
+			contentBlocks: blocks.length,
+			thoughtBlocks: responses.reduce((total, response) => total + response.thoughtBlocks.size, 0),
+			thoughtIntervals: interaction?.thoughtCoverage.intervals.length ?? 0,
+			maxContentTailUnits: blocks.reduce(
+				(maximum, block) => Math.max(maximum, block.tail.length),
+				0,
+			),
+			retainedContentUnits: blocks.reduce((total, block) => total + block.tail.length, 0),
+			estimateIncomplete: responses.some((response) => response.estimateIncomplete),
+		};
+	}
+
+	private activeRun(): RunState | undefined {
+		const run = this.interaction?.activeRun;
+		return run && !run.ended ? run : undefined;
+	}
+
+	private makeRunCapacity(interaction: InteractionState): void {
+		if (interaction.runs.length < MAX_RUNS) return;
+		const index = interaction.runs.findIndex((run) => run.ended);
+		if (index < 0) return;
+		const [run] = interaction.runs.splice(index, 1);
+		if (!run) return;
+		interaction.foldedCommitted = addTokens(interaction.foldedCommitted, this.runTokens(run));
+		interaction.thoughtCoverage.intervals = normalizeTaggedIntervals(
+			interaction.thoughtCoverage.intervals.map((interval) => ({
+				...interval,
+				sources: interval.sources.map((source) => (source === run.ordinal ? 0 : source)),
+			})),
+		);
+	}
+
+	private openResponse(run: RunState, key?: string): ResponseState {
+		run.responseOrdinal = safeAdd(run.responseOrdinal, 1);
+		run.lastClosedDisplay = undefined;
+		const estimateEnabled =
+			run.ordinal <= MAX_RUNS && run.responseOrdinal <= MAX_ESTIMATED_RESPONSES;
+		const response: ResponseState = {
+			ordinal: run.responseOrdinal,
+			authorized: true,
+			responseIdKey: key,
+			snapshot: { input: 0, output: 0 },
+			hasSnapshot: false,
+			thoughtBlocks: new Map(),
+			contentBlocks: new Map(),
+			generatedCodePoints: 0,
+			outputAnchor: 0,
+			outputAnchorCodePoints: 0,
+			liveOutputFloor: 0,
+			estimateIncomplete: !estimateEnabled,
+			estimateEnabled,
+		};
+		run.response = response;
+		run.responseLessClosed = false;
+		return response;
+	}
+
+	private responseForUpdate(run: RunState, message: InteractionMessage): ResponseState | undefined {
+		const key = responseIdKey(message);
+		const response = run.response;
+		if (!response?.authorized || (key && this.isDuplicateId(run, key))) return undefined;
+		if (response.responseIdKey && key && response.responseIdKey !== key) return undefined;
+		if (!response.responseIdKey && key) response.responseIdKey = key;
+		return response;
+	}
+
+	private isDuplicateId(run: RunState, key: string): boolean {
+		return run.committedResponseIds.has(key) || run.lastClosedResponseId === key;
+	}
+
+	private applyContentEvent(response: ResponseState, event: ValidatedEvent): boolean {
+		if (!response.estimateEnabled) {
+			response.estimateIncomplete = true;
+			return false;
+		}
+		if (event.oversizedDelta || event.oversizedSnapshot) {
+			response.estimateIncomplete = true;
+			const existing = response.contentBlocks.get(
+				`${event.type === "text_delta" ? "text" : event.type === "toolcall_delta" ? "toolcall" : "thinking"}:${event.contentIndex}`,
+			);
+			if (existing) existing.frozen = true;
+			return false;
+		}
+		const contentType =
+			event.type === "text_delta"
+				? "text"
+				: event.type === "toolcall_delta"
+					? "toolcall"
+					: "thinking";
+		const key = `${contentType}:${event.contentIndex}`;
+		let block = response.contentBlocks.get(key);
+		if (!block) {
+			if (response.contentBlocks.size >= MAX_CONTENT_BLOCKS) {
+				response.estimateIncomplete = true;
+				return false;
+			}
+			block = {
+				acceptedLength: 0,
+				codePoints: 0,
+				pendingHighSurrogate: false,
+				headHash: HASH_OFFSET,
+				headUnits: 0,
+				tail: "",
+				frozen: false,
+			};
+			response.contentBlocks.set(key, block);
+		}
+		if (block.frozen) return false;
+		let suffix = event.delta ?? "";
+		if (event.cumulative !== undefined) {
+			const snapshot = event.cumulative;
+			if (snapshot.length < block.acceptedLength) return false;
+			if (!contentFingerprintMatches(block, snapshot)) {
+				block.frozen = true;
+				response.estimateIncomplete = true;
+				return false;
+			}
+			if (snapshot.length === block.acceptedLength) return false;
+			if (snapshot.length - block.acceptedLength > MAX_DELTA_UNITS) {
+				block.frozen = true;
+				response.estimateIncomplete = true;
+				return false;
+			}
+			suffix = snapshot.slice(block.acceptedLength);
+		}
+		if (suffix.length === 0) return false;
+		if (block.acceptedLength + suffix.length > MAX_SNAPSHOT_UNITS) {
+			block.frozen = true;
+			response.estimateIncomplete = true;
+			return false;
+		}
+		const counted = appendCodePoints(suffix, block.pendingHighSurrogate);
+		if (response.generatedCodePoints + counted.codePoints > MAX_GENERATED_CODE_POINTS) {
+			block.frozen = true;
+			response.estimateIncomplete = true;
+			return false;
+		}
+		if (block.headUnits < HEAD_UNITS) {
+			const taken = Math.min(HEAD_UNITS - block.headUnits, suffix.length);
+			block.headHash = hashUnits(suffix, 0, taken, block.headHash);
+			block.headUnits += taken;
+		}
+		block.tail =
+			suffix.length >= TAIL_UNITS
+				? suffix.slice(-TAIL_UNITS)
+				: `${block.tail}${suffix}`.slice(-TAIL_UNITS);
+		block.acceptedLength += suffix.length;
+		block.codePoints += counted.codePoints;
+		block.pendingHighSurrogate = counted.pendingHighSurrogate;
+		response.generatedCodePoints += counted.codePoints;
+		return true;
+	}
+
+	private applyThoughtEvent(
+		run: RunState,
+		response: ResponseState,
+		event: ValidatedEvent,
+		now: number,
+	): boolean {
+		const at = safeTime(now);
+		let block = response.thoughtBlocks.get(event.contentIndex);
+		if (!block) {
+			if (response.thoughtBlocks.size >= MAX_THOUGHT_INTERVALS) return false;
+			block = { closed: false };
+			response.thoughtBlocks.set(event.contentIndex, block);
+		}
+		if (event.type === "thinking_end") {
+			if (block.closed || block.startedAt === undefined) {
+				block.closed = true;
+				return false;
+			}
+			this.closeBlock(run, block, at);
+			return true;
+		}
+		if (block.closed || block.startedAt !== undefined) return false;
+		block.startedAt = at;
+		return true;
+	}
+
+	private closeBlock(run: RunState, block: ThoughtBlock, now: number): void {
+		if (block.closed) return;
+		block.closed = true;
+		if (block.startedAt === undefined) return;
+		const end = safeTime(now);
+		if (end <= block.startedAt || !this.interaction) return;
+		addThoughtInterval(
+			this.interaction.thoughtCoverage,
+			{ start: block.startedAt, end },
+			run.ordinal,
+		);
+	}
+
+	private closeResponse(run: RunState, response: ResponseState, now: number): void {
+		if (run.response !== response) return;
+		for (const block of response.thoughtBlocks.values()) this.closeBlock(run, block, now);
+		if (response.responseIdKey) {
+			if (run.committedResponseIds.size < MAX_RESPONSE_IDS)
+				run.committedResponseIds.add(response.responseIdKey);
+			run.lastClosedResponseId = response.responseIdKey;
+		} else run.responseLessClosed = true;
+		response.authorized = false;
+		response.contentBlocks.clear();
+		response.thoughtBlocks.clear();
+		run.response = undefined;
+	}
+
+	private commitSnapshot(run: RunState, response: ResponseState): void {
+		if (!response.hasSnapshot) return;
+		run.committed = addTokens(run.committed, response.snapshot);
+		response.hasSnapshot = false;
+	}
+
+	private applyLiveUsage(response: ResponseState, tokens: InteractionTokens): boolean {
+		if (tokens.input === 0 && tokens.output === 0) return false;
+		if (
+			response.hasSnapshot &&
+			(tokens.input < response.snapshot.input || tokens.output < response.snapshot.output)
+		)
+			return false;
+		if (
+			response.hasSnapshot &&
+			tokens.input === response.snapshot.input &&
+			tokens.output === response.snapshot.output
+		)
+			return false;
+		const outputAdvanced = !response.hasSnapshot || tokens.output > response.snapshot.output;
+		response.snapshot = tokens;
+		response.hasSnapshot = true;
+		if (outputAdvanced) {
+			response.outputAnchor = tokens.output;
+			response.outputAnchorCodePoints = response.generatedCodePoints;
+		}
+		return true;
+	}
+
+	private liveDisplay(response: ResponseState): LiveTokenDisplay {
+		const committed = this.committedTokens();
+		const postAnchorCodePoints = Math.max(
+			0,
+			response.generatedCodePoints - response.outputAnchorCodePoints,
+		);
+		const candidate = safeAdd(response.outputAnchor, estimatedTokens(postAnchorCodePoints));
+		const responseOutput = Math.max(response.liveOutputFloor, candidate);
+		const exactCoverage =
+			response.hasSnapshot &&
+			postAnchorCodePoints === 0 &&
+			responseOutput === response.outputAnchor &&
+			!response.estimateIncomplete;
+		response.liveOutputFloor = responseOutput;
+		return {
+			input: safeAdd(committed.input, response.hasSnapshot ? response.snapshot.input : 0),
+			output: safeAdd(committed.output, responseOutput),
+			outputApproximate: !exactCoverage,
+		};
+	}
+
+	private runTokens(run: RunState): InteractionTokens {
+		return run.response?.hasSnapshot
+			? addTokens(run.committed, run.response.snapshot)
+			: run.committed;
+	}
+
+	private committedTokens(): InteractionTokens {
+		const interaction = this.interaction;
+		if (!interaction) return { input: 0, output: 0 };
+		let total = interaction.foldedCommitted;
+		for (const run of interaction.runs) total = addTokens(total, run.committed);
+		return total;
+	}
+
+	private totalTokens(): InteractionTokens {
+		const interaction = this.interaction;
+		if (!interaction) return { input: 0, output: 0 };
+		let total = interaction.foldedCommitted;
+		for (const run of interaction.runs) total = addTokens(total, this.runTokens(run));
+		return total;
+	}
+
+	private retainOpenThought(run: RunState, now: number): void {
+		const end = safeTime(now);
+		for (const block of run.response?.thoughtBlocks.values() ?? []) {
+			if (block.startedAt === undefined || block.closed || end <= block.startedAt) continue;
+			if (this.interaction) {
+				addThoughtInterval(
+					this.interaction.thoughtCoverage,
+					{ start: block.startedAt, end },
+					run.ordinal,
+				);
+			}
+			block.startedAt = end;
+		}
+	}
+
+	private thoughtSnapshot(interaction: InteractionState, now: number): ThoughtSnapshot {
+		const coverage: ThoughtCoverage = {
+			intervals: interaction.thoughtCoverage.intervals.map((interval) => ({
+				...interval,
+				sources: [...interval.sources],
+			})),
+			incomplete: interaction.thoughtCoverage.incomplete,
+		};
+		for (const run of interaction.runs) {
+			for (const block of run.response?.thoughtBlocks.values() ?? []) {
+				if (block.startedAt === undefined || block.closed) continue;
+				addThoughtInterval(coverage, { start: block.startedAt, end: safeTime(now) }, run.ordinal);
+			}
+		}
+		return {
+			durationMs: intervalDuration(coverage.intervals),
+			active: interaction.runs.some((run) =>
+				[...(run.response?.thoughtBlocks.values() ?? [])].some(
+					(block) => block.startedAt !== undefined && !block.closed,
+				),
+			),
+		};
+	}
+
+	private sameDisplay(
+		left: LiveTokenDisplay | undefined,
+		right: LiveTokenDisplay | undefined,
+	): boolean {
+		return (
+			left?.input === right?.input &&
+			left?.output === right?.output &&
+			left?.outputApproximate === right?.outputApproximate
+		);
+	}
+}
+
+function hasExactKeys(record: Record<string, unknown>, expected: readonly string[]): boolean {
+	return Object.keys(record).sort().join("\0") === [...expected].sort().join("\0");
+}
+
+export function isTurnSummaryData(value: unknown): value is TurnSummaryData {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	if (
+		!isNonnegativeSafeInteger(record.durationMs) ||
+		!isNonnegativeSafeInteger(record.input) ||
+		!isNonnegativeSafeInteger(record.output)
+	)
+		return false;
+	if (record.version === 1) {
+		return hasExactKeys(record, ["version", "durationMs", "input", "output"]);
+	}
+	if (record.version === 2) {
+		return (
+			hasExactKeys(record, ["version", "durationMs", "input", "output", "stylePrefix"]) &&
+			isSafeSgrStylePrefix(record.stylePrefix)
+		);
+	}
+	return (
+		record.version === TURN_SUMMARY_VERSION &&
+		hasExactKeys(record, [
+			"version",
+			"durationMs",
+			"thoughtDurationMs",
+			"input",
+			"output",
+			"stylePrefix",
+		]) &&
+		isNonnegativeSafeInteger(record.thoughtDurationMs) &&
+		isSafeSgrStylePrefix(record.stylePrefix)
+	);
+}
+
+export function formatTurnSummary(data: TurnSummaryData | TurnSummaryMetrics): string {
+	const thought =
+		"thoughtDurationMs" in data && data.thoughtDurationMs > 0
+			? ` · thought for ${formatElapsedDuration(data.thoughtDurationMs)}`
+			: "";
+	return ` Turn took ${formatElapsedDuration(data.durationMs)}${thought} · ↑${formatCount(data.input)} ↓${formatCount(data.output)}`;
+}
+
+export function renderTurnSummaryEntry(
+	entry: { data?: unknown },
+	themeOptions: unknown,
+	theme: Pick<Theme, "fg">,
+): Text | undefined {
+	if (!isTurnSummaryData(entry.data)) return undefined;
+	const text = formatTurnSummary(entry.data);
+	if (entry.data.version === 2 || entry.data.version === 3) {
+		return new Text(`${entry.data.stylePrefix}${text}${SGR_RESET}`, 0, 0);
+	}
+	const options = (themeOptions ?? {}) as {
+		colorSource?: ColorSource;
+		workingLineHigh?: ColorSpec;
+	};
+	return new Text(
+		`${renderWorkingLineHigh(
+			theme,
+			options.colorSource === "terminal" ? "terminal" : "theme",
+			options.workingLineHigh,
+			text,
+		)}${SGR_RESET}`,
+		0,
+		0,
+	);
+}

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -3,7 +3,16 @@ import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import type { ZentuiConfig } from "./config";
 import { sanitizeEditorMetadataText } from "./editor-metadata-format";
-import { buildContextGauge, contextColorTier, formatCount, formatCwdLabel } from "./format";
+import {
+	buildContextGauge,
+	contextColorTier,
+	formatCount,
+	formatCwdLabel,
+	formatElapsedDuration,
+} from "./format";
+
+export { formatElapsedDuration } from "./format";
+
 import {
 	EDITOR_ACCENT_FALLBACK,
 	EDITOR_BORDER_FALLBACK,
@@ -43,16 +52,6 @@ export type MinimalistFrameOptions = {
 	config: ZentuiConfig;
 	borderColor?: (text: string) => string;
 };
-
-export function formatElapsedDuration(durationMs: number): string {
-	const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
-	const hours = Math.floor(totalSeconds / 3600);
-	const minutes = Math.floor((totalSeconds % 3600) / 60);
-	const seconds = totalSeconds % 60;
-	if (hours > 0) return `${hours}h ${minutes}m`;
-	if (minutes > 0) return `${minutes}m ${seconds}s`;
-	return `${seconds}s`;
-}
 
 function fillLine(content: string, width: number): string {
 	const truncated = truncateToWidth(content, Math.max(0, width), "");

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -32,6 +32,9 @@ import {
 	isExtensionStatusColorMode,
 	isExtensionStatusPlacement,
 	isSeparatorStyle,
+	isValidWorkingLineIntervalMs,
+	MAX_WORKING_LINE_INTERVAL_MS,
+	MIN_WORKING_LINE_INTERVAL_MS,
 	type MinimalistConfig,
 	type ModelLabelSource,
 	type PathDisplayConfig,
@@ -40,11 +43,20 @@ import {
 	type SeparatorStyle,
 	type UserMessageStyle,
 	type UserMessagesComponentConfig,
+	type WorkingLineComponentPatch,
+	type WorkingLineSpinner,
+	type WorkingLineTextAnimation,
 } from "./config";
 import { sanitizeExtensionStatusText } from "./extension-status";
 import { isIconMode } from "./icons";
 import type { SessionLifecycle } from "./session-lifecycle";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, safeThemeFg } from "./style";
+import {
+	buildWorkingLinePreviewFrames,
+	normalizeWorkingLineMessages,
+	remapWorkingLineTextTick,
+	type WorkingLineFrames,
+} from "./working-line";
 
 const colorSourceValues: ColorSource[] = ["theme", "terminal"];
 const extensionStatusPlacementValues: ExtensionStatusPlacement[] = [
@@ -85,10 +97,34 @@ const minimalistContextFormatValues = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
 const compactFooterMaxLineValues = ["1", "2", "3", "unlimited"];
 const featureStateValues: FeatureState[] = ["enabled", "disabled"];
+const workingLineSpinnerLabels: Record<WorkingLineSpinner, string> = {
+	braille: "Braille Orbit",
+	"star-bloom": "Star Bloom",
+	pinwheel: "ASCII Pinwheel",
+	"claude-inspired": "Claude-inspired",
+	pulse: "Pulse",
+};
+const workingLineSpinnerValues = Object.values(workingLineSpinnerLabels);
+const workingLineSpinnerSpeedPresets = [
+	{ label: "Fast 60 ms", intervalMs: 60 },
+	{ label: "Normal 100 ms", intervalMs: 100 },
+	{ label: "Slow 160 ms", intervalMs: 160 },
+] as const;
+const workingLineTextSpeedPresets = [
+	{ label: "Fast 40 ms", intervalMs: 40 },
+	{ label: "Normal 60 ms", intervalMs: 60 },
+	{ label: "Slow 100 ms", intervalMs: 100 },
+] as const;
+const speedValues = (presets: readonly { label: string }[]) => [
+	...presets.map(({ label }) => label),
+	"Custom…",
+];
+const workingLineTextAnimationValues: WorkingLineTextAnimation[] = ["classic", "kitt", "disabled"];
 const settingsSections = [
 	"appearance",
 	"editor",
 	"userMessages",
+	"workingLine",
 	"footer",
 	"segments",
 	"git",
@@ -109,6 +145,11 @@ type UserMessagesPatch = Partial<
 >;
 type FooterPatch = Partial<Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel">>;
 type ApplyResult = { applied: boolean; reason?: string };
+type SettingsOutcome =
+	| "close"
+	| "edit-working-line-messages"
+	| "edit-working-line-spinner-speed"
+	| "edit-working-line-text-speed";
 
 type SettingsCommandDeps = {
 	sessionLifecycle: SessionLifecycle;
@@ -116,6 +157,7 @@ type SettingsCommandDeps = {
 	setEditorComponent: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
 	setMinimalist: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
 	setUserMessagesComponent: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
+	setWorkingLineComponent: (patch: WorkingLineComponentPatch, ctx: ExtensionContext) => ApplyResult;
 	setSelectorBordersComponent: (
 		patch: Partial<SelectorBordersComponentConfig>,
 		ctx: ExtensionContext,
@@ -149,6 +191,7 @@ const sectionLabels: Record<SettingsSection, string> = {
 	appearance: "Appearance",
 	editor: "Editor",
 	userMessages: "User messages",
+	workingLine: "Working line",
 	footer: "Footer",
 	segments: "Segments",
 	git: "Git",
@@ -210,6 +253,7 @@ const directCommandSuggestions = [
 	"viewport-indicators toggle",
 	"messages",
 	"user-messages",
+	"working-line",
 	"format clear",
 	"format $cwd on $git_branch $fill $context",
 ];
@@ -244,6 +288,19 @@ function userMessageStyleId(label: string): UserMessageStyle | undefined {
 	return (Object.entries(userMessageStyleLabels) as Array<[UserMessageStyle, string]>).find(
 		([, value]) => value === label,
 	)?.[0];
+}
+function workingLineSpinnerId(label: string): WorkingLineSpinner | undefined {
+	return (Object.entries(workingLineSpinnerLabels) as Array<[WorkingLineSpinner, string]>).find(
+		([, value]) => value === label,
+	)?.[0];
+}
+function workingLineSpeedLabel(
+	intervalMs: number,
+	presets: readonly { label: string; intervalMs: number }[],
+): string {
+	return (
+		presets.find((preset) => preset.intervalMs === intervalMs)?.label ?? `Custom ${intervalMs} ms`
+	);
 }
 function isFeatureState(value: string): value is FeatureState {
 	return value === "enabled" || value === "disabled";
@@ -325,6 +382,7 @@ function directSection(args: string): SettingsSection | undefined {
 	) {
 		return "userMessages";
 	}
+	if (normalized === "working-line" || normalized === "working line") return "workingLine";
 	return undefined;
 }
 
@@ -337,7 +395,7 @@ function argumentCompletions(prefix: string): AutocompleteItem[] | null {
 }
 
 function usageText(): string {
-	return "Usage: /zentui [editor|messages|statusline|viewport-indicators] [enable|disable|toggle], /zentui [messages|user-messages], or /zentui format <template>";
+	return "Usage: /zentui [editor|messages|statusline|viewport-indicators] [enable|disable|toggle], /zentui [messages|user-messages|working-line], or /zentui format <template>";
 }
 
 function buildAppearanceItems(config: PolishedTuiConfig): SettingItem[] {
@@ -503,6 +561,120 @@ function buildUserMessagesItems(config: PolishedTuiConfig): SettingItem[] {
 		},
 	];
 }
+function buildWorkingLineItems(config: PolishedTuiConfig): SettingItem[] {
+	const workingLine = config.components.workingLine;
+	const staticText = workingLine.textAnimation === "disabled";
+	const staticNote = staticText ? " Inactive in Static mode; saved for animated modes." : "";
+	return [
+		{
+			id: "workingLineEnabled",
+			label: "Enabled",
+			description: "Own and stylize Pi's complete working row.",
+			currentValue: featureValue(workingLine.enabled),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineTurnSummary",
+			label: "Turn summary",
+			description: workingLine.enabled
+				? "Append `Turn took …` after each fully settled interaction."
+				: "Append `Turn took …` after each fully settled interaction; inactive while Working line disabled.",
+			currentValue: featureValue(workingLine.turnSummary),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineSpinner",
+			label: "Spinner",
+			description: "Choose the fixed-width spinner preset; glyph motion is always active.",
+			currentValue: workingLineSpinnerLabels[workingLine.spinner],
+			values: workingLineSpinnerValues,
+		},
+		{
+			id: "workingLineSpinnerSpeed",
+			label: "Spinner speed",
+			description: `Set glyph cadence (${MIN_WORKING_LINE_INTERVAL_MS}–${MAX_WORKING_LINE_INTERVAL_MS} ms).`,
+			currentValue: workingLineSpeedLabel(
+				workingLine.spinnerIntervalMs,
+				workingLineSpinnerSpeedPresets,
+			),
+			values: speedValues(workingLineSpinnerSpeedPresets),
+		},
+		{
+			id: "workingLineAnimateSpinnerColor",
+			label: "Animate spinner color",
+			description: `Include spinner cells and separator in Classic/KITT color motion; glyph motion remains active.${staticNote}`,
+			currentValue: featureValue(workingLine.animateSpinnerColor),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineTextAnimation",
+			label: "Text animation",
+			description: "Animate the owned row or keep it uniformly static.",
+			currentValue: workingLine.textAnimation,
+			values: workingLineTextAnimationValues,
+		},
+		{
+			id: "workingLineTextSpeed",
+			label: "Text motion speed",
+			description: `Set Classic/KITT color cadence (${MIN_WORKING_LINE_INTERVAL_MS}–${MAX_WORKING_LINE_INTERVAL_MS} ms).${staticNote}`,
+			currentValue: workingLineSpeedLabel(workingLine.textIntervalMs, workingLineTextSpeedPresets),
+			values: speedValues(workingLineTextSpeedPresets),
+		},
+		{
+			id: "workingLineColorSource",
+			label: "Color source",
+			description: "Use Pi theme colors or independent terminal palette styles.",
+			currentValue: workingLine.colorSource,
+			values: colorSourceValues,
+		},
+		{
+			id: "workingLineCustomMessages",
+			label: "Custom messages",
+			description:
+				"Select from the editable list once per turn; off uses styled Working… without RNG.",
+			currentValue: featureValue(workingLine.messages.custom),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineTool",
+			label: "Tool",
+			description: "Show the latest active tool.",
+			currentValue: featureValue(workingLine.segments.tool),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineElapsed",
+			label: "Elapsed",
+			description: "Show whole-interaction elapsed time.",
+			currentValue: featureValue(workingLine.segments.elapsed),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineThought",
+			label: "Thinking",
+			description: "Show cumulative wall-clock thinking time and active updates.",
+			currentValue: featureValue(workingLine.segments.thought),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineTokens",
+			label: "Tokens",
+			description:
+				"Show whole-interaction tokens as ↑input ↓output; live output may be estimated until final usage reconciles.",
+			currentValue: featureValue(workingLine.segments.tokens),
+			values: featureStateValues,
+		},
+		{
+			id: "workingLineMessageList",
+			label: "Message list",
+			description:
+				"Edit one message per line; line order is preserved even while custom messages are off.",
+			currentValue: "Edit…",
+			values: ["Edit…"],
+		},
+	];
+}
+
 function buildFooterItems(config: PolishedTuiConfig): SettingItem[] {
 	const footer = config.components.footer;
 	const items: SettingItem[] = [
@@ -749,6 +921,8 @@ function buildSectionItems(
 			];
 		case "userMessages":
 			return buildUserMessagesItems(config);
+		case "workingLine":
+			return buildWorkingLineItems(config);
 		case "footer":
 			return [
 				...buildFooterItems(config),
@@ -891,348 +1065,634 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 			const mode = (ctx as typeof ctx & { mode?: string }).mode;
 			if (!ctx.hasUI || (mode !== undefined && mode !== "tui")) return;
 
-			await ctx.ui.custom<void>((tui, theme, _keybindings, done) => {
-				const listTheme = deps.settingsListTheme ?? getSettingsListTheme();
-				let activeSection = initialSection ?? "appearance";
-				let settingsList: SettingsList;
-				const notifyChange = (label: string, value: string) => {
-					deps.requestRender();
-					ctx.ui.notify(`${label}: ${value}`, "info");
-					tui.requestRender();
-				};
-				const makeSettingsList = (focusId?: string): SettingsList => {
-					const items = buildSectionItems(
-						activeSection,
-						deps.getConfig(),
-						deps.getActiveExtensionStatuses(),
-					);
-					const list = new SettingsList(
-						items,
-						8,
-						listTheme,
-						(id, newValue) => {
-							try {
-								const enabled = isFeatureState(newValue) ? newValue === "enabled" : undefined;
-								if (id === "editorEnabled" && enabled !== undefined) {
-									done(undefined);
-									deps.sessionLifecycle.defer(() => {
-										try {
-											const result = setEditor({ enabled }, ctx);
-											deps.requestRender();
-											ctx.ui.notify(
-												`Editor: ${newValue}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
-												"info",
-											);
-										} catch (error) {
-											ctx.ui.notify(
-												`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
-												"error",
-											);
-										}
-									});
-									return;
-								}
-								const selectedEditorStyle =
-									id === "editorStyle" ? editorStyleId(newValue) : undefined;
-								if (selectedEditorStyle) {
-									setEditor({ style: selectedEditorStyle }, ctx);
-									settingsList = makeSettingsList("editorStyle");
-									notifyChange("Editor style", newValue);
-									return;
-								}
-								if (id === "editorColorSource" && isColorSource(newValue)) {
-									setEditor({ colorSource: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Editor colors", newValue);
-									return;
-								}
-								if (id === "editorModelLabel" && (newValue === "id" || newValue === "name")) {
-									setEditor({ modelLabel: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Editor model label", newValue);
-									return;
-								}
-								if (
-									id === "editorBorderColorMode" &&
-									(newValue === "static" || newValue === "adaptive")
-								) {
-									setEditor({ borderColorMode: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Editor border color", newValue);
-									return;
-								}
-								if (id === "editorViewportIndicators" && enabled !== undefined) {
-									setEditor({ viewportIndicators: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Editor viewport indicators", newValue);
-									return;
-								}
-								if (id.startsWith("minimalist")) {
-									if (
-										id === "minimalistPathDisplay" &&
-										["compact", "project", "full"].includes(newValue)
-									)
-										deps.setMinimalist(
-											{ pathDisplay: newValue as MinimalistConfig["pathDisplay"] },
-											ctx,
-										);
-									else if (
-										id === "minimalistContextFormat" &&
-										["percent", "percent-total"].includes(newValue)
-									)
-										deps.setMinimalist(
-											{ contextFormat: newValue as MinimalistConfig["contextFormat"] },
-											ctx,
-										);
-									else if (enabled !== undefined) {
-										const key =
-											id === "minimalistContextGauge"
-												? "contextGauge"
-												: id === "minimalistShowSessionName"
-													? "showSessionName"
-													: id === "minimalistShowTimer"
-														? "showTimer"
-														: id === "minimalistShowCost"
-															? "showCost"
-															: id === "minimalistShowGit"
-																? "showGit"
-																: undefined;
-										if (!key) return;
-										deps.setMinimalist({ [key]: enabled }, ctx);
-									} else return;
-									settingsList.updateValue(id, newValue);
-									notifyChange(id, newValue);
-									return;
-								}
-
-								if (id === "userMessagesEnabled" && enabled !== undefined) {
-									setMessages({ enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("User messages", newValue);
-									return;
-								}
-								const selectedMessageStyle =
-									id === "userMessagesStyle" ? userMessageStyleId(newValue) : undefined;
-								if (selectedMessageStyle) {
-									setMessages({ style: selectedMessageStyle }, ctx);
-									settingsList = makeSettingsList("userMessagesStyle");
-									notifyChange("Message style", newValue);
-									return;
-								}
-								if (id === "userMessagesColorSource" && isColorSource(newValue)) {
-									setMessages({ colorSource: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Message colors", newValue);
-									return;
-								}
-								if (id === "selectorBordersEnabled" && enabled !== undefined) {
-									deps.setSelectorBordersComponent({ enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Selector borders", newValue);
-									return;
-								}
-								if (id === "selectorBordersStyle" && newValue === "zentui") {
-									deps.setSelectorBordersComponent({ style: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Selector border style", newValue);
-									return;
-								}
-								if (id === "selectorBordersColorSource" && isColorSource(newValue)) {
-									deps.setSelectorBordersComponent({ colorSource: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Selector border colors", newValue);
-									return;
-								}
-								if (id === "iconMode" && isIconMode(newValue)) {
-									deps.setIconMode(newValue);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Icon mode", newValue);
-									return;
-								}
-
-								const selectedFooterStyle =
-									id === "footerStyle" ? footerStyleId(newValue) : undefined;
-								if (selectedFooterStyle) {
-									setFooter({ style: selectedFooterStyle }, ctx);
-									settingsList = makeSettingsList("footerStyle");
-									notifyChange("Footer style", newValue);
-									return;
-								}
-								if (id === "footerColorSource" && isColorSource(newValue)) {
-									setFooter({ colorSource: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Footer colors", newValue);
-									return;
-								}
-								if (id === "footerModelLabel" && (newValue === "id" || newValue === "name")) {
-									setFooter({ modelLabel: newValue }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Footer model label", newValue);
-									return;
-								}
-
-								if (id === "responsiveFooter" && enabled !== undefined) {
-									deps.setResponsiveFooter({ responsiveFooter: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Responsive footer", newValue);
-									return;
-								}
-								if (
-									id === "compactFooterMaxLines" &&
-									compactFooterMaxLineValues.includes(newValue as never)
-								) {
-									const value: CompactFooterMaxLines =
-										newValue === "unlimited" ? "unlimited" : (Number(newValue) as 1 | 2 | 3);
-									deps.setResponsiveFooter({ compactFooterMaxLines: value }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Compact footer rows", newValue);
-									return;
-								}
-								if (
-									id === "contextStyle" &&
-									contextStyleValues.includes(newValue as ContextStyle)
-								) {
-									deps.setContextStyle(newValue as ContextStyle);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Context style", newValue);
-									return;
-								}
-								if (id === "separator" && isSeparatorStyle(newValue)) {
-									deps.setSeparator(newValue);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Separator", newValue);
-									return;
-								}
-								if (id === "pathDisplay" && pathDisplayModeValues.includes(newValue as never)) {
-									deps.setPathDisplay({ mode: newValue as PathDisplayConfig["mode"] });
-									settingsList.updateValue(id, newValue);
-									notifyChange("Path display", newValue);
-									return;
-								}
-								if (id === "pathDepth" && pathDepthValues.includes(newValue as never)) {
-									deps.setPathDisplay({ depth: Number(newValue) });
-									settingsList.updateValue(id, newValue);
-									notifyChange("Path depth", newValue);
-									return;
-								}
-
-								const segment = footerSegmentSettingFromId(id);
-								if (segment && enabled !== undefined) {
-									deps.setFooterSegments({ [segment]: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange(footerSegmentSettingLabels[segment], newValue);
-									return;
-								}
-								if (id === "branchLength") {
-									const value = newValue === "full" ? "full" : Number(newValue);
-									if (value !== "full" && (!Number.isInteger(value) || value <= 0)) return;
-									deps.setGitBranch({ maxLength: value });
-									settingsList.updateValue(id, newValue);
-									notifyChange("Branch length", newValue);
-									return;
-								}
-								if (id === "gitCommitOnlyDetached" && enabled !== undefined) {
-									deps.setGitCommit({ onlyDetached: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Commit only on detached HEAD", newValue);
-									return;
-								}
-								if (id === "gitCommitShowTag" && enabled !== undefined) {
-									deps.setGitCommit({ showTag: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Show exact-match tag", newValue);
-									return;
-								}
-								if (id === "gitMetricsOnlyNonzero" && enabled !== undefined) {
-									deps.setGitMetrics({ onlyNonzero: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Hide zero metrics", newValue);
-									return;
-								}
-								if (id === "gitMetricsIgnoreSubmodules" && enabled !== undefined) {
-									deps.setGitMetrics({ ignoreSubmodules: enabled }, ctx);
-									settingsList.updateValue(id, newValue);
-									notifyChange("Ignore submodules", newValue);
-									return;
-								}
-
-								if (
-									id === "extensionStatusDefaultPlacement" &&
-									isExtensionStatusPlacement(newValue)
-								) {
-									deps.setExtensionStatusDefaultPlacement(newValue);
-									settingsList = makeSettingsList("extensionStatusDefaultPlacement");
-									notifyChange("Default extension status placement", newValue);
-									return;
-								}
-								const thirdParty = thirdPartyStatusSettingFromId(id);
-								if (thirdParty?.kind === "placement" && isExtensionStatusPlacement(newValue)) {
-									deps.setExtensionStatusPlacement(thirdParty.key, newValue);
-									settingsList.updateValue(id, newValue);
-									notifyChange(`Third-party status ${thirdParty.key} placement`, newValue);
-									return;
-								}
-								if (thirdParty?.kind === "colorMode" && isExtensionStatusColorMode(newValue)) {
-									deps.setExtensionStatusColorMode(thirdParty.key, newValue);
-									settingsList.updateValue(id, newValue);
-									notifyChange(`Third-party status ${thirdParty.key} color`, newValue);
-								}
-							} catch (error) {
-								settingsList = makeSettingsList(id);
-								tui.requestRender();
-								ctx.ui.notify(
-									`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
-									"error",
+			let requestedSection = initialSection ?? "appearance";
+			let requestedFocusId: string | undefined;
+			while (true) {
+				const initialFocusId = requestedFocusId;
+				requestedFocusId = undefined;
+				const outcome = await ctx.ui.custom<SettingsOutcome>((tui, theme, _keybindings, done) => {
+					const listTheme = deps.settingsListTheme ?? getSettingsListTheme();
+					let activeSection = requestedSection;
+					let settingsList: SettingsList;
+					let preview: WorkingLineFrames | undefined;
+					let previewFrameIndex = 0;
+					let cancelPreview = () => {};
+					const stopPreview = (reset = true) => {
+						cancelPreview();
+						cancelPreview = () => {};
+						if (reset) {
+							preview = undefined;
+							previewFrameIndex = 0;
+						}
+					};
+					const startPreview = () => {
+						const previous = preview;
+						const previousState = previous?.frameStates[previewFrameIndex];
+						stopPreview(false);
+						if (activeSection !== "workingLine") return;
+						try {
+							const config = deps.getConfig();
+							const spinnerTick = previousState?.spinnerTick ?? 0;
+							let textTick = previousState?.textTick ?? 0;
+							let generated = buildWorkingLinePreviewFrames(
+								config.components.workingLine,
+								config.colors,
+								theme,
+								spinnerTick,
+								textTick,
+							);
+							if (previous && previousState) {
+								textTick = remapWorkingLineTextTick(
+									previous.textAnimation,
+									previous.textWidth,
+									previousState.textTick,
+									generated.textAnimation,
+									generated.textWidth,
+									previous.textOrigin,
+									generated.textOrigin,
+								);
+								generated = buildWorkingLinePreviewFrames(
+									config.components.workingLine,
+									config.colors,
+									theme,
+									spinnerTick,
+									textTick,
 								);
 							}
-						},
-						() => done(undefined),
-					);
-					if (focusId) {
-						const target = items.findIndex((item) => item.id === focusId);
-						for (let index = 0; index < target; index += 1) list.handleInput("\x1b[B");
-					}
-					return list;
-				};
-				settingsList = makeSettingsList();
-				return {
-					render(width: number) {
-						const border = renderChromeBorder(
-							theme,
-							deps.getConfig().components.selectorBorders.colorSource,
-							EDITOR_BORDER_STYLE,
-							"─".repeat(Math.max(0, width)),
+							preview = generated;
+							previewFrameIndex = 0;
+							const advance = () => {
+								if (activeSection !== "workingLine" || !preview || preview.frames.length === 0)
+									return;
+								previewFrameIndex = (previewFrameIndex + 1) % preview.frames.length;
+								tui.requestRender();
+								cancelPreview = deps.sessionLifecycle.defer(advance, preview.intervalMs);
+							};
+							cancelPreview = deps.sessionLifecycle.defer(advance, generated.intervalMs);
+						} catch {
+							stopPreview();
+						}
+					};
+					const finishSettings = (result: SettingsOutcome) => {
+						stopPreview();
+						done(result);
+					};
+					const notifyChange = (label: string, value: string, result?: ApplyResult) => {
+						deps.requestRender();
+						ctx.ui.notify(
+							`${label}: ${value}${result && !result.applied ? ` (${result.reason ?? "reload Pi to apply this change"})` : ""}`,
+							"info",
 						);
-						return [
-							truncateToWidth(border, width, ""),
-							truncateToWidth(formatSectionTabs(activeSection, theme, width), width, ""),
-							truncateToWidth(border, width, ""),
-							...withSectionFooter(settingsList.render(width), theme).map((line) =>
-								truncateToWidth(line, width, ""),
-							),
-							truncateToWidth(border, width, ""),
-						];
-					},
-					invalidate() {
-						settingsList.invalidate();
-					},
-					handleInput(data: string) {
-						if (matchesKey(data, Key.tab)) {
-							activeSection = nextSection(activeSection);
-							settingsList = makeSettingsList();
-							tui.requestRender();
-							return;
+						startPreview();
+						tui.requestRender();
+					};
+					const notifyWorkingLineChange = (
+						label: string,
+						value: string,
+						result: ApplyResult,
+						previewChanged = true,
+					) => {
+						ctx.ui.notify(
+							`${label}: ${value}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+							"info",
+						);
+						if (previewChanged) startPreview();
+						tui.requestRender();
+					};
+					const makeSettingsList = (focusId?: string): SettingsList => {
+						const items = buildSectionItems(
+							activeSection,
+							deps.getConfig(),
+							deps.getActiveExtensionStatuses(),
+						);
+						const list = new SettingsList(
+							items,
+							8,
+							listTheme,
+							(id, newValue) => {
+								try {
+									const enabled = isFeatureState(newValue) ? newValue === "enabled" : undefined;
+									if (id === "editorEnabled" && enabled !== undefined) {
+										finishSettings("close");
+										deps.sessionLifecycle.defer(() => {
+											try {
+												const result = setEditor({ enabled }, ctx);
+												deps.requestRender();
+												ctx.ui.notify(
+													`Editor: ${newValue}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+													"info",
+												);
+											} catch (error) {
+												ctx.ui.notify(
+													`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+													"error",
+												);
+											}
+										});
+										return;
+									}
+									const selectedEditorStyle =
+										id === "editorStyle" ? editorStyleId(newValue) : undefined;
+									if (selectedEditorStyle) {
+										setEditor({ style: selectedEditorStyle }, ctx);
+										settingsList = makeSettingsList("editorStyle");
+										notifyChange("Editor style", newValue);
+										return;
+									}
+									if (id === "editorColorSource" && isColorSource(newValue)) {
+										setEditor({ colorSource: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Editor colors", newValue);
+										return;
+									}
+									if (id === "editorModelLabel" && (newValue === "id" || newValue === "name")) {
+										setEditor({ modelLabel: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Editor model label", newValue);
+										return;
+									}
+									if (
+										id === "editorBorderColorMode" &&
+										(newValue === "static" || newValue === "adaptive")
+									) {
+										setEditor({ borderColorMode: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Editor border color", newValue);
+										return;
+									}
+									if (id === "editorViewportIndicators" && enabled !== undefined) {
+										setEditor({ viewportIndicators: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Editor viewport indicators", newValue);
+										return;
+									}
+									if (id.startsWith("minimalist")) {
+										if (
+											id === "minimalistPathDisplay" &&
+											["compact", "project", "full"].includes(newValue)
+										)
+											deps.setMinimalist(
+												{ pathDisplay: newValue as MinimalistConfig["pathDisplay"] },
+												ctx,
+											);
+										else if (
+											id === "minimalistContextFormat" &&
+											["percent", "percent-total"].includes(newValue)
+										)
+											deps.setMinimalist(
+												{ contextFormat: newValue as MinimalistConfig["contextFormat"] },
+												ctx,
+											);
+										else if (enabled !== undefined) {
+											const key =
+												id === "minimalistContextGauge"
+													? "contextGauge"
+													: id === "minimalistShowSessionName"
+														? "showSessionName"
+														: id === "minimalistShowTimer"
+															? "showTimer"
+															: id === "minimalistShowCost"
+																? "showCost"
+																: id === "minimalistShowGit"
+																	? "showGit"
+																	: undefined;
+											if (!key) return;
+											deps.setMinimalist({ [key]: enabled }, ctx);
+										} else return;
+										settingsList.updateValue(id, newValue);
+										notifyChange(id, newValue);
+										return;
+									}
+
+									if (id === "userMessagesEnabled" && enabled !== undefined) {
+										setMessages({ enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("User messages", newValue);
+										return;
+									}
+									const selectedMessageStyle =
+										id === "userMessagesStyle" ? userMessageStyleId(newValue) : undefined;
+									if (selectedMessageStyle) {
+										setMessages({ style: selectedMessageStyle }, ctx);
+										settingsList = makeSettingsList("userMessagesStyle");
+										notifyChange("Message style", newValue);
+										return;
+									}
+									if (id === "userMessagesColorSource" && isColorSource(newValue)) {
+										setMessages({ colorSource: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Message colors", newValue);
+										return;
+									}
+									if (id === "workingLineEnabled" && enabled !== undefined) {
+										const result = deps.setWorkingLineComponent({ enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Working line", newValue, result);
+										return;
+									}
+									if (id === "workingLineTurnSummary" && enabled !== undefined) {
+										const result = deps.setWorkingLineComponent({ turnSummary: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Turn summary", newValue, result, false);
+										return;
+									}
+									const selectedWorkingLineSpinner =
+										id === "workingLineSpinner" ? workingLineSpinnerId(newValue) : undefined;
+									if (selectedWorkingLineSpinner) {
+										const result = deps.setWorkingLineComponent(
+											{ spinner: selectedWorkingLineSpinner },
+											ctx,
+										);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Spinner", newValue, result);
+										return;
+									}
+									if (id === "workingLineSpinnerSpeed" || id === "workingLineTextSpeed") {
+										const spinnerSpeed = id === "workingLineSpinnerSpeed";
+										if (newValue === "Custom…") {
+											finishSettings(
+												spinnerSpeed
+													? "edit-working-line-spinner-speed"
+													: "edit-working-line-text-speed",
+											);
+											return;
+										}
+										const presets = spinnerSpeed
+											? workingLineSpinnerSpeedPresets
+											: workingLineTextSpeedPresets;
+										const intervalMs = presets.find(
+											(preset) => preset.label === newValue,
+										)?.intervalMs;
+										if (intervalMs !== undefined) {
+											const result = deps.setWorkingLineComponent(
+												spinnerSpeed
+													? { spinnerIntervalMs: intervalMs }
+													: { textIntervalMs: intervalMs },
+												ctx,
+											);
+											settingsList.updateValue(id, newValue);
+											notifyWorkingLineChange(
+												spinnerSpeed ? "Spinner speed" : "Text motion speed",
+												`${intervalMs} ms`,
+												result,
+											);
+										}
+										return;
+									}
+									if (
+										id === "workingLineTextAnimation" &&
+										workingLineTextAnimationValues.includes(newValue as WorkingLineTextAnimation)
+									) {
+										const result = deps.setWorkingLineComponent(
+											{ textAnimation: newValue as WorkingLineTextAnimation },
+											ctx,
+										);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Text animation", newValue, result);
+										return;
+									}
+									if (id === "workingLineColorSource" && isColorSource(newValue)) {
+										const result = deps.setWorkingLineComponent({ colorSource: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Color source", newValue, result);
+										return;
+									}
+									if (id === "workingLineAnimateSpinnerColor" && enabled !== undefined) {
+										const result = deps.setWorkingLineComponent(
+											{ animateSpinnerColor: enabled },
+											ctx,
+										);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Animate spinner color", newValue, result);
+										return;
+									}
+									if (id === "workingLineCustomMessages" && enabled !== undefined) {
+										const result = deps.setWorkingLineComponent(
+											{ messages: { custom: enabled } },
+											ctx,
+										);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange("Custom messages", newValue, result);
+										return;
+									}
+									if (
+										(id === "workingLineTool" ||
+											id === "workingLineElapsed" ||
+											id === "workingLineThought" ||
+											id === "workingLineTokens") &&
+										enabled !== undefined
+									) {
+										const key =
+											id === "workingLineTool"
+												? "tool"
+												: id === "workingLineElapsed"
+													? "elapsed"
+													: id === "workingLineThought"
+														? "thought"
+														: "tokens";
+										const result = deps.setWorkingLineComponent(
+											{ segments: { [key]: enabled } },
+											ctx,
+										);
+										settingsList.updateValue(id, newValue);
+										notifyWorkingLineChange(id.slice("workingLine".length), newValue, result);
+										return;
+									}
+									if (id === "workingLineMessageList") {
+										finishSettings("edit-working-line-messages");
+										return;
+									}
+									if (id === "selectorBordersEnabled" && enabled !== undefined) {
+										deps.setSelectorBordersComponent({ enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Selector borders", newValue);
+										return;
+									}
+									if (id === "selectorBordersStyle" && newValue === "zentui") {
+										deps.setSelectorBordersComponent({ style: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Selector border style", newValue);
+										return;
+									}
+									if (id === "selectorBordersColorSource" && isColorSource(newValue)) {
+										deps.setSelectorBordersComponent({ colorSource: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Selector border colors", newValue);
+										return;
+									}
+									if (id === "iconMode" && isIconMode(newValue)) {
+										deps.setIconMode(newValue);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Icon mode", newValue);
+										return;
+									}
+
+									const selectedFooterStyle =
+										id === "footerStyle" ? footerStyleId(newValue) : undefined;
+									if (selectedFooterStyle) {
+										setFooter({ style: selectedFooterStyle }, ctx);
+										settingsList = makeSettingsList("footerStyle");
+										notifyChange("Footer style", newValue);
+										return;
+									}
+									if (id === "footerColorSource" && isColorSource(newValue)) {
+										setFooter({ colorSource: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Footer colors", newValue);
+										return;
+									}
+									if (id === "footerModelLabel" && (newValue === "id" || newValue === "name")) {
+										setFooter({ modelLabel: newValue }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Footer model label", newValue);
+										return;
+									}
+
+									if (id === "responsiveFooter" && enabled !== undefined) {
+										deps.setResponsiveFooter({ responsiveFooter: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Responsive footer", newValue);
+										return;
+									}
+									if (
+										id === "compactFooterMaxLines" &&
+										compactFooterMaxLineValues.includes(newValue as never)
+									) {
+										const value: CompactFooterMaxLines =
+											newValue === "unlimited" ? "unlimited" : (Number(newValue) as 1 | 2 | 3);
+										deps.setResponsiveFooter({ compactFooterMaxLines: value }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Compact footer rows", newValue);
+										return;
+									}
+									if (
+										id === "contextStyle" &&
+										contextStyleValues.includes(newValue as ContextStyle)
+									) {
+										deps.setContextStyle(newValue as ContextStyle);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Context style", newValue);
+										return;
+									}
+									if (id === "separator" && isSeparatorStyle(newValue)) {
+										deps.setSeparator(newValue);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Separator", newValue);
+										return;
+									}
+									if (id === "pathDisplay" && pathDisplayModeValues.includes(newValue as never)) {
+										deps.setPathDisplay({ mode: newValue as PathDisplayConfig["mode"] });
+										settingsList.updateValue(id, newValue);
+										notifyChange("Path display", newValue);
+										return;
+									}
+									if (id === "pathDepth" && pathDepthValues.includes(newValue as never)) {
+										deps.setPathDisplay({ depth: Number(newValue) });
+										settingsList.updateValue(id, newValue);
+										notifyChange("Path depth", newValue);
+										return;
+									}
+
+									const segment = footerSegmentSettingFromId(id);
+									if (segment && enabled !== undefined) {
+										deps.setFooterSegments({ [segment]: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange(footerSegmentSettingLabels[segment], newValue);
+										return;
+									}
+									if (id === "branchLength") {
+										const value = newValue === "full" ? "full" : Number(newValue);
+										if (value !== "full" && (!Number.isInteger(value) || value <= 0)) return;
+										deps.setGitBranch({ maxLength: value });
+										settingsList.updateValue(id, newValue);
+										notifyChange("Branch length", newValue);
+										return;
+									}
+									if (id === "gitCommitOnlyDetached" && enabled !== undefined) {
+										deps.setGitCommit({ onlyDetached: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Commit only on detached HEAD", newValue);
+										return;
+									}
+									if (id === "gitCommitShowTag" && enabled !== undefined) {
+										deps.setGitCommit({ showTag: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Show exact-match tag", newValue);
+										return;
+									}
+									if (id === "gitMetricsOnlyNonzero" && enabled !== undefined) {
+										deps.setGitMetrics({ onlyNonzero: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Hide zero metrics", newValue);
+										return;
+									}
+									if (id === "gitMetricsIgnoreSubmodules" && enabled !== undefined) {
+										deps.setGitMetrics({ ignoreSubmodules: enabled }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Ignore submodules", newValue);
+										return;
+									}
+
+									if (
+										id === "extensionStatusDefaultPlacement" &&
+										isExtensionStatusPlacement(newValue)
+									) {
+										deps.setExtensionStatusDefaultPlacement(newValue);
+										settingsList = makeSettingsList("extensionStatusDefaultPlacement");
+										notifyChange("Default extension status placement", newValue);
+										return;
+									}
+									const thirdParty = thirdPartyStatusSettingFromId(id);
+									if (thirdParty?.kind === "placement" && isExtensionStatusPlacement(newValue)) {
+										deps.setExtensionStatusPlacement(thirdParty.key, newValue);
+										settingsList.updateValue(id, newValue);
+										notifyChange(`Third-party status ${thirdParty.key} placement`, newValue);
+										return;
+									}
+									if (thirdParty?.kind === "colorMode" && isExtensionStatusColorMode(newValue)) {
+										deps.setExtensionStatusColorMode(thirdParty.key, newValue);
+										settingsList.updateValue(id, newValue);
+										notifyChange(`Third-party status ${thirdParty.key} color`, newValue);
+									}
+								} catch (error) {
+									stopPreview();
+									settingsList = makeSettingsList(id);
+									tui.requestRender();
+									ctx.ui.notify(
+										`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+										"error",
+									);
+								}
+							},
+							() => finishSettings("close"),
+						);
+						if (focusId) {
+							const target = items.findIndex((item) => item.id === focusId);
+							for (let index = 0; index < target; index += 1) list.handleInput("\x1b[B");
 						}
-						if (matchesKey(data, Key.shift("tab"))) {
-							activeSection = previousSection(activeSection);
-							settingsList = makeSettingsList();
-							tui.requestRender();
-							return;
+						return list;
+					};
+					settingsList = makeSettingsList(initialFocusId);
+					startPreview();
+					return {
+						render(width: number) {
+							const border = renderChromeBorder(
+								theme,
+								deps.getConfig().components.selectorBorders.colorSource,
+								EDITOR_BORDER_STYLE,
+								"─".repeat(Math.max(0, width)),
+							);
+							return [
+								truncateToWidth(border, width, ""),
+								truncateToWidth(formatSectionTabs(activeSection, theme, width), width, ""),
+								truncateToWidth(border, width, ""),
+								...(activeSection === "workingLine" && preview && preview.frames.length > 0
+									? [
+											truncateToWidth(
+												`  ${preview.frames[previewFrameIndex] ?? preview.frames[0]}`,
+												width,
+												"",
+											),
+										]
+									: []),
+								...withSectionFooter(settingsList.render(width), theme).map((line) =>
+									truncateToWidth(line, width, ""),
+								),
+								truncateToWidth(border, width, ""),
+							];
+						},
+						invalidate() {
+							settingsList.invalidate();
+						},
+						handleInput(data: string) {
+							if (matchesKey(data, Key.tab)) {
+								stopPreview();
+								activeSection = nextSection(activeSection);
+								settingsList = makeSettingsList();
+								startPreview();
+								tui.requestRender();
+								return;
+							}
+							if (matchesKey(data, Key.shift("tab"))) {
+								stopPreview();
+								activeSection = previousSection(activeSection);
+								settingsList = makeSettingsList();
+								startPreview();
+								tui.requestRender();
+								return;
+							}
+							settingsList.handleInput(data);
+						},
+						dispose() {
+							stopPreview();
+						},
+					};
+				});
+				if (outcome === "close" || outcome === undefined) return;
+				if (
+					outcome === "edit-working-line-spinner-speed" ||
+					outcome === "edit-working-line-text-speed"
+				) {
+					const spinnerSpeed = outcome === "edit-working-line-spinner-speed";
+					const workingLine = deps.getConfig().components.workingLine;
+					const before = spinnerSpeed ? workingLine.spinnerIntervalMs : workingLine.textIntervalMs;
+					const label = spinnerSpeed ? "Spinner speed" : "Text motion speed";
+					try {
+						const edited = await ctx.ui.input(
+							`${label} (${MIN_WORKING_LINE_INTERVAL_MS}–${MAX_WORKING_LINE_INTERVAL_MS} ms)`,
+							String(before),
+						);
+						if (edited === undefined) {
+							ctx.ui.notify(`${label} unchanged (input canceled)`, "info");
+						} else {
+							const trimmed = edited.trim();
+							const intervalMs = /^[+-]?\d+$/.test(trimmed) ? Number(trimmed) : Number.NaN;
+							if (!isValidWorkingLineIntervalMs(intervalMs)) {
+								ctx.ui.notify(
+									`${label} must be a whole number from ${MIN_WORKING_LINE_INTERVAL_MS} to ${MAX_WORKING_LINE_INTERVAL_MS} ms; unchanged.`,
+									"warning",
+								);
+							} else {
+								const result = deps.setWorkingLineComponent(
+									spinnerSpeed ? { spinnerIntervalMs: intervalMs } : { textIntervalMs: intervalMs },
+									ctx,
+								);
+								ctx.ui.notify(
+									`${label}: ${intervalMs} ms${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+									"info",
+								);
+							}
 						}
-						settingsList.handleInput(data);
-					},
-				};
-			});
+					} catch (error) {
+						ctx.ui.notify(
+							`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+							"error",
+						);
+					}
+					requestedSection = "workingLine";
+					requestedFocusId = spinnerSpeed ? "workingLineSpinnerSpeed" : "workingLineTextSpeed";
+					continue;
+				}
+				try {
+					const before = deps.getConfig().components.workingLine.messages.values.join("\n");
+					const edited = await ctx.ui.editor("Working line message list", before);
+					if (edited !== undefined) {
+						const values = normalizeWorkingLineMessages(edited.split(/\r?\n/));
+						const result = deps.setWorkingLineComponent({ messages: { values } }, ctx);
+						ctx.ui.notify(
+							`Message list: ${values.length}${values.length === 0 ? " (using styled Working…)" : ""}${result.applied ? "" : ` (${result.reason ?? "reload Pi to apply this change"})`}`,
+							"info",
+						);
+					}
+				} catch (error) {
+					ctx.ui.notify(
+						`Could not update Zentui settings: ${error instanceof Error ? error.message : String(error)}`,
+						"error",
+					);
+				}
+				requestedSection = "workingLine";
+				requestedFocusId = "workingLineMessageList";
+			}
 		},
 	});
 }

--- a/extensions/zentui/style.ts
+++ b/extensions/zentui/style.ts
@@ -12,6 +12,8 @@ export type { ThemeLike };
 
 export const EDITOR_ACCENT_STYLE = "blue";
 export const EDITOR_BORDER_STYLE = "bright-black";
+export const MAX_SAFE_SGR_PREFIX_CODE_UNITS = 96;
+export const MAX_SAFE_SGR_PREFIX_SEQUENCES = 4;
 
 export type SourceStyleFallback = {
 	theme: ColorSpec;
@@ -239,6 +241,66 @@ export function colorize(theme: ThemeLike, color: ColorSpec, text: string): stri
  * Render text with Starship-style terminal styling strings (e.g. "bold red", "fg:202",
  * "bg:blue", "underline bg:#bf5700").
  */
+function isSafeSgrParameters(parameters: string): boolean {
+	const tokens = parameters.split(";");
+	if (tokens.some((token) => !/^\d+$/.test(token))) return false;
+	const values = tokens.map(Number);
+	for (let index = 0; index < values.length; index += 1) {
+		const value = values[index];
+		if (
+			value === 1 ||
+			value === 2 ||
+			value === 3 ||
+			value === 4 ||
+			(value !== undefined && value >= 30 && value <= 37) ||
+			(value !== undefined && value >= 40 && value <= 47) ||
+			(value !== undefined && value >= 90 && value <= 97) ||
+			(value !== undefined && value >= 100 && value <= 107)
+		) {
+			continue;
+		}
+		if (value !== 38 && value !== 48) return false;
+		const mode = values[index + 1];
+		if (mode === 5) {
+			const color = values[index + 2];
+			if (color === undefined || color < 0 || color > 255) return false;
+			index += 2;
+			continue;
+		}
+		if (mode === 2) {
+			const channels = values.slice(index + 2, index + 5);
+			if (channels.length !== 3 || channels.some((channel) => channel < 0 || channel > 255)) {
+				return false;
+			}
+			index += 4;
+			continue;
+		}
+		return false;
+	}
+	return true;
+}
+
+/** Accept only the bounded SGR subset emitted by Zentui's supported style tokens. */
+export function isSafeSgrStylePrefix(value: unknown): value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value.length > MAX_SAFE_SGR_PREFIX_CODE_UNITS
+	) {
+		return false;
+	}
+	const sequence = /\x1b\[([0-9]+(?:;[0-9]+)*)m/g;
+	let offset = 0;
+	let count = 0;
+	for (const match of value.matchAll(sequence)) {
+		if (match.index !== offset || !isSafeSgrParameters(match[1] ?? "")) return false;
+		offset = match.index + match[0].length;
+		count += 1;
+		if (count > MAX_SAFE_SGR_PREFIX_SEQUENCES) return false;
+	}
+	return count > 0 && offset === value.length;
+}
+
 export function renderTerminalStyle(style: string, text: string): string {
 	const codes: string[] = [];
 	for (const token of style.trim().split(/\s+/)) {

--- a/extensions/zentui/working-line-messages.ts
+++ b/extensions/zentui/working-line-messages.ts
@@ -1,0 +1,24 @@
+/** The built-in Working-line verb catalog, in display order. */
+export const PI_WORKING_LINE_DEFAULT_PHRASES = [
+	"Sautéing",
+	"Cooking",
+	"Ionizing",
+	"Zigzagging",
+	"Razzle-dazzling",
+	"Photosynthesizing",
+	"Nucleating",
+	"Brewing",
+	"Combobulating",
+	"Boogieing",
+	"Befuddling",
+	"Alchemizing",
+	"Conjuring",
+	"Baking",
+	"Simmering",
+	"Blanching",
+] as const;
+
+/** Complete visible messages derived consistently from the built-in verb catalog. */
+export const PI_WORKING_LINE_MESSAGES = PI_WORKING_LINE_DEFAULT_PHRASES.map(
+	(phrase) => `${phrase}…`,
+);

--- a/extensions/zentui/working-line-spinners.ts
+++ b/extensions/zentui/working-line-spinners.ts
@@ -1,0 +1,54 @@
+import type { WorkingLineSpinner } from "./config";
+
+/*
+ * Pulse frames adapted from Funky UI's animations.ts:
+ * https://github.com/pi-zza/funky-ui/blob/e9aed319a4de61c2b2a5e99009821efa7b67b178/packages/funky-ui/extensions/funky-ui/animations.ts
+ * Frozen imported source revision:
+ * https://github.com/lmilojevicc/pi-zza/blob/37d82d565c1f5a9aa9b31d4b1711fa5604eb04a1/packages/funky-ui/extensions/funky-ui/animations.ts
+ *
+ * Funky UI's NOTICE states that the package combines Marko Nakic's Funky UI
+ * source with code derived from FammasMaz/pi-cc-tools, published as
+ * pi-claude-style-tools.
+ *
+ * MIT License
+ *
+ * Copyright (c) FammasMaz/pi-cc-tools contributors
+ * Copyright (c) 2026 Marko Nakic
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/** Spinner definitions contain frames only; spinnerIntervalMs remains user-controlled. */
+export const WORKING_LINE_SPINNERS = {
+	braille: {
+		frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+	},
+	"star-bloom": {
+		frames: ["·", "✦", "✧", "✶", "✧", "✦"],
+	},
+	pinwheel: {
+		frames: ["-", "\\", "|", "/"],
+	},
+	"claude-inspired": {
+		frames: ["·", "✢", "✳", "✶", "✻", "✽"],
+	},
+	pulse: {
+		frames: ["⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈"],
+	},
+} as const satisfies Record<WorkingLineSpinner, { frames: readonly string[] }>;

--- a/extensions/zentui/working-line.ts
+++ b/extensions/zentui/working-line.ts
@@ -1,4 +1,5 @@
-import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { stripVTControlCharacters } from "node:util";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import type {
 	ColorSpec,
 	PolishedTuiColors,
@@ -198,7 +199,7 @@ function stripC1TerminalSequences(value: string): string {
 export function normalizeWorkingLineMessage(value: unknown): string {
 	if (typeof value !== "string") return "";
 	const bounded = boundRawWorkingLineInput(value);
-	const withoutTerminalSequences = stripTerminalSequences(stripC1TerminalSequences(bounded));
+	const withoutTerminalSequences = stripVTControlCharacters(stripC1TerminalSequences(bounded));
 	const withoutControls = withoutTerminalSequences
 		.replaceAll(/[\u0000-\u001f\u007f-\u009f]/g, " ")
 		.replaceAll(/[\u034f\u061c\u200b\u200e\u200f\u202a-\u202e\u2060\u2066-\u206f]/g, "");

--- a/extensions/zentui/working-line.ts
+++ b/extensions/zentui/working-line.ts
@@ -1,0 +1,1431 @@
+import { stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import type {
+	ColorSpec,
+	PolishedTuiColors,
+	WorkingLineComponentConfig,
+	WorkingLineTextAnimation,
+	ZentuiConfig,
+} from "./config";
+import {
+	isSafeSgrStylePrefix,
+	isSupportedColorSpec,
+	renderStyleForSourceOrFallback,
+	type SourceStyleFallback,
+	type ThemeLike,
+} from "./style";
+import { PI_WORKING_LINE_MESSAGES } from "./working-line-messages";
+import { WORKING_LINE_SPINNERS } from "./working-line-spinners";
+
+export { WORKING_LINE_SPINNERS } from "./working-line-spinners";
+
+export const BUILT_IN_WORKING_LINE_MESSAGES = PI_WORKING_LINE_MESSAGES;
+export const WORKING_LINE_FALLBACK_MESSAGE = "Working…";
+
+export const MAX_WORKING_LINE_MESSAGES = 48;
+/** Complete Loader row, including its two margins and Pi's indicator separator. */
+export const MAX_WORKING_LINE_ROW_CELLS = 80;
+/** Indicator payload budget inside the complete Loader row. */
+export const MAX_WORKING_LINE_FRAME_CELLS = MAX_WORKING_LINE_ROW_CELLS - 3;
+export const MAX_WORKING_LINE_MESSAGE_CELLS = 43;
+export const MAX_WORKING_LINE_TOOL_CELLS = 18;
+export const MAX_WORKING_LINE_FRAMES = 1024;
+export const MAX_WORKING_LINE_FRAME_CODE_UNITS = 512 * 1024;
+export const MAX_WORKING_LINE_RAW_CODE_UNITS = 4096;
+/** Keeps combining-rich visible text bounded before it is copied into every animation frame. */
+export const MAX_WORKING_LINE_NORMALIZED_CODE_UNITS = 256;
+/** Three modifiers plus one color are sufficient for each Working-line tier. */
+export const MAX_WORKING_LINE_STYLE_TOKENS = 4;
+export const MAX_WORKING_LINE_STYLE_CODE_UNITS = 48;
+export const MAX_WORKING_LINE_ENTRIES_EXAMINED = 256;
+
+const WORKING_LINE_FALLBACKS: Record<"low" | "mid" | "high", SourceStyleFallback> = {
+	low: { theme: "dim", terminal: "bright-black" },
+	mid: { theme: "muted", terminal: "cyan" },
+	high: { theme: "bold accent", terminal: "bold cyan" },
+};
+const CLASSIC_PADDING_CELLS = 4;
+const CLASSIC_HIGHLIGHT_HALF_WIDTH = 4;
+const KITT_TRAIL_CELLS = 4;
+const SGR_RESET = "\x1b[0m";
+
+type Tier = "low" | "mid" | "high";
+type GraphemeCell = { text: string; start: number; width: number };
+
+type WorkingLineUi = {
+	setWorkingMessage(message?: string): void;
+	setWorkingIndicator(options?: { frames?: string[]; intervalMs?: number }): void;
+};
+
+type WorkingLineContext = {
+	hasUI?: boolean;
+	mode?: string;
+	ui: object;
+};
+
+type AgentDurationListener = (durationMs: number) => void;
+
+/** One agent-duration clock shared by minimalist Editor and Working-line consumers. */
+export class AgentDurationClock {
+	private startedAt: number | undefined;
+	private completedMs: number | undefined;
+	private timer: ReturnType<typeof setInterval> | undefined;
+	private readonly listeners = new Set<AgentDurationListener>();
+
+	start(now = Date.now()): void {
+		this.stopTimer();
+		this.startedAt = now;
+		this.completedMs = 0;
+		this.notify();
+		this.reconcileTimer();
+	}
+
+	finish(now = Date.now()): void {
+		if (this.startedAt !== undefined) this.completedMs = Math.max(0, now - this.startedAt);
+		this.startedAt = undefined;
+		this.notify();
+		this.stopTimer();
+	}
+
+	reset(): void {
+		this.stopTimer();
+		this.startedAt = undefined;
+		this.completedMs = undefined;
+	}
+
+	isActive(): boolean {
+		return this.startedAt !== undefined;
+	}
+
+	elapsedMs(now = Date.now()): number | undefined {
+		return this.startedAt === undefined ? this.completedMs : Math.max(0, now - this.startedAt);
+	}
+
+	subscribe(listener: AgentDurationListener): () => void {
+		this.listeners.add(listener);
+		this.reconcileTimer();
+		let active = true;
+		return () => {
+			if (!active) return;
+			active = false;
+			this.listeners.delete(listener);
+			this.reconcileTimer();
+		};
+	}
+
+	private notify(): void {
+		const elapsed = this.elapsedMs();
+		if (elapsed === undefined) return;
+		for (const listener of this.listeners) listener(elapsed);
+	}
+
+	private reconcileTimer(): void {
+		if (!this.isActive() || this.listeners.size === 0) {
+			this.stopTimer();
+			return;
+		}
+		if (this.timer !== undefined) return;
+		this.timer = setInterval(() => this.notify(), 1000);
+	}
+
+	private stopTimer(): void {
+		if (this.timer === undefined) return;
+		clearInterval(this.timer);
+		this.timer = undefined;
+	}
+}
+
+function segmentGraphemes(value: string): Iterable<string> {
+	try {
+		const Segmenter = Intl.Segmenter;
+		if (typeof Segmenter === "function") {
+			const segments = new Segmenter(undefined, { granularity: "grapheme" }).segment(value);
+			return {
+				*[Symbol.iterator]() {
+					for (const part of segments) yield part.segment;
+				},
+			};
+		}
+	} catch {
+		// Without Intl.Segmenter, treat the complete value as one conservative grapheme.
+	}
+	return [value];
+}
+
+function truncateGraphemes(
+	value: string,
+	maximumCells: number,
+	maximumCodeUnits = Number.POSITIVE_INFINITY,
+): string {
+	let width = 0;
+	let codeUnits = 0;
+	const output: string[] = [];
+	for (const grapheme of segmentGraphemes(value)) {
+		if (width >= maximumCells) break;
+		const nextWidth = visibleWidth(grapheme);
+		if (width + nextWidth > maximumCells) break;
+		if (codeUnits + grapheme.length > maximumCodeUnits) break;
+		output.push(grapheme);
+		width += nextWidth;
+		codeUnits += grapheme.length;
+	}
+	while (output.length > 0 && /^\s+$/u.test(output.at(-1) ?? "")) output.pop();
+	return output.join("");
+}
+
+function boundRawWorkingLineInput(value: string): string {
+	if (value.length <= MAX_WORKING_LINE_RAW_CODE_UNITS) return value;
+	const prefix = value.slice(0, MAX_WORKING_LINE_RAW_CODE_UNITS);
+	const graphemes = [...segmentGraphemes(prefix)];
+	// The last segmented item may be only the prefix of a grapheme that crosses the raw bound.
+	graphemes.pop();
+	return graphemes.join("");
+}
+
+function trimGraphemeWhitespace(value: string): string {
+	const graphemes = [...segmentGraphemes(value)];
+	while (graphemes.length > 0 && /^\s+$/u.test(graphemes[0] ?? "")) graphemes.shift();
+	while (graphemes.length > 0 && /^\s+$/u.test(graphemes.at(-1) ?? "")) graphemes.pop();
+	return graphemes.join("");
+}
+
+function stripC1TerminalSequences(value: string): string {
+	return value
+		.replaceAll(/[\u0090\u0098\u009d\u009e\u009f][\s\S]*?(?:\u0007|\u009c|\x1b\\|$)/g, "")
+		.replaceAll(/\u009b[0-?]*[ -/]*[@-~]/g, "");
+}
+
+/** Normalize untrusted user-authored text before it can reach Pi's working row. */
+export function normalizeWorkingLineMessage(value: unknown): string {
+	if (typeof value !== "string") return "";
+	const bounded = boundRawWorkingLineInput(value);
+	const withoutTerminalSequences = stripTerminalSequences(stripC1TerminalSequences(bounded));
+	const withoutControls = withoutTerminalSequences
+		.replaceAll(/[\u0000-\u001f\u007f-\u009f]/g, " ")
+		.replaceAll(/[\u034f\u061c\u200b\u200e\u200f\u202a-\u202e\u2060\u2066-\u206f]/g, "");
+	const normalized = trimGraphemeWhitespace(
+		withoutControls.normalize("NFC").replaceAll(/\s+/gu, " "),
+	);
+	const truncated = truncateGraphemes(
+		normalized,
+		MAX_WORKING_LINE_MESSAGE_CELLS,
+		MAX_WORKING_LINE_NORMALIZED_CODE_UNITS,
+	);
+	return visibleWidth(truncated) > 0 ? truncated : "";
+}
+
+export function normalizeWorkingLineMessages(values: unknown): string[] {
+	if (!Array.isArray(values)) return [];
+	const output: string[] = [];
+	const seen = new Set<string>();
+	const examined = Math.min(values.length, MAX_WORKING_LINE_ENTRIES_EXAMINED);
+	for (let index = 0; index < examined; index += 1) {
+		const normalized = normalizeWorkingLineMessage(values[index]);
+		if (!normalized || seen.has(normalized)) continue;
+		seen.add(normalized);
+		output.push(normalized);
+		if (output.length === MAX_WORKING_LINE_MESSAGES) break;
+	}
+	return output;
+}
+
+export function effectiveWorkingLineMessages(config: WorkingLineComponentConfig): string[] {
+	if (!config.messages.custom) return [WORKING_LINE_FALLBACK_MESSAGE];
+	const custom = normalizeWorkingLineMessages(config.messages.values);
+	return custom.length > 0 ? custom : [WORKING_LINE_FALLBACK_MESSAGE];
+}
+
+export function selectWorkingLineMessage(
+	config: WorkingLineComponentConfig,
+	random: () => number = Math.random,
+): string {
+	const pool = effectiveWorkingLineMessages(config);
+	if (!config.messages.custom || pool.length <= 1) return pool[0] ?? WORKING_LINE_FALLBACK_MESSAGE;
+	const sample = random();
+	const finite = Number.isFinite(sample) ? sample : 0;
+	const index = Math.min(pool.length - 1, Math.max(0, Math.floor(finite * pool.length)));
+	return pool[index] ?? WORKING_LINE_FALLBACK_MESSAGE;
+}
+
+function gcd(left: number, right: number): number {
+	let a = left;
+	let b = right;
+	while (b !== 0) {
+		const remainder = a % b;
+		a = b;
+		b = remainder;
+	}
+	return a;
+}
+
+function lcm(left: number, right: number): number {
+	return (left / gcd(left, right)) * right;
+}
+
+function schedulePeriod(intervalMs: number, cycleAdvances: number, quantumMs: number): number {
+	const product = intervalMs * cycleAdvances;
+	return product / gcd(quantumMs, product);
+}
+
+function graphemeCells(message: string): { cells: GraphemeCell[]; width: number } {
+	const cells: GraphemeCell[] = [];
+	let start = 0;
+	for (const text of segmentGraphemes(message)) {
+		const width = visibleWidth(text);
+		cells.push({ text, start, width });
+		start += width;
+	}
+	return { cells, width: start };
+}
+
+function classicTier(cell: GraphemeCell, tick: number): Tier {
+	const center = tick - CLASSIC_PADDING_CELLS;
+	const cellCenter = cell.start + Math.max(0, cell.width - 1) / 2;
+	const distance = Math.abs(cellCenter - center);
+	if (distance <= 1) return "high";
+	if (distance <= CLASSIC_HIGHLIGHT_HALF_WIDTH) return "mid";
+	return "low";
+}
+
+function kittHead(tick: number, width: number): { position: number; direction: 1 | -1 } {
+	const span = width + KITT_TRAIL_CELLS - 1;
+	if (tick < span) return { position: tick - (KITT_TRAIL_CELLS - 1), direction: 1 };
+	return {
+		position: span * 2 - 2 - tick - (KITT_TRAIL_CELLS - 1),
+		direction: -1,
+	};
+}
+
+function kittTier(cell: GraphemeCell, tick: number, width: number): Tier {
+	const { position, direction } = kittHead(tick, width);
+	const cellEnd = cell.start + cell.width;
+	if (position >= cell.start && position < cellEnd) return "high";
+	const cellCenter = cell.start + Math.max(0, cell.width - 1) / 2;
+	const distance = direction === 1 ? position - cellCenter : cellCenter - position;
+	if (distance > 0 && distance <= KITT_TRAIL_CELLS) return "mid";
+	return "low";
+}
+
+function textPeriod(animation: WorkingLineTextAnimation, width: number): number {
+	switch (animation) {
+		case "classic":
+			return width + CLASSIC_PADDING_CELLS * 2;
+		case "kitt":
+			return (width + KITT_TRAIL_CELLS - 2) * 2;
+		case "disabled":
+			return 1;
+	}
+}
+
+type TextSpatialPhase = { position: number; direction: 1 | -1 };
+
+function normalizedPhaseTick(tick: number, period: number): number {
+	const integral = Number.isFinite(tick) ? Math.floor(tick) : 0;
+	return ((integral % period) + period) % period;
+}
+
+function textSpatialPhase(
+	animation: WorkingLineTextAnimation,
+	width: number,
+	tick: number,
+): TextSpatialPhase | undefined {
+	const phase = normalizedPhaseTick(tick, textPeriod(animation, width));
+	switch (animation) {
+		case "classic":
+			return { position: phase - CLASSIC_PADDING_CELLS, direction: 1 };
+		case "kitt":
+			return kittHead(phase, width);
+		case "disabled":
+			return undefined;
+	}
+}
+
+function textTickForSpatialPhase(
+	animation: WorkingLineTextAnimation,
+	width: number,
+	spatial: TextSpatialPhase | undefined,
+): number {
+	if (!spatial || animation === "disabled") return 0;
+	if (animation === "classic") {
+		const position = Math.min(
+			width + CLASSIC_PADDING_CELLS - 1,
+			Math.max(-CLASSIC_PADDING_CELLS, spatial.position),
+		);
+		return position + CLASSIC_PADDING_CELLS;
+	}
+	if (spatial.direction === 1) {
+		const position = Math.min(width - 1, Math.max(-(KITT_TRAIL_CELLS - 1), spatial.position));
+		return position + KITT_TRAIL_CELLS - 1;
+	}
+	const position = Math.min(width - 2, Math.max(-(KITT_TRAIL_CELLS - 2), spatial.position));
+	return width * 2 + 1 - position;
+}
+
+export function remapWorkingLineTextTick(
+	fromAnimation: WorkingLineTextAnimation,
+	fromWidth: number,
+	fromTick: number,
+	toAnimation: WorkingLineTextAnimation,
+	toWidth: number,
+	fromOrigin = 0,
+	toOrigin = 0,
+): number {
+	const spatial = textSpatialPhase(fromAnimation, fromWidth, fromTick);
+	return textTickForSpatialPhase(
+		toAnimation,
+		toWidth,
+		spatial ? { ...spatial, position: spatial.position + fromOrigin - toOrigin } : undefined,
+	);
+}
+
+function styleForTier(colors: PolishedTuiColors, tier: Tier): ColorSpec | undefined {
+	switch (tier) {
+		case "low":
+			return colors.workingLineLow;
+		case "mid":
+			return colors.workingLineMid;
+		case "high":
+			return colors.workingLineHigh;
+	}
+}
+
+/** Normalize only Working-line palette specs before they are repeated across generated frames. */
+export function normalizeWorkingLineStyleSpec(value: ColorSpec | undefined): ColorSpec | undefined {
+	if (value === undefined) return undefined;
+	const tokens: string[] = [];
+	const seen = new Set<string>();
+	let codeUnits = 0;
+	for (const match of value.matchAll(/\S+/g)) {
+		const token = match[0];
+		if (!isSupportedColorSpec(token)) return undefined;
+		const lower = token.toLowerCase();
+		const equivalent = lower === "dimmed" ? "dim" : lower;
+		if (seen.has(equivalent)) continue;
+		const separator = tokens.length > 0 ? 1 : 0;
+		if (
+			tokens.length === MAX_WORKING_LINE_STYLE_TOKENS ||
+			codeUnits + separator + token.length > MAX_WORKING_LINE_STYLE_CODE_UNITS
+		) {
+			return undefined;
+		}
+		seen.add(equivalent);
+		tokens.push(equivalent === "dim" ? "dim" : token);
+		codeUnits += separator + token.length;
+	}
+	return tokens.join(" ");
+}
+
+function renderTier(
+	theme: ThemeLike,
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	tier: Tier,
+	text: string,
+): string {
+	return renderStyleForSourceOrFallback(
+		theme,
+		config.colorSource,
+		normalizeWorkingLineStyleSpec(styleForTier(colors, tier)),
+		WORKING_LINE_FALLBACKS[tier],
+		text,
+	);
+}
+
+/** Resolve the fixed, nonanimated high-tier style used by persisted Turn summaries. */
+export function renderWorkingLineHigh(
+	theme: ThemeLike,
+	colorSource: WorkingLineComponentConfig["colorSource"],
+	style: ColorSpec | undefined,
+	text: string,
+): string {
+	return renderStyleForSourceOrFallback(
+		theme,
+		colorSource,
+		normalizeWorkingLineStyleSpec(style),
+		WORKING_LINE_FALLBACKS.high,
+		text,
+	);
+}
+
+export function snapshotWorkingLineHighStyle(
+	theme: ThemeLike,
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+): string {
+	const sentinel = "\u{f0000}";
+	const rendered = renderWorkingLineHigh(
+		theme,
+		config.colorSource,
+		colors.workingLineHigh,
+		sentinel,
+	);
+	const position = rendered.indexOf(sentinel);
+	const prefix = position >= 0 ? rendered.slice(0, position) : "";
+	return isSafeSgrStylePrefix(prefix) ? prefix : "\x1b[1;36m";
+}
+
+function renderAnimatedText(
+	theme: ThemeLike,
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	cells: GraphemeCell[],
+	width: number,
+	tick: number,
+	animation: WorkingLineTextAnimation,
+): string {
+	const runs: Array<{ tier: Tier; text: string }> = [];
+	for (const cell of cells) {
+		const tier =
+			animation === "disabled"
+				? "mid"
+				: animation === "classic"
+					? classicTier(cell, tick)
+					: kittTier(cell, tick, width);
+		const previous = runs.at(-1);
+		if (previous?.tier === tier) previous.text += cell.text;
+		else runs.push({ tier, text: cell.text });
+	}
+	return runs.map((run) => renderTier(theme, config, colors, run.tier, run.text)).join("");
+}
+
+export type WorkingLineRuntimeSegments = {
+	tool?: string;
+	elapsedMs?: number;
+	thought?: { durationMs: number; active: boolean };
+	tokens?: { input: number; output: number; outputApproximate?: boolean };
+};
+
+export type WorkingLineFrameState = {
+	spinnerTick: number;
+	textTick: number;
+};
+
+export type WorkingLineSchedulerMetadata = {
+	quantumMs: number;
+	effectiveSpinnerIntervalMs: number;
+	effectiveTextIntervalMs?: number;
+	exact: boolean;
+	spinnerSeamless: boolean;
+	textSeamless: boolean;
+	spinnerAdvances: number;
+	textAdvances: number;
+};
+
+export type WorkingLineFrames = {
+	frames: string[];
+	frameStates: WorkingLineFrameState[];
+	intervalMs: number;
+	message: string;
+	row: string;
+	textAnimation: WorkingLineTextAnimation;
+	textWidth: number;
+	textOrigin: number;
+	scheduler: WorkingLineSchedulerMetadata;
+};
+
+export function formatWorkingLineElapsed(durationMs: number): string {
+	const totalSeconds = Math.max(0, Math.floor(durationMs / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0)
+		return `${hours}h${String(minutes).padStart(2, "0")}m${String(seconds).padStart(2, "0")}s`;
+	if (minutes > 0) return `${minutes}m${String(seconds).padStart(2, "0")}s`;
+	return `${seconds}s`;
+}
+
+export function formatWorkingLineThought(
+	thought: NonNullable<WorkingLineRuntimeSegments["thought"]>,
+): string | undefined {
+	if (!thought.active && thought.durationMs <= 0) return undefined;
+	return `${thought.active ? "thinking" : "thought for"} ${formatWorkingLineElapsed(thought.durationMs)}`;
+}
+
+export function normalizeWorkingLineToolLabel(value: unknown): string {
+	const normalized = normalizeWorkingLineMessage(value);
+	if (visibleWidth(normalized) <= MAX_WORKING_LINE_TOOL_CELLS) return normalized;
+	const prefix = truncateGraphemes(normalized, MAX_WORKING_LINE_TOOL_CELLS - 1);
+	return prefix ? `${prefix}…` : "";
+}
+
+export function formatWorkingLineTokens(
+	tokens: WorkingLineRuntimeSegments["tokens"],
+): string | undefined {
+	if (
+		!tokens ||
+		!Number.isSafeInteger(tokens.input) ||
+		!Number.isSafeInteger(tokens.output) ||
+		tokens.input < 0 ||
+		tokens.output < 0 ||
+		(tokens.outputApproximate !== undefined && typeof tokens.outputApproximate !== "boolean")
+	) {
+		return undefined;
+	}
+	return `↑${tokens.input} ↓${tokens.output}`;
+}
+
+function truncateWithEllipsis(value: string, capacity: number): string {
+	if (visibleWidth(value) <= capacity) return value;
+	if (capacity <= 0) return "";
+	if (capacity === 1) return "…";
+	const prefix = truncateGraphemes(value, capacity - 1);
+	return prefix ? `${prefix}…` : "";
+}
+
+export type ComposedWorkingLine = { message: string; row: string };
+
+/** Validate and measure the fixed visible width shared by every frame in a preset. */
+export function workingLineSpinnerWidth(spinnerId: WorkingLineComponentConfig["spinner"]): number {
+	const frames: readonly string[] = WORKING_LINE_SPINNERS[spinnerId].frames;
+	const width = visibleWidth(frames[0] ?? "");
+	if (width <= 0 || frames.some((frame) => visibleWidth(frame) !== width)) {
+		throw new Error("Working-line spinner frames must share a positive fixed width");
+	}
+	return width;
+}
+
+/** Compose visual Message · Tool · Elapsed · Thought · Tokens order with tokens reserved first. */
+export function composeWorkingLineRow(
+	config: WorkingLineComponentConfig,
+	message: string,
+	runtime: WorkingLineRuntimeSegments = {},
+): ComposedWorkingLine {
+	const normalized = normalizeWorkingLineMessage(message) || WORKING_LINE_FALLBACK_MESSAGE;
+	const maximumRowCells =
+		MAX_WORKING_LINE_FRAME_CELLS - workingLineSpinnerWidth(config.spinner) - visibleWidth(" ");
+	const delimiter = " · ";
+	const tokens = config.segments.tokens ? formatWorkingLineTokens(runtime.tokens) : undefined;
+	const mandatoryWidth = tokens ? visibleWidth(delimiter) + visibleWidth(tokens) : 0;
+	const messageCapacity = maximumRowCells - mandatoryWidth;
+	const fittedMessage = truncateWithEllipsis(normalized, messageCapacity);
+	const segments: string[] = [fittedMessage];
+	let remaining = maximumRowCells - visibleWidth(fittedMessage) - mandatoryWidth;
+	const elapsed =
+		config.segments.elapsed && runtime.elapsedMs !== undefined
+			? formatWorkingLineElapsed(runtime.elapsedMs)
+			: undefined;
+	const thought =
+		config.segments.thought && runtime.thought
+			? formatWorkingLineThought(runtime.thought)
+			: undefined;
+	const tool =
+		config.segments.tool && runtime.tool ? normalizeWorkingLineToolLabel(runtime.tool) : undefined;
+	const accepted = new Set<"thought" | "elapsed" | "tool">();
+	for (const [key, label] of [
+		["thought", thought],
+		["elapsed", elapsed],
+	] as const) {
+		if (label && remaining >= visibleWidth(delimiter) + visibleWidth(label)) {
+			remaining -= visibleWidth(delimiter) + visibleWidth(label);
+			accepted.add(key);
+		}
+	}
+	let fittedTool = "";
+	if (tool && remaining > visibleWidth(delimiter)) {
+		fittedTool = truncateWithEllipsis(tool, remaining - visibleWidth(delimiter));
+		if (fittedTool) accepted.add("tool");
+	}
+	if (accepted.has("tool")) segments.push(fittedTool);
+	if (accepted.has("elapsed") && elapsed) segments.push(elapsed);
+	if (accepted.has("thought") && thought) segments.push(thought);
+	if (tokens) segments.push(tokens);
+	return { message: normalized, row: segments.filter(Boolean).join(delimiter) };
+}
+
+type ScheduleDefinition = {
+	frameCount: number;
+	stateAt: (index: number) => WorkingLineFrameState;
+	metadata: WorkingLineSchedulerMetadata;
+};
+
+function exactSchedule(
+	spinnerIntervalMs: number,
+	textIntervalMs: number,
+	spinnerCycle: number,
+	textCycle: number,
+): ScheduleDefinition {
+	const quantumMs = Math.max(30, gcd(spinnerIntervalMs, textIntervalMs));
+	const spinnerPeriod = schedulePeriod(spinnerIntervalMs, spinnerCycle, quantumMs);
+	const textSchedulePeriod = schedulePeriod(textIntervalMs, textCycle, quantumMs);
+	const frameCount = lcm(spinnerPeriod, textSchedulePeriod);
+	return {
+		frameCount,
+		stateAt: (index) => ({
+			spinnerTick: Math.floor((index * quantumMs) / spinnerIntervalMs),
+			textTick: Math.floor((index * quantumMs) / textIntervalMs),
+		}),
+		metadata: {
+			quantumMs,
+			effectiveSpinnerIntervalMs: spinnerIntervalMs,
+			effectiveTextIntervalMs: textIntervalMs,
+			exact: true,
+			spinnerSeamless: true,
+			textSeamless: true,
+			spinnerAdvances: (frameCount * quantumMs) / spinnerIntervalMs,
+			textAdvances: (frameCount * quantumMs) / textIntervalMs,
+		},
+	};
+}
+
+function fallbackSchedule(
+	frameCount: number,
+	quantumMs: number,
+	spinnerIntervalMs: number,
+	textIntervalMs: number,
+	spinnerCycle: number,
+	textCycle: number,
+): ScheduleDefinition {
+	const idealSpinnerAdvances = (frameCount * quantumMs) / spinnerIntervalMs;
+	const spinnerAdvances = Math.max(
+		spinnerCycle,
+		Math.round(idealSpinnerAdvances / spinnerCycle) * spinnerCycle,
+	);
+	const textAdvances = Math.max(1, Math.round((frameCount * quantumMs) / textIntervalMs));
+	return {
+		frameCount,
+		stateAt: (index) => ({
+			spinnerTick: Math.floor((index * spinnerAdvances) / frameCount),
+			textTick: Math.floor((index * textAdvances) / frameCount),
+		}),
+		metadata: {
+			quantumMs,
+			effectiveSpinnerIntervalMs: (frameCount * quantumMs) / spinnerAdvances,
+			effectiveTextIntervalMs: (frameCount * quantumMs) / textAdvances,
+			exact: false,
+			spinnerSeamless: spinnerAdvances % spinnerCycle === 0,
+			textSeamless: textAdvances % textCycle === 0,
+			spinnerAdvances,
+			textAdvances,
+		},
+	};
+}
+
+function bestFallbackFrameCount(
+	maximum: number,
+	quantumMs: number,
+	spinnerIntervalMs: number,
+	spinnerCycle: number,
+): number {
+	let best = 1;
+	let bestError = Number.POSITIVE_INFINITY;
+	for (let count = 1; count <= maximum; count += 1) {
+		const advances = Math.max(
+			spinnerCycle,
+			Math.round((count * quantumMs) / spinnerIntervalMs / spinnerCycle) * spinnerCycle,
+		);
+		const effective = (count * quantumMs) / advances;
+		const error = Math.abs(effective - spinnerIntervalMs);
+		if (error < bestError || (error === bestError && count > best)) {
+			best = count;
+			bestError = error;
+		}
+	}
+	return best;
+}
+
+function renderWorkingLineSchedule(
+	definition: ScheduleDefinition,
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	theme: ThemeLike,
+	row: string,
+	width: number,
+	textCycle: number,
+	spinnerStartTick: number,
+	textStartTick: number,
+	scheduleStartFrame: number,
+): { frames: string[]; frameStates: WorkingLineFrameState[] } | undefined {
+	const spinner = WORKING_LINE_SPINNERS[config.spinner];
+	const frames: string[] = [];
+	const frameStates: WorkingLineFrameState[] = [];
+	let codeUnits = 0;
+	const scheduleOrigin = definition.stateAt(scheduleStartFrame);
+	for (let index = 0; index < definition.frameCount; index += 1) {
+		const scheduled = definition.stateAt(scheduleStartFrame + index);
+		const state = {
+			spinnerTick: spinnerStartTick + scheduled.spinnerTick - scheduleOrigin.spinnerTick,
+			textTick: normalizedPhaseTick(
+				textStartTick + scheduled.textTick - scheduleOrigin.textTick,
+				textCycle,
+			),
+		};
+		const spinnerGlyph =
+			spinner.frames[state.spinnerTick % spinner.frames.length] ?? spinner.frames[0];
+		const frame = config.animateSpinnerColor
+			? `${renderAnimatedText(
+					theme,
+					config,
+					colors,
+					graphemeCells(`${spinnerGlyph} ${row}`).cells,
+					width,
+					state.textTick,
+					config.textAnimation,
+				)}${SGR_RESET}`
+			: `${renderTier(theme, config, colors, "high", spinnerGlyph)} ${renderAnimatedText(
+					theme,
+					config,
+					colors,
+					graphemeCells(row).cells,
+					width,
+					state.textTick,
+					config.textAnimation,
+				)}${SGR_RESET}`;
+		codeUnits += frame.length;
+		if (codeUnits > MAX_WORKING_LINE_FRAME_CODE_UNITS) return undefined;
+		frames.push(frame);
+		frameStates.push(state);
+	}
+	return { frames, frameStates };
+}
+
+export function buildWorkingLineFrames(
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	theme: ThemeLike,
+	message: string,
+	runtime: WorkingLineRuntimeSegments = {},
+	spinnerStartTick = 0,
+	textStartTick = spinnerStartTick,
+	scheduleStartFrame = 0,
+): WorkingLineFrames {
+	const composed = composeWorkingLineRow(config, message, runtime);
+	const spinner = WORKING_LINE_SPINNERS[config.spinner];
+	const spinnerWidth = workingLineSpinnerWidth(config.spinner);
+	const { width: rowWidth } = graphemeCells(composed.row);
+	const frameWidth = spinnerWidth + visibleWidth(" ") + rowWidth;
+	if (frameWidth > MAX_WORKING_LINE_FRAME_CELLS) {
+		throw new Error("Working-line row exceeds its visible-width cap");
+	}
+	const spinnerPhase = Number.isFinite(spinnerStartTick)
+		? Math.max(0, Math.floor(spinnerStartTick))
+		: 0;
+	const animatedTextWidth = config.animateSpinnerColor ? frameWidth : rowWidth;
+	const textOrigin = config.animateSpinnerColor ? 0 : spinnerWidth + visibleWidth(" ");
+	const textCycle = textPeriod(config.textAnimation, animatedTextWidth);
+	const textPhase = normalizedPhaseTick(textStartTick, textCycle);
+
+	if (config.textAnimation === "disabled") {
+		const frameStates = Array.from({ length: spinner.frames.length }, (_, index) => ({
+			spinnerTick: spinnerPhase + index,
+			textTick: 0,
+		}));
+		let codeUnits = 0;
+		const frames = frameStates.map((state) => {
+			const glyph = spinner.frames[state.spinnerTick % spinner.frames.length] ?? spinner.frames[0];
+			const frame = `${renderAnimatedText(
+				theme,
+				config,
+				colors,
+				graphemeCells(`${glyph} ${composed.row}`).cells,
+				frameWidth,
+				0,
+				"disabled",
+			)}${SGR_RESET}`;
+			codeUnits += frame.length;
+			if (codeUnits > MAX_WORKING_LINE_FRAME_CODE_UNITS)
+				throw new Error("Working-line animation exceeds its memory cap");
+			return frame;
+		});
+		return {
+			frames,
+			frameStates,
+			intervalMs: config.spinnerIntervalMs,
+			message: composed.message,
+			row: composed.row,
+			textAnimation: config.textAnimation,
+			textWidth: frameWidth,
+			textOrigin: 0,
+			scheduler: {
+				quantumMs: config.spinnerIntervalMs,
+				effectiveSpinnerIntervalMs: config.spinnerIntervalMs,
+				exact: true,
+				spinnerSeamless: true,
+				textSeamless: true,
+				spinnerAdvances: spinner.frames.length,
+				textAdvances: 0,
+			},
+		};
+	}
+
+	const exact = exactSchedule(
+		config.spinnerIntervalMs,
+		config.textIntervalMs,
+		spinner.frames.length,
+		textCycle,
+	);
+	if (exact.frameCount <= MAX_WORKING_LINE_FRAMES) {
+		const rendered = renderWorkingLineSchedule(
+			exact,
+			config,
+			colors,
+			theme,
+			composed.row,
+			animatedTextWidth,
+			textCycle,
+			spinnerPhase,
+			textPhase,
+			scheduleStartFrame,
+		);
+		if (rendered) {
+			return {
+				...rendered,
+				intervalMs: exact.metadata.quantumMs,
+				message: composed.message,
+				row: composed.row,
+				textAnimation: config.textAnimation,
+				textWidth: animatedTextWidth,
+				textOrigin,
+				scheduler: exact.metadata,
+			};
+		}
+	}
+
+	const quantumMs = exact.metadata.quantumMs;
+	let maximum = MAX_WORKING_LINE_FRAMES;
+	while (maximum > 0) {
+		const frameCount = bestFallbackFrameCount(
+			maximum,
+			quantumMs,
+			config.spinnerIntervalMs,
+			spinner.frames.length,
+		);
+		const fallback = fallbackSchedule(
+			frameCount,
+			quantumMs,
+			config.spinnerIntervalMs,
+			config.textIntervalMs,
+			spinner.frames.length,
+			textCycle,
+		);
+		const rendered = renderWorkingLineSchedule(
+			fallback,
+			config,
+			colors,
+			theme,
+			composed.row,
+			animatedTextWidth,
+			textCycle,
+			spinnerPhase,
+			textPhase,
+			scheduleStartFrame,
+		);
+		if (rendered) {
+			return {
+				...rendered,
+				intervalMs: quantumMs,
+				message: composed.message,
+				row: composed.row,
+				textAnimation: config.textAnimation,
+				textWidth: animatedTextWidth,
+				textOrigin,
+				scheduler: fallback.metadata,
+			};
+		}
+		maximum = frameCount - 1;
+	}
+	throw new Error("Working-line animation exceeds its memory cap");
+}
+
+export function buildWorkingLineSpinnerFrames(
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	theme: ThemeLike,
+	startTick = 0,
+): { frames: string[]; frameStates: WorkingLineFrameState[]; intervalMs: number } {
+	const spinner = WORKING_LINE_SPINNERS[config.spinner];
+	workingLineSpinnerWidth(config.spinner);
+	const phase = Number.isFinite(startTick) ? Math.max(0, Math.floor(startTick)) : 0;
+	const frameStates = Array.from({ length: spinner.frames.length }, (_, index) => ({
+		spinnerTick: phase + index,
+		textTick: 0,
+	}));
+	const frames = frameStates.map((state) => {
+		const glyph = spinner.frames[state.spinnerTick % spinner.frames.length] ?? spinner.frames[0];
+		return `${renderTier(theme, config, colors, "high", glyph)}${SGR_RESET}`;
+	});
+	return { frames, frameStates, intervalMs: config.spinnerIntervalMs };
+}
+
+export function buildWorkingLinePreviewFrames(
+	config: WorkingLineComponentConfig,
+	colors: PolishedTuiColors,
+	theme: ThemeLike,
+	spinnerStartTick = 0,
+	textStartTick = spinnerStartTick,
+): WorkingLineFrames {
+	const message = effectiveWorkingLineMessages(config)[0] ?? WORKING_LINE_FALLBACK_MESSAGE;
+	return buildWorkingLineFrames(
+		config,
+		colors,
+		theme,
+		message,
+		{
+			tool: "read",
+			elapsedMs: 62_000,
+			thought: { durationMs: 10_000, active: true },
+			tokens: { input: 1234, output: 56 },
+		},
+		spinnerStartTick,
+		textStartTick,
+	);
+}
+
+function workingLineUi(ctx: WorkingLineContext): WorkingLineUi | undefined {
+	if (ctx.hasUI === false || (ctx.mode !== undefined && ctx.mode !== "tui")) return undefined;
+	const ui = ctx.ui as unknown as Partial<WorkingLineUi>;
+	if (typeof ui.setWorkingMessage !== "function" || typeof ui.setWorkingIndicator !== "function") {
+		return undefined;
+	}
+	return ui as WorkingLineUi;
+}
+
+export type WorkingLineReconcileResult = { applied: boolean; reason?: string };
+
+type InstalledAnimationPhase = {
+	/** Logical beginning of the dwell for frameStates[0]. */
+	frameEpochMs: number;
+	/** Scheduler frame represented by frameStates[0], retained across array rebuilds. */
+	scheduleFrame: number;
+	intervalMs: number;
+	frameStates: WorkingLineFrameState[];
+	textAnimation: WorkingLineTextAnimation;
+	textWidth: number;
+	textOrigin: number;
+};
+
+type WorkingIndicatorOptions = { frames?: string[]; intervalMs?: number };
+
+type InstallationSnapshot = {
+	installed: boolean;
+	ownsIndicator: boolean;
+	ownsMessage: boolean;
+	selectedMessage: string | undefined;
+	frameKey: string | undefined;
+	installedPhase: InstalledAnimationPhase | undefined;
+	indicatorOptions: WorkingIndicatorOptions | undefined;
+	elapsedUpdatesActive: boolean;
+	elapsedUpdatesContext: WorkingLineContext | undefined;
+	elapsedUpdatesGeneration: number;
+	stopElapsedUpdates: (() => void) | undefined;
+};
+
+/** Owns Pi's public, unkeyed working-row message and indicator configuration. */
+export class WorkingLineController {
+	private installed = false;
+	private ownsIndicator = false;
+	private ownsMessage = false;
+	private agentActive = false;
+	private selectedMessage: string | undefined;
+	private frameKey: string | undefined;
+	private installedPhase: InstalledAnimationPhase | undefined;
+	private installedIndicatorOptions: WorkingIndicatorOptions | undefined;
+	private tokens: WorkingLineRuntimeSegments["tokens"];
+	private thought: WorkingLineRuntimeSegments["thought"];
+	private readonly activeTools = new Map<string, string>();
+	private elapsedUpdatesActive = false;
+	private elapsedUpdatesContext: WorkingLineContext | undefined;
+	private elapsedUpdatesGeneration = 0;
+	private stopElapsedUpdates: (() => void) | undefined;
+
+	constructor(
+		private readonly getConfig: () => ZentuiConfig,
+		private readonly getTheme: () => ThemeLike,
+		private readonly durationClock: AgentDurationClock = new AgentDurationClock(),
+		private readonly random: () => number = Math.random,
+		private readonly now: () => number = Date.now,
+		private readonly getThought: () => WorkingLineRuntimeSegments["thought"] = () => this.thought,
+	) {}
+
+	startSession(ctx: WorkingLineContext): WorkingLineReconcileResult {
+		this.clearRuntime();
+		this.selectedMessage = undefined;
+		this.installedPhase = undefined;
+		if (!this.getConfig().components.workingLine.enabled) return { applied: true };
+		return this.install(ctx);
+	}
+
+	startAgent(ctx: WorkingLineContext): void {
+		this.agentActive = true;
+		this.activeTools.clear();
+		if (this.getConfig().components.workingLine.enabled) {
+			// Pi emits extension handlers before constructing its Loader. Force and rebase the
+			// stored indicator so the subsequently constructed Loader begins at intended frame zero.
+			this.install(ctx, true, true);
+		}
+		this.reconcileElapsedUpdates(ctx);
+	}
+
+	startTurn(ctx: WorkingLineContext): WorkingLineReconcileResult {
+		const config = this.getConfig().components.workingLine;
+		this.activeTools.clear();
+		const selectedMessage = selectWorkingLineMessage(config, this.random);
+		if (!config.enabled) {
+			this.selectedMessage = selectedMessage;
+			return { applied: true };
+		}
+		return this.install(ctx, false, false, selectedMessage);
+	}
+
+	updateMetrics(
+		tokens: WorkingLineRuntimeSegments["tokens"],
+		thought: WorkingLineRuntimeSegments["thought"],
+		ctx: WorkingLineContext,
+	): void {
+		this.tokens = tokens;
+		this.thought = thought;
+		this.updateIndicator(ctx);
+		this.reconcileElapsedUpdates(ctx);
+	}
+
+	updateTokens(tokens: WorkingLineRuntimeSegments["tokens"], ctx: WorkingLineContext): void {
+		this.updateMetrics(tokens, this.getThought(), ctx);
+	}
+
+	startTool(toolCallId: string, toolName: string, ctx: WorkingLineContext): void {
+		this.activeTools.delete(toolCallId);
+		this.activeTools.set(toolCallId, normalizeWorkingLineToolLabel(toolName));
+		this.updateIndicator(ctx);
+	}
+
+	finishTool(toolCallId: string, ctx: WorkingLineContext): void {
+		this.activeTools.delete(toolCallId);
+		this.updateIndicator(ctx);
+	}
+
+	finishAgent(ctx: WorkingLineContext): void {
+		this.agentActive = false;
+		this.activeTools.clear();
+		this.deactivateElapsedUpdates();
+		this.updateIndicator(ctx);
+	}
+
+	settle(
+		tokens: WorkingLineRuntimeSegments["tokens"],
+		thought: WorkingLineRuntimeSegments["thought"],
+		ctx: WorkingLineContext,
+	): void {
+		this.tokens = tokens;
+		this.thought = thought;
+		this.updateIndicator(ctx);
+		this.reconcileElapsedUpdates(ctx);
+	}
+
+	reconcile(ctx: WorkingLineContext): WorkingLineReconcileResult {
+		const config = this.getConfig().components.workingLine;
+		if (!config.enabled) {
+			this.reset(ctx);
+			return { applied: true };
+		}
+		const effective = effectiveWorkingLineMessages(config);
+		const selectedMessage =
+			this.selectedMessage && effective.includes(this.selectedMessage)
+				? this.selectedMessage
+				: (effective[0] ?? WORKING_LINE_FALLBACK_MESSAGE);
+		return this.install(ctx, false, false, selectedMessage);
+	}
+
+	dispose(ctx: WorkingLineContext): void {
+		this.reset(ctx);
+		this.clearRuntime();
+		this.selectedMessage = undefined;
+		this.installedPhase = undefined;
+	}
+
+	currentMessage(): string | undefined {
+		return this.selectedMessage;
+	}
+
+	private install(
+		ctx: WorkingLineContext,
+		forceIndicator = false,
+		rebasePhase = false,
+		selectedMessage?: string,
+	): WorkingLineReconcileResult {
+		const ui = workingLineUi(ctx);
+		if (!ui) {
+			this.installed = false;
+			this.deactivateElapsedUpdates();
+			return { applied: false, reason: "Working line requires a newer Pi TUI" };
+		}
+		const rootConfig = this.getConfig();
+		const config = rootConfig.components.workingLine;
+		const nextMessage =
+			selectedMessage ?? this.selectedMessage ?? effectiveWorkingLineMessages(config)[0];
+		const snapshot = this.installationSnapshot();
+		try {
+			if (!this.ownsMessage) {
+				this.ownsMessage = true;
+				ui.setWorkingMessage("");
+			}
+			this.applyIndicator(ui, rootConfig, nextMessage, forceIndicator, rebasePhase);
+			this.selectedMessage = nextMessage;
+			this.reconcileElapsedUpdates(ctx);
+			return { applied: true };
+		} catch {
+			this.recoverOrReleaseAfterFailure(ui, snapshot);
+			return { applied: false, reason: "Pi could not apply the Working line" };
+		}
+	}
+
+	private makeFrameKey(rootConfig: ZentuiConfig, selectedMessage: string | undefined): string {
+		const config = rootConfig.components.workingLine;
+		const { row } = composeWorkingLineRow(
+			config,
+			selectedMessage ?? WORKING_LINE_FALLBACK_MESSAGE,
+			this.runtimeSegments(),
+		);
+		return JSON.stringify([
+			"owned",
+			config.spinner,
+			config.spinnerIntervalMs,
+			...(config.textAnimation === "disabled"
+				? [config.textAnimation, config.colorSource, rootConfig.colors.workingLineMid]
+				: [
+						config.textIntervalMs,
+						config.textAnimation,
+						config.animateSpinnerColor,
+						config.colorSource,
+						rootConfig.colors.workingLineLow,
+						rootConfig.colors.workingLineMid,
+						rootConfig.colors.workingLineHigh,
+					]),
+			row,
+		]);
+	}
+
+	private runtimeSegments(): WorkingLineRuntimeSegments {
+		const thought = this.getThought() ?? this.thought;
+		return {
+			tool: [...this.activeTools.values()].at(-1),
+			elapsedMs: this.agentActive ? this.durationClock.elapsedMs() : undefined,
+			thought,
+			tokens: this.tokens,
+		};
+	}
+
+	private applyIndicator(
+		ui: WorkingLineUi,
+		rootConfig: ZentuiConfig,
+		selectedMessage = this.selectedMessage,
+		force = false,
+		rebase = false,
+	): void {
+		const key = this.makeFrameKey(rootConfig, selectedMessage);
+		if (!force && this.installed && this.frameKey === key) return;
+		const config = rootConfig.components.workingLine;
+		const sampledAtMs = this.now();
+		let spinnerTick = 0;
+		let spatial: TextSpatialPhase | undefined;
+		let scheduleStartFrame = 0;
+		let intervalFraction = 0;
+		if (!rebase && this.installedPhase && this.installedPhase.frameStates.length > 0) {
+			const elapsedMs = Math.max(0, sampledAtMs - this.installedPhase.frameEpochMs);
+			const elapsedFrames = Math.floor(elapsedMs / this.installedPhase.intervalMs);
+			scheduleStartFrame = this.installedPhase.scheduleFrame + elapsedFrames;
+			const remainderMs = elapsedMs % this.installedPhase.intervalMs;
+			intervalFraction = remainderMs / this.installedPhase.intervalMs;
+			const sampled =
+				this.installedPhase.frameStates[elapsedFrames % this.installedPhase.frameStates.length] ??
+				this.installedPhase.frameStates[0];
+			spinnerTick = sampled?.spinnerTick ?? 0;
+			spatial = textSpatialPhase(
+				this.installedPhase.textAnimation,
+				this.installedPhase.textWidth,
+				sampled?.textTick ?? 0,
+			);
+		}
+		const message = selectedMessage ?? WORKING_LINE_FALLBACK_MESSAGE;
+		const runtime = this.runtimeSegments();
+		const composed = composeWorkingLineRow(config, message, runtime);
+		const spinnerWidth = workingLineSpinnerWidth(config.spinner);
+		const textWidth =
+			config.textAnimation !== "disabled" && config.animateSpinnerColor
+				? spinnerWidth + 1 + visibleWidth(composed.row)
+				: config.textAnimation === "disabled"
+					? spinnerWidth + 1 + visibleWidth(composed.row)
+					: visibleWidth(composed.row);
+		const textOrigin =
+			config.textAnimation !== "disabled" && !config.animateSpinnerColor ? spinnerWidth + 1 : 0;
+		const relativeSpatial = spatial
+			? {
+					...spatial,
+					position: spatial.position + (this.installedPhase?.textOrigin ?? 0) - textOrigin,
+				}
+			: undefined;
+		const textTick = textTickForSpatialPhase(config.textAnimation, textWidth, relativeSpatial);
+		const generated = buildWorkingLineFrames(
+			config,
+			rootConfig.colors,
+			this.getTheme(),
+			message,
+			runtime,
+			spinnerTick,
+			textTick,
+			scheduleStartFrame,
+		);
+		// Pi's public Loader always gives replacement frame zero a full first interval. Carrying
+		// the logical fractional dwell in this epoch keeps later rebuilds wall-clock-correct; the
+		// visible replacement can still jitter by less than one interval because the API cannot
+		// schedule a fractional first interval.
+		const frameEpochMs = sampledAtMs - intervalFraction * generated.intervalMs;
+		this.ownsIndicator = true;
+		const indicatorOptions = { frames: generated.frames, intervalMs: generated.intervalMs };
+		ui.setWorkingIndicator(indicatorOptions);
+		this.installedPhase = {
+			frameEpochMs: rebase ? this.now() : frameEpochMs,
+			scheduleFrame: rebase ? 0 : scheduleStartFrame,
+			intervalMs: generated.intervalMs,
+			frameStates: generated.frameStates,
+			textAnimation: generated.textAnimation,
+			textWidth: generated.textWidth,
+			textOrigin: generated.textOrigin,
+		};
+		this.installed = true;
+		this.frameKey = key;
+		this.installedIndicatorOptions = indicatorOptions;
+	}
+
+	private updateIndicator(ctx: WorkingLineContext): void {
+		const rootConfig = this.getConfig();
+		if (!rootConfig.components.workingLine.enabled || !this.installed) return;
+		const ui = workingLineUi(ctx);
+		if (!ui) return;
+		const snapshot = this.installationSnapshot();
+		try {
+			this.applyIndicator(ui, rootConfig);
+		} catch {
+			// A transient last-writer/public-API failure must not break the agent turn.
+			this.recoverOrReleaseAfterFailure(ui, snapshot);
+		}
+	}
+
+	private reconcileElapsedUpdates(ctx: WorkingLineContext): void {
+		this.elapsedUpdatesContext = ctx;
+		const config = this.getConfig().components.workingLine;
+		const thoughtActive = Boolean(this.getThought()?.active);
+		const needed =
+			this.installed &&
+			this.agentActive &&
+			config.enabled &&
+			(config.segments.elapsed || (config.segments.thought && thoughtActive));
+		if (!needed) {
+			this.deactivateElapsedUpdates();
+			return;
+		}
+		if (this.elapsedUpdatesActive) return;
+		this.elapsedUpdatesActive = true;
+		const generation = ++this.elapsedUpdatesGeneration;
+		this.stopElapsedUpdates = this.durationClock.subscribe(() => {
+			if (!this.elapsedUpdatesActive || generation !== this.elapsedUpdatesGeneration) return;
+			const latest = this.elapsedUpdatesContext;
+			if (latest) this.updateIndicator(latest);
+		});
+	}
+
+	private deactivateElapsedUpdates(): void {
+		this.elapsedUpdatesActive = false;
+		this.elapsedUpdatesContext = undefined;
+		this.elapsedUpdatesGeneration++;
+		this.stopElapsedUpdates?.();
+		this.stopElapsedUpdates = undefined;
+	}
+
+	private installationSnapshot(): InstallationSnapshot {
+		return {
+			installed: this.installed,
+			ownsIndicator: this.ownsIndicator,
+			ownsMessage: this.ownsMessage,
+			selectedMessage: this.selectedMessage,
+			frameKey: this.frameKey,
+			installedPhase: this.installedPhase,
+			indicatorOptions: this.installedIndicatorOptions,
+			elapsedUpdatesActive: this.elapsedUpdatesActive,
+			elapsedUpdatesContext: this.elapsedUpdatesContext,
+			elapsedUpdatesGeneration: this.elapsedUpdatesGeneration,
+			stopElapsedUpdates: this.stopElapsedUpdates,
+		};
+	}
+
+	private recoverOrReleaseAfterFailure(ui: WorkingLineUi, snapshot: InstallationSnapshot): void {
+		if (!snapshot.installed || !snapshot.ownsIndicator || !snapshot.indicatorOptions) {
+			this.releaseAfterFailure(ui);
+			return;
+		}
+		this.installed = snapshot.installed;
+		this.ownsIndicator = snapshot.ownsIndicator;
+		this.ownsMessage = snapshot.ownsMessage;
+		this.selectedMessage = snapshot.selectedMessage;
+		this.frameKey = snapshot.frameKey;
+		this.installedPhase = snapshot.installedPhase;
+		this.installedIndicatorOptions = snapshot.indicatorOptions;
+		this.elapsedUpdatesActive = snapshot.elapsedUpdatesActive;
+		this.elapsedUpdatesContext = snapshot.elapsedUpdatesContext;
+		this.elapsedUpdatesGeneration = snapshot.elapsedUpdatesGeneration;
+		this.stopElapsedUpdates = snapshot.stopElapsedUpdates;
+		try {
+			ui.setWorkingIndicator(snapshot.indicatorOptions);
+			if (snapshot.ownsMessage) ui.setWorkingMessage("");
+		} catch {
+			// Recovery is deliberately direct rather than recursive. If either setter cannot
+			// restore the last successful public state, release both unkeyed surfaces.
+			this.releaseAfterFailure(ui);
+		}
+	}
+
+	private releaseAfterFailure(ui: WorkingLineUi): void {
+		this.deactivateElapsedUpdates();
+		if (this.ownsIndicator) {
+			try {
+				ui.setWorkingIndicator();
+			} catch {
+				// Best-effort release after a partial public-API installation failure.
+			}
+		}
+		if (this.ownsMessage) {
+			try {
+				ui.setWorkingMessage();
+			} catch {
+				// Best-effort release after a partial public-API installation failure.
+			}
+		}
+		this.installed = false;
+		this.ownsIndicator = false;
+		this.ownsMessage = false;
+		this.frameKey = undefined;
+		this.installedPhase = undefined;
+		this.installedIndicatorOptions = undefined;
+	}
+
+	private reset(ctx: WorkingLineContext): void {
+		this.deactivateElapsedUpdates();
+		if (!this.ownsIndicator && !this.ownsMessage) return;
+		const ui = workingLineUi(ctx);
+		if (ui && this.ownsIndicator) {
+			try {
+				ui.setWorkingIndicator();
+			} catch {
+				// Cleanup is best effort and remains idempotent.
+			}
+		}
+		if (ui && this.ownsMessage) {
+			try {
+				ui.setWorkingMessage();
+			} catch {
+				// Cleanup is best effort and remains idempotent.
+			}
+		}
+		this.installed = false;
+		this.ownsIndicator = false;
+		this.ownsMessage = false;
+		this.frameKey = undefined;
+		this.installedPhase = undefined;
+		this.installedIndicatorOptions = undefined;
+	}
+
+	private clearRuntime(): void {
+		this.deactivateElapsedUpdates();
+		this.agentActive = false;
+		this.activeTools.clear();
+		this.tokens = undefined;
+		this.thought = undefined;
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,9 @@
 				"vitest": "^4.1.8"
 			},
 			"peerDependencies": {
-				"@earendil-works/pi-ai": ">=0.80.3",
-				"@earendil-works/pi-coding-agent": ">=0.80.3",
-				"@earendil-works/pi-tui": ">=0.80.3"
+				"@earendil-works/pi-ai": ">=0.80.5",
+				"@earendil-works/pi-coding-agent": ">=0.80.5",
+				"@earendil-works/pi-tui": ">=0.80.5"
 			}
 		},
 		"node_modules/@anthropic-ai/sdk": {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
 		"prepublishOnly": "npm run verify && npm run pack:check"
 	},
 	"peerDependencies": {
-		"@earendil-works/pi-ai": ">=0.80.3",
-		"@earendil-works/pi-coding-agent": ">=0.80.3",
-		"@earendil-works/pi-tui": ">=0.80.3"
+		"@earendil-works/pi-ai": ">=0.80.5",
+		"@earendil-works/pi-coding-agent": ">=0.80.5",
+		"@earendil-works/pi-tui": ">=0.80.5"
 	},
 	"pi": {
 		"extensions": [

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -14,6 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_COMPACT_FOOTER_FORMAT,
@@ -52,6 +53,7 @@ import {
 	saveStarshipFooterStylePatch,
 	saveUiFeaturesPatch,
 	saveUserMessagesComponentPatch,
+	saveWorkingLineComponentPatch,
 } from "../extensions/zentui/config";
 import {
 	colorize,
@@ -121,6 +123,21 @@ describe("canonical config resolution", () => {
 				style: "framed",
 				colorSource: "theme",
 				styles: { framed: {}, "framed-copy-friendly": {}, compact: {}, labeled: {} },
+			},
+			workingLine: {
+				enabled: false,
+				turnSummary: true,
+				spinner: "star-bloom",
+				spinnerIntervalMs: 100,
+				animateSpinnerColor: false,
+				textIntervalMs: 60,
+				textAnimation: "classic",
+				colorSource: "theme",
+				messages: {
+					custom: true,
+					values: [...defaultConfig.components.workingLine.messages.values],
+				},
+				segments: { tool: true, elapsed: true, thought: true, tokens: true },
 			},
 			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 			footer: {
@@ -476,6 +493,268 @@ describe("canonical config resolution", () => {
 	});
 });
 
+describe("working-line config", () => {
+	it("defaults to cloned custom presets and migrates legacy modes without losing values", () => {
+		const first = mergeConfig({}).components.workingLine.messages;
+		const second = mergeConfig({}).components.workingLine.messages;
+		expect(first).toEqual({
+			custom: true,
+			values: defaultConfig.components.workingLine.messages.values,
+		});
+		expect(first.values).not.toBe(second.values);
+		expect(first.values).not.toBe(defaultConfig.components.workingLine.messages.values);
+		expect(
+			mergeConfig({ components: { workingLine: { messages: { mode: "native", values: [] } } } })
+				.components.workingLine.messages,
+		).toEqual({ custom: false, values: defaultConfig.components.workingLine.messages.values });
+		expect(
+			mergeConfig({ components: { workingLine: { messages: { mode: "replace", values: [] } } } })
+				.components.workingLine.messages,
+		).toEqual({ custom: true, values: defaultConfig.components.workingLine.messages.values });
+		expect(
+			mergeConfig({
+				components: { workingLine: { messages: { mode: "replace", values: [" Custom "] } } },
+			}).components.workingLine.messages,
+		).toEqual({ custom: true, values: ["Custom"] });
+		const appendValues = Array.from({ length: 32 }, (_, index) => `legacy-${index}`);
+		const append = mergeConfig({
+			components: { workingLine: { messages: { mode: "append", values: appendValues } } },
+		}).components.workingLine.messages;
+		expect(append.custom).toBe(true);
+		expect(append.values).toEqual([
+			...defaultConfig.components.workingLine.messages.values,
+			...appendValues,
+		]);
+		expect(append.values).toHaveLength(48);
+	});
+
+	it("gives canonical custom presence precedence and preserves explicit empty values", () => {
+		expect(
+			mergeConfig({
+				components: {
+					workingLine: { messages: { custom: false, mode: "append", values: [] } },
+				},
+			}).components.workingLine.messages,
+		).toEqual({ custom: false, values: [] });
+		expect(
+			mergeConfig({
+				components: { workingLine: { messages: { custom: "bad", mode: "native" } } },
+			}).components.workingLine.messages,
+		).toEqual({ custom: true, values: defaultConfig.components.workingLine.messages.values });
+		expect(
+			mergeConfig({ components: { workingLine: { messages: { values: [] } } } }).components
+				.workingLine.messages,
+		).toEqual({ custom: true, values: [] });
+	});
+
+	it.each([
+		[30, 30],
+		[1000, 1000],
+		[29, 100],
+		[1001, 100],
+		[60.5, 100],
+		["60", 100],
+		[Number.NaN, 100],
+		[Number.MAX_SAFE_INTEGER, 100],
+	] as const)(
+		"migrates legacy Working-line interval %s to spinner speed %s ms",
+		(intervalMs, expected) => {
+			expect(
+				mergeConfig({ components: { workingLine: { intervalMs } } }).components.workingLine
+					.spinnerIntervalMs,
+			).toBe(expected);
+			expect(
+				mergeConfig({ components: { workingLine: { intervalMs } } }).components.workingLine
+					.textIntervalMs,
+			).toBe(60);
+		},
+	);
+
+	it.each([
+		[30, 30],
+		[1000, 1000],
+		[29, 60],
+		[1001, 60],
+		[60.5, 60],
+		["60", 60],
+	] as const)("normalizes canonical text speed %s to %s ms", (textIntervalMs, expected) => {
+		expect(
+			mergeConfig({ components: { workingLine: { textIntervalMs } } }).components.workingLine
+				.textIntervalMs,
+		).toBe(expected);
+	});
+
+	it("gives canonical spinner speed presence precedence over legacy input", () => {
+		expect(
+			mergeConfig({
+				components: { workingLine: { intervalMs: 180, spinnerIntervalMs: 160 } },
+			}).components.workingLine.spinnerIntervalMs,
+		).toBe(160);
+		expect(
+			mergeConfig({
+				components: { workingLine: { intervalMs: 180, spinnerIntervalMs: "bad" } },
+			}).components.workingLine.spinnerIntervalMs,
+		).toBe(100);
+	});
+
+	it("defaults malformed or missing Turn summary to true and preserves explicit false", () => {
+		expect(mergeConfig({}).components.workingLine.turnSummary).toBe(true);
+		expect(
+			mergeConfig({ components: { workingLine: { turnSummary: "bad" } } }).components.workingLine
+				.turnSummary,
+		).toBe(true);
+		expect(
+			mergeConfig({ components: { workingLine: { turnSummary: false } } }).components.workingLine
+				.turnSummary,
+		).toBe(false);
+	});
+
+	it("saves Turn summary while preserving unknown config", () => {
+		withConfig(
+			{ components: { workingLine: { unknown: { keep: true } } }, topLevel: "keep" },
+			(path) => {
+				const config = saveWorkingLineComponentPatch({ turnSummary: false }, path);
+				const raw = JSON.parse(readFileSync(path, "utf8"));
+				expect(config.components.workingLine.turnSummary).toBe(false);
+				expect(raw.components.workingLine.turnSummary).toBe(false);
+				expect(raw.components.workingLine.unknown).toEqual({ keep: true });
+				expect(raw.topLevel).toBe("keep");
+			},
+		);
+	});
+
+	it("parses Pulse without changing established Working-line defaults", () => {
+		expect(mergeConfig({}).components.workingLine.spinner).toBe("star-bloom");
+		expect(
+			mergeConfig({
+				components: { workingLine: { spinner: "pulse", spinnerIntervalMs: 180 } },
+			}).components.workingLine,
+		).toMatchObject({ spinner: "pulse", spinnerIntervalMs: 180, textIntervalMs: 60 });
+	});
+
+	it("normalizes each independent field, messages, and palette override", () => {
+		const config = mergeConfig({
+			components: {
+				workingLine: {
+					enabled: true,
+					spinner: "pinwheel",
+					spinnerIntervalMs: 160,
+					animateSpinnerColor: true,
+					textIntervalMs: 40,
+					textAnimation: "kitt",
+					colorSource: "terminal",
+					messages: {
+						mode: "replace",
+						values: [" One ", "One", "\x1b[31mTwo\x1b[0m", "\n"],
+					},
+					segments: { tool: false, elapsed: true, thought: true, tokens: false },
+				},
+			},
+			colors: {
+				workingLineLow: "fg:240",
+				workingLineMid: "cyan",
+				workingLineHigh: "bold cyan",
+				editorAccent: "red",
+			},
+		});
+		expect(config.components.workingLine).toEqual({
+			enabled: true,
+			turnSummary: true,
+			spinner: "pinwheel",
+			spinnerIntervalMs: 160,
+			animateSpinnerColor: true,
+			textIntervalMs: 40,
+			textAnimation: "kitt",
+			colorSource: "terminal",
+			messages: { custom: true, values: ["One", "Two"] },
+			segments: { tool: false, elapsed: true, thought: true, tokens: false },
+		});
+		expect(config.colors).toMatchObject({
+			workingLineLow: "fg:240",
+			workingLineMid: "cyan",
+			workingLineHigh: "bold cyan",
+			editorAccent: "red",
+		});
+	});
+
+	it("falls back malformed leaves independently and enforces message caps", () => {
+		const values = Array.from({ length: 40 }, (_, index) => `${index}:${"界".repeat(30)}`);
+		const component = mergeConfig({
+			components: {
+				workingLine: {
+					enabled: "yes",
+					spinner: "future",
+					intervalMs: 29,
+					animateSpinnerColor: "yes",
+					textAnimation: "pulse",
+					colorSource: "editor",
+					messages: { mode: "rotate", values },
+				},
+			},
+			colors: { workingLineLow: "not-a-color" },
+		}).components.workingLine;
+		expect(component).toMatchObject({
+			enabled: false,
+			spinner: "star-bloom",
+			spinnerIntervalMs: 100,
+			animateSpinnerColor: false,
+			textIntervalMs: 60,
+			textAnimation: "classic",
+			colorSource: "theme",
+			messages: { custom: true },
+			segments: { tool: true, elapsed: true, thought: true, tokens: true },
+		});
+		expect(component.messages.values).toHaveLength(40);
+		expect(component.messages.values.every((value) => value.length > 0)).toBe(true);
+		expect(component.messages.values.every((value) => visibleWidth(value) <= 43)).toBe(true);
+	});
+
+	it("saves nested patches, copies arrays, and preserves unknown fields", () => {
+		withConfig(
+			{
+				unknownTop: true,
+				components: {
+					workingLine: {
+						future: { keep: true },
+						intervalMs: 180,
+						messages: { mode: "append", futureMessages: true, values: ["Old"] },
+					},
+				},
+			},
+			(path) => {
+				const values = [" New ", "New", "Other"];
+				const saved = saveWorkingLineComponentPatch(
+					{
+						spinner: "braille",
+						spinnerIntervalMs: 60,
+						animateSpinnerColor: true,
+						messages: { custom: true, values },
+						segments: { elapsed: false },
+					},
+					path,
+				);
+				values[0] = "mutated";
+				const raw = readRaw(path);
+				expect(saved.components.workingLine).toMatchObject({
+					spinner: "braille",
+					spinnerIntervalMs: 60,
+					animateSpinnerColor: true,
+					textIntervalMs: 60,
+					messages: { custom: true, values: ["New", "Other"] },
+					segments: { tool: true, elapsed: false, thought: true, tokens: true },
+				});
+				expect(raw.unknownTop).toBe(true);
+				expect(raw.components.workingLine.future).toEqual({ keep: true });
+				expect(raw.components.workingLine.messages.futureMessages).toBe(true);
+				expect(raw.components.workingLine.messages.values).toEqual(["New", "Other"]);
+				expect(raw.components.workingLine.messages.custom).toBe(true);
+				expect(raw.components.workingLine.messages).not.toHaveProperty("mode");
+				expect(raw.components.workingLine).not.toHaveProperty("intervalMs");
+			},
+		);
+	});
+});
+
 describe("Phase 4 style migration", () => {
 	it.each([
 		[true, "opencode-copy-friendly"],
@@ -817,6 +1096,7 @@ describe("canonical snapshot persistence", () => {
 					expect.arrayContaining([
 						"editor",
 						"userMessages",
+						"workingLine",
 						"selectorBorders",
 						"footer",
 						"futureDomain",
@@ -1023,6 +1303,7 @@ describe("compatibility saver recipes", () => {
 				"footer",
 				"selectorBorders",
 				"userMessages",
+				"workingLine",
 			]);
 			expect(raw.components.editor.enabled).toBe(false);
 			expect(raw.components.userMessages.enabled).toBe(false);

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -97,6 +97,7 @@ const settingsCommandDefaults: SettingsCommandDeps = {
 	setEditorComponent: () => ({ applied: true }),
 	setMinimalist() {},
 	setUserMessagesComponent() {},
+	setWorkingLineComponent: () => ({ applied: true }),
 	setSelectorBordersComponent() {},
 	setFooterComponent() {},
 	setFooterSegments() {},
@@ -159,6 +160,13 @@ function canonicalizeTestConfig(config: PolishedTuiConfig): PolishedTuiConfig {
 					? config.colorSources.userMessages
 					: messages.colorSource,
 				styles: { ...messages.styles },
+			},
+			workingLine: {
+				...config.components.workingLine,
+				messages: {
+					...config.components.workingLine.messages,
+					values: [...config.components.workingLine.messages.values],
+				},
 			},
 			selectorBorders: {
 				...selectors,
@@ -5653,7 +5661,7 @@ describe("Pi docs compliance", () => {
 		const themeLines = await renderSettings(defaultConfig);
 		expect(themeLines[0]).toContain("[borderMuted]────");
 		expect(themeLines.join("\n")).toContain("Appearance");
-		expect(themeLines.join("\n")).toContain("(1/7)");
+		expect(themeLines.join("\n")).toContain("(1/8)");
 		expect(themeLines.join("\n")).toContain("Tab/Shift+Tab to switch sections");
 		expect(themeLines.at(-1)).toContain("[borderMuted]────");
 		expect(themeLines.every((line) => visibleWidth(stripTestTags(line)) <= settingsWidth)).toBe(
@@ -5771,7 +5779,7 @@ describe("Pi docs compliance", () => {
 					const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 						handleInput?: (data: string) => void;
 					};
-					for (let index = 0; index < 3; index += 1) component.handleInput?.("\t");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
 					for (let index = 0; index < 3; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.("\x1b[B");
@@ -5843,7 +5851,7 @@ describe("Pi docs compliance", () => {
 						{},
 						() => {},
 					) as { handleInput?: (data: string) => void };
-					for (let index = 0; index < 3; index += 1) component.handleInput?.("\t");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\t");
 					for (let index = 0; index < 6; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
@@ -5861,7 +5869,7 @@ describe("Pi docs compliance", () => {
 			"Separator: pipe",
 		]);
 		expect(dependencyRenderRequests).toBe(4);
-		expect(tuiRenderRequests).toBe(7);
+		expect(tuiRenderRequests).toBe(8);
 	});
 
 	it("cycles branch length presets and returns custom JSON values to full", async () => {
@@ -5912,7 +5920,7 @@ describe("Pi docs compliance", () => {
 						const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 							handleInput?: (data: string) => void;
 						};
-						for (let index = 0; index < 5; index += 1) component.handleInput?.("\t");
+						for (let index = 0; index < 6; index += 1) component.handleInput?.("\t");
 						component.handleInput?.("\x1b[B");
 						for (let index = 0; index < presses; index += 1) component.handleInput?.(" ");
 					},
@@ -6069,6 +6077,7 @@ describe("Pi docs compliance", () => {
 			| "Appearance"
 			| "Editor"
 			| "User messages"
+			| "Working line"
 			| "Footer"
 			| "Segments"
 			| "Git"
@@ -6078,6 +6087,7 @@ describe("Pi docs compliance", () => {
 			"Appearance",
 			"Editor",
 			"User messages",
+			"Working line",
 			"Footer",
 			"Segments",
 			"Git",
@@ -6335,7 +6345,7 @@ describe("Pi docs compliance", () => {
 
 		expect(placements).toEqual([{ key: "alpha", placement: "off" }]);
 		expect(dependencyRenderRequests).toBe(1);
-		expect(tuiRenderRequests).toBe(7);
+		expect(tuiRenderRequests).toBe(8);
 	});
 
 	it("does not show inactive saved placements in the extension segments tab", async () => {
@@ -6952,7 +6962,7 @@ describe("three-state Footer lifecycle", () => {
 			const settings = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput(data: string): void;
 			};
-			for (let index = 0; index < 3; index++) settings.handleInput("\t");
+			for (let index = 0; index < 4; index++) settings.handleInput("\t");
 			settings.handleInput(" ");
 		};
 		const ctx = makeContext({ ui: harness.ui });

--- a/test/interaction-summary.test.ts
+++ b/test/interaction-summary.test.ts
@@ -1,0 +1,1400 @@
+import { buildSessionContext } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+	formatTurnSummary,
+	InteractionMetricsTracker,
+	isTurnSummaryData,
+	parseAssistantMessageTokens,
+	renderTurnSummaryEntry,
+	subtractThoughtIntervalsWithinCap,
+	TURN_SUMMARY_ENTRY_TYPE,
+} from "../extensions/zentui/interaction-summary";
+
+type AssistantOptions = {
+	responseId?: string;
+	timestamp?: number;
+	provider?: string;
+	model?: string;
+	stopReason?: string;
+	content?: unknown[];
+};
+
+function assistant(input: number, output: number, options: AssistantOptions = {}) {
+	return {
+		role: "assistant" as const,
+		usage: { input, output, cacheRead: 999, cacheWrite: 888, cost: { total: 1 } },
+		content: options.content ?? [],
+		api: "test",
+		provider: options.provider ?? "provider",
+		model: options.model ?? "model",
+		stopReason: options.stopReason ?? "stop",
+		timestamp: options.timestamp ?? 1,
+		responseId: options.responseId,
+	};
+}
+
+function delta(
+	type: "text_delta" | "thinking_delta",
+	contentIndex: number,
+	value: string,
+	cumulative?: string,
+) {
+	const content: unknown[] = [];
+	if (cumulative !== undefined) {
+		content[contentIndex] =
+			type === "text_delta"
+				? { type: "text", text: cumulative }
+				: { type: "thinking", thinking: cumulative };
+	}
+	return {
+		type,
+		contentIndex,
+		delta: value,
+		partial: assistant(0, 0, { content }),
+	} as never;
+}
+
+function toolDelta(contentIndex: number, value: string, includeBlock = true) {
+	const content: unknown[] = [];
+	if (includeBlock) {
+		content[contentIndex] = { type: "toolCall", id: "call-1", name: "bash", arguments: {} };
+	}
+	return {
+		type: "toolcall_delta",
+		contentIndex,
+		delta: value,
+		partial: assistant(0, 0, { content }),
+	} as never;
+}
+
+function accepted(
+	tokens: { input: number; output: number },
+	source: "final" | "last-snapshot" | "no-snapshot" = "final",
+	displayTokens = { ...tokens, outputApproximate: false },
+) {
+	return { status: "accepted", tokens, displayTokens, source };
+}
+
+describe("live interaction token display", () => {
+	it("starts terminal-only streams at zero approximate and estimates text plus thinking", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		expect(tracker.messageUpdate(assistant(0, 0)).displayTokens).toEqual({
+			input: 0,
+			output: 0,
+			outputApproximate: true,
+		});
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "abc", "abc")).displayTokens,
+		).toEqual({ input: 0, output: 1, outputApproximate: true });
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("thinking_delta", 1, "defgh", "defgh"))
+				.displayTokens,
+		).toEqual({ input: 0, output: 2, outputApproximate: true });
+	});
+
+	it("counts cumulative Unicode code points and ignores unchanged or stale snapshots", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		const first = tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "💡ab", "💡ab"));
+		expect(first.displayTokens).toEqual({ input: 0, output: 1, outputApproximate: true });
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "💡ab", "💡ab")).usageChanged,
+		).toBe(false);
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "x", "💡a")).usageChanged,
+		).toBe(false);
+	});
+
+	it("counts split surrogate pairs once in raw fallback and saturates estimates", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "\ud83d"));
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "\udca1abc")).displayTokens,
+		).toEqual({ input: 0, output: 1, outputApproximate: true });
+		const huge = new InteractionMetricsTracker();
+		huge.agentStart();
+		huge.turnStart();
+		huge.messageUpdate(assistant(0, Number.MAX_SAFE_INTEGER));
+		expect(
+			huge.messageUpdate(assistant(0, Number.MAX_SAFE_INTEGER), delta("text_delta", 0, "more"))
+				.displayTokens,
+		).toEqual({ input: 0, output: Number.MAX_SAFE_INTEGER, outputApproximate: true });
+	});
+
+	it("anchors estimates to advancing provider output and final corrects downward", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(10, 2), delta("text_delta", 0, "abcdefgh", "abcdefgh"));
+		expect(
+			tracker.messageUpdate(assistant(10, 2), delta("text_delta", 0, "ijkl", "abcdefghijkl"))
+				.displayTokens,
+		).toEqual({ input: 10, output: 3, outputApproximate: true });
+		expect(tracker.messageUpdate(assistant(9, 1)).displayTokens).toEqual({
+			input: 10,
+			output: 3,
+			outputApproximate: true,
+		});
+		expect(tracker.messageEnd(assistant(10, 2))).toEqual(accepted({ input: 10, output: 2 }));
+		expect(tracker.currentTokens()).toEqual({ input: 10, output: 2 });
+	});
+
+	it("retains live estimate state across non-idle partition while settling provider-only totals", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart();
+		tracker.messageEnd(assistant(5, 1, { responseId: "settled" }));
+		tracker.agentEnd(10);
+		tracker.agentStart(20);
+		tracker.turnStart();
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "live" }),
+			delta("text_delta", 0, "abcdefgh", "abcdefgh"),
+		);
+		expect(tracker.settle(false, 30)).toMatchObject({
+			summary: { input: 5, output: 1 },
+			nextTokens: { input: 0, output: 2, outputApproximate: true },
+		});
+		expect(tracker.currentDisplayTokens()).toEqual({
+			input: 0,
+			output: 2,
+			outputApproximate: true,
+		});
+	});
+
+	it("handles sparse cumulative thinking indexes and divergent snapshots conservatively", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("thinking_delta", 7, "abcd", "abcd"))
+				.displayTokens,
+		).toEqual({ input: 0, output: 1, outputApproximate: true });
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("thinking_delta", 7, "efgh", "abcdefgh"))
+				.displayTokens,
+		).toEqual({ input: 0, output: 2, outputApproximate: true });
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("thinking_delta", 7, "zzzz", "abcdzzzz"))
+				.usageChanged,
+		).toBe(false);
+		expect(tracker.diagnostics()).toMatchObject({
+			contentBlocks: 1,
+			retainedContentUnits: 8,
+			estimateIncomplete: true,
+		});
+	});
+
+	it("joins cumulative split surrogates across an unchanged pending snapshot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "\ud83d", "\ud83d"));
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "", "\ud83d")).usageChanged,
+		).toBe(false);
+		expect(
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "\udca1abc", "💡abc"))
+				.displayTokens,
+		).toEqual({ input: 0, output: 1, outputApproximate: true });
+	});
+
+	it("validates malformed event boundaries before any mutation", () => {
+		for (const event of [
+			{ type: "thinking_delta", contentIndex: 0, delta: "x" },
+			{ type: "thinking_delta", contentIndex: 0, delta: 1, partial: { content: [] } },
+			{ type: "thinking_delta", contentIndex: 0, delta: "x", partial: { content: {} } },
+			{
+				type: "thinking_delta",
+				contentIndex: 0,
+				delta: "x",
+				partial: { content: [{ type: "text", text: "x" }] },
+			},
+			{ type: "thinking_start", contentIndex: 65_536, partial: { content: [] } },
+		] as const) {
+			const tracker = new InteractionMetricsTracker();
+			tracker.agentStart(0);
+			tracker.turnStart(0);
+			expect(() => tracker.messageUpdate(assistant(-1, 1), event as never, 10)).not.toThrow();
+			expect(tracker.currentTokens()).toEqual({ input: 0, output: 0 });
+			expect(tracker.currentThought(20)).toEqual({ durationMs: 0, active: false });
+			expect(tracker.diagnostics().contentBlocks).toBe(0);
+		}
+	});
+
+	it("releases bounded estimator state on closure", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "abcdefgh", "abcdefgh"));
+		expect(tracker.diagnostics()).toMatchObject({ activeResponses: 1, contentBlocks: 1 });
+		expect(tracker.messageEnd(assistant(2, 1))).toEqual(accepted({ input: 2, output: 1 }));
+		expect(tracker.diagnostics()).toMatchObject({
+			activeResponses: 0,
+			contentBlocks: 0,
+			retainedContentUnits: 0,
+		});
+	});
+
+	it("processes progressive cumulative snapshots incrementally with bounded retention", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		let cumulative = "";
+		const started = performance.now();
+		for (let index = 0; index < 20_000; index++) {
+			cumulative += "x";
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "x", cumulative));
+		}
+		expect(performance.now() - started).toBeLessThan(5_000);
+		expect(tracker.currentDisplayTokens()).toEqual({
+			input: 0,
+			output: 5_000,
+			outputApproximate: true,
+		});
+		expect(tracker.diagnostics()).toMatchObject({
+			contentBlocks: 1,
+			maxContentTailUnits: 64,
+			retainedContentUnits: 64,
+		});
+	});
+
+	it("bounds block, delta, snapshot, generated, and thought estimator state without losing final usage", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		for (let index = 0; index < 129; index++) {
+			expect(() =>
+				tracker.messageUpdate(assistant(0, 0), delta("text_delta", index, "x")),
+			).not.toThrow();
+		}
+		expect(tracker.diagnostics().contentBlocks).toBe(128);
+		expect(() =>
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "x".repeat(65_537))),
+		).not.toThrow();
+		expect(() =>
+			tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "x", "x".repeat(1_048_577))),
+		).not.toThrow();
+		for (let index = 0; index < 65; index++) {
+			expect(() =>
+				tracker.messageUpdate(
+					assistant(0, 0),
+					delta("text_delta", index % 128, "x".repeat(65_536)),
+				),
+			).not.toThrow();
+		}
+		for (let index = 0; index < 257; index++) {
+			expect(() =>
+				tracker.messageUpdate(
+					assistant(0, 0),
+					{
+						type: "thinking_start",
+						contentIndex: index,
+						partial: { content: [] },
+					} as never,
+					index,
+				),
+			).not.toThrow();
+		}
+		expect(tracker.diagnostics()).toMatchObject({
+			contentBlocks: 128,
+			thoughtBlocks: 256,
+			estimateIncomplete: true,
+		});
+		expect(tracker.messageEnd(assistant(11, 7), 300)).toEqual(accepted({ input: 11, output: 7 }));
+	});
+
+	it("counts every raw tool-call chunk independently and exact final usage reconciles it", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		expect(tracker.messageUpdate(assistant(0, 0), toolDelta(0, "abcdefgh"), 10)).toMatchObject({
+			displayTokens: { input: 0, output: 2, outputApproximate: true },
+			usageChanged: true,
+			thoughtChanged: false,
+		});
+		expect(
+			tracker.messageUpdate(assistant(0, 0), toolDelta(0, "abcdefgh"), 20).displayTokens,
+		).toEqual({ input: 0, output: 4, outputApproximate: true });
+		expect(tracker.currentThought(30)).toEqual({ durationMs: 0, active: false });
+		expect(tracker.diagnostics()).toMatchObject({ contentBlocks: 1, thoughtBlocks: 0 });
+		expect(tracker.messageEnd(assistant(7, 1), 40)).toEqual(accepted({ input: 7, output: 1 }));
+	});
+
+	it("ceilings mixed text, thinking, and tool-call output together", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "abc", "abc"));
+		tracker.messageUpdate(assistant(0, 0), delta("thinking_delta", 1, "def", "def"));
+		expect(tracker.messageUpdate(assistant(0, 0), toolDelta(2, "ghi")).displayTokens).toEqual({
+			input: 0,
+			output: 3,
+			outputApproximate: true,
+		});
+		expect(tracker.diagnostics().contentBlocks).toBe(3);
+	});
+
+	it("rejects malformed tool deltas atomically and bounds oversized tool-call state", () => {
+		for (const event of [
+			{ type: "toolcall_delta", contentIndex: 0, delta: "x" },
+			{ type: "toolcall_delta", contentIndex: 0, delta: 1, partial: { content: [] } },
+			{ type: "toolcall_delta", contentIndex: 0, delta: "x", partial: { content: [] } },
+			{ type: "toolcall_delta", contentIndex: 0, delta: "x", partial: { content: {} } },
+			{
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: "x",
+				partial: { content: [{ type: "text", text: "x" }] },
+			},
+		] as const) {
+			const tracker = new InteractionMetricsTracker();
+			tracker.agentStart();
+			tracker.turnStart();
+			expect(tracker.messageUpdate(assistant(0, 0), event as never).usageChanged).toBe(false);
+			expect(tracker.diagnostics()).toMatchObject({ contentBlocks: 0, estimateIncomplete: false });
+		}
+
+		const oversized = new InteractionMetricsTracker();
+		oversized.agentStart();
+		oversized.turnStart();
+		expect(
+			oversized.messageUpdate(assistant(0, 0), toolDelta(0, "x".repeat(65_537))).usageChanged,
+		).toBe(true);
+		expect(oversized.currentDisplayTokens()).toEqual({
+			input: 0,
+			output: 0,
+			outputApproximate: true,
+		});
+		expect(oversized.diagnostics()).toMatchObject({
+			contentBlocks: 0,
+			estimateIncomplete: true,
+		});
+		expect(oversized.messageEnd(assistant(11, 7))).toEqual(accepted({ input: 11, output: 7 }));
+	});
+
+	it("caps tool-call blocks and preserves exact final reconciliation", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		for (let index = 0; index < 129; index++) {
+			tracker.messageUpdate(assistant(0, 0), toolDelta(index, "x"));
+		}
+		expect(tracker.diagnostics()).toMatchObject({
+			contentBlocks: 128,
+			estimateIncomplete: true,
+		});
+		expect(tracker.messageEnd(assistant(9, 4))).toEqual(accepted({ input: 9, output: 4 }));
+		expect(tracker.diagnostics()).toMatchObject({ contentBlocks: 0, retainedContentUnits: 0 });
+	});
+
+	it("never commits an estimate on malformed closure", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0), delta("text_delta", 0, "abcdefgh", "abcdefgh"));
+		expect(tracker.messageEnd(assistant(-1, 1))).toEqual(
+			accepted({ input: 0, output: 0 }, "no-snapshot", {
+				input: 0,
+				output: 2,
+				outputApproximate: true,
+			}),
+		);
+		expect(tracker.currentTokens()).toEqual({ input: 0, output: 0 });
+	});
+});
+
+describe("interaction metrics tracker", () => {
+	it("promotes a response-less stream to a normalized ID and ignores its duplicate final", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(1_000);
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(assistant(100, 4, { timestamp: 1, provider: "first", model: "first" }))
+				.displayTokens,
+		).toEqual({ input: 100, output: 4, outputApproximate: false });
+		expect(
+			tracker.messageUpdate(
+				assistant(120, 7, {
+					responseId: "  response-a  ",
+					timestamp: 2,
+					provider: "second",
+					model: "second",
+				}),
+			).displayTokens,
+		).toEqual({ input: 120, output: 7, outputApproximate: false });
+		expect(
+			tracker.messageEnd(assistant(150, 9, { responseId: "response-a", timestamp: 3 })),
+		).toEqual(accepted({ input: 150, output: 9 }));
+		expect(
+			tracker.messageEnd(assistant(999, 99, { responseId: " response-a ", timestamp: 4 })),
+		).toEqual({ status: "rejected" });
+	});
+
+	it("deduplicates the same ID even after a new turn slot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { responseId: "a" }));
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(10, 1, { responseId: " a " }))).toEqual({
+			status: "duplicate",
+		});
+	});
+
+	it("keeps short IDs exact and treats overlong IDs as anonymous", () => {
+		const tracker = new InteractionMetricsTracker();
+		const first = `${"a".repeat(126)}-1`;
+		const second = `${"a".repeat(126)}-2`;
+		tracker.agentStart();
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(10, 1, { responseId: first }))).toEqual(
+			accepted({ input: 10, output: 1 }),
+		);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: second }))).toEqual(
+			accepted({ input: 30, output: 3 }),
+		);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: first }))).toEqual({
+			status: "duplicate",
+		});
+
+		const overlong = "x".repeat(129);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(3, 4, { responseId: overlong }))).toEqual(
+			accepted({ input: 33, output: 7 }),
+		);
+		expect(tracker.diagnostics().responseIds).toBe(2);
+	});
+
+	it("rejects multi-megabyte response IDs before normalization or retention", () => {
+		const tracker = new InteractionMetricsTracker();
+		const overlong = ` ${"x".repeat(2 * 1024 * 1024)} `;
+		tracker.agentStart();
+		tracker.turnStart();
+		const startedAt = performance.now();
+		expect(tracker.messageUpdate(assistant(2, 1, { responseId: overlong })).displayTokens).toEqual({
+			input: 2,
+			output: 1,
+			outputApproximate: false,
+		});
+		expect(tracker.messageEnd(assistant(7, 3, { responseId: overlong }))).toEqual(
+			accepted({ input: 7, output: 3 }),
+		);
+		expect(performance.now() - startedAt).toBeLessThan(1_000);
+		expect(tracker.diagnostics().responseIds).toBe(0);
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: overlong }))).toEqual({
+			status: "rejected",
+		});
+	});
+
+	it("counts a reused response ID independently in a later low-level run", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { responseId: "reused" }));
+		tracker.agentEnd();
+		tracker.agentStart();
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: " reused " }))).toEqual(
+			accepted({
+				input: 30,
+				output: 3,
+			}),
+		);
+	});
+
+	it("rejects distinct finals until turn_start authorizes each slot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		expect(tracker.messageEnd(assistant(10, 1, { responseId: "a", timestamp: 7 }))).toEqual({
+			status: "rejected",
+		});
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "b", timestamp: 7 }))).toEqual(
+			accepted({ input: 20, output: 2 }),
+		);
+	});
+
+	it("counts response-less same-metadata responses only when turn_start separates them", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { timestamp: 7 }));
+		expect(tracker.messageEnd(assistant(10, 1, { timestamp: 7 }))).toEqual({ status: "rejected" });
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(10, 1, { timestamp: 7 }))).toEqual(
+			accepted({
+				input: 20,
+				output: 2,
+			}),
+		);
+	});
+
+	it("deduplicates a streaming error final despite changed metadata and timestamp", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(
+			assistant(5, 1, {
+				responseId: "error-response",
+				provider: "first",
+				model: "first",
+				timestamp: 1,
+			}),
+		);
+		expect(
+			tracker.messageEnd(
+				assistant(8, 2, {
+					responseId: "error-response",
+					provider: "second",
+					model: "second",
+					stopReason: "error",
+					timestamp: 2,
+				}),
+			),
+		).toEqual(accepted({ input: 8, output: 2 }));
+		expect(
+			tracker.messageEnd(
+				assistant(80, 20, {
+					responseId: "error-response",
+					provider: "third",
+					model: "third",
+					stopReason: "error",
+					timestamp: 3,
+				}),
+			),
+		).toEqual({ status: "rejected" });
+	});
+
+	it("deduplicates a response-less aborted streaming final", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(4, 1, { stopReason: "aborted", timestamp: 1 }));
+		expect(tracker.messageEnd(assistant(6, 2, { stopReason: "aborted", timestamp: 2 }))).toEqual(
+			accepted({
+				input: 6,
+				output: 2,
+			}),
+		);
+		expect(tracker.messageEnd(assistant(60, 20, { stopReason: "aborted", timestamp: 3 }))).toEqual({
+			status: "rejected",
+		});
+	});
+
+	it("displays cumulative usage throughout a three-response tool loop", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		for (const [input, output, expectedUpdate, expectedFinal, responseId, stopReason] of [
+			[
+				10,
+				1,
+				{ input: 9, output: 1, outputApproximate: false },
+				{ input: 10, output: 1 },
+				"a",
+				"toolUse",
+			],
+			[
+				20,
+				2,
+				{ input: 29, output: 3, outputApproximate: false },
+				{ input: 30, output: 3 },
+				"b",
+				"toolUse",
+			],
+			[
+				30,
+				3,
+				{ input: 59, output: 6, outputApproximate: false },
+				{ input: 60, output: 6 },
+				"c",
+				"stop",
+			],
+		] as const) {
+			tracker.turnStart();
+			expect(
+				tracker.messageUpdate(assistant(input - 1, output, { responseId, stopReason }))
+					.displayTokens,
+			).toEqual(expectedUpdate);
+			expect(tracker.messageEnd(assistant(input, output, { responseId, stopReason }))).toEqual(
+				accepted(expectedFinal),
+			);
+		}
+		expect(tracker.currentTokens()).toEqual({ input: 60, output: 6 });
+	});
+
+	it("retains committed totals for a next response's initial zero snapshot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { responseId: "first" }));
+		tracker.turnStart();
+		expect(tracker.messageUpdate(assistant(0, 0, { responseId: "second" })).displayTokens).toEqual({
+			input: 10,
+			output: 1,
+			outputApproximate: true,
+		});
+		expect(tracker.messageUpdate(assistant(7, 2, { responseId: "second" })).displayTokens).toEqual({
+			input: 17,
+			output: 3,
+			outputApproximate: false,
+		});
+	});
+
+	it.each([undefined, "final-id"])(
+		"accepts authorized final-only usage with ID %s",
+		(responseId) => {
+			const tracker = new InteractionMetricsTracker();
+			tracker.agentStart();
+			tracker.turnStart();
+			expect(tracker.messageEnd(assistant(4, 2, { responseId }))).toEqual(
+				accepted({ input: 4, output: 2 }),
+			);
+		},
+	);
+
+	it("shows repeated initial zero updates once and ignores placeholder regression", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		expect(tracker.messageUpdate(assistant(0, 0, { responseId: "stream" })).displayTokens).toEqual({
+			input: 0,
+			output: 0,
+			outputApproximate: true,
+		});
+		expect(tracker.messageUpdate(assistant(0, 0, { responseId: "stream" })).usageChanged).toBe(
+			false,
+		);
+		expect(tracker.currentTokens()).toEqual({ input: 0, output: 0 });
+		expect(tracker.messageUpdate(assistant(8, 2, { responseId: "stream" })).displayTokens).toEqual({
+			input: 8,
+			output: 2,
+			outputApproximate: false,
+		});
+		expect(tracker.messageUpdate(assistant(0, 0, { responseId: "stream" })).displayTokens).toEqual({
+			input: 8,
+			output: 2,
+			outputApproximate: false,
+		});
+		expect(tracker.currentTokens()).toEqual({ input: 8, output: 2 });
+	});
+
+	it("commits a zero-only final exactly once", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(1_000);
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(assistant(0, 0, { responseId: "zero-only" })).displayTokens,
+		).toEqual({ input: 0, output: 0, outputApproximate: true });
+		expect(tracker.messageEnd(assistant(0, 0, { responseId: "zero-only" }))).toEqual(
+			accepted({
+				input: 0,
+				output: 0,
+			}),
+		);
+		expect(tracker.messageEnd(assistant(9, 3, { responseId: "zero-only" }))).toEqual({
+			status: "rejected",
+		});
+		tracker.agentEnd();
+		expect(tracker.settle(true, 2_000)?.summary).toEqual({
+			durationMs: 1_000,
+			thoughtDurationMs: 0,
+			input: 0,
+			output: 0,
+		});
+	});
+
+	it("rejects invalid and non-assistant updates without changing accounting", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(8, 2));
+		expect(tracker.messageUpdate(assistant(-1, 4)).usageChanged).toBe(false);
+		expect(
+			tracker.messageUpdate({ role: "user", usage: { input: 99, output: 99 } }).usageChanged,
+		).toBe(false);
+		expect(tracker.currentTokens()).toEqual({ input: 8, output: 2 });
+	});
+
+	it.each([
+		[assistant(0, 0), { input: 0, output: 0 }],
+		[assistant(-1, 0), undefined],
+		[assistant(0, 1.5), undefined],
+		[assistant(Number.POSITIVE_INFINITY, 0), undefined],
+		[assistant(Number.MAX_SAFE_INTEGER + 1, 0), undefined],
+		[{ role: "user", usage: { input: 0, output: 0 } }, undefined],
+	])("strictly parses assistant usage %#", (message, expected) => {
+		expect(parseAssistantMessageTokens(message)).toEqual(expected);
+	});
+
+	it("saturates token fields independently and settles valid data with a clamped duration", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(1_000);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(-1, 4, { responseId: "invalid-negative" }))).toEqual(
+			accepted({ input: 0, output: 0 }, "no-snapshot"),
+		);
+		expect(
+			tracker.messageEnd(
+				assistant(Number.MAX_SAFE_INTEGER + 1, 4, { responseId: "invalid-unsafe" }),
+			),
+		).toEqual({ status: "rejected" });
+		tracker.turnStart();
+		tracker.messageEnd(assistant(Number.MAX_SAFE_INTEGER - 2, 10, { responseId: "first-valid" }));
+		tracker.turnStart();
+		expect(
+			tracker.messageEnd(
+				assistant(5, Number.MAX_SAFE_INTEGER - 20, { responseId: "second-valid" }),
+			),
+		).toEqual(
+			accepted({
+				input: Number.MAX_SAFE_INTEGER,
+				output: Number.MAX_SAFE_INTEGER - 10,
+			}),
+		);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(0, 20, { responseId: "third-valid" }))).toEqual(
+			accepted({
+				input: Number.MAX_SAFE_INTEGER,
+				output: Number.MAX_SAFE_INTEGER,
+			}),
+		);
+		tracker.agentEnd();
+		const settled = tracker.settle(true, Number.POSITIVE_INFINITY);
+		expect(settled?.summary).toEqual({
+			durationMs: Number.MAX_SAFE_INTEGER,
+			thoughtDurationMs: 0,
+			input: Number.MAX_SAFE_INTEGER,
+			output: Number.MAX_SAFE_INTEGER,
+		});
+		expect(
+			isTurnSummaryData({
+				version: 1,
+				durationMs: settled?.summary.durationMs,
+				input: settled?.summary.input,
+				output: settled?.summary.output,
+			}),
+		).toBe(true);
+	});
+
+	it("spans low-level runs and resets only after settlement", () => {
+		const tracker = new InteractionMetricsTracker();
+		expect(tracker.agentStart(1_000)).toEqual({ interactionStarted: true });
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 2, { responseId: "a" }));
+		tracker.agentEnd();
+		expect(tracker.agentStart(2_000)).toEqual({ interactionStarted: false });
+		tracker.turnStart();
+		tracker.messageEnd(assistant(20, 3, { responseId: "b" }));
+		tracker.agentEnd();
+		expect(tracker.settle(true, 3_000)?.summary).toEqual({
+			durationMs: 2_000,
+			thoughtDurationMs: 0,
+			input: 30,
+			output: 5,
+		});
+		expect(tracker.settle(true)).toBeUndefined();
+		tracker.agentStart(50_000);
+		tracker.shutdown();
+		expect(tracker.settle(true)).toBeUndefined();
+	});
+
+	it.each(["error", "aborted"])(
+		"commits the last valid snapshot once when a matching %s final has malformed usage",
+		(stopReason) => {
+			const tracker = new InteractionMetricsTracker();
+			tracker.agentStart(1_000);
+			tracker.turnStart();
+			tracker.messageUpdate(assistant(10, 1, { responseId: "a" }));
+			const malformed = assistant(-1, 99, { responseId: "a", stopReason });
+			expect(tracker.messageEnd(malformed)).toEqual(
+				accepted({ input: 10, output: 1 }, "last-snapshot"),
+			);
+			expect(tracker.currentTokens()).toEqual({ input: 10, output: 1 });
+			expect(tracker.messageEnd(malformed)).toEqual({ status: "rejected" });
+			expect(tracker.currentTokens()).toEqual({ input: 10, output: 1 });
+
+			tracker.turnStart();
+			expect(tracker.messageEnd(assistant(20, 2, { responseId: "b" }))).toEqual(
+				accepted({
+					input: 30,
+					output: 3,
+				}),
+			);
+			tracker.agentEnd();
+			expect(tracker.settle(true, 2_000)?.summary).toEqual({
+				durationMs: 1_000,
+				thoughtDurationMs: 0,
+				input: 30,
+				output: 3,
+			});
+		},
+	);
+
+	it("preserves a live estimate when a malformed final has no valid snapshot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "invalid" }),
+			delta("thinking_delta", 0, "abcdefgh", "abcdefgh"),
+		);
+		expect(tracker.messageEnd(assistant(-1, 1, { responseId: "invalid" }))).toEqual(
+			accepted({ input: 0, output: 0 }, "no-snapshot", {
+				input: 0,
+				output: 2,
+				outputApproximate: true,
+			}),
+		);
+		expect(tracker.currentTokens()).toEqual({ input: 0, output: 0 });
+		expect(tracker.currentDisplayTokens()).toEqual({
+			input: 0,
+			output: 2,
+			outputApproximate: true,
+		});
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "b" }))).toEqual(
+			accepted({
+				input: 20,
+				output: 2,
+			}),
+		);
+	});
+
+	it("preserves an estimate above a lower provider anchor on malformed final", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(10, 1, { responseId: "anchored" }));
+		tracker.messageUpdate(
+			assistant(10, 1, { responseId: "anchored" }),
+			delta("text_delta", 0, "abcdefghijkl", "abcdefghijkl"),
+		);
+		expect(tracker.messageEnd(assistant(-1, 9, { responseId: "anchored" }))).toEqual(
+			accepted({ input: 10, output: 1 }, "last-snapshot", {
+				input: 10,
+				output: 4,
+				outputApproximate: true,
+			}),
+		);
+		tracker.agentEnd();
+		expect(tracker.settle(true)?.summary).toMatchObject({ input: 10, output: 1 });
+	});
+
+	it("commits an unfinalized valid snapshot before opening the next response", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(10, 1, { responseId: "a" }));
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "b" }))).toEqual(
+			accepted({
+				input: 30,
+				output: 3,
+			}),
+		);
+	});
+
+	it("rejects mismatched updates and finals without modifying or closing the active response", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		tracker.messageUpdate(
+			assistant(10, 1, { responseId: "a" }),
+			{
+				type: "thinking_start",
+				contentIndex: 0,
+				partial: assistant(0, 0),
+			} as never,
+			0,
+		);
+		expect(tracker.messageUpdate(assistant(99, 9, { responseId: "b" }), undefined, 10)).toEqual({
+			displayTokens: { input: 10, output: 1, outputApproximate: false },
+			usageChanged: false,
+			thoughtChanged: false,
+		});
+		expect(tracker.messageEnd(assistant(99, 9, { responseId: "b" }), 20)).toEqual({
+			status: "rejected",
+		});
+		expect(tracker.currentThought(30)).toEqual({ durationMs: 30, active: true });
+		expect(tracker.messageEnd(assistant(12, 2, { responseId: "a" }), 40)).toEqual(
+			accepted({
+				input: 12,
+				output: 2,
+			}),
+		);
+		expect(tracker.currentThought(50)).toEqual({ durationMs: 40, active: false });
+	});
+
+	it("does not let a mismatched malformed final close or commit the active response", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		tracker.messageUpdate(
+			assistant(10, 1, { responseId: "a" }),
+			{
+				type: "thinking_start",
+				contentIndex: 0,
+				partial: assistant(0, 0),
+			} as never,
+			0,
+		);
+		expect(tracker.messageEnd(assistant(-1, 9, { responseId: "b" }), 20)).toEqual({
+			status: "rejected",
+		});
+		expect(tracker.currentTokens()).toEqual({ input: 10, output: 1 });
+		expect(tracker.currentThought(30)).toEqual({ durationMs: 30, active: true });
+		expect(tracker.messageEnd(assistant(-1, 9, { responseId: "a" }), 40)).toEqual(
+			accepted({ input: 10, output: 1 }, "last-snapshot"),
+		);
+		expect(tracker.currentTokens()).toEqual({ input: 10, output: 1 });
+		expect(tracker.currentThought(50)).toEqual({ durationMs: 40, active: false });
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "b" }))).toEqual(
+			accepted({
+				input: 30,
+				output: 3,
+			}),
+		);
+	});
+
+	it("does not let a stale committed ID promote a fresh response-less turn slot", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { responseId: "a" }));
+		tracker.turnStart();
+		expect(tracker.messageUpdate(assistant(99, 9, { responseId: "a" })).usageChanged).toBe(false);
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "b" }))).toEqual(
+			accepted({
+				input: 30,
+				output: 3,
+			}),
+		);
+	});
+
+	it("keeps authorized live and exact accounting at estimator and response-ID caps", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart();
+		for (let index = 0; index < 128; index++) {
+			tracker.turnStart();
+			tracker.messageUpdate(
+				assistant(0, 0, { responseId: `estimated-${index}` }),
+				delta("text_delta", 0, "abcd", "abcd"),
+			);
+			tracker.messageEnd(assistant(1, 1, { responseId: `estimated-${index}` }));
+		}
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(
+				assistant(0, 0, { responseId: "exact-only" }),
+				delta("text_delta", 0, "abcd", "abcd"),
+			).displayTokens,
+		).toEqual({ input: 128, output: 128, outputApproximate: true });
+		expect(tracker.messageEnd(assistant(2, 3, { responseId: "exact-only" }))).toEqual(
+			accepted({ input: 130, output: 131 }),
+		);
+
+		for (let index = 129; index < 256; index++) {
+			tracker.turnStart();
+			tracker.messageEnd(assistant(1, 1, { responseId: `exact-${index}` }));
+		}
+		expect(tracker.diagnostics().responseIds).toBe(256);
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(3, 4, { responseId: "overflow-id" }))).toEqual(
+			accepted({ input: 260, output: 262 }),
+		);
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(
+				assistant(99, 99, { responseId: "overflow-id" }),
+				delta("text_delta", 0, "replay", "replay"),
+			),
+		).toMatchObject({ usageChanged: false });
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: "overflow-id" }))).toEqual({
+			status: "duplicate",
+		});
+		expect(tracker.messageEnd(assistant(5, 6, { responseId: "fresh-after-overflow" }))).toEqual(
+			accepted({ input: 265, output: 268 }),
+		);
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: "fresh-after-overflow" }))).toEqual({
+			status: "rejected",
+		});
+		expect(tracker.messageEnd(assistant(99, 99))).toEqual({ status: "rejected" });
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: "overflow-unsolicited" }))).toEqual({
+			status: "rejected",
+		});
+
+		tracker.turnStart();
+		expect(tracker.messageEnd(assistant(1, 1))).toEqual(accepted({ input: 266, output: 269 }));
+		expect(tracker.messageEnd(assistant(99, 99))).toEqual({ status: "rejected" });
+
+		tracker.turnStart();
+		expect(
+			tracker.messageUpdate(
+				assistant(4, 2, { responseId: "authorized-at-cap" }),
+				delta("text_delta", 0, "abcdefgh", "abcdefgh"),
+			).displayTokens,
+		).toEqual({ input: 270, output: 271, outputApproximate: true });
+		expect(tracker.messageUpdate(assistant(99, 99, { responseId: "mismatch" })).usageChanged).toBe(
+			false,
+		);
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: "mismatch" }))).toEqual({
+			status: "rejected",
+		});
+		expect(tracker.messageEnd(assistant(9, 9, { responseId: "authorized-at-cap" }))).toEqual(
+			accepted({ input: 275, output: 278 }),
+		);
+		expect(tracker.diagnostics().responseIds).toBe(256);
+		expect(tracker.messageEnd(assistant(99, 99, { responseId: "authorized-at-cap" }))).toEqual({
+			status: "rejected",
+		});
+		expect(
+			tracker.messageUpdate(assistant(99, 99, { responseId: "unknown" }), {
+				type: "unknown",
+			} as never).usageChanged,
+		).toBe(false);
+	});
+
+	it("bounds run state while preserving folded exact totals", () => {
+		const tracker = new InteractionMetricsTracker();
+		for (let index = 0; index < 40; index++) {
+			tracker.agentStart(index);
+			tracker.turnStart(index);
+			tracker.messageEnd(assistant(1, 2, { responseId: `run-${index}` }));
+			tracker.agentEnd(index + 1);
+		}
+		expect(tracker.currentTokens()).toEqual({ input: 40, output: 80 });
+		expect(tracker.diagnostics().runs).toBeLessThanOrEqual(32);
+	});
+
+	it("ignores late events after agent_end and accepts them only after a real next agent_start", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		tracker.messageEnd(assistant(10, 1, { responseId: "a" }));
+		tracker.agentEnd(10);
+		expect(tracker.messageUpdate(assistant(90, 9, { responseId: "late" })).usageChanged).toBe(
+			false,
+		);
+		expect(tracker.messageEnd(assistant(90, 9, { responseId: "late" }))).toEqual({
+			status: "rejected",
+		});
+		expect(tracker.currentTokens()).toEqual({ input: 10, output: 1 });
+		tracker.agentStart(20);
+		tracker.turnStart(20);
+		expect(tracker.messageEnd(assistant(20, 2, { responseId: "late" }))).toEqual(
+			accepted({
+				input: 30,
+				output: 3,
+			}),
+		);
+	});
+
+	it("retains a live response ID and snapshot across non-idle partitioning", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(1_000);
+		tracker.turnStart();
+		tracker.messageEnd(assistant(10, 1, { responseId: "settled" }));
+		tracker.agentEnd();
+		tracker.agentStart(5_000);
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(7, 2, { responseId: " live " }));
+		expect(tracker.settle(false, 6_000)).toEqual({
+			summary: { durationMs: 5_000, thoughtDurationMs: 0, input: 10, output: 1 },
+			nextStartedAt: 5_000,
+			nextTokens: { input: 7, output: 2, outputApproximate: false },
+			nextThought: { durationMs: 0, active: false },
+		});
+		expect(tracker.messageEnd(assistant(9, 3, { responseId: "live", timestamp: 99 }))).toEqual(
+			accepted({
+				input: 9,
+				output: 3,
+			}),
+		);
+		expect(tracker.messageEnd(assistant(9, 3, { responseId: "live" }))).toEqual({
+			status: "rejected",
+		});
+	});
+});
+
+describe("thought duration tracking", () => {
+	const thinking = (
+		type: "thinking_start" | "thinking_delta" | "thinking_end",
+		contentIndex: number,
+	) =>
+		({
+			type,
+			contentIndex,
+			partial: assistant(0, 0),
+			...(type === "thinking_delta" ? { delta: "x" } : {}),
+			...(type === "thinking_end" ? { content: "x" } : {}),
+		}) as never;
+
+	it("retains a bounded exact lower bound after adversarial subtraction", () => {
+		const result = subtractThoughtIntervalsWithinCap(
+			[{ start: 0, end: 513 }],
+			Array.from({ length: 257 }, (_, index) => ({
+				start: index * 2 + 1,
+				end: index * 2 + 2,
+			})),
+		);
+		expect(result.incomplete).toBe(true);
+		expect(result.intervals).toHaveLength(256);
+		expect(result.intervals[0]).toEqual({ start: 0, end: 1 });
+		expect(result.intervals.at(-1)).toEqual({ start: 510, end: 511 });
+		for (let index = 0; index < result.intervals.length; index++) {
+			const interval = result.intervals[index];
+			expect(interval.end).toBeGreaterThan(interval.start);
+			expect(interval.start).toBeGreaterThanOrEqual(0);
+			expect(interval.end).toBeLessThanOrEqual(513);
+			if (index > 0) expect(interval.start).toBeGreaterThan(result.intervals[index - 1].end);
+		}
+	});
+
+	it("counts the union of overlapping blocks and updates open elapsed from receipt time", () => {
+		let now = 1_000;
+		const tracker = new InteractionMetricsTracker(() => now);
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_start", 0));
+		now = 2_000;
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_start", 1));
+		now = 3_000;
+		expect(tracker.currentThought()).toEqual({ durationMs: 2_000, active: true });
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_end", 0));
+		now = 4_000;
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_end", 1));
+		expect(tracker.currentThought()).toEqual({ durationMs: 3_000, active: false });
+	});
+
+	it("keeps an exact lower-bound union after the strict thought interval cap", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		for (let index = 0; index < 256; index++) {
+			tracker.turnStart(index * 4);
+			tracker.messageUpdate(
+				assistant(0, 0, { responseId: `thought-${index}` }),
+				thinking("thinking_start", 0),
+				index * 4,
+			);
+			tracker.messageUpdate(
+				assistant(0, 0, { responseId: `thought-${index}` }),
+				thinking("thinking_end", 0),
+				index * 4 + 1,
+			);
+			tracker.messageEnd(assistant(0, 0, { responseId: `thought-${index}` }), index * 4 + 1);
+		}
+		expect(tracker.diagnostics().thoughtIntervals).toBe(256);
+		expect(tracker.currentThought(2_000)).toEqual({ durationMs: 256, active: false });
+
+		tracker.turnStart(2_000);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "overflow" }),
+			thinking("thinking_start", 0),
+			2_000,
+		);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "overflow" }),
+			thinking("thinking_end", 0),
+			2_001,
+		);
+		expect(tracker.diagnostics().thoughtIntervals).toBe(256);
+		expect(tracker.currentThought(2_001)).toEqual({ durationMs: 256, active: false });
+
+		tracker.turnStart(500);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "covered-overlap" }),
+			thinking("thinking_start", 0),
+			500,
+		);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "covered-overlap" }),
+			thinking("thinking_end", 0),
+			505,
+		);
+		expect(tracker.diagnostics().thoughtIntervals).toBe(256);
+		expect(tracker.currentThought(2_100)).toEqual({ durationMs: 256, active: false });
+
+		tracker.turnStart(2_002);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "gap-after-incomplete" }),
+			thinking("thinking_start", 0),
+			2_002,
+		);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "gap-after-incomplete" }),
+			thinking("thinking_end", 0),
+			2_003,
+		);
+		expect(tracker.diagnostics().thoughtIntervals).toBe(256);
+		expect(tracker.currentThought(2_100)).toEqual({ durationMs: 256, active: false });
+		expect(tracker.settle(true, 2_100)?.summary.thoughtDurationMs).toBe(256);
+		expect(tracker.currentThought()).toBeUndefined();
+	});
+
+	it("handles duplicates, delta without start, missing ends, and reused content indexes", () => {
+		let now = 10;
+		const tracker = new InteractionMetricsTracker(() => now);
+		tracker.agentStart();
+		tracker.turnStart();
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_delta", 0));
+		tracker.messageUpdate(assistant(0, 0, { responseId: "a" }), thinking("thinking_start", 0));
+		now = 20;
+		tracker.messageEnd(assistant(1, 1, { responseId: "a" }));
+		tracker.turnStart();
+		now = 30;
+		tracker.messageUpdate(assistant(0, 0, { responseId: "b" }), thinking("thinking_start", 0));
+		now = 40;
+		tracker.agentEnd();
+		expect(tracker.currentThought()).toEqual({ durationMs: 20, active: false });
+	});
+
+	it("ignores late thought after agent_end", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.agentEnd(10);
+		const result = tracker.messageUpdate(
+			assistant(0, 0, { responseId: "late" }),
+			thinking("thinking_start", 0),
+			20,
+		);
+		expect(result.thoughtChanged).toBe(false);
+		expect(tracker.currentThought(30)).toEqual({ durationMs: 0, active: false });
+	});
+
+	it("partitions ended thought without double-counting a concurrent retained run", () => {
+		const tracker = new InteractionMetricsTracker();
+		tracker.agentStart(0);
+		tracker.turnStart(0);
+		tracker.messageUpdate(assistant(0, 0, { responseId: "old" }), thinking("thinking_start", 0), 0);
+		tracker.agentEnd(100);
+		tracker.agentStart(50);
+		tracker.turnStart(50);
+		tracker.messageUpdate(
+			assistant(0, 0, { responseId: "live" }),
+			thinking("thinking_start", 0),
+			50,
+		);
+		const split = tracker.settle(false, 100);
+		expect(split?.summary.thoughtDurationMs).toBe(100);
+		expect(split?.nextThought).toEqual({ durationMs: 0, active: true });
+		expect(tracker.currentThought(150)).toEqual({ durationMs: 50, active: true });
+	});
+});
+
+describe("turn summary entry", () => {
+	it("validates versioned numeric data and formats exact persistent text", () => {
+		const data = { version: 1 as const, durationMs: 42_999, input: 1234, output: 380 };
+		expect(isTurnSummaryData(data)).toBe(true);
+		expect(formatTurnSummary(data)).toBe(" Turn took 42s · ↑1.2k ↓380");
+		const rendered = renderTurnSummaryEntry(
+			{ data },
+			{},
+			{ fg: (_color: string, text: string) => `\x1b[2m${text}\x1b[0m` },
+		);
+		expect(stripTerminalSequences(rendered?.render(100).join("\n") ?? "").trimEnd()).toBe(
+			" Turn took 42s · ↑1.2k ↓380",
+		);
+	});
+
+	it("validates and renders v2 with its persisted style independently of the current theme", () => {
+		const data = {
+			version: 2 as const,
+			durationMs: 1,
+			input: 2,
+			output: 3,
+			stylePrefix: "\x1b[1;38;5;202m",
+		};
+		expect(isTurnSummaryData(data)).toBe(true);
+		const rendered = renderTurnSummaryEntry(
+			{ data },
+			{ colorSource: "theme", workingLineHigh: "green" },
+			{ fg: () => "changed-theme" },
+		)?.render(100)[0];
+		expect(rendered).toContain("\x1b[1;38;5;202m Turn took 0s · ↑2 ↓3\x1b[0m");
+		expect(rendered).not.toContain("changed-theme");
+	});
+
+	it("validates v3 exactly and formats thought while omitting zero", () => {
+		const data = {
+			version: 3 as const,
+			durationMs: 56_999,
+			thoughtDurationMs: 10_999,
+			input: 7_100,
+			output: 779,
+			stylePrefix: "\x1b[1;36m",
+		};
+		expect(isTurnSummaryData(data)).toBe(true);
+		expect(formatTurnSummary(data)).toBe(" Turn took 56s · thought for 10s · ↑7.1k ↓779");
+		expect(formatTurnSummary({ ...data, thoughtDurationMs: 0 })).toBe(
+			" Turn took 56s · ↑7.1k ↓779",
+		);
+		expect(isTurnSummaryData({ ...data, thoughtDurationMs: -1 })).toBe(false);
+		expect(isTurnSummaryData({ ...data, extra: true })).toBe(false);
+		expect(isTurnSummaryData({ ...data, stylePrefix: "\x1b]8;;bad\x07" })).toBe(false);
+	});
+
+	it("accepts four safe SGR sequences but rejects a fifth sequence and injected controls", () => {
+		const safe = {
+			version: 2 as const,
+			durationMs: 1,
+			input: 2,
+			output: 3,
+			stylePrefix: "\x1b[38;5;202m\x1b[4m\x1b[3m\x1b[1m",
+		};
+		expect(isTurnSummaryData(safe)).toBe(true);
+		const rendered = renderTurnSummaryEntry({ data: safe }, {}, { fg: (_color, text) => text })
+			?.render(100)
+			.join("\n");
+		expect(rendered).toContain(`${safe.stylePrefix} Turn took 0s · ↑2 ↓3\x1b[0m`);
+		expect(isTurnSummaryData({ ...safe, stylePrefix: `${safe.stylePrefix}\x1b[2m` })).toBe(false);
+		expect(isTurnSummaryData({ ...safe, stylePrefix: `${safe.stylePrefix}\x1b]8;;bad\x07` })).toBe(
+			false,
+		);
+		expect(
+			isTurnSummaryData({
+				...safe,
+				stylePrefix: "\x1b[38;2;0000000255;0000000255;0000000255m".repeat(4),
+			}),
+		).toBe(false);
+	});
+
+	it.each([
+		null,
+		{},
+		{ version: 2, durationMs: 1, input: 1, output: 1 },
+		{ version: 2, durationMs: 1, input: 1, output: 1, stylePrefix: "\x1b[0m" },
+		{ version: 2, durationMs: 1, input: 1, output: 1, stylePrefix: "\x1b[31mprint" },
+		{ version: 2, durationMs: 1, input: 1, output: 1, stylePrefix: "\x1b]8;;bad\x07" },
+		{ version: 2, durationMs: 1, input: 1, output: 1, stylePrefix: "\x1b[2J" },
+		{ version: 2, durationMs: 1, input: 1, output: 1, stylePrefix: "\x1b[31m", extra: true },
+		{ version: 1, durationMs: -1, input: 1, output: 1 },
+		{ version: 1, durationMs: 1, input: 1.5, output: 1 },
+		{ version: 1, durationMs: 1, input: 1, output: 1, extra: true },
+	])("rejects invalid renderer data %#", (data) => {
+		expect(renderTurnSummaryEntry({ data }, {}, { fg: (_color, text) => text })).toBeUndefined();
+	});
+
+	it("proves custom entries persist while contributing zero model messages", () => {
+		const entry = {
+			type: "custom" as const,
+			id: "summary",
+			parentId: null,
+			timestamp: new Date(0).toISOString(),
+			customType: TURN_SUMMARY_ENTRY_TYPE,
+			data: { version: 1, durationMs: 1, input: 0, output: 0 },
+		};
+		const entries = [entry];
+		expect(entries[0]?.data).toEqual(entry.data);
+		expect(buildSessionContext(entries).messages).toEqual([]);
+	});
+});

--- a/test/interaction-summary.test.ts
+++ b/test/interaction-summary.test.ts
@@ -1,5 +1,5 @@
+import { stripVTControlCharacters } from "node:util";
 import { buildSessionContext } from "@earendil-works/pi-coding-agent";
-import { stripTerminalSequences } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import {
 	formatTurnSummary,
@@ -10,6 +10,8 @@ import {
 	subtractThoughtIntervalsWithinCap,
 	TURN_SUMMARY_ENTRY_TYPE,
 } from "../extensions/zentui/interaction-summary";
+
+const stripTerminalSequences = stripVTControlCharacters;
 
 type AssistantOptions = {
 	responseId?: string;

--- a/test/live-context-integration.test.ts
+++ b/test/live-context-integration.test.ts
@@ -291,10 +291,12 @@ describe("live streaming context event integration", () => {
 		await emit(handlers, "session_tree", harness.ctx);
 		expect(rendered(footer)).toContain("10.0%/10k");
 
+		await emit(handlers, "turn_start", harness.ctx);
 		await seedLive();
 		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100, "error") });
 		expect(rendered(footer)).toContain("10.0%/10k");
 
+		await emit(handlers, "turn_start", harness.ctx);
 		await seedLive();
 		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100, "aborted") });
 		expect(rendered(footer)).toContain("10.0%/10k");

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -687,7 +687,7 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			for (let index = 0; index < 3; index++) component.handleInput?.("\t");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
 			for (let index = 0; index < 3; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
@@ -731,7 +731,7 @@ describe("responsive footer dependency reconciliation", () => {
 				render(width: number): string[];
 				handleInput(data: string): void;
 			};
-			for (let index = 0; index < 5; index++) component.handleInput("\t");
+			for (let index = 0; index < 6; index++) component.handleInput("\t");
 			const label = target === "showTag" ? "Show exact-match tag" : "Ignore submodules";
 			for (let attempts = 0; attempts < 12; attempts++) {
 				if (component.render(140).some((line) => line.includes(`> ${label}`))) break;
@@ -762,7 +762,7 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
+			for (let index = 0; index < 5; index++) component.handleInput?.("\t");
 			for (let index = 0; index < 11; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
@@ -782,7 +782,7 @@ describe("responsive footer dependency reconciliation", () => {
 			const component = factory({ requestRender() {} }, makeTheme(), {}, () => {}) as {
 				handleInput?: (data: string) => void;
 			};
-			for (let index = 0; index < 3; index++) component.handleInput?.("\t");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\t");
 			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1,6 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	defaultConfig,
 	type EditorComponentConfig,
@@ -9,6 +9,7 @@ import {
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type UserMessagesComponentConfig,
+	type WorkingLineComponentPatch,
 } from "../extensions/zentui/config";
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
 import { registerZentuiSettingsCommand } from "../extensions/zentui/settings-command";
@@ -22,6 +23,7 @@ const sectionNames = [
 	"Appearance",
 	"Editor",
 	"User messages",
+	"Working line",
 	"Footer",
 	"Segments",
 	"Git",
@@ -70,14 +72,21 @@ function expectFocusOrder(component: Component, labels: readonly string[]): void
 	expect(focusedRow(component)).toBe(first);
 }
 
-function createHarness(config = cloneConfig(), overrides: Record<string, unknown> = {}) {
+function createHarness(
+	config = cloneConfig(),
+	overrides: Record<string, unknown> = {},
+	uiOverrides: Record<string, unknown> = {},
+) {
 	let command: Command | undefined;
 	let component: Component | undefined;
 	const notifications: string[] = [];
 	let doneCalls = 0;
+	const sessionLifecycle = new SessionLifecycle();
 	const calls = {
 		editor: [] as Partial<EditorComponentConfig>[],
 		messages: [] as Partial<UserMessagesComponentConfig>[],
+		workingLine: [] as WorkingLineComponentPatch[],
+		renders: { shared: 0, local: 0 },
 		selectors: [] as Partial<SelectorBordersComponentConfig>[],
 		footer: [] as Partial<FooterComponentConfig>[],
 		minimalist: [] as Array<Record<string, unknown>>,
@@ -88,7 +97,7 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		recipe: [] as boolean[],
 	};
 	const deps = {
-		sessionLifecycle: new SessionLifecycle(),
+		sessionLifecycle,
 		getConfig: () => config,
 		setEditorComponent(patch: Partial<EditorComponentConfig>) {
 			calls.editor.push(patch);
@@ -102,6 +111,14 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		setUserMessagesComponent(patch: Partial<UserMessagesComponentConfig>) {
 			calls.messages.push(patch);
 			Object.assign(config.components.userMessages, patch);
+		},
+		setWorkingLineComponent(patch: WorkingLineComponentPatch) {
+			calls.workingLine.push(patch);
+			const { messages, segments, ...componentPatch } = patch;
+			Object.assign(config.components.workingLine, componentPatch);
+			if (messages) Object.assign(config.components.workingLine.messages, messages);
+			if (segments) Object.assign(config.components.workingLine.segments, segments);
+			return { applied: true };
 		},
 		setSelectorBordersComponent(patch: Partial<SelectorBordersComponentConfig>) {
 			calls.selectors.push(patch);
@@ -137,7 +154,9 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		},
 		setExtensionStatusPlacement() {},
 		setExtensionStatusColorMode() {},
-		requestRender() {},
+		requestRender() {
+			calls.renders.shared += 1;
+		},
 		settingsListTheme: {
 			label: (text: string) => text,
 			value: (text: string) => text,
@@ -165,10 +184,23 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 				notifications.push(message);
 			},
 			async custom(factory: (...args: unknown[]) => unknown) {
-				component = factory({ requestRender() {} }, theme(), {}, () => {
-					doneCalls += 1;
-				}) as Component;
+				component = factory(
+					{
+						requestRender() {
+							calls.renders.local += 1;
+						},
+					},
+					theme(),
+					{},
+					() => {
+						doneCalls += 1;
+					},
+				) as Component;
 			},
+			async editor() {
+				return undefined;
+			},
+			...uiOverrides,
 		},
 	};
 	return {
@@ -184,12 +216,17 @@ function createHarness(config = cloneConfig(), overrides: Record<string, unknown
 		ctx,
 		calls,
 		notifications,
+		sessionLifecycle,
 		doneCalls: () => doneCalls,
 	};
 }
 
+afterEach(() => {
+	vi.useRealTimers();
+});
+
 describe("component-oriented /zentui settings", () => {
-	it("uses the exact seven-section order in wide and narrow navigation", async () => {
+	it("uses the exact eight-section order in wide and narrow navigation", async () => {
 		const harness = createHarness();
 		await harness.command().handler("", harness.ctx);
 		const component = harness.component();
@@ -203,10 +240,22 @@ describe("component-oriented /zentui settings", () => {
 		for (const [index, name] of sectionNames.entries()) {
 			const lines = component.render(40);
 			expect(lines[1]).toContain(name);
-			expect(lines[1]).toContain(`(${index + 1}/7)`);
+			expect(lines[1]).toContain(`(${index + 1}/8)`);
 			expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
 			component.handleInput("\t");
 		}
+	});
+
+	it("describes elapsed and tokens unequivocally as whole-interaction totals", async () => {
+		const harness = createHarness();
+		await harness.command().handler("working-line", harness.ctx);
+		const component = harness.component();
+		selectLabel(component, "Elapsed");
+		expect(component.render(100).join("\n")).toContain("Show whole-interaction elapsed time.");
+		selectLabel(component, "Tokens");
+		expect(component.render(100).join("\n")).toContain(
+			"Show whole-interaction tokens as ↑input ↓output; live output may be estimated until final usage",
+		);
 	});
 
 	it("uses exact component-owned row sets and ordering", async () => {
@@ -232,6 +281,23 @@ describe("component-oriented /zentui settings", () => {
 
 		component.handleInput("\t");
 		expectFocusOrder(component, ["User messages", "Message style", "Message colors"]);
+		component.handleInput("\t");
+		expectFocusOrder(component, [
+			"Enabled",
+			"Turn summary",
+			"Spinner",
+			"Spinner speed",
+			"Animate spinner color",
+			"Text animation",
+			"Text motion speed",
+			"Color source",
+			"Custom messages",
+			"Tool",
+			"Elapsed",
+			"Thinking",
+			"Tokens",
+			"Message list",
+		]);
 		component.handleInput("\t");
 		expectFocusOrder(component, [
 			"Footer style",
@@ -405,7 +471,7 @@ describe("component-oriented /zentui settings", () => {
 			{ showGit: false },
 		]);
 
-		for (let index = 0; index < 4; index += 1) component.handleInput("\t");
+		for (let index = 0; index < 5; index += 1) component.handleInput("\t");
 		for (const [label, value] of [
 			["Commit only on detached HEAD", "disabled"],
 			["Show exact-match tag", "disabled"],
@@ -486,6 +552,7 @@ describe("component-oriented /zentui settings", () => {
 		component.handleInput("\t");
 		selectLabel(component, "Message colors");
 		component.handleInput(" ");
+		component.handleInput("\t");
 		component.handleInput("\t");
 		selectLabel(component, "Footer colors");
 		component.handleInput(" ");
@@ -569,6 +636,7 @@ describe("component-oriented /zentui settings", () => {
 		component.handleInput("\t");
 		component.handleInput("\t");
 		component.handleInput("\t");
+		component.handleInput("\t");
 		selectLabel(component, "Ignore submodules");
 		component.handleInput(" ");
 		component.handleInput("\x1b[Z");
@@ -582,6 +650,7 @@ describe("component-oriented /zentui settings", () => {
 		goToSection(component, "Editor");
 		expect(row(component, "Editor border color")).toContain("adaptive");
 		expect(row(component, "Editor model label")).toContain("name");
+		component.handleInput("\t");
 		component.handleInput("\t");
 		component.handleInput("\t");
 		component.handleInput("\t");
@@ -616,6 +685,7 @@ describe("component-oriented /zentui settings", () => {
 		component.handleInput("\t");
 		component.handleInput("\t");
 		component.handleInput("\t");
+		component.handleInput("\t");
 		selectLabel(component, "Model info");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Model info");
@@ -628,9 +698,387 @@ describe("component-oriented /zentui settings", () => {
 		]);
 	});
 
+	it("routes all Working-line rows independently", async () => {
+		const harness = createHarness();
+		await harness.command().handler("working-line", harness.ctx);
+		const component = harness.component();
+		expectFocusOrder(component, [
+			"Enabled",
+			"Turn summary",
+			"Spinner",
+			"Spinner speed",
+			"Animate spinner color",
+			"Text animation",
+			"Text motion speed",
+			"Color source",
+			"Custom messages",
+			"Tool",
+			"Elapsed",
+			"Thinking",
+			"Tokens",
+			"Message list",
+		]);
+		for (const [label, expected] of [
+			["Enabled", "enabled"],
+			["Turn summary", "disabled"],
+			["Spinner", "ASCII Pinwheel"],
+			["Spinner speed", "Slow 160 ms"],
+			["Animate spinner color", "enabled"],
+			["Text animation", "kitt"],
+			["Text motion speed", "Slow 100 ms"],
+			["Color source", "terminal"],
+			["Custom messages", "disabled"],
+			["Tool", "disabled"],
+			["Elapsed", "disabled"],
+			["Thinking", "disabled"],
+			["Tokens", "disabled"],
+		] as const) {
+			selectLabel(component, label);
+			component.handleInput(" ");
+			expect(focusedRow(component)).toContain(expected);
+		}
+		expect(harness.calls.workingLine).toEqual([
+			{ enabled: true },
+			{ turnSummary: false },
+			{ spinner: "pinwheel" },
+			{ spinnerIntervalMs: 160 },
+			{ animateSpinnerColor: true },
+			{ textAnimation: "kitt" },
+			{ textIntervalMs: 100 },
+			{ colorSource: "terminal" },
+			{ messages: { custom: false } },
+			{ segments: { tool: false } },
+			{ segments: { elapsed: false } },
+			{ segments: { thought: false } },
+			{ segments: { tokens: false } },
+		]);
+		expect(harness.calls.renders).toEqual({ shared: 0, local: 13 });
+	});
+
+	it("displays, previews, and stores all named spinner presets with canonical IDs", async () => {
+		const current = cloneConfig();
+		current.components.workingLine.spinnerIntervalMs = 180;
+		const harness = createHarness(current);
+		await harness.command().handler("working-line", harness.ctx);
+		selectLabel(harness.component(), "Spinner");
+		for (const label of [
+			"Star Bloom",
+			"ASCII Pinwheel",
+			"Claude-inspired",
+			"Pulse",
+			"Braille Orbit",
+		]) {
+			expect(focusedRow(harness.component())).toContain(label);
+			if (label === "Pulse") {
+				expect(harness.component().render(100)[3]).toContain("⠀⠶⠀");
+				expect(current.components.workingLine.spinnerIntervalMs).toBe(180);
+			}
+			harness.component().handleInput(" ");
+		}
+		expect(harness.calls.workingLine).toEqual([
+			{ spinner: "pinwheel" },
+			{ spinner: "claude-inspired" },
+			{ spinner: "pulse" },
+			{ spinner: "braille" },
+			{ spinner: "star-bloom" },
+		]);
+		expect(current.components.workingLine.spinnerIntervalMs).toBe(180);
+	});
+
+	it("closes for Custom speed input, saves a valid integer, and reopens with Speed focused", async () => {
+		vi.useFakeTimers();
+		const current = cloneConfig();
+		current.components.workingLine.spinnerIntervalMs = 160;
+		const focusedAfterOpen: string[] = [];
+		let customCount = 0;
+		const harness = createHarness(
+			current,
+			{},
+			{
+				async custom(factory: (...args: unknown[]) => unknown) {
+					let outcome: unknown;
+					const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+						outcome = value;
+					}) as Component;
+					if (customCount++ === 0) {
+						selectLabel(component, "Spinner speed");
+						component.handleInput(" ");
+					} else {
+						focusedAfterOpen.push(focusedRow(component));
+						component.handleInput("\x1b");
+					}
+					return outcome;
+				},
+				async input(title: string, placeholder: string) {
+					expect(title).toBe("Spinner speed (30–1000 ms)");
+					expect(placeholder).toBe("160");
+					return " 77 ";
+				},
+			},
+		);
+		harness.sessionLifecycle.start();
+		await harness.command().handler("working-line", harness.ctx);
+		expect(harness.calls.workingLine).toEqual([{ spinnerIntervalMs: 77 }]);
+		expect(focusedAfterOpen).toEqual([expect.stringContaining("> Spinner speed")]);
+		expect(focusedAfterOpen[0]).toContain("Custom 77 ms");
+		expect(harness.notifications).toContain("Spinner speed: 77 ms");
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("uses a separate Custom text-speed dialog and reopens on its originating row", async () => {
+		const current = cloneConfig();
+		current.components.workingLine.textIntervalMs = 100;
+		let customCount = 0;
+		const focusedAfterOpen: string[] = [];
+		const harness = createHarness(
+			current,
+			{},
+			{
+				async custom(factory: (...args: unknown[]) => unknown) {
+					let outcome: unknown;
+					const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+						outcome = value;
+					}) as Component;
+					if (customCount++ === 0) {
+						selectLabel(component, "Text motion speed");
+						component.handleInput(" ");
+					} else {
+						focusedAfterOpen.push(focusedRow(component));
+						component.handleInput("\x1b");
+					}
+					return outcome;
+				},
+				async input(title: string, placeholder: string) {
+					expect(title).toBe("Text motion speed (30–1000 ms)");
+					expect(placeholder).toBe("100");
+					return "73";
+				},
+			},
+		);
+		await harness.command().handler("working-line", harness.ctx);
+		expect(harness.calls.workingLine).toEqual([{ textIntervalMs: 73 }]);
+		expect(focusedAfterOpen[0]).toContain("> Text motion speed");
+		expect(focusedAfterOpen[0]).toContain("Custom 73 ms");
+	});
+
+	it.each([
+		[undefined, "Spinner speed unchanged (input canceled)"],
+		["29", "Spinner speed must be a whole number from 30 to 1000 ms; unchanged."],
+		["60.5", "Spinner speed must be a whole number from 30 to 1000 ms; unchanged."],
+	] as const)(
+		"preserves Custom speed on canceled or invalid input %s",
+		async (response, notice) => {
+			const current = cloneConfig();
+			current.components.workingLine.spinnerIntervalMs = 160;
+			let customCount = 0;
+			const harness = createHarness(
+				current,
+				{},
+				{
+					async custom(factory: (...args: unknown[]) => unknown) {
+						let outcome: unknown;
+						const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+							outcome = value;
+						}) as Component;
+						if (customCount++ === 0) {
+							selectLabel(component, "Spinner speed");
+							component.handleInput(" ");
+						} else {
+							expect(focusedRow(component)).toContain("> Spinner speed");
+							component.handleInput("\x1b");
+						}
+						return outcome;
+					},
+					async input() {
+						return response;
+					},
+				},
+			);
+			await harness.command().handler("working-line", harness.ctx);
+			expect(current.components.workingLine.spinnerIntervalMs).toBe(160);
+			expect(harness.calls.workingLine).toEqual([]);
+			expect(harness.notifications).toContain(notice);
+		},
+	);
+
+	it("preserves shared rendering for settings outside Working line", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		selectLabel(harness.component(), "Selector borders");
+		harness.component().handleInput(" ");
+		expect(harness.calls.renders).toEqual({ shared: 1, local: 1 });
+	});
+
+	it("animates the preview and cleans its single timer on changes, exits, errors, and shutdown", async () => {
+		vi.useFakeTimers();
+		const harness = createHarness();
+		harness.sessionLifecycle.start();
+		await harness.command().handler("working-line", harness.ctx);
+		const component = harness.component();
+		const firstPreview = component.render(100)[3];
+		expect(firstPreview).toContain("Sautéing…");
+		expect(firstPreview).toContain("read");
+		expect(harness.calls.workingLine).toEqual([]);
+		expect(vi.getTimerCount()).toBe(1);
+		vi.advanceTimersByTime(300);
+		expect(component.render(100)[3]).not.toBe(firstPreview);
+		selectLabel(component, "Custom messages");
+		component.handleInput(" ");
+		const fallbackPreview = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "");
+		expect(fallbackPreview).toContain("Working…");
+		expect(fallbackPreview).toContain("read");
+		vi.advanceTimersByTime(1200);
+		const stablePreview = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "") ?? "";
+		expect(stablePreview).toContain("Working…");
+		expect(stablePreview).toContain("read · 1m02s · thinking 10s · ↑1234 ↓56");
+		selectLabel(component, "Tool");
+		component.handleInput(" ");
+		const withoutTool = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "") ?? "";
+		expect(withoutTool).not.toContain("read");
+		expect(withoutTool).toContain("1m02s · thinking 10s · ↑1234 ↓56");
+		selectLabel(component, "Spinner");
+		component.handleInput(" ");
+		expect(vi.getTimerCount()).toBe(1);
+		selectLabel(component, "Spinner speed");
+		component.handleInput(" ");
+		expect(vi.getTimerCount()).toBe(1);
+		component.handleInput("\t");
+		expect(vi.getTimerCount()).toBe(0);
+		component.handleInput("\x1b[Z");
+		expect(vi.getTimerCount()).toBe(1);
+		component.handleInput("\x1b");
+		expect(vi.getTimerCount()).toBe(0);
+
+		const failed = createHarness(cloneConfig(), {
+			setWorkingLineComponent() {
+				throw new Error("read-only working line");
+			},
+		});
+		failed.sessionLifecycle.start();
+		await failed.command().handler("working-line", failed.ctx);
+		failed.component().handleInput(" ");
+		expect(vi.getTimerCount()).toBe(0);
+		expect(failed.notifications).toContain(
+			"Could not update Zentui settings: read-only working line",
+		);
+
+		const shutdown = createHarness();
+		shutdown.sessionLifecycle.start();
+		await shutdown.command().handler("working-line", shutdown.ctx);
+		expect(vi.getTimerCount()).toBe(1);
+		shutdown.sessionLifecycle.shutdown();
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("saves an empty Message list canonically and reopens its styled fallback preview with focus restored", async () => {
+		vi.useFakeTimers();
+		let openCount = 0;
+		let reopenedPreview = "";
+		const harness = createHarness(
+			cloneConfig(),
+			{},
+			{
+				async custom(factory: (...args: unknown[]) => unknown) {
+					let outcome: unknown;
+					const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+						outcome = value;
+					}) as Component;
+					if (openCount++ === 0) {
+						selectLabel(component, "Message list");
+						component.handleInput(" ");
+					} else {
+						expect(focusedRow(component)).toContain("> Message list");
+						reopenedPreview = component.render(100)[3] ?? "";
+						component.handleInput("\x1b");
+					}
+					return outcome;
+				},
+				async editor(title: string) {
+					expect(title).toBe("Working line message list");
+					return " \n\t\r\n";
+				},
+			},
+		);
+		harness.sessionLifecycle.start();
+
+		await harness.command().handler("working-line", harness.ctx);
+
+		expect(openCount).toBe(2);
+		expect(harness.calls.workingLine).toEqual([{ messages: { values: [] } }]);
+		expect(harness.config.components.workingLine.messages.values).toEqual([]);
+		expect(harness.notifications).toContain("Message list: 0 (using styled Working…)");
+		expect(reopenedPreview.replaceAll("[", "").replaceAll("]", "")).toContain("Working…");
+		expect(reopenedPreview).toMatch(/\[[^\]]+\]/);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("closes for multiline message editing, normalizes save, preserves cancel, and reopens Working line", async () => {
+		vi.useFakeTimers();
+		const openedSections: string[] = [];
+		let customCount = 0;
+		const harness = createHarness(
+			cloneConfig(),
+			{},
+			{
+				async custom(factory: (...args: unknown[]) => unknown) {
+					let outcome: unknown;
+					const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+						outcome = value;
+					}) as Component;
+					openedSections.push(component.render(40)[1] ?? "");
+					if (customCount++ === 0) {
+						selectLabel(component, "Message list");
+						component.handleInput(" ");
+					} else component.handleInput("\x1b");
+					return outcome;
+				},
+				async editor(title: string, prefill: string) {
+					expect(title).toBe("Working line message list");
+					expect(prefill).toBe(defaultConfig.components.workingLine.messages.values.join("\n"));
+					return " One \nOne\n\x1b[31mTwo\x1b[0m\n";
+				},
+			},
+		);
+		harness.sessionLifecycle.start();
+		await harness.command().handler("working-line", harness.ctx);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(openedSections).toHaveLength(2);
+		expect(openedSections.every((line) => line.includes("Working line"))).toBe(true);
+		expect(harness.calls.workingLine).toEqual([{ messages: { values: ["One", "Two"] } }]);
+		expect(harness.calls.renders.shared).toBe(0);
+
+		let cancelCustomCount = 0;
+		const canceled = createHarness(
+			cloneConfig(),
+			{},
+			{
+				async custom(factory: (...args: unknown[]) => unknown) {
+					let outcome: unknown;
+					const component = factory({ requestRender() {} }, theme(), {}, (value: unknown) => {
+						outcome = value;
+					}) as Component;
+					if (cancelCustomCount++ === 0) {
+						selectLabel(component, "Message list");
+						component.handleInput(" ");
+					} else component.handleInput("\x1b");
+					return outcome;
+				},
+				async editor() {
+					return undefined;
+				},
+			},
+		);
+		canceled.sessionLifecycle.start();
+		await canceled.command().handler("working-line", canceled.ctx);
+		expect(vi.getTimerCount()).toBe(0);
+		expect(cancelCustomCount).toBe(2);
+		expect(canceled.calls.workingLine).toEqual([]);
+	});
+
 	it.each([
 		["messages", "User messages"],
 		["user-messages", "User messages"],
+		["working-line", "Working line"],
 	])("opens %s directly in %s", async (argument, section) => {
 		const harness = createHarness();
 		await harness.command().handler(argument, harness.ctx);

--- a/test/telemetry-lifecycle-integration.test.ts
+++ b/test/telemetry-lifecycle-integration.test.ts
@@ -229,7 +229,9 @@ describe("telemetry lifecycle integration", () => {
 		capabilities.throwAutoCompaction = false;
 		capabilities.subscription = true;
 		capabilities.autoCompaction = true;
-		await emit(handlers, "message_end", harness.ctx, { message: { role: "assistant" } });
+		await emit(handlers, "message_end", harness.ctx, {
+			message: { role: "assistant", usage: { input: 5, output: 3 } },
+		});
 		harness.entries.push(
 			usageEntry("persisted-final", { input: 5, output: 3, read: 1_200, write: 300 }),
 		);

--- a/test/turn-summary-lifecycle.integration.test.ts
+++ b/test/turn-summary-lifecycle.integration.test.ts
@@ -1,0 +1,324 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { stripTerminalSequences, type Text } from "@earendil-works/pi-tui";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TURN_SUMMARY_ENTRY_TYPE } from "../extensions/zentui/interaction-summary";
+
+const runtime = vi.hoisted(() => ({
+	enabled: true,
+	turnSummary: true,
+	tokens: true,
+	thought: true,
+}));
+
+vi.mock("../extensions/zentui/config", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/config")>();
+	return {
+		...actual,
+		ensureConfigExists() {},
+		loadConfig: () => {
+			const config = structuredClone(actual.defaultConfig);
+			config.projectRefreshIntervalMs = 0;
+			config.components.editor.enabled = false;
+			config.components.userMessages.enabled = false;
+			config.components.selectorBorders.enabled = false;
+			config.components.footer.style = "native";
+			config.components.workingLine.enabled = runtime.enabled;
+			config.components.workingLine.turnSummary = runtime.turnSummary;
+			config.components.workingLine.segments.tokens = runtime.tokens;
+			config.components.workingLine.segments.thought = runtime.thought;
+			config.components.workingLine.messages = { custom: true, values: ["Stable"] };
+			return config;
+		},
+	};
+});
+
+import zentui from "../extensions/zentui/index";
+
+type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
+
+function assistant(input: number, output: number, timestamp: number) {
+	return {
+		role: "assistant",
+		usage: { input, output },
+		content: [],
+		api: "test",
+		provider: "provider",
+		model: "model",
+		stopReason: "stop",
+		timestamp,
+	};
+}
+
+function harness(options: { renderer?: boolean; appendError?: boolean } = {}) {
+	const handlers = new Map<string, Handler[]>();
+	const appended: Array<[string, unknown]> = [];
+	const appendEntry = vi.fn((type: string, data: unknown) => {
+		if (options.appendError) throw new Error("append failed");
+		appended.push([type, data]);
+	});
+	const renderers = new Map<string, unknown>();
+	const workingIndicators: Array<{ frames?: string[] }> = [];
+	const sendMessage = vi.fn();
+	zentui({
+		on(name: string, handler: Handler) {
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+		},
+		registerCommand() {},
+		...(options.renderer === false
+			? {}
+			: {
+					registerEntryRenderer(type: string, renderer: unknown) {
+						renderers.set(type, renderer);
+					},
+				}),
+		appendEntry,
+		sendMessage,
+		getThinkingLevel: () => "off",
+	} as never);
+	let idle = true;
+	const ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd: process.cwd(),
+		model: undefined,
+		isIdle: () => idle,
+		getContextUsage: () => null,
+		sessionManager: { getBranch: () => [], getSessionName: () => undefined },
+		ui: {
+			theme: {
+				fg: (_color: string, text: string) => text,
+				bold: (text: string) => text,
+			} as Theme,
+			getEditorComponent: () => undefined,
+			setWorkingMessage() {},
+			setWorkingIndicator(indicator?: { frames?: string[] }) {
+				if (indicator) workingIndicators.push(indicator);
+			},
+		},
+	};
+	const emit = async (name: string, event: unknown = {}) => {
+		for (const handler of handlers.get(name) ?? []) await handler(event, ctx);
+	};
+	return {
+		appended,
+		appendEntry,
+		renderers,
+		workingIndicators,
+		sendMessage,
+		ctx,
+		emit,
+		setIdle: (value: boolean) => (idle = value),
+	};
+}
+
+beforeEach(() => {
+	runtime.enabled = true;
+	runtime.turnSummary = true;
+	runtime.tokens = true;
+	runtime.thought = true;
+	vi.useRealTimers();
+});
+
+describe("turn summary lifecycle integration", () => {
+	it("appends exactly once at full settlement, never at agent_end, using only appendEntry", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("turn_start");
+		await current.emit("message_end", { message: assistant(1000, 10, 1) });
+		await current.emit("agent_end");
+		expect(current.appended).toEqual([]);
+		vi.setSystemTime(43_000);
+		await current.emit("agent_settled");
+		expect(current.appended).toEqual([
+			[
+				TURN_SUMMARY_ENTRY_TYPE,
+				{
+					version: 3,
+					durationMs: 42_000,
+					thoughtDurationMs: 0,
+					input: 1000,
+					output: 10,
+					stylePrefix: "\x1b[1;36m",
+				},
+			],
+		]);
+		await current.emit("agent_settled");
+		expect(current.appended).toHaveLength(1);
+		expect(current.sendMessage).not.toHaveBeenCalled();
+		expect(current.renderers.has(TURN_SUMMARY_ENTRY_TYPE)).toBe(true);
+	});
+
+	it("persists thought in v3 even when the live Thinking segment is disabled", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		runtime.thought = false;
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("turn_start");
+		const message = assistant(7_100, 779, 1);
+		await current.emit("message_update", {
+			message,
+			assistantMessageEvent: { type: "thinking_start", contentIndex: 0, partial: message },
+		});
+		const activeThoughtFrames = current.workingIndicators.at(-1)?.frames ?? [];
+		expect(activeThoughtFrames.length).toBeGreaterThan(0);
+		for (const frame of activeThoughtFrames) {
+			const liveText = stripTerminalSequences(frame);
+			expect(liveText).not.toMatch(/(?:^| · )thinking \d+s(?: · |$)/);
+			expect(liveText).not.toMatch(/(?:^| · )thought for \d+s(?: · |$)/);
+		}
+		vi.setSystemTime(11_999);
+		await current.emit("message_update", {
+			message,
+			assistantMessageEvent: {
+				type: "thinking_end",
+				contentIndex: 0,
+				content: "done",
+				partial: message,
+			},
+		});
+		await current.emit("message_end", { message });
+		await current.emit("agent_end");
+		vi.setSystemTime(57_999);
+		await current.emit("agent_settled");
+		expect(current.appended[0]?.[1]).toEqual(
+			expect.objectContaining({ version: 3, thoughtDurationMs: 10_999, input: 7_100, output: 779 }),
+		);
+		const renderer = current.renderers.get(TURN_SUMMARY_ENTRY_TYPE) as
+			| ((entry: { data: unknown }, options: unknown, theme: Theme) => Text | undefined)
+			| undefined;
+		const rendered = renderer?.({ data: current.appended[0]?.[1] }, {}, current.ctx.ui.theme)
+			?.render(100)
+			.join("\n");
+		expect(stripTerminalSequences(rendered ?? "")).toContain("thought for 10s");
+	});
+
+	it.each([
+		[false, true],
+		[true, false],
+	] as const)(
+		"gates append by Working-line enabled=%s and summary=%s",
+		async (enabled, summary) => {
+			runtime.enabled = enabled;
+			runtime.turnSummary = summary;
+			const current = harness();
+			await current.emit("session_start");
+			await current.emit("agent_start");
+			await current.emit("agent_end");
+			await current.emit("agent_settled");
+			expect(current.appended).toEqual([]);
+		},
+	);
+
+	it("initializes and settles without registerEntryRenderer", async () => {
+		const current = harness({ renderer: false });
+		await expect(current.emit("session_start")).resolves.toBeUndefined();
+		await current.emit("agent_start");
+		await current.emit("agent_end");
+		await expect(current.emit("agent_settled")).resolves.toBeUndefined();
+		expect(current.appended).toHaveLength(1);
+	});
+
+	it("contains append failures after atomic settlement and handles the next interaction", async () => {
+		const current = harness({ appendError: true });
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("agent_end");
+		await expect(current.emit("agent_settled")).resolves.toBeUndefined();
+		expect(current.appendEntry).toHaveBeenCalledTimes(1);
+		await current.emit("agent_settled");
+		expect(current.appendEntry).toHaveBeenCalledTimes(1);
+
+		await current.emit("agent_start");
+		await current.emit("agent_end");
+		await current.emit("agent_settled");
+		expect(current.appendEntry).toHaveBeenCalledTimes(2);
+	});
+
+	it("partitions a completed run from concurrent live usage on non-idle settlement", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000);
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("turn_start");
+		await current.emit("message_end", { message: assistant(10, 1, 1) });
+		await current.emit("agent_end");
+
+		vi.setSystemTime(5_000);
+		await current.emit("agent_start");
+		await current.emit("turn_start");
+		await current.emit("message_update", { message: assistant(7, 2, 2) });
+		current.setIdle(false);
+		vi.setSystemTime(6_000);
+		await current.emit("agent_settled");
+		expect(current.appended).toEqual([
+			[
+				TURN_SUMMARY_ENTRY_TYPE,
+				expect.objectContaining({
+					version: 3,
+					durationMs: 5_000,
+					thoughtDurationMs: 0,
+					input: 10,
+					output: 1,
+				}),
+			],
+		]);
+
+		await current.emit("message_end", { message: assistant(9, 3, 2) });
+		await current.emit("agent_end");
+		current.setIdle(true);
+		vi.setSystemTime(9_000);
+		await current.emit("agent_settled");
+		expect(current.appended[1]).toEqual([
+			TURN_SUMMARY_ENTRY_TYPE,
+			expect.objectContaining({
+				version: 3,
+				durationMs: 4_000,
+				thoughtDurationMs: 0,
+				input: 9,
+				output: 3,
+			}),
+		]);
+		await current.emit("agent_settled");
+		expect(current.appended).toHaveLength(2);
+	});
+
+	it("commits and settles zero-only final usage exactly once", async () => {
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("turn_start");
+		await current.emit("message_update", { message: assistant(0, 0, 1) });
+		await current.emit("message_update", { message: assistant(0, 0, 1) });
+		await current.emit("message_end", { message: assistant(0, 0, 1) });
+		await current.emit("agent_end");
+		await current.emit("agent_settled");
+		await current.emit("agent_settled");
+		expect(current.appended).toEqual([
+			[TURN_SUMMARY_ENTRY_TYPE, expect.objectContaining({ input: 0, output: 0 })],
+		]);
+	});
+
+	it("includes zero totals when live Tokens is disabled", async () => {
+		runtime.tokens = false;
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("agent_end");
+		await current.emit("agent_settled");
+		expect(current.appended[0]?.[1]).toMatchObject({ input: 0, output: 0 });
+	});
+
+	it("does not synthesize a summary on shutdown", async () => {
+		const current = harness();
+		await current.emit("session_start");
+		await current.emit("agent_start");
+		await current.emit("session_shutdown");
+		expect(current.appended).toEqual([]);
+	});
+});

--- a/test/turn-summary-lifecycle.integration.test.ts
+++ b/test/turn-summary-lifecycle.integration.test.ts
@@ -1,7 +1,10 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { stripTerminalSequences, type Text } from "@earendil-works/pi-tui";
+import type { Text } from "@earendil-works/pi-tui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TURN_SUMMARY_ENTRY_TYPE } from "../extensions/zentui/interaction-summary";
+
+const stripTerminalSequences = stripVTControlCharacters;
 
 const runtime = vi.hoisted(() => ({
 	enabled: true,

--- a/test/working-line-lifecycle.integration.test.ts
+++ b/test/working-line-lifecycle.integration.test.ts
@@ -1,0 +1,665 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Loader, stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => ({
+	enabled: true,
+	custom: true,
+	message: "Stable",
+	spinner: "star-bloom" as "star-bloom" | "pulse",
+	spinnerIntervalMs: 100,
+	textIntervalMs: 60,
+}));
+
+vi.mock("../extensions/zentui/config", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../extensions/zentui/config")>();
+	return {
+		...actual,
+		ensureConfigExists() {},
+		loadConfig: () => {
+			const config = structuredClone(actual.defaultConfig);
+			config.projectRefreshIntervalMs = 0;
+			config.components.editor.enabled = false;
+			config.components.userMessages.enabled = false;
+			config.components.selectorBorders.enabled = false;
+			config.components.footer.style = "native";
+			config.components.workingLine.enabled = runtime.enabled;
+			config.components.workingLine.spinner = runtime.spinner;
+			config.components.workingLine.spinnerIntervalMs = runtime.spinnerIntervalMs;
+			config.components.workingLine.textIntervalMs = runtime.textIntervalMs;
+			config.components.workingLine.messages = {
+				custom: runtime.custom,
+				values: [runtime.message],
+			};
+			return config;
+		},
+	};
+});
+
+import zentui from "../extensions/zentui/index";
+
+type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
+
+function theme(): Theme {
+	return {
+		fg(color: string, text: string) {
+			const codes: Record<string, number> = { dim: 90, muted: 36, accent: 96 };
+			return `\x1b[${codes[color] ?? 37}m${text}\x1b[0m`;
+		},
+		bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+	} as Theme;
+}
+
+function loaderPhase(rendered: string): [string, number | undefined] {
+	const stripped = stripTerminalSequences(rendered);
+	const plain = stripped.trimStart();
+	const separatorIndex = plain.indexOf(" ");
+	if (separatorIndex < 0) throw new Error("Expected a spinner separator in the working row");
+	const spinner = plain.slice(0, separatorIndex);
+	const textOffset =
+		visibleWidth(stripped) - visibleWidth(plain) + visibleWidth(plain.slice(0, separatorIndex + 1));
+	const marker = [...rendered.matchAll(/\x1b\[96m\x1b\[1m/g)].find((match) => {
+		if (match.index === undefined) return false;
+		return visibleWidth(stripTerminalSequences(rendered.slice(0, match.index))) >= textOffset;
+	});
+	return [
+		spinner,
+		marker?.index === undefined
+			? undefined
+			: visibleWidth(stripTerminalSequences(rendered.slice(0, marker.index))) - textOffset,
+	];
+}
+
+function loadExtension() {
+	const handlers = new Map<string, Handler[]>();
+	zentui({
+		registerEntryRenderer() {},
+		appendEntry() {},
+		on(name: string, handler: Handler) {
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+		},
+		registerCommand() {},
+		getThinkingLevel: () => "off",
+	} as never);
+	return handlers;
+}
+
+async function emit(
+	handlers: Map<string, Handler[]>,
+	name: string,
+	ctx: unknown,
+	event: unknown = {},
+) {
+	for (const handler of handlers.get(name) ?? []) await handler(event, ctx);
+}
+
+function harness() {
+	const calls: Array<[string, unknown?]> = [];
+	const forbidden = vi.fn();
+	let indicator: { frames?: string[]; intervalMs?: number } | undefined;
+	let message = "";
+	let loader: Loader | undefined;
+	const ui = {
+		theme: theme(),
+		getEditorComponent: () => undefined,
+		setEditorComponent: forbidden,
+		setFooter: forbidden,
+		setWidget: forbidden,
+		setWorkingVisible: forbidden,
+		setWorkingMessage(value?: string) {
+			calls.push(["message", value]);
+			message = value ?? "Working...";
+			loader?.setMessage(message);
+		},
+		setWorkingIndicator(value?: unknown) {
+			calls.push(["indicator", value]);
+			indicator = value as typeof indicator;
+			loader?.setIndicator(indicator);
+		},
+	};
+	return {
+		calls,
+		forbidden,
+		activateLoader() {
+			loader = new Loader(
+				{ requestRender() {} } as never,
+				(text) => text,
+				(text) => text,
+				message,
+				indicator,
+			);
+			return loader;
+		},
+		ctx: {
+			hasUI: true,
+			mode: "tui",
+			cwd: process.cwd(),
+			model: undefined,
+			getContextUsage: () => null,
+			sessionManager: { getBranch: () => [], getSessionName: () => undefined },
+			ui,
+		},
+	};
+}
+
+beforeEach(() => {
+	runtime.enabled = true;
+	runtime.custom = true;
+	runtime.message = "Stable";
+	runtime.spinner = "star-bloom";
+	runtime.spinnerIntervalMs = 100;
+	runtime.textIntervalMs = 60;
+});
+
+describe("working-line extension lifecycle integration", () => {
+	it("wires full-row rebuilds, authoritative usage, parallel tools, and isolated cleanup", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		await emit(handlers, "session_start", current.ctx);
+		expect(current.calls.slice(0, 2).map(([name, value]) => [name, value])).toEqual([
+			["message", ""],
+			["indicator", expect.any(Object)],
+		]);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx, { turnIndex: 0, timestamp: Date.now() });
+		const partialAssistant = {
+			role: "assistant",
+			usage: { input: 100, output: 4 },
+			content: [],
+			api: "google-generative-ai",
+			provider: "google",
+			model: "test",
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+		};
+		const laterPartialAssistant = { ...partialAssistant, usage: { input: 120, output: 7 } };
+		const finalAssistant = { ...partialAssistant, usage: { input: 150, output: 9 } };
+		await emit(handlers, "message_update", current.ctx, { message: partialAssistant });
+		expect(row()).toMatch(/Stable · \d+s · ↑100 ↓4/);
+		const beforeDuplicate = current.calls.length;
+		await emit(handlers, "message_update", current.ctx, { message: partialAssistant });
+		expect(current.calls).toHaveLength(beforeDuplicate);
+		await emit(handlers, "message_update", current.ctx, { message: laterPartialAssistant });
+		expect(row()).toMatch(/Stable · \d+s · ↑120 ↓7/);
+		await emit(handlers, "message_end", current.ctx, { message: finalAssistant });
+		expect(row()).toMatch(/Stable · \d+s · ↑150 ↓9/);
+		await emit(handlers, "tool_execution_start", current.ctx, {
+			toolCallId: "one",
+			toolName: "read",
+		});
+		expect(row()).toMatch(/Stable · read · \d+s · ↑150 ↓9/);
+		await emit(handlers, "tool_execution_start", current.ctx, {
+			toolCallId: "two",
+			toolName: "bash",
+		});
+		expect(row()).toMatch(/Stable · bash · \d+s · ↑150 ↓9/);
+		await emit(handlers, "tool_execution_end", current.ctx, { toolCallId: "two" });
+		expect(row()).toMatch(/Stable · read · \d+s · ↑150 ↓9/);
+		await emit(handlers, "tool_execution_end", current.ctx, { toolCallId: "one" });
+		expect(row()).toMatch(/Stable · \d+s · ↑150 ↓9/);
+		await emit(handlers, "turn_start", current.ctx, {
+			turnIndex: 1,
+			timestamp: Date.now(),
+		});
+		expect(row()).toContain("↑150 ↓9");
+		await emit(handlers, "agent_end", current.ctx);
+		expect(current.calls.filter(([name]) => name === "message")).toEqual([["message", ""]]);
+		expect(current.forbidden).not.toHaveBeenCalled();
+		const beforeLateEnds = current.calls.length;
+		await emit(handlers, "message_end", current.ctx, {
+			message: { role: "user", usage: { input: 99, output: 99 } },
+		});
+		await emit(handlers, "message_end", current.ctx, {
+			message: { ...finalAssistant, responseId: "late-after-agent" },
+		});
+		expect(current.calls).toHaveLength(beforeLateEnds);
+		await emit(handlers, "session_shutdown", current.ctx);
+		expect(current.calls.slice(-2).map(([name, value]) => [name, value])).toEqual([
+			["indicator", undefined],
+			["message", undefined],
+		]);
+		expect(current.forbidden).not.toHaveBeenCalled();
+	});
+
+	it("shows exact whole-interaction usage when the aggregate widens the row", async () => {
+		runtime.message = "Response usage stays visible here";
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const assistant = (input: number, output: number, responseId: string) => ({
+			role: "assistant",
+			usage: { input, output },
+			content: [],
+			api: "openai-completions",
+			provider: "openai-compatible",
+			model: "test",
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+			responseId,
+		});
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistant(1_000_000_000, 1_000_000_000, "first"),
+		});
+		expect(row()).toContain("↑1000000000 ↓1000000000");
+
+		await emit(handlers, "turn_start", current.ctx);
+		expect(row()).toContain("↑1000000000 ↓1000000000");
+		await emit(handlers, "tool_execution_start", current.ctx, {
+			toolCallId: "wide",
+			toolName: "123456789012345678",
+		});
+		const writesBeforeLiveUsage = current.calls.length;
+		await emit(handlers, "message_update", current.ctx, {
+			message: assistant(12, 3, "second"),
+		});
+		expect(row()).toContain("↑1000000012 ↓1000000003");
+		expect(current.calls).toHaveLength(writesBeforeLiveUsage + 1);
+
+		await emit(handlers, "tool_execution_end", current.ctx, { toolCallId: "wide" });
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistant(14, 5, "second"),
+		});
+		expect(row()).toContain("↑1000000014 ↓1000000005");
+	});
+
+	it("keeps committed tokens through retry lifecycle and initial zero usage, then accumulates final usage", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const assistant = (input: number, output: number, responseId: string) => ({
+			role: "assistant",
+			usage: { input, output },
+			provider: "mistral",
+			responseId,
+		});
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistant(20, 4, "committed"),
+		});
+		expect(row()).toContain("↑20 ↓4");
+
+		await emit(handlers, "agent_end", current.ctx);
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "agent_start", current.ctx);
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "turn_start", current.ctx);
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "message_update", current.ctx, {
+			message: assistant(0, 0, "retry"),
+		});
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistant(5, 2, "retry"),
+		});
+		expect(row()).toContain("↑25 ↓6");
+	});
+
+	it("shows OpenAI Codex Responses placeholder usage as a zero estimate until exact final usage", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const partial = {
+			role: "assistant",
+			content: [{ type: "text", text: "streaming" }],
+			// Codex Responses reports exact usage only on terminal response.completed.
+			usage: { input: 0, output: 0 },
+			provider: "openai-codex",
+			model: "gpt-5.4",
+			responseId: "terminal-only",
+		};
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		const writesBeforeUpdates = current.calls.length;
+		await emit(handlers, "message_update", current.ctx, { message: partial });
+		await emit(handlers, "message_update", current.ctx, { message: partial });
+		await emit(handlers, "message_update", current.ctx, {
+			message: { role: "assistant", usage: { input: 2.5, output: 1 } },
+		});
+		await emit(handlers, "message_update", current.ctx, {
+			message: { role: "user", usage: { input: 99, output: 99 } },
+		});
+		expect(current.calls).toHaveLength(writesBeforeUpdates + 1);
+		expect(row()).toContain("↑0 ↓0");
+		await emit(handlers, "message_end", current.ctx, {
+			message: { ...partial, usage: { input: 42, output: 6 } },
+		});
+		expect(row()).toContain("↑42 ↓6");
+	});
+
+	it("preserves approximation across rejected finals and ignores late messages", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const assistantMessage = (input: number, output: number, responseId: string) => ({
+			role: "assistant",
+			usage: { input, output },
+			content: [],
+			responseId,
+		});
+		const partial = assistantMessage(0, 0, "active");
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(1, 1, "already-committed"),
+		});
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_update", current.ctx, { message: partial });
+		expect(row()).toContain("↑1 ↓1");
+		const beforeRejected = current.calls.length;
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(90, 9, "mismatched"),
+		});
+		expect(current.calls).toHaveLength(beforeRejected);
+		expect(row()).toContain("↑1 ↓1");
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(90, 9, "already-committed"),
+		});
+		expect(current.calls).toHaveLength(beforeRejected);
+		expect(row()).toContain("↑1 ↓1");
+		const beforeLateMessages = current.calls.length;
+		await emit(handlers, "message_end", current.ctx, {
+			message: { role: "user", usage: { input: 99, output: 99 } },
+		});
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(99, 99, "late-unmatched"),
+		});
+		expect(current.calls).toHaveLength(beforeLateMessages);
+		expect(row()).toContain("↑1 ↓1");
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(7, 2, "active"),
+		});
+		expect(row()).toContain("↑8 ↓3");
+		const beforeDuplicate = current.calls.length;
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistantMessage(99, 99, "active"),
+		});
+		expect(current.calls).toHaveLength(beforeDuplicate);
+		expect(row()).toContain("↑8 ↓3");
+	});
+
+	it("streams OpenCode tool-call arguments immediately and reconciles whole-interaction totals", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const rows = () =>
+			current.calls
+				.filter(([name, value]) => name === "indicator" && value !== undefined)
+				.map(([, value]) =>
+					stripTerminalSequences((value as { frames?: string[] }).frames?.[0] ?? ""),
+				);
+		const message = (
+			input: number,
+			output: number,
+			responseId: string,
+			content: unknown[] = [],
+		) => ({
+			role: "assistant",
+			usage: { input, output },
+			content,
+			api: "openai-completions",
+			provider: "opencode",
+			model: "openai/gpt-5",
+			stopReason: "toolUse",
+			timestamp: Date.now(),
+			responseId,
+		});
+		const toolCall = { type: "toolCall", id: "call-1", name: "bash", arguments: {} };
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_end", current.ctx, { message: message(10, 2, "first") });
+		await emit(handlers, "turn_start", current.ctx);
+		const partial = message(0, 0, "tool-response", [toolCall]);
+		await emit(handlers, "message_update", current.ctx, {
+			message: partial,
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				partial,
+			},
+		});
+		const beforeDeltas = current.calls.length;
+		await emit(handlers, "message_update", current.ctx, {
+			message: partial,
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: '{"command":',
+				partial,
+			},
+		});
+		await emit(handlers, "message_update", current.ctx, {
+			message: partial,
+			assistantMessageEvent: {
+				type: "toolcall_delta",
+				contentIndex: 0,
+				delta: '{"command":',
+				partial,
+			},
+		});
+		expect(current.calls).toHaveLength(beforeDeltas + 2);
+		expect(rows().some((row) => row.includes("↑10 ↓5"))).toBe(true);
+		expect(rows().at(-1)).toContain("↑10 ↓8");
+		expect(rows().at(-1)).not.toMatch(/thinking|thought for/);
+		const beforeEnd = current.calls.length;
+		await emit(handlers, "message_update", current.ctx, {
+			message: partial,
+			assistantMessageEvent: {
+				type: "toolcall_end",
+				contentIndex: 0,
+				toolCall,
+				partial,
+			},
+		});
+		expect(current.calls).toHaveLength(beforeEnd);
+		await emit(handlers, "message_end", current.ctx, {
+			message: message(15, 4, "tool-response", [toolCall]),
+		});
+		expect(rows().at(-1)).toContain("↑25 ↓6");
+		expect(rows().at(-1)).not.toMatch(/thinking|thought for/);
+	});
+
+	it("preserves estimated values on malformed finals and reconciles exact finals", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const message = (input: number, output: number, responseId: string) => ({
+			role: "assistant",
+			usage: { input, output },
+			content: [],
+			responseId,
+		});
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_update", current.ctx, {
+			message: message(0, 0, "malformed"),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "abcdefghijkl",
+				partial: { content: [{ type: "text", text: "abcdefghijkl" }] },
+			},
+		});
+		expect(row()).toContain("↑0 ↓3");
+		await emit(handlers, "message_end", current.ctx, {
+			message: message(-1, 9, "malformed"),
+		});
+		expect(row()).toContain("↑0 ↓3");
+
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_update", current.ctx, {
+			message: message(0, 0, "exact"),
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "abcdefgh",
+				partial: { content: [{ type: "text", text: "abcdefgh" }] },
+			},
+		});
+		expect(row()).toContain("↑0 ↓2");
+		await emit(handlers, "message_end", current.ctx, {
+			message: message(4, 1, "exact"),
+		});
+		expect(row()).toContain("↑4 ↓1");
+	});
+
+	it("ignores an all-zero placeholder after nonzero live usage", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const message = (input: number, output: number) => ({
+			role: "assistant",
+			usage: { input, output },
+			provider: "mistral",
+			responseId: "zero-snapshot",
+		});
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_update", current.ctx, { message: message(20, 4) });
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "message_update", current.ctx, { message: message(0, 0) });
+		expect(row()).toContain("↑20 ↓4");
+		await emit(handlers, "message_end", current.ctx, { message: message(25, 7) });
+		expect(row()).toContain("↑25 ↓7");
+	});
+
+	it.each(["star-bloom", "pulse"] as const)(
+		"rebases the %s spinner and animated text on delayed Loader activation and later rebuilds",
+		async (spinner) => {
+			runtime.spinner = spinner;
+			vi.useFakeTimers();
+			vi.setSystemTime(0);
+			const handlers = loadExtension();
+			const current = harness();
+			let loader: Loader | undefined;
+			try {
+				await emit(handlers, "session_start", current.ctx);
+				vi.advanceTimersByTime(5000);
+				loader = current.activateLoader();
+				const activatedAtFrameZero = loader.render(80)[1] ?? "";
+				await emit(handlers, "agent_start", current.ctx);
+				await emit(handlers, "turn_start", current.ctx, { turnIndex: 0, timestamp: Date.now() });
+				expect(current.calls.filter(([name]) => name === "indicator")).toHaveLength(2);
+				expect(loaderPhase(loader.render(80)[1] ?? "")).toEqual(loaderPhase(activatedAtFrameZero));
+
+				vi.advanceTimersByTime(900);
+				const beforeRebuild = loader.render(80)[1] ?? "";
+				const beforePhase = loaderPhase(beforeRebuild);
+				expect(beforePhase[1], "expected animated-text high tier before rebuild").toBeDefined();
+				const assistant = {
+					role: "assistant",
+					usage: { input: 12, output: 3 },
+					content: [],
+					api: "google-generative-ai",
+					provider: "google",
+					model: "test",
+					stopReason: "toolUse",
+					timestamp: Date.now(),
+				};
+				await emit(handlers, "message_update", current.ctx, { message: assistant });
+				const afterRebuild = loader.render(80)[1] ?? "";
+				expect(stripTerminalSequences(afterRebuild)).toContain("↑12 ↓3");
+				const afterPhase = loaderPhase(afterRebuild);
+				expect(afterPhase[1], "expected animated-text high tier after rebuild").toBeDefined();
+				expect(afterPhase).toEqual(beforePhase);
+				const writesAfterRebuild = current.calls.length;
+				await emit(handlers, "message_update", current.ctx, { message: assistant });
+				expect(current.calls).toHaveLength(writesAfterRebuild);
+			} finally {
+				loader?.stop();
+				await emit(handlers, "session_shutdown", current.ctx);
+				vi.useRealTimers();
+			}
+		},
+	);
+
+	it("regenerates repeated meaningful streaming rows within the worst bounded scheduler budget", async () => {
+		runtime.message = "m".repeat(43);
+		runtime.spinnerIntervalMs = 997;
+		runtime.textIntervalMs = 900;
+		const handlers = loadExtension();
+		const current = harness();
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		const callsBeforeStreaming = current.calls.length;
+		const started = performance.now();
+		for (let output = 1; output <= 20; output++) {
+			await emit(handlers, "message_update", current.ctx, {
+				message: {
+					role: "assistant",
+					usage: { input: 999_999_999, output },
+					responseId: "performance-stream",
+				},
+			});
+		}
+		const elapsedMs = performance.now() - started;
+		expect(current.calls).toHaveLength(callsBeforeStreaming + 20);
+		expect(elapsedMs).toBeLessThan(10_000);
+		await emit(handlers, "session_shutdown", current.ctx);
+	});
+
+	it("owns the full fallback row while custom messages are off and releases both APIs", async () => {
+		runtime.custom = false;
+		const handlers = loadExtension();
+		const current = harness();
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx, { turnIndex: 0, timestamp: Date.now() });
+		await emit(handlers, "agent_end", current.ctx);
+		expect(current.calls[0]).toEqual(["message", ""]);
+		const indicator = current.calls.at(-1)?.[1] as { frames?: string[] };
+		expect(stripTerminalSequences(indicator.frames?.[0] ?? "")).toContain("Working…");
+		await emit(handlers, "session_shutdown", current.ctx);
+		expect(current.calls.slice(-2)).toEqual([
+			["indicator", undefined],
+			["message", undefined],
+		]);
+	});
+
+	it("makes zero working-row calls when startup is disabled", async () => {
+		runtime.enabled = false;
+		const handlers = loadExtension();
+		const current = harness();
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "agent_end", current.ctx);
+		await emit(handlers, "session_shutdown", current.ctx);
+		expect(current.calls).toEqual([]);
+		expect(current.forbidden).not.toHaveBeenCalled();
+	});
+});

--- a/test/working-line-lifecycle.integration.test.ts
+++ b/test/working-line-lifecycle.integration.test.ts
@@ -1,6 +1,9 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { Loader, stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { Loader, visibleWidth } from "@earendil-works/pi-tui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stripTerminalSequences = stripVTControlCharacters;
 
 const runtime = vi.hoisted(() => ({
 	enabled: true,

--- a/test/working-line-messages.test.ts
+++ b/test/working-line-messages.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+	PI_WORKING_LINE_DEFAULT_PHRASES,
+	PI_WORKING_LINE_MESSAGES,
+} from "../extensions/zentui/working-line-messages";
+
+const EXPECTED_PHRASES = [
+	"Sautéing",
+	"Cooking",
+	"Ionizing",
+	"Zigzagging",
+	"Razzle-dazzling",
+	"Photosynthesizing",
+	"Nucleating",
+	"Brewing",
+	"Combobulating",
+	"Boogieing",
+	"Befuddling",
+	"Alchemizing",
+	"Conjuring",
+	"Baking",
+	"Simmering",
+	"Blanching",
+];
+
+describe("Working-line message catalog", () => {
+	it("contains exactly the agreed 16 entries in display order", () => {
+		expect(PI_WORKING_LINE_DEFAULT_PHRASES).toEqual(EXPECTED_PHRASES);
+	});
+
+	it("converts every verb consistently to a complete visible ellipsis message", () => {
+		expect(PI_WORKING_LINE_MESSAGES).toEqual(EXPECTED_PHRASES.map((phrase) => `${phrase}…`));
+	});
+});

--- a/test/working-line.test.ts
+++ b/test/working-line.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { Loader, stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { Loader, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
 import {
@@ -50,6 +51,8 @@ function theme(): Theme {
 function config(): PolishedTuiConfig {
 	return structuredClone(defaultConfig);
 }
+
+const stripTerminalSequences = stripVTControlCharacters;
 
 function strippedFrames(frames: string[]): string[] {
 	return frames.map((frame) => stripTerminalSequences(frame));
@@ -939,7 +942,11 @@ describe("working-line row composition", () => {
 	it("sanitizes tools and applies bounded wording, tool, elapsed, token priority", () => {
 		const component = config().components.workingLine;
 		component.messages.custom = true;
-		expect(normalizeWorkingLineToolLabel("\x1b[31mread\nsecret\x1b[0m")).toBe("read secret");
+		expect(
+			normalizeWorkingLineToolLabel(
+				"\x1b[31mread\x1b[0m \x1b]2;title\x07safe \u009b32mtool\u009b0m \u009dsecret\u009c",
+			),
+		).toBe("read safe tool");
 		expect(normalizeWorkingLineToolLabel("a".repeat(30))).toBe(`${"a".repeat(17)}…`);
 		const all = composeWorkingLineRow(component, "Working…", {
 			tool: "read",

--- a/test/working-line.test.ts
+++ b/test/working-line.test.ts
@@ -1,0 +1,1985 @@
+import { readFileSync } from "node:fs";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { Loader, stripTerminalSequences, visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import {
+	AgentDurationClock,
+	BUILT_IN_WORKING_LINE_MESSAGES,
+	buildWorkingLineFrames,
+	buildWorkingLinePreviewFrames,
+	buildWorkingLineSpinnerFrames,
+	composeWorkingLineRow,
+	effectiveWorkingLineMessages,
+	formatWorkingLineThought,
+	formatWorkingLineTokens,
+	MAX_WORKING_LINE_ENTRIES_EXAMINED,
+	MAX_WORKING_LINE_FRAME_CELLS,
+	MAX_WORKING_LINE_FRAME_CODE_UNITS,
+	MAX_WORKING_LINE_FRAMES,
+	MAX_WORKING_LINE_MESSAGE_CELLS,
+	MAX_WORKING_LINE_NORMALIZED_CODE_UNITS,
+	MAX_WORKING_LINE_RAW_CODE_UNITS,
+	MAX_WORKING_LINE_ROW_CELLS,
+	MAX_WORKING_LINE_STYLE_CODE_UNITS,
+	MAX_WORKING_LINE_STYLE_TOKENS,
+	normalizeWorkingLineMessage,
+	normalizeWorkingLineMessages,
+	normalizeWorkingLineStyleSpec,
+	normalizeWorkingLineToolLabel,
+	remapWorkingLineTextTick,
+	selectWorkingLineMessage,
+	snapshotWorkingLineHighStyle,
+	WORKING_LINE_SPINNERS,
+	WorkingLineController,
+	workingLineSpinnerWidth,
+} from "../extensions/zentui/working-line";
+
+function theme(): Theme {
+	return {
+		fg(color: string, text: string) {
+			const codes: Record<string, number> = { dim: 90, muted: 36, accent: 96 };
+			return `\x1b[${codes[color] ?? 37}m${text}\x1b[0m`;
+		},
+		bold(text: string) {
+			return `\x1b[1m${text}\x1b[0m`;
+		},
+	} as Theme;
+}
+
+function config(): PolishedTuiConfig {
+	return structuredClone(defaultConfig);
+}
+
+function strippedFrames(frames: string[]): string[] {
+	return frames.map((frame) => stripTerminalSequences(frame));
+}
+
+function highTierStart(frame: string): number | undefined {
+	const marker = [...frame.matchAll(/\x1b\[96m\x1b\[1m/g)][1];
+	if (marker?.index === undefined) return undefined;
+	const stripped = stripTerminalSequences(frame);
+	const separatorIndex = stripped.indexOf(" ");
+	const rowOffset = visibleWidth(stripped.slice(0, separatorIndex + 1));
+	return visibleWidth(stripTerminalSequences(frame.slice(0, marker.index))) - rowOffset;
+}
+
+function phaseSignature(frame: string): [string, number | undefined] {
+	return [stripTerminalSequences(frame).split(" ", 1)[0] ?? "", highTierStart(frame)];
+}
+
+function phaseMotionSignature(frames: string[], index: number) {
+	const current = phaseSignature(frames[index % frames.length] ?? "");
+	const next = phaseSignature(frames[(index + 1) % frames.length] ?? "");
+	return {
+		spinnerGlyph: current[0],
+		textPosition: current[1],
+		textDirection:
+			current[1] === undefined || next[1] === undefined
+				? undefined
+				: Math.sign(next[1] - current[1]),
+	};
+}
+
+function gcdForTest(left: number, right: number): number {
+	let a = left;
+	let b = right;
+	while (b !== 0) [a, b] = [b, a % b];
+	return a;
+}
+
+describe("working-line token formatting", () => {
+	it("formats approximate and exact output identically while validating metadata", () => {
+		expect(formatWorkingLineTokens({ input: 123, output: 45, outputApproximate: false })).toBe(
+			"↑123 ↓45",
+		);
+		expect(formatWorkingLineTokens({ input: 123, output: 45, outputApproximate: true })).toBe(
+			"↑123 ↓45",
+		);
+		expect(
+			formatWorkingLineTokens({ input: 1, output: 2, outputApproximate: "yes" } as never),
+		).toBeUndefined();
+	});
+
+	it("reserves the maximum-safe token label within the complete 80-cell row", () => {
+		const current = config();
+		const composed = composeWorkingLineRow(current.components.workingLine, "x".repeat(43), {
+			tokens: {
+				input: Number.MAX_SAFE_INTEGER,
+				output: Number.MAX_SAFE_INTEGER,
+				outputApproximate: true,
+			},
+		});
+		expect(composed.row).toContain(`↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`);
+		expect(visibleWidth(composed.row)).toBeLessThanOrEqual(MAX_WORKING_LINE_FRAME_CELLS - 2);
+	});
+});
+
+describe("working-line presets and frame generation", () => {
+	it("ships pinned Funky UI Pulse provenance and the required MIT notices", () => {
+		const source = readFileSync(
+			new URL("../extensions/zentui/working-line-spinners.ts", import.meta.url),
+			"utf8",
+		);
+		expect(source).toContain(
+			"https://github.com/pi-zza/funky-ui/blob/e9aed319a4de61c2b2a5e99009821efa7b67b178/packages/funky-ui/extensions/funky-ui/animations.ts",
+		);
+		expect(source).toContain("37d82d565c1f5a9aa9b31d4b1711fa5604eb04a1");
+		expect(source).toContain("Copyright (c) FammasMaz/pi-cc-tools contributors");
+		expect(source).toContain("Copyright (c) 2026 Marko Nakic");
+		expect(source).toContain("Permission is hereby granted, free of charge");
+	});
+
+	it("defines the exact fixed-width spinner frames without preset-owned cadences", () => {
+		expect(WORKING_LINE_SPINNERS).toEqual({
+			braille: {
+				frames: ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+			},
+			"star-bloom": {
+				frames: ["·", "✦", "✧", "✶", "✧", "✦"],
+			},
+			pinwheel: { frames: ["-", "\\", "|", "/"] },
+			"claude-inspired": { frames: ["·", "✢", "✳", "✶", "✻", "✽"] },
+			pulse: { frames: ["⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈"] },
+		});
+		for (const [id, preset] of Object.entries(WORKING_LINE_SPINNERS)) {
+			const widths = new Set(preset.frames.map((frame) => visibleWidth(frame)));
+			expect(widths).toEqual(new Set([id === "pulse" ? 3 : 1]));
+			expect(workingLineSpinnerWidth(id as keyof typeof WORKING_LINE_SPINNERS)).toBe(
+				id === "pulse" ? 3 : 1,
+			);
+		}
+	});
+
+	it("rejects zero-width and inconsistent spinner definitions defensively", () => {
+		const mutable = WORKING_LINE_SPINNERS as unknown as { pulse: { frames: string[] } };
+		const original = mutable.pulse.frames;
+		try {
+			mutable.pulse.frames = ["", ""];
+			expect(() => workingLineSpinnerWidth("pulse")).toThrow(/positive fixed width/);
+			mutable.pulse.frames = ["⠶", "⠰⣿⠆"];
+			expect(() => workingLineSpinnerWidth("pulse")).toThrow(/positive fixed width/);
+		} finally {
+			mutable.pulse.frames = original;
+		}
+	});
+
+	it("builds standalone spinner frames for preset validation", () => {
+		const current = config();
+		current.components.workingLine.messages.custom = false;
+		const generated = buildWorkingLineSpinnerFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+		);
+		expect(strippedFrames(generated.frames)).toEqual(["·", "✦", "✧", "✶", "✧", "✦"]);
+		const offset = buildWorkingLineSpinnerFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			7,
+		);
+		expect(strippedFrames(offset.frames)).toEqual(["✦", "✧", "✶", "✧", "✦", "·"]);
+		expect(generated.frames.some((frame) => frame.includes("Working"))).toBe(false);
+	});
+
+	it("renders exact owned Pulse frames in preset order", () => {
+		const current = config();
+		current.components.workingLine.spinner = "pulse";
+		current.components.workingLine.spinnerIntervalMs = 180;
+		current.components.workingLine.textAnimation = "disabled";
+		const expected = ["⠀⠶⠀", "⠰⣿⠆", "⢾⣉⡷", "⣏⠀⣹", "⡁⠀⢈"];
+		const generated = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+		);
+		expect(strippedFrames(generated.frames)).toEqual(expected.map((frame) => `${frame} Ready`));
+		expect(generated.intervalMs).toBe(180);
+	});
+
+	it.each([
+		["classic", "braille"],
+		["classic", "pulse"],
+		["kitt", "braille"],
+		["kitt", "pulse"],
+	] as const)("keeps the %s %s spinner fixed while text tiers move", (textAnimation, spinner) => {
+		const current = config();
+		current.components.workingLine.spinner = spinner;
+		current.components.workingLine.messages.custom = true;
+		current.components.workingLine.textAnimation = textAnimation;
+		current.components.workingLine.colorSource = "terminal";
+		current.colors.workingLineLow = "bright-black";
+		current.colors.workingLineMid = "cyan";
+		current.colors.workingLineHigh = "bold green";
+		const generated = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+			{ tool: "read", elapsedMs: 1000, tokens: { input: 12, output: 3 } },
+		);
+		const preset = WORKING_LINE_SPINNERS[spinner];
+		const observedGlyphs = new Set<string>();
+		const textHighPositions = new Set<number>();
+		for (const [index, frame] of generated.frames.entries()) {
+			const state = generated.frameStates[index];
+			const glyph = preset.frames[(state?.spinnerTick ?? 0) % preset.frames.length] ?? "";
+			const spinnerPrefix = `\x1b[1;32m${glyph}\x1b[0m `;
+			expect(frame.startsWith(spinnerPrefix)).toBe(true);
+			observedGlyphs.add(glyph);
+			const text = frame.slice(spinnerPrefix.length);
+			for (const match of text.matchAll(/\x1b\[1;32m/g)) {
+				textHighPositions.add(visibleWidth(stripTerminalSequences(text.slice(0, match.index))));
+			}
+		}
+		expect(observedGlyphs).toEqual(new Set(preset.frames));
+		expect(generated.frames.some((frame) => frame.includes("\x1b[90m"))).toBe(true);
+		expect(generated.frames.some((frame) => frame.includes("\x1b[36m"))).toBe(true);
+		expect(textHighPositions.size).toBeGreaterThan(1);
+		expect(generated.textWidth).toBe(visibleWidth(generated.row));
+		expect(generated.textOrigin).toBe(workingLineSpinnerWidth(spinner) + 1);
+	});
+
+	it.each([
+		["classic", "braille"],
+		["classic", "pulse"],
+		["kitt", "braille"],
+		["kitt", "pulse"],
+	] as const)(
+		"includes the %s %s spinner and separator in the color sweep",
+		(animation, spinner) => {
+			const current = config();
+			current.components.workingLine.spinner = spinner;
+			current.components.workingLine.textAnimation = animation;
+			current.components.workingLine.animateSpinnerColor = true;
+			current.components.workingLine.colorSource = "terminal";
+			current.colors.workingLineLow = "bright-black";
+			current.colors.workingLineMid = "cyan";
+			current.colors.workingLineHigh = "bold green";
+			const generated = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				"Ready",
+			);
+			expect(generated.textOrigin).toBe(0);
+			expect(generated.textWidth).toBe(
+				workingLineSpinnerWidth(spinner) + 1 + visibleWidth(generated.row),
+			);
+			expect(generated.frames.some((frame) => frame.startsWith("\x1b[90m"))).toBe(true);
+			expect(generated.frames.some((frame) => frame.startsWith("\x1b[1;32m"))).toBe(true);
+		},
+	);
+
+	it("keeps Static rendering identical when spinner-color participation changes", () => {
+		const current = config();
+		current.components.workingLine.spinner = "pulse";
+		current.components.workingLine.textAnimation = "disabled";
+		const fixed = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+		);
+		current.components.workingLine.animateSpinnerColor = true;
+		const ignored = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+		);
+		expect(ignored.frames).toEqual(fixed.frames);
+		expect(ignored.frameStates).toEqual(fixed.frameStates);
+	});
+
+	it.each([30, 100, 180, 1000] as const)(
+		"keeps the canonical configured %s ms cadence for Pulse",
+		(intervalMs) => {
+			const current = config();
+			current.components.workingLine.spinner = "pulse";
+			current.components.workingLine.spinnerIntervalMs = intervalMs;
+			const owned = buildWorkingLineFrames(
+				{ ...current.components.workingLine, messages: { custom: true, values: [] } },
+				current.colors,
+				theme(),
+				"Ready",
+			);
+			expect(owned.intervalMs).toBeGreaterThanOrEqual(30);
+			expect(owned.scheduler.effectiveSpinnerIntervalMs).toBeCloseTo(intervalMs, 8);
+		},
+	);
+
+	it.each([
+		["classic", 160, 30],
+		["kitt", 40, 30],
+		["disabled", 6, 100],
+	] as const)("generates deterministic %s full-row frames", (textAnimation, count, intervalMs) => {
+		const current = config();
+		current.components.workingLine.textAnimation = textAnimation;
+		const result = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Working…",
+		);
+		expect(result.frames).toHaveLength(count);
+		expect(result.intervalMs).toBe(intervalMs);
+		expect(result.frames.every((frame) => frame.endsWith("\x1b[0m"))).toBe(true);
+		expect(new Set(strippedFrames(result.frames))).toEqual(
+			new Set(["· Working…", "✦ Working…", "✧ Working…", "✶ Working…"]),
+		);
+		expect(result.frames.some((frame) => frame.includes("\x1b[1m"))).toBe(
+			textAnimation !== "disabled",
+		);
+	});
+
+	it.each([
+		[100, 60],
+		[60, 40],
+		[160, 100],
+	] as const)("schedules exact independent %s/%s ms cadences", (spinnerMs, textMs) => {
+		const current = config();
+		current.components.workingLine.spinnerIntervalMs = spinnerMs;
+		current.components.workingLine.textIntervalMs = textMs;
+		const generated = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Working…",
+		);
+		expect(generated.scheduler).toMatchObject({
+			effectiveSpinnerIntervalMs: spinnerMs,
+			effectiveTextIntervalMs: textMs,
+			exact: true,
+			spinnerSeamless: true,
+			textSeamless: true,
+		});
+		expect(generated.intervalMs).toBe(Math.max(30, gcdForTest(spinnerMs, textMs)));
+	});
+
+	it("regenerates repeated worst-case streaming rows within a bounded budget", () => {
+		const current = config();
+		const component = current.components.workingLine;
+		component.spinner = "star-bloom";
+		component.spinnerIntervalMs = 997;
+		component.textIntervalMs = 900;
+		component.textAnimation = "classic";
+		component.animateSpinnerColor = false;
+		const started = performance.now();
+		let generatedFrames = 0;
+		for (let output = 1; output <= 20; output++) {
+			const generated = buildWorkingLineFrames(
+				component,
+				current.colors,
+				theme(),
+				"m".repeat(MAX_WORKING_LINE_MESSAGE_CELLS),
+				{
+					tool: "t".repeat(18),
+					elapsedMs: 99_999_999,
+					thought: { durationMs: 9_999_999, active: true },
+					tokens: { input: 999_999_999, output, outputApproximate: true },
+				},
+			);
+			generatedFrames += generated.frames.length;
+			expect(generated.frames.length).toBeLessThanOrEqual(MAX_WORKING_LINE_FRAMES);
+			expect(generated.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+				MAX_WORKING_LINE_FRAME_CODE_UNITS,
+			);
+		}
+		expect(generatedFrames).toBe(19_940);
+		expect(performance.now() - started).toBeLessThan(10_000);
+	});
+
+	it("permits one Classic text reset per bounded fallback array cycle", () => {
+		const current = config();
+		current.components.workingLine.spinner = "star-bloom";
+		current.components.workingLine.textAnimation = "classic";
+		current.components.workingLine.spinnerIntervalMs = 997;
+		current.components.workingLine.textIntervalMs = 900;
+		current.components.workingLine.animateSpinnerColor = false;
+		const started = performance.now();
+		const generated = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"1234567",
+		);
+		expect(generated.frames).toHaveLength(997);
+		expect(generated.frames.length).toBeLessThanOrEqual(MAX_WORKING_LINE_FRAMES);
+		expect(generated.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+			MAX_WORKING_LINE_FRAME_CODE_UNITS,
+		);
+		expect(generated.scheduler).toMatchObject({
+			quantumMs: 30,
+			effectiveSpinnerIntervalMs: 997,
+			exact: false,
+			spinnerSeamless: true,
+			textSeamless: false,
+			spinnerAdvances: 30,
+			textAdvances: 33,
+		});
+		expect(generated.textWidth).toBe(7);
+		const textCycle = 15;
+		expect(new Set(generated.frameStates.map(({ textTick }) => textTick)).size).toBe(textCycle);
+		expect(generated.scheduler.textAdvances % textCycle).toBe(3);
+		expect(generated.scheduler.effectiveTextIntervalMs).toBeCloseTo(29910 / 33, 8);
+		expect(performance.now() - started).toBeLessThan(2000);
+	});
+
+	it.each([
+		["braille", 10],
+		["star-bloom", 6],
+		["pinwheel", 4],
+		["claude-inspired", 6],
+		["pulse", 5],
+	] as const)("uses configured cadence with the %s static frames", (spinner, frameCount) => {
+		const current = config();
+		current.components.workingLine.spinner = spinner;
+		current.components.workingLine.spinnerIntervalMs = 160;
+		current.components.workingLine.textAnimation = "disabled";
+		const result = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+		);
+		expect(result.intervalMs).toBe(160);
+		expect(result.frames).toHaveLength(frameCount);
+	});
+
+	it.each([
+		[
+			"classic",
+			{ braille: 170, "star-bloom": 510, pinwheel: 340, "claude-inspired": 510, pulse: 85 },
+		],
+		[
+			"kitt",
+			{ braille: 790, "star-bloom": 474, pinwheel: 316, "claude-inspired": 474, pulse: 790 },
+		],
+	] as const)(
+		"keeps every maximum-width %s spinner animated within hard caps",
+		(animation, _counts) => {
+			const current = config();
+			current.components.workingLine.messages.custom = true;
+			current.components.workingLine.textAnimation = animation;
+			const runtime = {
+				tool: "y".repeat(18),
+				elapsedMs: 3_600_000,
+				tokens: { input: 12, output: 2 },
+			};
+			for (const spinner of Object.keys(WORKING_LINE_SPINNERS) as Array<
+				keyof typeof WORKING_LINE_SPINNERS
+			>) {
+				current.components.workingLine.spinner = spinner;
+				const generated = buildWorkingLineFrames(
+					current.components.workingLine,
+					current.colors,
+					theme(),
+					"x".repeat(MAX_WORKING_LINE_MESSAGE_CELLS),
+					runtime,
+				);
+				expect(visibleWidth(stripTerminalSequences(generated.frames[0] ?? ""))).toBe(
+					MAX_WORKING_LINE_FRAME_CELLS,
+				);
+				expect(generated.frames.length).toBeGreaterThan(
+					WORKING_LINE_SPINNERS[spinner].frames.length,
+				);
+				expect(generated.textAnimation).toBe(animation);
+				expect(generated.frames.length).toBeLessThanOrEqual(MAX_WORKING_LINE_FRAMES);
+				expect(generated.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+					MAX_WORKING_LINE_FRAME_CODE_UNITS,
+				);
+			}
+		},
+	);
+
+	it.each([
+		["classic", 170],
+		["kitt", 790],
+	] as const)(
+		"keeps maximum-code-unit Braille %s rows grapheme-complete and under the memory cap",
+		(animation, _count) => {
+			const combiningMessage = `x${"x".repeat(41)}y${"\u0338".repeat(213)}`;
+			const zwjMessage = `${"x".repeat(41)}${"👩‍".repeat(71)}💻`;
+			for (const message of [combiningMessage, zwjMessage]) {
+				expect(message).toHaveLength(MAX_WORKING_LINE_NORMALIZED_CODE_UNITS);
+				expect(visibleWidth(message)).toBe(MAX_WORKING_LINE_MESSAGE_CELLS);
+				expect(normalizeWorkingLineMessage(`${message}z`)).toBe(message);
+
+				const current = config();
+				current.components.workingLine.spinner = "braille";
+				current.components.workingLine.messages.custom = true;
+				current.components.workingLine.textAnimation = animation;
+				current.components.workingLine.colorSource = "terminal";
+				const maximumStyle = "underline fg:#ffffff bg:#ffffff";
+				current.colors.workingLineLow = maximumStyle;
+				current.colors.workingLineMid = maximumStyle;
+				current.colors.workingLineHigh = maximumStyle;
+				const generated = buildWorkingLineFrames(
+					current.components.workingLine,
+					current.colors,
+					theme(),
+					`${message}z`,
+					{
+						tool: "y".repeat(18),
+						elapsedMs: 3_600_000,
+						tokens: { input: 1, output: 2 },
+					},
+				);
+				expect(generated.message).toBe(message);
+				expect(generated.frames.length).toBeGreaterThan(
+					WORKING_LINE_SPINNERS.braille.frames.length,
+				);
+				expect(generated.textAnimation).toBe(animation);
+				expect(visibleWidth(stripTerminalSequences(generated.frames[0] ?? ""))).toBe(
+					MAX_WORKING_LINE_FRAME_CELLS,
+				);
+				expect(generated.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+					MAX_WORKING_LINE_FRAME_CODE_UNITS,
+				);
+				for (const frame of strippedFrames(generated.frames))
+					expect(frame.slice(2)).toBe(generated.row);
+			}
+		},
+	);
+
+	it.each(["classic", "kitt"] as const)(
+		"deduplicates adversarial repeated palette tokens without disabling %s animation",
+		(animation) => {
+			const current = config();
+			current.components.workingLine.spinner = "braille";
+			current.components.workingLine.messages.custom = true;
+			current.components.workingLine.textAnimation = animation;
+			current.components.workingLine.colorSource = "terminal";
+			current.colors.workingLineLow = "dim ".repeat(1000);
+			current.colors.workingLineMid = "cyan ".repeat(1000);
+			current.colors.workingLineHigh = "bold ".repeat(1000);
+			const generated = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				"x".repeat(MAX_WORKING_LINE_MESSAGE_CELLS),
+				{ tool: "y".repeat(18), elapsedMs: 3_600_000, tokens: { input: 1, output: 2 } },
+			);
+			expect(generated.textAnimation).toBe(animation);
+			expect(generated.frames.length).toBeGreaterThan(WORKING_LINE_SPINNERS.braille.frames.length);
+			expect(generated.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+				MAX_WORKING_LINE_FRAME_CODE_UNITS,
+			);
+			expect(generated.frames.some((frame) => frame.includes("\x1b[1m"))).toBe(true);
+		},
+	);
+
+	it("bounds and canonicalizes Working-line-only palette specs", () => {
+		expect(normalizeWorkingLineStyleSpec("bold ".repeat(1000))).toBe("bold");
+		expect(normalizeWorkingLineStyleSpec("DIMMED dim fg:202 FG:202 bold bold")).toBe(
+			"dim fg:202 bold",
+		);
+		expect(normalizeWorkingLineStyleSpec("bold italic underline red")).toBe(
+			"bold italic underline red",
+		);
+		expect(normalizeWorkingLineStyleSpec("bold italic underline red dim")).toBeUndefined();
+		expect(MAX_WORKING_LINE_STYLE_TOKENS).toBe(4);
+		expect(MAX_WORKING_LINE_STYLE_CODE_UNITS).toBe(48);
+	});
+
+	it.each([
+		["no modifier", [], "\x1b[38;5;202m"],
+		["one modifier", ["bold"], "\x1b[38;5;202m\x1b[1m"],
+		["two modifiers", ["bold", "italic"], "\x1b[38;5;202m\x1b[3m\x1b[1m"],
+		["three modifiers", ["bold", "italic", "underline"], "\x1b[38;5;202m\x1b[4m\x1b[3m\x1b[1m"],
+	] as const)("persists theme high style with %s", (_label, modifiers, expected) => {
+		const current = config();
+		current.components.workingLine.colorSource = "theme";
+		current.colors.workingLineHigh = [...modifiers, "accent"].join(" ");
+		const separateTheme = {
+			fg: (_color: string, text: string) => `\x1b[38;5;202m${text}\x1b[0m`,
+			bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+			italic: (text: string) => `\x1b[3m${text}\x1b[0m`,
+			underline: (text: string) => `\x1b[4m${text}\x1b[0m`,
+		};
+		expect(
+			snapshotWorkingLineHighStyle(separateTheme, current.components.workingLine, current.colors),
+		).toBe(expected);
+	});
+
+	it.each([
+		["named", "bold italic underline cyan", "\x1b[1;3;4;36m"],
+		["256-color", "bold italic underline fg:202", "\x1b[1;3;4;38;5;202m"],
+		["truecolor", "bold italic underline #bf5700", "\x1b[1;3;4;38;2;191;87;0m"],
+	] as const)("persists combined terminal %s high style", (_label, style, expected) => {
+		const current = config();
+		current.components.workingLine.colorSource = "terminal";
+		current.colors.workingLineHigh = style;
+		expect(
+			snapshotWorkingLineHighStyle(theme(), current.components.workingLine, current.colors),
+		).toBe(expected);
+	});
+
+	it("reverses full-row KITT motion without duplicating the wording endpoint", () => {
+		const current = config();
+		current.components.workingLine.textAnimation = "kitt";
+		const { frames } = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"abcdefgh",
+		);
+		const brightHead = (frame: string) => frame.match(/\x1b\[96m\x1b\[1m([a-h])/)?.[1];
+		const movingHeads = frames
+			.map(brightHead)
+			.filter((value): value is string => value !== undefined)
+			.filter((value, index, values) => index === 0 || value !== values[index - 1]);
+		expect(movingHeads.slice(0, 9)).toEqual(["a", "b", "c", "d", "e", "f", "g", "h", "g"]);
+	});
+
+	it.each(["你好世界", "e\u0301lan", "👩‍💻 works", "👨‍👩‍👧‍👦 family"])(
+		"keeps graphemes and visible text stable for %s",
+		(message) => {
+			const current = config();
+			const result = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				message,
+			);
+			const stripped = strippedFrames(result.frames);
+			const expectedWidth = visibleWidth(
+				`${WORKING_LINE_SPINNERS["star-bloom"].frames[0]} ${result.message}`,
+			);
+			for (const frame of stripped) {
+				expect(frame.slice(2)).toBe(result.message);
+				expect(visibleWidth(frame)).toBe(expectedWidth);
+			}
+		},
+	);
+
+	it.each(["界", "😀"])("gives every occupied KITT head cell the high tier for %s", (message) => {
+		const current = config();
+		current.components.workingLine.textAnimation = "kitt";
+		const result = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			`${message}a`,
+		);
+		expect(result.frames.some((frame) => frame.includes(`\x1b[96m\x1b[1m${message}`))).toBe(true);
+		const expectedWidth = visibleWidth(`· ${result.message}`);
+		for (const frame of strippedFrames(result.frames)) {
+			expect(frame.slice(2)).toBe(result.message);
+			expect(visibleWidth(frame)).toBe(expectedWidth);
+		}
+	});
+
+	it.each(["star-bloom", "pulse"] as const)(
+		"fits the complete maximum %s row through Pi's real Loader without a wrapped blank row",
+		(spinner) => {
+			const current = config();
+			current.components.workingLine.spinner = spinner;
+			current.components.workingLine.textAnimation = "disabled";
+			current.components.workingLine.messages.custom = true;
+			const generated = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				"x".repeat(MAX_WORKING_LINE_MESSAGE_CELLS),
+				{
+					tool: "y".repeat(18),
+					elapsedMs: 3_600_000,
+					tokens: { input: 12, output: 2 },
+				},
+			);
+			const [frame] = generated.frames;
+			expect(visibleWidth(stripTerminalSequences(frame))).toBe(MAX_WORKING_LINE_FRAME_CELLS);
+			const loader = new Loader(
+				{ requestRender() {} } as never,
+				(text) => text,
+				(text) => text,
+				"",
+				{ frames: [frame], intervalMs: generated.intervalMs },
+			);
+			try {
+				const rendered = loader.render(MAX_WORKING_LINE_ROW_CELLS);
+				expect(rendered).toHaveLength(2);
+				expect(stripTerminalSequences(rendered[1] ?? "")).toBe(
+					` ${stripTerminalSequences(frame)}  `,
+				);
+				expect(visibleWidth(rendered[1] ?? "")).toBe(MAX_WORKING_LINE_ROW_CELLS);
+			} finally {
+				loader.stop();
+			}
+		},
+	);
+
+	it("compensates for the real Loader resetting every installed indicator to frame zero", () => {
+		vi.useFakeTimers();
+		const loader = new Loader(
+			{ requestRender() {} } as never,
+			(text) => text,
+			(text) => text,
+			"",
+			{ frames: ["zero", "one", "two"], intervalMs: 30 },
+		);
+		try {
+			vi.advanceTimersByTime(60);
+			expect(stripTerminalSequences(loader.render(20)[1] ?? "")).toContain("two");
+			loader.setIndicator({ frames: ["sampled-two", "next"], intervalMs: 30 });
+			expect(stripTerminalSequences(loader.render(20)[1] ?? "")).toContain("sampled-two");
+		} finally {
+			loader.stop();
+			vi.useRealTimers();
+		}
+	});
+
+	it("honors independent working-line palette overrides", () => {
+		const current = config();
+		current.components.workingLine.colorSource = "terminal";
+		current.components.workingLine.textAnimation = "disabled";
+		current.colors.workingLineMid = "bold red";
+		current.colors.workingLineHigh = "bold green";
+		const [frame] = buildWorkingLineFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+			"Ready",
+		).frames;
+		expect(frame).not.toContain("\x1b[1;32m");
+		expect(frame).toContain("\x1b[1;31m· Ready");
+	});
+
+	it.each(["classic", "kitt"] as const)(
+		"moves %s color through the complete composed row and preserves phase offsets",
+		(animation) => {
+			const current = config();
+			current.components.workingLine.messages.custom = true;
+			current.components.workingLine.textAnimation = animation;
+			const runtime = { tool: "read", elapsedMs: 62_000, tokens: { input: 12, output: 3 } };
+			const generated = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				"Ready",
+				runtime,
+			);
+			expect(new Set(strippedFrames(generated.frames))).toEqual(
+				new Set([
+					"· Ready · read · 1m02s · ↑12 ↓3",
+					"✦ Ready · read · 1m02s · ↑12 ↓3",
+					"✧ Ready · read · 1m02s · ↑12 ↓3",
+					"✶ Ready · read · 1m02s · ↑12 ↓3",
+				]),
+			);
+			expect(
+				generated.frames.some((frame) =>
+					[...frame.matchAll(/\x1b\[96m\x1b\[1m([^\x1b]*)/g)].some((match) =>
+						match[1]?.includes("↓"),
+					),
+				),
+			).toBe(true);
+			const offset = buildWorkingLineFrames(
+				current.components.workingLine,
+				current.colors,
+				theme(),
+				"Ready",
+				runtime,
+				7,
+				7,
+			);
+			expect(offset.frameStates[0]).toEqual({ spinnerTick: 7, textTick: 7 });
+		},
+	);
+
+	it("keeps preview mode and configured segment presence stable", () => {
+		const current = config();
+		current.components.workingLine.messages = { custom: true, values: ["Configured"] };
+		current.components.workingLine.segments = {
+			tool: true,
+			elapsed: false,
+			thought: false,
+			tokens: true,
+		};
+		const generated = buildWorkingLinePreviewFrames(
+			current.components.workingLine,
+			current.colors,
+			theme(),
+		);
+		for (const frame of strippedFrames(generated.frames)) {
+			expect(frame).toMatch(/^[·✦✧✶] Configured · read · ↑1234 ↓56$/);
+			expect(frame).not.toContain("1m02s");
+		}
+		current.components.workingLine.messages.custom = false;
+		const fallback = strippedFrames(
+			buildWorkingLinePreviewFrames(current.components.workingLine, current.colors, theme()).frames,
+		);
+		expect(fallback.every((frame) => frame.includes(" Working… · read · ↑1234 ↓56"))).toBe(true);
+	});
+});
+
+describe("working-line phase mapping", () => {
+	it.each([
+		["classic", 5],
+		["kitt", 15],
+	] as const)(
+		"preserves %s position and direction across spinner-color domain changes",
+		(animation, tick) => {
+			const included = remapWorkingLineTextTick(animation, 10, tick, animation, 12, 2, 0);
+			const restored = remapWorkingLineTextTick(animation, 12, included, animation, 10, 0, 2);
+			expect(restored).toBe(tick);
+		},
+	);
+});
+
+describe("working-line message normalization and selection", () => {
+	it("strips terminal/control/bidi data, normalizes whitespace, and truncates safely", () => {
+		const unsafe =
+			"\x1b[31m  hello\x1b[0m\tworld\n\x1b]8;;https://bad.test\x07link\x1b]8;;\x07\u202E  ";
+		expect(normalizeWorkingLineMessage(unsafe)).toBe("hello world link");
+		expect(normalizeWorkingLineMessage(`${"界".repeat(30)}👩‍💻`)).toBe(
+			"界".repeat(Math.floor(MAX_WORKING_LINE_MESSAGE_CELLS / 2)),
+		);
+		expect(visibleWidth(normalizeWorkingLineMessage("a".repeat(100)))).toBe(
+			MAX_WORKING_LINE_MESSAGE_CELLS,
+		);
+	});
+
+	it("removes C1 sequences and embedded invisible controls while preserving grapheme joiners", () => {
+		const unsafe =
+			"\u009b31mRed\u009b0m \u009d2;title\u0007Visible \u0090secret\u009c Done\u200b\u206a\u206f";
+		expect(normalizeWorkingLineMessage(unsafe)).toBe("Red Visible Done");
+		expect(normalizeWorkingLineMessage("\u200b\u206a\u206f\u034f")).toBe("");
+		expect(normalizeWorkingLineMessage("pay\u034fpal word\u2060joiner bidi\u200emark")).toBe(
+			"paypal wordjoiner bidimark",
+		);
+		expect(normalizeWorkingLineMessage("👩‍💻 ❤️ 👨‍👩‍👧‍👦 क्‍ष")).toBe("👩‍💻 ❤️ 👨‍👩‍👧‍👦 क्‍ष");
+	});
+
+	it("bounds raw normalization and invalid-entry examination before output caps", () => {
+		expect(
+			normalizeWorkingLineMessage(
+				`${"\u200b".repeat(MAX_WORKING_LINE_RAW_CODE_UNITS)}Visible beyond the raw cap`,
+			),
+		).toBe("");
+		expect(normalizeWorkingLineMessage("x".repeat(1_000_000))).toBe(
+			"x".repeat(MAX_WORKING_LINE_MESSAGE_CELLS),
+		);
+		expect(
+			normalizeWorkingLineMessage(`${"\u200b".repeat(MAX_WORKING_LINE_RAW_CODE_UNITS - 1)}👩‍💻`),
+		).toBe("");
+		const combiningGrapheme = `x${"\u0338".repeat(20)}`;
+		const combiningOutput = normalizeWorkingLineMessage(combiningGrapheme.repeat(43));
+		expect(combiningOutput).toBe(
+			combiningGrapheme.repeat(
+				Math.floor(MAX_WORKING_LINE_NORMALIZED_CODE_UNITS / combiningGrapheme.length),
+			),
+		);
+		expect(combiningOutput.length).toBeLessThanOrEqual(MAX_WORKING_LINE_NORMALIZED_CODE_UNITS);
+		const oversizedZwjGrapheme = `${"👩‍".repeat(100)}💻`;
+		expect(normalizeWorkingLineMessage(oversizedZwjGrapheme)).toBe("");
+		const fallback = buildWorkingLineFrames(
+			config().components.workingLine,
+			config().colors,
+			theme(),
+			oversizedZwjGrapheme,
+		);
+		expect(fallback.message).toBe("Working…");
+		expect(fallback.frames.reduce((sum, frame) => sum + frame.length, 0)).toBeLessThanOrEqual(
+			MAX_WORKING_LINE_FRAME_CODE_UNITS,
+		);
+		const values = [
+			...Array.from({ length: 31 }, (_, index) => `valid-${index}`),
+			...Array.from({ length: MAX_WORKING_LINE_ENTRIES_EXAMINED - 32 }, () => "\u200b"),
+			"last-valid",
+			"not-examined",
+		];
+		const normalized = normalizeWorkingLineMessages(values);
+		expect(normalized).toHaveLength(32);
+		expect(normalized.at(-1)).toBe("last-valid");
+		expect(normalized).not.toContain("not-examined");
+	});
+
+	it("deduplicates normalized values, discards empties, and caps the pool", () => {
+		const values = [
+			" A ",
+			"A",
+			"\x1b[31mA\x1b[0m",
+			"\n",
+			...Array.from({ length: 60 }, (_, index) => `m${index}`),
+		];
+		const normalized = normalizeWorkingLineMessages(values);
+		expect(normalized[0]).toBe("A");
+		expect(normalized).toHaveLength(48);
+		expect(new Set(normalized).size).toBe(48);
+	});
+
+	it("supports custom toggle, fallback, and uniform endpoint-safe selection", () => {
+		const current = config().components.workingLine;
+		expect(BUILT_IN_WORKING_LINE_MESSAGES).toHaveLength(16);
+		expect(effectiveWorkingLineMessages(current)).toEqual(BUILT_IN_WORKING_LINE_MESSAGES);
+		current.messages = { custom: true, values: ["Custom"] };
+		expect(effectiveWorkingLineMessages(current)).toEqual(["Custom"]);
+		current.messages.values = [];
+		expect(effectiveWorkingLineMessages(current)).toEqual(["Working…"]);
+		current.messages.values = ["\u200b\u206a"];
+		expect(effectiveWorkingLineMessages(current)).toEqual(["Working…"]);
+		current.messages.custom = false;
+		const random = vi.fn(() => 0.9);
+		expect(selectWorkingLineMessage(current, random)).toBe("Working…");
+		expect(random).not.toHaveBeenCalled();
+		current.messages.custom = true;
+		current.messages.values = ["A", "B"];
+		expect(selectWorkingLineMessage(current, () => 0)).toBe("A");
+		expect(selectWorkingLineMessage(current, () => 0.999999)).toBe("B");
+		expect(selectWorkingLineMessage(current, () => 1)).toBe("B");
+	});
+});
+
+describe("working-line row composition", () => {
+	it("sanitizes tools and applies bounded wording, tool, elapsed, token priority", () => {
+		const component = config().components.workingLine;
+		component.messages.custom = true;
+		expect(normalizeWorkingLineToolLabel("\x1b[31mread\nsecret\x1b[0m")).toBe("read secret");
+		expect(normalizeWorkingLineToolLabel("a".repeat(30))).toBe(`${"a".repeat(17)}…`);
+		const all = composeWorkingLineRow(component, "Working…", {
+			tool: "read",
+			elapsedMs: 62_000,
+			tokens: { input: 1234, output: 56 },
+		});
+		expect(all.row).toBe("Working… · read · 1m02s · ↑1234 ↓56");
+		expect(2 + visibleWidth(all.row) + 1 + 2).toBeLessThanOrEqual(MAX_WORKING_LINE_ROW_CELLS);
+		component.spinner = "pulse";
+		const constrained = composeWorkingLineRow(component, "x".repeat(43), {
+			tool: "parallel-tool-label-too-long",
+			elapsedMs: 360_000_000,
+			tokens: { input: Number.MAX_SAFE_INTEGER, output: Number.MAX_SAFE_INTEGER },
+		});
+		expect(constrained.row).toBe(
+			`${"x".repeat(34)}… · ↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`,
+		);
+		expect(workingLineSpinnerWidth("pulse") + 1 + visibleWidth(constrained.row)).toBe(
+			MAX_WORKING_LINE_FRAME_CELLS,
+		);
+		expect(constrained.row).not.toContain("parallel");
+	});
+
+	it("reserves exact Tokens, then allocates Message, Elapsed, and truncated Tool within 80 cells", () => {
+		const component = config().components.workingLine;
+		const composed = composeWorkingLineRow(component, "x".repeat(43), {
+			tool: "parallel-tool-label",
+			elapsedMs: 62_000,
+			tokens: { input: 12, output: 3 },
+		});
+		expect(composed.row).toBe(`${"x".repeat(43)} · parallel-to… · 1m02s · ↑12 ↓3`);
+		expect(composed.row.indexOf("1m02s")).toBeLessThan(composed.row.indexOf("↑12 ↓3"));
+		expect(composed.row).not.toContain("parallel-tool-label");
+		expect(workingLineSpinnerWidth(component.spinner) + 1 + visibleWidth(composed.row) + 3).toBe(
+			MAX_WORKING_LINE_ROW_CELLS,
+		);
+	});
+
+	it("honors independent segment toggles for custom and fallback wording", () => {
+		const component = config().components.workingLine;
+		const runtime = { tool: "read", elapsedMs: 1_000, tokens: { input: 12, output: 3 } };
+		component.segments = { tool: false, elapsed: true, thought: false, tokens: false };
+		expect(composeWorkingLineRow(component, "Configured", runtime).row).toBe("Configured · 1s");
+		component.messages.custom = false;
+		expect(composeWorkingLineRow(component, "Working…", runtime).row).toBe("Working… · 1s");
+	});
+});
+
+describe("working-line thought segment", () => {
+	it("formats active zero and floors active/inactive duration consistently", () => {
+		expect(formatWorkingLineThought({ durationMs: 0, active: true })).toBe("thinking 0s");
+		expect(formatWorkingLineThought({ durationMs: 10_999, active: true })).toBe("thinking 10s");
+		expect(formatWorkingLineThought({ durationMs: 10_999, active: false })).toBe("thought for 10s");
+		expect(formatWorkingLineThought({ durationMs: 0, active: false })).toBeUndefined();
+	});
+
+	it("uses Thought before Elapsed and Tool allocation while preserving token text and row cap", () => {
+		const component = config().components.workingLine;
+		component.spinner = "pulse";
+		const composed = composeWorkingLineRow(component, "Ready", {
+			tool: "parallel-tool-label",
+			elapsedMs: Number.MAX_SAFE_INTEGER,
+			thought: { durationMs: 10_000, active: true },
+			tokens: { input: Number.MAX_SAFE_INTEGER, output: Number.MAX_SAFE_INTEGER },
+		});
+		expect(composed.row).toContain(`↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`);
+		expect(composed.row).toContain("thinking");
+		expect(composed.row).not.toContain("parallel-tool-label");
+		expect(
+			workingLineSpinnerWidth(component.spinner) + 1 + visibleWidth(composed.row) + 3,
+		).toBeLessThanOrEqual(MAX_WORKING_LINE_ROW_CELLS);
+	});
+});
+
+describe("working-line runtime ownership", () => {
+	function runtime(
+		enabled: boolean,
+		random = () => 0.75,
+		now: () => number = Date.now,
+		getTheme: () => Theme = theme,
+	) {
+		const current = config();
+		current.components.workingLine.enabled = enabled;
+		current.components.workingLine.messages = { custom: true, values: ["A", "B"] };
+		const clock = new AgentDurationClock();
+		const calls: Array<[string, unknown?]> = [];
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				setWorkingMessage(value?: string) {
+					calls.push(["message", value]);
+				},
+				setWorkingIndicator(value?: unknown) {
+					calls.push(["indicator", value]);
+				},
+			},
+		};
+		return {
+			current,
+			clock,
+			calls,
+			ctx,
+			controller: new WorkingLineController(() => current, getTheme, clock, random, now),
+		};
+	}
+
+	it("makes exactly zero working-row calls while disabled", () => {
+		const harness = runtime(false);
+		harness.controller.startSession(harness.ctx);
+		harness.clock.start();
+		harness.controller.startAgent(harness.ctx);
+		harness.controller.startTurn(harness.ctx);
+		harness.controller.finishAgent(harness.ctx);
+		harness.controller.dispose(harness.ctx);
+		harness.clock.reset();
+		expect(harness.calls).toEqual([]);
+	});
+
+	it("fails open when either public capability is missing", () => {
+		const harness = runtime(true);
+		for (const ui of [{ setWorkingMessage: vi.fn() }, { setWorkingIndicator: vi.fn() }]) {
+			const result = harness.controller.startSession({ hasUI: true, mode: "tui", ui });
+			expect(result.applied).toBe(false);
+			expect(Object.values(ui).every((fn) => !fn.mock.calls.length)).toBe(true);
+		}
+		expect(harness.calls).toEqual([]);
+	});
+
+	it("owns and styles the full fallback row with no RNG when custom messages are off", () => {
+		const random = vi.fn(() => 0.75);
+		const harness = runtime(true, random);
+		harness.current.components.workingLine.spinner = "pulse";
+		harness.current.components.workingLine.messages.custom = false;
+		harness.controller.startSession(harness.ctx);
+		harness.clock.start();
+		harness.controller.startAgent(harness.ctx);
+		harness.controller.startTurn(harness.ctx);
+		harness.controller.updateTokens({ input: 12, output: 3 }, harness.ctx);
+		expect(random).not.toHaveBeenCalled();
+		expect(harness.calls[0]).toEqual(["message", ""]);
+		const indicator = harness.calls.at(-1)?.[1] as { frames: string[] } | undefined;
+		expect(
+			strippedFrames(indicator?.frames ?? []).every((frame) =>
+				frame.includes("Working… · 0s · ↑12 ↓3"),
+			),
+		).toBe(true);
+		harness.controller.dispose(harness.ctx);
+		expect(harness.calls.slice(-2)).toEqual([
+			["indicator", undefined],
+			["message", undefined],
+		]);
+	});
+
+	it("does not rewrite Static frames for text-speed or spinner-color participation changes", () => {
+		const harness = runtime(true);
+		harness.current.components.workingLine.textAnimation = "disabled";
+		harness.controller.startSession(harness.ctx);
+		harness.calls.length = 0;
+		harness.current.components.workingLine.textIntervalMs = 40;
+		harness.current.components.workingLine.animateSpinnerColor = true;
+		expect(harness.controller.reconcile(harness.ctx).applied).toBe(true);
+		expect(harness.calls).toEqual([]);
+	});
+
+	it("selects exactly once per turn_start and keeps that message through tool activity", () => {
+		const random = vi.fn(() => 0.75);
+		const harness = runtime(true, random);
+		harness.controller.startSession(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("A");
+		harness.clock.start();
+		harness.controller.startAgent(harness.ctx);
+		expect(random).not.toHaveBeenCalled();
+		harness.controller.startTurn(harness.ctx);
+		expect(random).toHaveBeenCalledTimes(1);
+		expect(harness.controller.currentMessage()).toBe("B");
+		harness.controller.startTool("one", "read", harness.ctx);
+		harness.controller.finishTool("one", harness.ctx);
+		harness.current.components.workingLine.spinner = "pinwheel";
+		harness.controller.reconcile(harness.ctx);
+		expect(random).toHaveBeenCalledTimes(1);
+		expect(harness.controller.currentMessage()).toBe("B");
+		harness.controller.startTurn(harness.ctx);
+		expect(random).toHaveBeenCalledTimes(2);
+	});
+
+	it("reconciles live message edits deterministically without rerolling the turn", () => {
+		const random = vi.fn(() => 0.75);
+		const harness = runtime(true, random);
+		harness.controller.startSession(harness.ctx);
+		harness.controller.startTurn(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("B");
+		harness.current.components.workingLine.messages.values = ["B", "C"];
+		harness.controller.reconcile(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("B");
+		harness.current.components.workingLine.messages.values = ["C"];
+		harness.controller.reconcile(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("C");
+		harness.current.components.workingLine.messages.custom = false;
+		harness.controller.reconcile(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("Working…");
+		harness.current.components.workingLine.messages = { custom: true, values: ["A", "B"] };
+		harness.controller.reconcile(harness.ctx);
+		expect(harness.controller.currentMessage()).toBe("A");
+		expect(random).toHaveBeenCalledTimes(1);
+	});
+
+	it("reinstalls full rows only for visible token/tool changes and tracks parallel tools", () => {
+		const harness = runtime(true);
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		expect(harness.calls[0]).toEqual(["message", ""]);
+		harness.clock.start();
+		harness.controller.startAgent(harness.ctx);
+		harness.controller.startTurn(harness.ctx);
+		harness.calls.length = 0;
+		const usage = { role: "assistant" as const, usage: { input: 120, output: 7 } };
+		harness.controller.updateTokens(usage.usage, harness.ctx);
+		harness.controller.updateTokens(usage.usage, harness.ctx);
+		harness.controller.startTool("a", "read", harness.ctx);
+		harness.controller.startTool("b", "bash", harness.ctx);
+		harness.controller.startTool("b", "bash", harness.ctx);
+		const text = () =>
+			stripTerminalSequences(
+				(harness.calls.at(-1)?.[1] as { frames?: string[] } | undefined)?.frames?.[0] ?? "",
+			);
+		expect(text()).toMatch(/B · bash · ↑120 ↓7/);
+		harness.controller.finishTool("b", harness.ctx);
+		expect(text()).toMatch(/B · read · ↑120 ↓7/);
+		harness.controller.finishTool("a", harness.ctx);
+		expect(text()).toMatch(/B · ↑120 ↓7/);
+		expect(harness.calls.every(([name]) => name === "indicator")).toBe(true);
+		expect(harness.calls).toHaveLength(5);
+		harness.controller.finishTool("missing", harness.ctx);
+		expect(harness.calls).toHaveLength(5);
+		harness.controller.startTurn(harness.ctx);
+		expect(text()).toMatch(/↑120 ↓7/);
+		expect(harness.calls).toHaveLength(5);
+		harness.current.components.workingLine.segments.tool = false;
+		harness.controller.reconcile(harness.ctx);
+		expect(harness.calls).toHaveLength(5);
+		harness.controller.dispose(harness.ctx);
+		harness.clock.reset();
+	});
+
+	it.each([
+		["classic", "star-bloom", 900],
+		["classic", "pulse", 900],
+		["kitt", "star-bloom", 1400],
+		["kitt", "pulse", 1400],
+	] as const)(
+		"preserves %s spatial position, KITT direction, and %s phase across token/tool widths",
+		(animation, spinner, firstChangeAt) => {
+			let now = 0;
+			const harness = runtime(
+				true,
+				() => 0,
+				() => now,
+			);
+			harness.current.components.workingLine.messages.values = ["Stable"];
+			harness.current.components.workingLine.spinner = spinner;
+			harness.current.components.workingLine.textAnimation = animation;
+			harness.current.components.workingLine.segments.elapsed = false;
+			harness.controller.startSession(harness.ctx);
+			harness.controller.startAgent(harness.ctx);
+			harness.controller.startTurn(harness.ctx);
+			const activation = harness.calls.at(-1)?.[1] as {
+				frames: string[];
+				intervalMs: number;
+			};
+
+			now = firstChangeAt;
+			const activationIndex =
+				Math.floor(firstChangeAt / activation.intervalMs) % activation.frames.length;
+			harness.controller.updateTokens({ input: 12, output: 3 }, harness.ctx);
+			const withTokens = harness.calls.at(-1)?.[1] as { frames: string[] };
+			const beforeSignature = phaseSignature(activation.frames[activationIndex] ?? "");
+			const afterSignature = phaseSignature(withTokens.frames[0] ?? "");
+			expect(afterSignature[0]).toBe(beforeSignature[0]);
+			if (beforeSignature[1] !== undefined) expect(afterSignature[1]).toBe(beforeSignature[1]);
+
+			now += 100;
+			harness.controller.startTool("one", "read", harness.ctx);
+			const withTool = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+			const carriedRemainder = firstChangeAt % withTool.intervalMs;
+			const withTokensIndex = Math.floor((carriedRemainder + 100) / withTool.intervalMs);
+			expect(phaseSignature(withTool.frames[0] ?? "")).toEqual(
+				phaseSignature(withTokens.frames[withTokensIndex] ?? ""),
+			);
+		},
+	);
+
+	it.each([
+		[
+			"speed",
+			(current: PolishedTuiConfig): void => {
+				current.components.workingLine.spinnerIntervalMs = 60;
+			},
+		],
+		[
+			"preset",
+			(current: PolishedTuiConfig): void => {
+				current.components.workingLine.spinner = "pulse";
+			},
+		],
+		[
+			"width",
+			(current: PolishedTuiConfig): void => {
+				current.components.workingLine.messages.values = ["A much wider stable message"];
+			},
+		],
+		[
+			"animation",
+			(current: PolishedTuiConfig): void => {
+				current.components.workingLine.textAnimation = "kitt";
+			},
+		],
+	] as const)("carries fractional phase across a live %s change", (_kind, change) => {
+		let now = 0;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textIntervalMs = 100;
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		const before = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+
+		now = 250;
+		change(harness.current);
+		harness.controller.reconcile(harness.ctx);
+		const after = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+		const sampledIndex = Math.floor(250 / before.intervalMs);
+		if (_kind !== "preset") {
+			expect(phaseSignature(after.frames[0] ?? "")[0]).toBe(
+				phaseSignature(before.frames[sampledIndex] ?? "")[0],
+			);
+		} else {
+			expect(after.frames[0]).toBeDefined();
+		}
+
+		now = 250 + Math.ceil(after.intervalMs / 2);
+		harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+		const carried = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(carried.frames[0] ?? "")[0]).toBe(
+			phaseSignature(after.frames[1] ?? "")[0],
+		);
+	});
+
+	it("advances logical frame zero on rapid rebuilds without relying on Loader ticks", () => {
+		let now = 0;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinner = "pulse";
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textAnimation = "disabled";
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		const original = harness.calls.at(-1)?.[1] as { frames: string[] };
+		for (now = 20; now <= 200; now += 20) {
+			harness.controller.updateTokens({ input: now, output: 1 }, harness.ctx);
+			const rebuilt = harness.calls.at(-1)?.[1] as { frames: string[] };
+			const expectedIndex = Math.floor(now / 100);
+			expect(phaseSignature(rebuilt.frames[0] ?? "")[0]).toBe(
+				phaseSignature(original.frames[expectedIndex] ?? "")[0],
+			);
+		}
+	});
+
+	it("matches uninterrupted exact independent spinner/text schedules during rapid rebuilds", () => {
+		let now = 0;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textIntervalMs = 60;
+		harness.current.components.workingLine.textAnimation = "classic";
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		const uninterrupted = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+		expect(uninterrupted.intervalMs).toBe(30);
+		for (now = 30; now <= 600; now += 30) {
+			harness.controller.updateTokens({ input: now, output: 1 }, harness.ctx);
+			const rebuilt = harness.calls.at(-1)?.[1] as { frames: string[] };
+			expect(phaseSignature(rebuilt.frames[0] ?? "")).toEqual(
+				phaseSignature(uninterrupted.frames[(now / 30) % uninterrupted.frames.length] ?? ""),
+			);
+		}
+	});
+
+	it("preserves bounded fallback phase across its frame-array wrap", () => {
+		let now = 0;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinnerIntervalMs = 997;
+		harness.current.components.workingLine.textIntervalMs = 900;
+		harness.current.components.workingLine.textAnimation = "classic";
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		const uninterrupted = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+		const wrapAt = uninterrupted.frames.length * uninterrupted.intervalMs;
+		now = wrapAt + uninterrupted.intervalMs;
+		harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+		const rebuilt = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(rebuilt.frames[0] ?? "")).toEqual(
+			phaseSignature(uninterrupted.frames[1] ?? ""),
+		);
+	});
+
+	it("bounds visible Loader reset jitter below one replacement interval", () => {
+		vi.useFakeTimers();
+		try {
+			let now = 0;
+			let loader: Loader | undefined;
+			const harness = runtime(
+				true,
+				() => 0,
+				() => now,
+			);
+			harness.current.components.workingLine.messages.values = ["Stable"];
+			harness.current.components.workingLine.spinnerIntervalMs = 100;
+			harness.current.components.workingLine.textAnimation = "disabled";
+			harness.current.components.workingLine.segments.elapsed = false;
+			const recordIndicator = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+			harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+				recordIndicator(value);
+				if (value !== undefined) {
+					const indicator = value as { frames: string[]; intervalMs: number };
+					if (loader) loader.setIndicator(indicator);
+					else
+						loader = new Loader(
+							{ requestRender() {} } as never,
+							(text) => text,
+							(text) => text,
+							"",
+							indicator,
+						);
+				}
+			};
+			harness.controller.startSession(harness.ctx);
+			now = 90;
+			harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+			const replacement = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+			const logicalBoundaryAt = 100;
+			const visibleReplacementBoundaryAt = now + replacement.intervalMs;
+			expect(visibleReplacementBoundaryAt - logicalBoundaryAt).toBeLessThan(replacement.intervalMs);
+			expect(stripTerminalSequences(loader?.render(40)[1] ?? "")).toContain(
+				stripTerminalSequences(replacement.frames[0] ?? ""),
+			);
+			now = 100;
+			harness.controller.updateTokens({ input: 2, output: 1 }, harness.ctx);
+			const corrected = harness.calls.at(-1)?.[1] as { frames: string[] };
+			expect(phaseSignature(corrected.frames[0] ?? "")[0]).toBe(
+				phaseSignature(replacement.frames[1] ?? "")[0],
+			);
+			loader?.stop();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("rebases frame zero at successful agent_start installation time", () => {
+		let now = 0;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinner = "pulse";
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textAnimation = "disabled";
+		harness.current.components.workingLine.segments.elapsed = false;
+		harness.controller.startSession(harness.ctx);
+		now = 250;
+		harness.controller.startAgent(harness.ctx);
+		const rebased = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(rebased.frames[0] ?? "")[0]).toBe("⠀⠶⠀");
+		now = 349;
+		harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+		const beforeTick = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(beforeTick.frames[0] ?? "")[0]).toBe("⠀⠶⠀");
+		now = 350;
+		harness.controller.updateTokens({ input: 2, output: 1 }, harness.ctx);
+		const afterTick = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(afterTick.frames[0] ?? "")[0]).toBe("⠰⣿⠆");
+	});
+
+	it.each(["classic", "kitt"] as const)(
+		"keeps %s on its logical epoch when frame generation and setters advance the clock",
+		(animation) => {
+			let now = 0;
+			let generationPending = true;
+			const delayedTheme = theme();
+			const baseFg = delayedTheme.fg.bind(delayedTheme);
+			delayedTheme.fg = (color, text) => {
+				if (generationPending) {
+					now += 250;
+					generationPending = false;
+				}
+				return baseFg(color, text);
+			};
+			const harness = runtime(
+				true,
+				() => 0,
+				() => now,
+				() => delayedTheme,
+			);
+			const control = runtime(
+				true,
+				() => 0,
+				() => now,
+			);
+			for (const current of [harness.current, control.current]) {
+				current.components.workingLine.messages.values = ["Stable"];
+				current.components.workingLine.spinner = "pulse";
+				current.components.workingLine.spinnerIntervalMs = 100;
+				current.components.workingLine.textIntervalMs = 100;
+				current.components.workingLine.textAnimation = animation;
+				current.components.workingLine.segments.elapsed = false;
+			}
+			control.controller.startSession(control.ctx);
+			const recordIndicator = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+			harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+				recordIndicator(value);
+				now += 40;
+				generationPending = true;
+			};
+			harness.controller.startSession(harness.ctx);
+			expect(now).toBe(290);
+
+			now += 560;
+			control.controller.updateTokens({ input: 12, output: 3 }, control.ctx);
+			harness.controller.updateTokens({ input: 12, output: 3 }, harness.ctx);
+			const expected = control.calls.at(-1)?.[1] as { frames: string[] };
+			const rebuilt = harness.calls.at(-1)?.[1] as { frames: string[] };
+			expect(phaseMotionSignature(rebuilt.frames, 0)).toEqual(
+				phaseMotionSignature(expected.frames, 0),
+			);
+
+			now += 560;
+			control.controller.startTool("one", "read", control.ctx);
+			harness.controller.startTool("one", "read", harness.ctx);
+			const expectedAgain = control.calls.at(-1)?.[1] as { frames: string[] };
+			const rebuiltAgain = harness.calls.at(-1)?.[1] as { frames: string[] };
+			expect(phaseMotionSignature(rebuiltAgain.frames, 0)).toEqual(
+				phaseMotionSignature(expectedAgain.frames, 0),
+			);
+		},
+	);
+
+	it("recovers the last successful epoch when reconcile mutates then throws and retries on tokens", () => {
+		let now = 0;
+		let failSetter = false;
+		let setterCalls = 0;
+		let failedAtMs = 0;
+		let indicatorSurface: unknown;
+		let failedAttempt: { frames: string[]; intervalMs: number } | undefined;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		const control = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		const recordIndicator = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+		harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			setterCalls += 1;
+			indicatorSurface = value;
+			if (failSetter) {
+				failSetter = false;
+				failedAtMs = now;
+				failedAttempt = value as { frames: string[]; intervalMs: number };
+				now += 4500;
+				throw new Error("setter unavailable");
+			}
+			recordIndicator(value);
+		};
+		for (const current of [harness.current, control.current]) {
+			current.components.workingLine.messages.values = ["Stable"];
+			current.components.workingLine.spinner = "pulse";
+			current.components.workingLine.spinnerIntervalMs = 100;
+			current.components.workingLine.textIntervalMs = 100;
+			current.components.workingLine.textAnimation = "classic";
+			current.components.workingLine.segments.elapsed = false;
+		}
+		harness.controller.startSession(harness.ctx);
+		control.controller.startSession(control.ctx);
+		const lastSuccessfulSurface = indicatorSurface;
+
+		now = 100;
+		for (const current of [harness.current, control.current]) {
+			current.components.workingLine.spinnerIntervalMs = 200;
+			current.components.workingLine.textIntervalMs = 200;
+			current.components.workingLine.textAnimation = "kitt";
+		}
+		failSetter = true;
+		expect(harness.controller.reconcile(harness.ctx).applied).toBe(false);
+		expect(indicatorSurface).toBe(lastSuccessfulSurface);
+		failSetter = false;
+		control.controller.updateTokens({ input: 12, output: 3 }, control.ctx);
+		harness.controller.updateTokens({ input: 12, output: 3 }, harness.ctx);
+
+		expect(setterCalls).toBe(4);
+		expect(harness.calls.filter(([name]) => name === "indicator")).toHaveLength(3);
+		const retried = harness.calls.at(-1)?.[1] as { frames: string[] };
+		const expected = control.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseMotionSignature(retried.frames, 0)).toEqual(
+			phaseMotionSignature(expected.frames, 0),
+		);
+		const failed = failedAttempt as unknown as { frames: string[]; intervalMs: number };
+		const incorrectlyPublishedIndex =
+			Math.floor((now - failedAtMs) / failed.intervalMs) % failed.frames.length;
+		expect(phaseMotionSignature(retried.frames, 0)).not.toEqual(
+			phaseMotionSignature(failed.frames, incorrectlyPublishedIndex),
+		);
+	});
+
+	it("preserves the elapsed subscription while recovering a transient reinstall failure", () => {
+		vi.useFakeTimers();
+		try {
+			const harness = runtime(true, () => 0);
+			harness.current.components.workingLine.messages.values = ["Stable"];
+			let failSetter = false;
+			const setter = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+			harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+				if (failSetter) {
+					failSetter = false;
+					throw new Error("mutated before throwing");
+				}
+				setter(value);
+			};
+			harness.controller.startSession(harness.ctx);
+			harness.clock.start();
+			harness.controller.startAgent(harness.ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.current.components.workingLine.spinnerIntervalMs += 1;
+			failSetter = true;
+			expect(harness.controller.reconcile(harness.ctx).applied).toBe(false);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.controller.dispose(harness.ctx);
+			harness.clock.reset();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("restores the previous message and phase when startTurn installation fails", () => {
+		let now = 0;
+		let failSetter = false;
+		let indicatorSurface: unknown;
+		const harness = runtime(
+			true,
+			() => 0.75,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["A", "B"];
+		harness.current.components.workingLine.spinner = "pulse";
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textAnimation = "disabled";
+		harness.current.components.workingLine.segments.elapsed = false;
+		const setter = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+		harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			indicatorSurface = value;
+			if (failSetter) {
+				failSetter = false;
+				now = 250;
+				throw new Error("mutated before throwing");
+			}
+			setter(value);
+		};
+		harness.controller.startSession(harness.ctx);
+		const lastSuccessfulSurface = indicatorSurface;
+		expect(harness.controller.currentMessage()).toBe("A");
+
+		failSetter = true;
+		expect(harness.controller.startTurn(harness.ctx).applied).toBe(false);
+		expect(indicatorSurface).toBe(lastSuccessfulSurface);
+		expect(harness.controller.currentMessage()).toBe("A");
+		harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+		const retried = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(stripTerminalSequences(retried.frames[0] ?? "")).toContain("A");
+		expect(phaseSignature(retried.frames[0] ?? "")[0]).toBe("⢾⣉⡷");
+	});
+
+	it("does not publish a failed forced agent-start rebase epoch", () => {
+		let now = 0;
+		let failSetter = false;
+		let indicatorSurface: unknown;
+		const harness = runtime(
+			true,
+			() => 0,
+			() => now,
+		);
+		harness.current.components.workingLine.messages.values = ["Stable"];
+		harness.current.components.workingLine.spinner = "pulse";
+		harness.current.components.workingLine.spinnerIntervalMs = 100;
+		harness.current.components.workingLine.textAnimation = "disabled";
+		harness.current.components.workingLine.segments.elapsed = false;
+		const setter = harness.ctx.ui.setWorkingIndicator.bind(harness.ctx.ui);
+		harness.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			indicatorSurface = value;
+			if (failSetter) {
+				failSetter = false;
+				now = 350;
+				throw new Error("mutated before throwing");
+			}
+			setter(value);
+		};
+		harness.controller.startSession(harness.ctx);
+		const lastSuccessfulSurface = indicatorSurface;
+		now = 250;
+		failSetter = true;
+		harness.controller.startAgent(harness.ctx);
+		expect(indicatorSurface).toBe(lastSuccessfulSurface);
+		harness.controller.updateTokens({ input: 1, output: 1 }, harness.ctx);
+		const retried = harness.calls.at(-1)?.[1] as { frames: string[] };
+		expect(phaseSignature(retried.frames[0] ?? "")[0]).toBe("⣏⠀⣹");
+	});
+
+	it("releases ownership when recovery also throws and waits for a clean reinstall", () => {
+		const current = config();
+		current.components.workingLine.enabled = true;
+		current.components.workingLine.messages.values = ["Stable"];
+		current.components.workingLine.segments.elapsed = false;
+		const calls: string[] = [];
+		let indicatorSurface: unknown;
+		let messageSurface: string | undefined;
+		let failureSets = 0;
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				setWorkingMessage(value?: string) {
+					messageSurface = value;
+					calls.push(value === undefined ? "message-reset" : "message-set");
+				},
+				setWorkingIndicator(value?: unknown) {
+					indicatorSurface = value;
+					calls.push(value === undefined ? "indicator-reset" : "indicator-set");
+					if (value !== undefined && failureSets > 0) {
+						failureSets -= 1;
+						throw new Error("setter mutated before throwing");
+					}
+				},
+			},
+		};
+		const controller = new WorkingLineController(() => current, theme);
+		expect(controller.startSession(ctx).applied).toBe(true);
+		current.components.workingLine.spinnerIntervalMs += 1;
+		failureSets = 2;
+		expect(controller.reconcile(ctx).applied).toBe(false);
+		expect(calls.slice(-4)).toEqual([
+			"indicator-set",
+			"indicator-set",
+			"indicator-reset",
+			"message-reset",
+		]);
+		expect(indicatorSurface).toBeUndefined();
+		expect(messageSurface).toBeUndefined();
+		const afterRelease = calls.length;
+		controller.updateTokens({ input: 1, output: 1 }, ctx);
+		expect(calls).toHaveLength(afterRelease);
+		expect(controller.reconcile(ctx).applied).toBe(true);
+		expect(calls.slice(-2)).toEqual(["message-set", "indicator-set"]);
+	});
+
+	it.each(["classic", "kitt"] as const)(
+		"preserves %s phase across the 9s to 10s elapsed-width change",
+		(animation) => {
+			vi.useFakeTimers();
+			vi.setSystemTime(0);
+			try {
+				const harness = runtime(true, () => 0);
+				harness.current.components.workingLine.messages.values = ["Stable"];
+				harness.current.components.workingLine.textAnimation = animation;
+				harness.controller.startSession(harness.ctx);
+				harness.clock.start(0);
+				harness.controller.startAgent(harness.ctx);
+				harness.controller.startTurn(harness.ctx);
+				vi.advanceTimersByTime(9000);
+				const atNine = harness.calls.at(-1)?.[1] as { frames: string[]; intervalMs: number };
+				expect(stripTerminalSequences(atNine.frames[0] ?? "")).toContain(" · 9s");
+				vi.advanceTimersByTime(1000);
+				const atTen = harness.calls.at(-1)?.[1] as { frames: string[] };
+				expect(stripTerminalSequences(atTen.frames[0] ?? "")).toContain(" · 10s");
+				const sampledIndex = Math.floor(1000 / atNine.intervalMs) % atNine.frames.length;
+				expect(phaseSignature(atTen.frames[0] ?? "")).toEqual(
+					phaseSignature(atNine.frames[sampledIndex] ?? ""),
+				);
+				harness.controller.dispose(harness.ctx);
+				harness.clock.reset();
+			} finally {
+				vi.useRealTimers();
+			}
+		},
+	);
+
+	it("writes elapsed only when its one-second label changes", () => {
+		vi.useFakeTimers();
+		const harness = runtime(true);
+		harness.controller.startSession(harness.ctx);
+		harness.clock.start();
+		harness.controller.startAgent(harness.ctx);
+		harness.controller.startTurn(harness.ctx);
+		harness.calls.length = 0;
+		vi.advanceTimersByTime(999);
+		expect(harness.calls).toEqual([]);
+		vi.advanceTimersByTime(1);
+		expect(harness.calls).toHaveLength(1);
+		expect(harness.calls[0]?.[0]).toBe("indicator");
+		expect(
+			stripTerminalSequences(
+				(harness.calls[0]?.[1] as { frames?: string[] } | undefined)?.frames?.[0] ?? "",
+			),
+		).toContain(" · 1s");
+		vi.advanceTimersByTime(1000);
+		expect(harness.calls).toHaveLength(2);
+		expect(
+			stripTerminalSequences(
+				(harness.calls.at(-1)?.[1] as { frames?: string[] } | undefined)?.frames?.[0] ?? "",
+			),
+		).toContain(" · 2s");
+		harness.controller.dispose(harness.ctx);
+		harness.clock.reset();
+		vi.useRealTimers();
+	});
+
+	it("keeps one shared clock subscription through frequent eligible updates", () => {
+		vi.useFakeTimers();
+		try {
+			const harness = runtime(true);
+			harness.controller.startSession(harness.ctx);
+			harness.clock.start();
+			harness.controller.startAgent(harness.ctx);
+			harness.controller.startTurn(harness.ctx);
+			for (let elapsed = 0; elapsed < 1_000; elapsed += 100) {
+				harness.controller.updateMetrics(
+					{ input: elapsed, output: 1 },
+					{ durationMs: elapsed, active: true },
+					harness.ctx,
+				);
+				harness.controller.reconcile(harness.ctx);
+				vi.advanceTimersByTime(100);
+				expect(vi.getTimerCount()).toBe(1);
+			}
+			const latest = stripTerminalSequences(
+				(harness.calls.at(-1)?.[1] as { frames?: string[] } | undefined)?.frames?.[0] ?? "",
+			);
+			expect(latest).toContain(" · 1s");
+			harness.controller.dispose(harness.ctx);
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("transitions thought-only clock subscription strictly with active thought", () => {
+		vi.useFakeTimers();
+		try {
+			const harness = runtime(true);
+			harness.current.components.workingLine.segments.elapsed = false;
+			harness.current.components.workingLine.segments.thought = true;
+			harness.controller.startSession(harness.ctx);
+			harness.clock.start();
+			harness.controller.startAgent(harness.ctx);
+			expect(vi.getTimerCount()).toBe(0);
+			harness.controller.updateMetrics(undefined, { durationMs: 0, active: true }, harness.ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.controller.updateMetrics(undefined, { durationMs: 1, active: true }, harness.ctx);
+			harness.controller.startTurn(harness.ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.controller.updateMetrics(undefined, { durationMs: 2, active: false }, harness.ctx);
+			expect(vi.getTimerCount()).toBe(0);
+			harness.current.components.workingLine.enabled = false;
+			harness.controller.reconcile(harness.ctx);
+			expect(vi.getTimerCount()).toBe(0);
+			harness.current.components.workingLine.enabled = true;
+			harness.controller.reconcile(harness.ctx);
+			harness.controller.updateMetrics(undefined, { durationMs: 3, active: true }, harness.ctx);
+			expect(vi.getTimerCount()).toBe(1);
+			harness.controller.finishAgent(harness.ctx);
+			expect(vi.getTimerCount()).toBe(0);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("releases a first message setter that mutates then throws before a clean retry", () => {
+		const current = config();
+		current.components.workingLine.enabled = true;
+		const calls: string[] = [];
+		let failFirstMessageSet = true;
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				setWorkingMessage(value?: string) {
+					calls.push(value === undefined ? "message-reset" : "message-set");
+					if (value === "" && failFirstMessageSet) {
+						failFirstMessageSet = false;
+						throw new Error("message setter mutated before throwing");
+					}
+				},
+				setWorkingIndicator(value?: unknown) {
+					calls.push(value === undefined ? "indicator-reset" : "indicator-set");
+				},
+			},
+		};
+		const controller = new WorkingLineController(() => current, theme);
+
+		expect(controller.startSession(ctx).applied).toBe(false);
+		expect(calls).toEqual(["message-set", "message-reset"]);
+		controller.dispose(ctx);
+		expect(calls).toEqual(["message-set", "message-reset"]);
+
+		expect(controller.startSession(ctx).applied).toBe(true);
+		expect(calls.slice(-2)).toEqual(["message-set", "indicator-set"]);
+		const afterRetry = calls.length;
+		expect(controller.reconcile(ctx).applied).toBe(true);
+		expect(calls).toHaveLength(afterRetry);
+		controller.dispose(ctx);
+		controller.dispose(ctx);
+		expect(calls.slice(-2)).toEqual(["indicator-reset", "message-reset"]);
+	});
+
+	it("releases a first indicator setter that mutates then throws before a phase-clean retry", () => {
+		const current = config();
+		current.components.workingLine.enabled = true;
+		current.components.workingLine.messages.values = ["Stable"];
+		current.components.workingLine.segments.elapsed = false;
+		let now = 0;
+		let failFirstIndicatorSet = true;
+		const calls: string[] = [];
+		let failedFrames: string[] | undefined;
+		let retriedFrames: string[] | undefined;
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				setWorkingMessage(value?: string) {
+					calls.push(value === undefined ? "message-reset" : "message-set");
+				},
+				setWorkingIndicator(value?: unknown) {
+					calls.push(value === undefined ? "indicator-reset" : "indicator-set");
+					if (value !== undefined && failFirstIndicatorSet) {
+						failedFrames = (value as { frames: string[] }).frames;
+						failFirstIndicatorSet = false;
+						now = 500;
+						throw new Error("indicator setter mutated before throwing");
+					}
+					if (value !== undefined) retriedFrames = (value as { frames: string[] }).frames;
+				},
+			},
+		};
+		const controller = new WorkingLineController(
+			() => current,
+			theme,
+			new AgentDurationClock(),
+			() => 0,
+			() => now,
+		);
+
+		expect(controller.startSession(ctx).applied).toBe(false);
+		expect(calls).toEqual(["message-set", "indicator-set", "indicator-reset", "message-reset"]);
+		controller.dispose(ctx);
+		expect(calls).toHaveLength(4);
+
+		expect(controller.startSession(ctx).applied).toBe(true);
+		expect(calls.slice(-2)).toEqual(["message-set", "indicator-set"]);
+		expect(retriedFrames).toEqual(failedFrames);
+		const afterRetry = calls.length;
+		expect(controller.reconcile(ctx).applied).toBe(true);
+		expect(calls).toHaveLength(afterRetry);
+		controller.dispose(ctx);
+		controller.dispose(ctx);
+		expect(calls.slice(-2)).toEqual(["indicator-reset", "message-reset"]);
+	});
+
+	it("contains cleanup API failures and stays idempotent", () => {
+		const current = config();
+		current.components.workingLine.enabled = true;
+		current.components.workingLine.messages.custom = true;
+		const calls: string[] = [];
+		const ctx = {
+			hasUI: true,
+			mode: "tui",
+			ui: {
+				setWorkingMessage(value?: string) {
+					calls.push(value === undefined ? "message-reset" : "message-set");
+				},
+				setWorkingIndicator(value?: unknown) {
+					calls.push(value === undefined ? "indicator-reset" : "indicator-set");
+					if (value === undefined) throw new Error("reset unavailable");
+				},
+			},
+		};
+		const controller = new WorkingLineController(() => current, theme);
+		expect(controller.startSession(ctx).applied).toBe(true);
+		expect(() => controller.dispose(ctx)).not.toThrow();
+		expect(() => controller.dispose(ctx)).not.toThrow();
+		expect(calls).toEqual(["message-set", "indicator-set", "indicator-reset", "message-reset"]);
+	});
+
+	it("live-enables and resets indicator then message exactly once on disable or cleanup", () => {
+		const harness = runtime(false);
+		harness.controller.startTurn(harness.ctx);
+		harness.current.components.workingLine.enabled = true;
+		expect(harness.controller.reconcile(harness.ctx).applied).toBe(true);
+		expect(harness.controller.currentMessage()).toBe("B");
+		harness.current.components.workingLine.enabled = false;
+		harness.controller.reconcile(harness.ctx);
+		harness.controller.dispose(harness.ctx);
+		harness.controller.dispose(harness.ctx);
+		expect(
+			harness.calls.map(([name, value]) => [name, value === undefined ? "reset" : "set"]),
+		).toEqual([
+			["message", "set"],
+			["indicator", "set"],
+			["indicator", "reset"],
+			["message", "reset"],
+		]);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a configurable Zentui-owned Working line with:

- five spinner presets, independent spinner/text cadence, Classic/KITT/static color modes, and optional spinner-color participation;
- editable whimsical messages, Tool/Elapsed/Thinking/Tokens segments, and bounded 80-column rendering;
- smooth whole-interaction token streaming from text, thinking, and tool-call deltas using native `↑ input` / `↓ output` semantics;
- cumulative wall-clock thinking time across tool loops, retries, and continuations;
- persistent, context-free `Turn took …` summaries with stable Working-line styling;
- `/zentui` controls and a live preview;
- strict lifecycle, failure-recovery, memory, CPU, Unicode, and terminal-style bounds.

The minimum supported Pi version is raised to `0.80.5` for `agent_settled` and custom-entry renderer APIs.

Follow-up: #83 tracks equivalent Editor and User-message settings previews.

## Screenshots / recordings

Manually exercised in a live Pi pseudo-terminal and compared against a supplied MP4 recording for smooth in-place token streaming, spinner continuity, tool transitions, and final reconciliation. No public recording is attached because the source recording contains local session content.

## Testing

- [x] `npm run verify` — 1,040 tests across 31 files
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev` / live pseudo-terminal
- [x] Added or updated tests where practical

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Package dry-run contains required source-level MIT notice for the Pulse frames

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [x] Updated `README.md` or config docs if user-facing behavior changed.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; new logic lives in focused modules.
- [x] Used a conventional commit-style PR title.
