### PR TITLE
chore: release v0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.18.1",
+	"version": "0.19.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.18.1",
+			"version": "0.19.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.18.1",
+	"version": "0.19.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Bumps `pi-zentui` from `0.18.1` to `0.19.0` after merging the configurable Working-line feature in #84.

This keeps `package.json` and both root `package-lock.json` version fields synchronized. No dependency, source, config-schema, or generated artifact changes are included.

## Screenshots / recordings

N/A — release metadata only. The user-facing Working-line rendering was validated in #84.

## Testing

- [x] `npm run verify` — 1,040 tests across 31 files
- [x] `npm run pack:check` — `pi-zentui-0.19.0.tgz`, 35 files
- [ ] Manual Pi test via `npm run pi:dev` (not applicable to metadata-only change)
- [ ] Added or updated tests where practical (not applicable)

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Independent release-diff review

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no source changes).
- [x] Updated `README.md` or config docs if user-facing behavior changed (handled in #84).
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration (no source changes).
- [x] Used a conventional commit-style PR title.
