### PR TITLE
feat: add settings style previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Editor, User messages, Working line, and selector borders use independent `enabl
 - Opencode autocomplete rows retain Pi's original unframed trailing layout; Minimalist keeps autocomplete inside its rounded frame
 - Configurable model, provider, thinking-level, accent, and border colors
 
-Editor previews:
+Editor styles:
 
 <h4 align="center"><code>opencode</code></h4>
 
@@ -193,15 +193,15 @@ User config lives at `~/.pi/agent/zentui.json`. The file is optional: missing or
 The interactive `/zentui` menu is split into exactly eight component-oriented sections, in this order. Use `Tab` and `Shift+Tab` to switch sections:
 
 1. **Appearance** — selector-border enablement, style, and colors; icon mode.
-2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, and settings for the selected editor style.
-3. **User messages** — message enablement, `framed | framed-copy-friendly | compact | labeled` style selection (including **Framed (copy-friendly)**), and colors.
-4. **Working line** — ownership, settled Turn summary, spinner and text speeds, optional spinner-color motion, text animation, color source, custom-message toggle and editable list, Tool/Elapsed/Thinking/Tokens toggles, and preview.
+2. **Editor** — editor enablement, style, colors, model label, border behavior, viewport indicators, settings for the selected editor style, and a static synthetic preview.
+3. **User messages** — message enablement, `framed | framed-copy-friendly | compact | labeled` style selection (including **Framed (copy-friendly)**), colors, and a static synthetic Markdown preview.
+4. **Working line** — ownership, settled Turn summary, spinner and text speeds, optional spinner-color motion, text animation, color source, custom-message toggle and editable list, Tool/Elapsed/Thinking/Tokens toggles, and animated preview.
 5. **Footer** — `Native | Starship | Hidden` style selection. Starship additionally shows colors, model label, responsive layout, separator, context style, and path display.
 6. **Segments** — visibility toggles for non-Git Starship segments.
 7. **Git** — Starship Git segment and probe controls.
 8. **Extensions** — Starship extension-status placement and color controls for active keys.
 
-Editor, User messages, and Working line retain independent configuration. Footer's single style selects Pi's built-in Footer (`Native`), Zentui's Starship Footer, or an owned zero-row Footer (`Hidden`). Color and model-label rows update only their owning component.
+Editor, User messages, and Working line retain independent configuration. Editor and User-message previews use fixed synthetic content and remain visible while their component is disabled; the Working-line preview reflects its current configured sample, state, and animation. Each preview appears above its settings. Only the Working-line preview owns an animation timer. Footer's single style selects Pi's built-in Footer (`Native`), Zentui's Starship Footer, or an owned zero-row Footer (`Hidden`). Color and model-label rows update only their owning component.
 
 Starship-specific Footer rows are shown only while Starship is selected. The **Segments**, **Git**, and **Extensions** sections remain available for preconfiguration under every Footer style. Free-form values such as custom formats, Opencode metadata format, raw colors/styles, and inactive extension keys remain JSON-only; Working-line speed accepts validated custom milliseconds in `/zentui`.
 

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -50,6 +50,11 @@ import {
 import { sanitizeExtensionStatusText } from "./extension-status";
 import { isIconMode } from "./icons";
 import type { SessionLifecycle } from "./session-lifecycle";
+import {
+	renderEditorSettingsPreview,
+	renderUserMessageSettingsPreview,
+	SETTINGS_PREVIEW_MAX_WIDTH,
+} from "./settings-previews";
 import { EDITOR_BORDER_STYLE, renderChromeBorder, safeThemeFg } from "./style";
 import {
 	buildWorkingLinePreviewFrames,
@@ -120,6 +125,7 @@ const speedValues = (presets: readonly { label: string }[]) => [
 	"Custom…",
 ];
 const workingLineTextAnimationValues: WorkingLineTextAnimation[] = ["classic", "kitt", "disabled"];
+
 const settingsSections = [
 	"appearance",
 	"editor",
@@ -1574,6 +1580,22 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 					};
 					settingsList = makeSettingsList(initialFocusId);
 					startPreview();
+					const renderPreviewRows = (previewWidth: number): string[] => {
+						if (previewWidth <= 0) return [];
+						if (activeSection === "editor")
+							return renderEditorSettingsPreview(deps.getConfig(), theme, previewWidth);
+						if (activeSection === "userMessages")
+							return renderUserMessageSettingsPreview(deps.getConfig(), theme, previewWidth);
+						if (activeSection === "workingLine" && preview && preview.frames.length > 0)
+							return [
+								truncateToWidth(
+									preview.frames[previewFrameIndex] ?? preview.frames[0],
+									Math.min(SETTINGS_PREVIEW_MAX_WIDTH, previewWidth),
+									"",
+								),
+							];
+						return [];
+					};
 					return {
 						render(width: number) {
 							const border = renderChromeBorder(
@@ -1582,22 +1604,23 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 								EDITOR_BORDER_STYLE,
 								"─".repeat(Math.max(0, width)),
 							);
+							const settingsRows = withSectionFooter(settingsList.render(width), theme).map(
+								(line) => truncateToWidth(line, width, ""),
+							);
+							const previewRows = renderPreviewRows(Math.max(0, width - 4));
+							while (previewRows.length > 0 && visibleWidth(previewRows.at(-1) ?? "") === 0)
+								previewRows.pop();
+							const indentedPreviewRows = previewRows.map((line) =>
+								truncateToWidth(`  ${line}`, width, ""),
+							);
+							const bodyRows = indentedPreviewRows.some((line) => visibleWidth(line) > 0)
+								? ["", ...indentedPreviewRows, "", ...settingsRows]
+								: settingsRows;
 							return [
 								truncateToWidth(border, width, ""),
 								truncateToWidth(formatSectionTabs(activeSection, theme, width), width, ""),
 								truncateToWidth(border, width, ""),
-								...(activeSection === "workingLine" && preview && preview.frames.length > 0
-									? [
-											truncateToWidth(
-												`  ${preview.frames[previewFrameIndex] ?? preview.frames[0]}`,
-												width,
-												"",
-											),
-										]
-									: []),
-								...withSectionFooter(settingsList.render(width), theme).map((line) =>
-									truncateToWidth(line, width, ""),
-								),
+								...bodyRows,
 								truncateToWidth(border, width, ""),
 							];
 						},

--- a/extensions/zentui/settings-previews.ts
+++ b/extensions/zentui/settings-previews.ts
@@ -1,0 +1,110 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { PolishedTuiConfig } from "./config";
+import { sanitizeEditorMetadataText } from "./editor-metadata-format";
+import { renderMinimalistFrame } from "./minimalist-editor";
+import { safeThemeFg } from "./style";
+import { renderPolishedEditorFrame } from "./ui";
+import { renderUserMessageStyle } from "./user-message-styles";
+
+export const SETTINGS_PREVIEW_MAX_WIDTH = 72;
+export const SETTINGS_PREVIEW_MAX_ROWS = 8;
+export const EDITOR_PREVIEW_INPUT = "Explain this change safely.";
+export const USER_MESSAGE_PREVIEW_MARKDOWN = "Please review **this change** safely.";
+
+function boundedRows(rows: string[], width: number): string[] {
+	const safeWidth = Math.max(0, Math.min(SETTINGS_PREVIEW_MAX_WIDTH, width));
+	if (safeWidth <= 0) return [];
+	const bounded = rows
+		.slice(0, SETTINGS_PREVIEW_MAX_ROWS)
+		.map((line) => truncateToWidth(line, safeWidth, ""));
+	while (bounded.length > 0 && visibleWidth(bounded.at(-1) ?? "") === 0) bounded.pop();
+	return bounded;
+}
+
+function previewConfig(config: PolishedTuiConfig): PolishedTuiConfig {
+	const derived = structuredClone(config);
+	derived.icons = Object.fromEntries(
+		Object.entries(derived.icons).map(([key, value]) => [
+			key,
+			typeof value === "string" ? sanitizeEditorMetadataText(value) : value,
+		]),
+	) as typeof derived.icons;
+	return derived;
+}
+
+function adaptiveBorder(theme: Theme): (text: string) => string {
+	return (text) => safeThemeFg(theme, "thinkingHigh", text);
+}
+
+export function renderEditorSettingsPreview(
+	config: PolishedTuiConfig,
+	theme: Theme,
+	width: number,
+): string[] {
+	const previewWidth = Math.max(0, Math.min(SETTINGS_PREVIEW_MAX_WIDTH, width));
+	if (previewWidth <= 0) return [];
+	const safeConfig = previewConfig(config);
+	const editor = safeConfig.components.editor;
+	const borderColor = adaptiveBorder(theme);
+	const modelLabel = editor.modelLabel === "name" ? "Sonnet 4" : "sonnet-4";
+	const editorLines = [EDITOR_PREVIEW_INPUT];
+	const viewport = editor.viewportIndicators ? { above: "2", below: "3" } : undefined;
+	const frame =
+		editor.style === "minimalist"
+			? renderMinimalistFrame({
+					width: previewWidth,
+					editorLines,
+					viewport,
+					inputText: EDITOR_PREVIEW_INPUT,
+					metadata: {
+						cwd: "/workspace/zentui/src",
+						projectRoot: "/workspace/zentui",
+						branch: "feat/settings-previews",
+						dirty: true,
+						ahead: 2,
+						behind: 1,
+						costLabel: "$.12",
+						modelLabel,
+						thinkingLevel: "high",
+						contextPercent: 75,
+						contextWindow: 372_000,
+						sessionName: "Preview",
+						agentDurationMs: 12_000,
+						agentActive: true,
+					},
+					uiTheme: theme,
+					config: safeConfig,
+					borderColor,
+				})
+			: renderPolishedEditorFrame({
+					width: previewWidth,
+					editorLines,
+					viewport,
+					uiTheme: theme,
+					config: safeConfig,
+					modelMeta: {
+						modelLabel,
+						modelId: "sonnet-4",
+						modelName: "Sonnet 4",
+						providerLabel: "Anthropic",
+						sessionName: "Preview",
+					},
+					thinkingLevel: "high",
+					borderColor,
+				});
+	return boundedRows(frame, previewWidth);
+}
+
+export function renderUserMessageSettingsPreview(
+	config: PolishedTuiConfig,
+	theme: Theme,
+	width: number,
+	text = USER_MESSAGE_PREVIEW_MARKDOWN,
+): string[] {
+	const previewWidth = Math.max(0, Math.min(SETTINGS_PREVIEW_MAX_WIDTH, width));
+	if (previewWidth <= 0) return [];
+	const safeConfig = previewConfig(config);
+	const frame = renderUserMessageStyle({ text, width: previewWidth, theme, config: safeConfig });
+	return boundedRows(frame, previewWidth);
+}

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -20,7 +20,7 @@ import {
 
 const LEGACY_SPLIT_POLISHED_FRAME = Symbol.for("pi-zentui.polished-frame");
 
-type ViewportCounts = {
+export type ViewportCounts = {
 	above?: string;
 	below?: string;
 };
@@ -75,12 +75,25 @@ type WrappedEditor = EditorComponent &
 		setAutocompleteMaxVisible?: (maxVisible: number) => void;
 	};
 
-type EditorMeta = {
+export type EditorMeta = {
 	modelLabel: string;
 	modelId?: string;
 	modelName?: string;
 	providerLabel: string;
 	sessionName?: string;
+};
+
+export type PolishedEditorFrameOptions = {
+	width: number;
+	editorLines: string[];
+	autocompleteLines?: string[];
+	viewport?: ViewportCounts;
+	uiTheme: Theme;
+	config: ZentuiConfig;
+	modelMeta: EditorMeta;
+	thinkingLevel?: string;
+	rightStatus?: string;
+	borderColor?: (text: string) => string;
 };
 
 type PolishedFrameOptions = {
@@ -542,12 +555,6 @@ function renderPolishedFrame({
 }: PolishedFrameOptions): PolishedFrameResult {
 	if (width <= 2) return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 
-	const reset = "\x1b[0m";
-	const colorSource = config.components.editor.colorSource;
-	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
-	const innerWidth = Math.max(0, width - railWidth);
-	const lowRailContinuation = " ".repeat(promptWidth);
-
 	if (baseRendered.length < 2) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
@@ -584,6 +591,48 @@ function renderPolishedFrame({
 		above: parsedTop?.count,
 		below: parsedBottom?.count,
 	};
+	const lines = renderPolishedEditorFrame({
+		width,
+		editorLines,
+		autocompleteLines,
+		viewport,
+		uiTheme,
+		config,
+		modelMeta,
+		thinkingLevel,
+		rightStatus,
+		borderColor,
+	});
+	POLISHED_FRAME_SPLITS.set(lines, {
+		rows: Object.freeze([...lines]),
+		split: {
+			editorLines,
+			trailingLines: autocompleteLines,
+			viewport,
+		},
+	});
+	return { lines, decorated: true };
+}
+
+/** Pure Opencode frame composition shared by the live editor and settings preview. */
+export function renderPolishedEditorFrame({
+	width,
+	editorLines,
+	autocompleteLines = [],
+	viewport = {},
+	uiTheme,
+	config,
+	modelMeta,
+	thinkingLevel,
+	rightStatus,
+	borderColor,
+}: PolishedEditorFrameOptions): string[] {
+	if (width <= 2) return clampRenderedLines(editorLines, width);
+	const reset = "\x1b[0m";
+	const colorSource = config.components.editor.colorSource;
+	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
+	const innerWidth = Math.max(0, width - railWidth);
+	const lowRailContinuation = " ".repeat(promptWidth);
 	const meta = renderEditorMetadataFormat(
 		selectedPolishedConfig(config)?.metadataFormat ??
 			config.components.editor.styles.opencode.metadataFormat,
@@ -658,19 +707,7 @@ function renderPolishedFrame({
 				...autocompleteLines,
 			];
 
-	const clamped = clampRenderedLines(renderedLines, width);
-	POLISHED_FRAME_SPLITS.set(clamped, {
-		rows: Object.freeze([...clamped]),
-		split: {
-			editorLines,
-			trailingLines: autocompleteLines,
-			viewport,
-		},
-	});
-	return {
-		lines: clamped,
-		decorated: true,
-	};
+	return clampRenderedLines(renderedLines, width);
 }
 
 export class PolishedEditor extends CustomEditor {

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -62,6 +62,30 @@ function row(component: Component, label: string): string {
 function focusedRow(component: Component): string {
 	return component.render(200).find((line) => line.includes("> ")) ?? "";
 }
+function previewRow(rows: string[], text: string): number {
+	const index = rows.findIndex((line) => line.includes(text));
+	if (index < 0) throw new Error(`Could not find preview row containing ${text}`);
+	return index;
+}
+function expectStackedPreview(rows: string[], previewText: string): void {
+	const previewIndex = previewRow(rows, previewText);
+	const settingsIndex = rows.findIndex(
+		(line, index) => index > previewIndex && line.includes("> "),
+	);
+	if (settingsIndex < 0) throw new Error("Could not find settings below preview");
+	expect(rows[3]).toBe("");
+	expect(rows[4]).not.toBe("");
+	expect(rows[settingsIndex - 1]).toBe("");
+	expect(rows[settingsIndex - 2]).not.toBe("");
+}
+function leadingEmptyRowCount(rows: string[]): number {
+	let count = 0;
+	for (const row of rows.slice(3)) {
+		if (row !== "") break;
+		count += 1;
+	}
+	return count;
+}
 function expectFocusOrder(component: Component, labels: readonly string[]): void {
 	const first = focusedRow(component);
 	for (const [index, label] of labels.entries()) {
@@ -253,9 +277,10 @@ describe("component-oriented /zentui settings", () => {
 		selectLabel(component, "Elapsed");
 		expect(component.render(100).join("\n")).toContain("Show whole-interaction elapsed time.");
 		selectLabel(component, "Tokens");
-		expect(component.render(100).join("\n")).toContain(
-			"Show whole-interaction tokens as ↑input ↓output; live output may be estimated until final usage",
-		);
+		const tokenRows = component.render(100).join("\n");
+		expect(tokenRows).toContain("Show whole-interaction tokens as ↑input");
+		expect(tokenRows).toContain("until final usage");
+		expect(tokenRows).toContain("reconciles.");
 	});
 
 	it("uses exact component-owned row sets and ordering", async () => {
@@ -770,7 +795,8 @@ describe("component-oriented /zentui settings", () => {
 		]) {
 			expect(focusedRow(harness.component())).toContain(label);
 			if (label === "Pulse") {
-				expect(harness.component().render(100)[3]).toContain("⠀⠶⠀");
+				const rows = harness.component().render(100);
+				expect(rows[previewRow(rows, "⠀⠶⠀")]).toContain("⠀⠶⠀");
 				expect(current.components.workingLine.spinnerIntervalMs).toBe(180);
 			}
 			harness.component().handleInput(" ");
@@ -909,31 +935,181 @@ describe("component-oriented /zentui settings", () => {
 		expect(harness.calls.renders).toEqual({ shared: 1, local: 1 });
 	});
 
+	it.each([
+		["Editor", "Explain"],
+		["User messages", "Please review"],
+		["Working line", "Sautéing…"],
+	] as const)(
+		"stacks the %s preview above settings at every width",
+		async (section, previewText) => {
+			vi.useFakeTimers();
+			const harness = createHarness();
+			harness.sessionLifecycle.start();
+			await harness.command().handler("", harness.ctx);
+			const component = harness.component();
+			goToSection(component, section);
+			const zeroWidthRows = component.render(0);
+			const oneCellRows = component.render(1);
+			expect(zeroWidthRows).toHaveLength(oneCellRows.length);
+			for (const width of [0, 1, 4]) {
+				const rows = component.render(width);
+				expect(rows.every((line) => visibleWidth(line) <= width)).toBe(true);
+				expect(rows.join("")).not.toContain(previewText);
+			}
+			for (const width of [24, 80, 99, 100, 118, 140, 160, 200]) {
+				const rows = component.render(width);
+				expect(rows.every((line) => visibleWidth(line) <= width)).toBe(true);
+				expectStackedPreview(rows, previewText);
+				expect(rows.some((line) => line.includes("> "))).toBe(true);
+			}
+			component.handleInput("\x1b");
+			expect(vi.getTimerCount()).toBe(0);
+		},
+	);
+
+	it.each(["Appearance", "Footer", "Segments", "Git", "Extensions"] as const)(
+		"does not add preview spacer rows in %s",
+		async (section) => {
+			const harness = createHarness();
+			await harness.command().handler("", harness.ctx);
+			const component = harness.component();
+			goToSection(component, section);
+			for (const width of [24, 80, 99, 100, 118, 140, 160, 200]) {
+				const rows = component.render(width);
+				expect(rows.every((line) => visibleWidth(line) <= width)).toBe(true);
+				expect(leadingEmptyRowCount(rows)).toBe(0);
+			}
+		},
+	);
+
+	it("shows static previews only in their owning sections without timers or extra setters", async () => {
+		vi.useFakeTimers();
+		const harness = createHarness();
+		harness.sessionLifecycle.start();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		const appearanceRows = component.render(100);
+		expect(appearanceRows.join("\n")).not.toContain("Explain this change safely.");
+		expect(leadingEmptyRowCount(appearanceRows)).toBe(0);
+		component.handleInput("\t");
+		const editorRows = component.render(100);
+		expectStackedPreview(editorRows, "Explain this change safely.");
+		const editor = editorRows.join("\n");
+		expect(editor).toContain("Explain this change safely.");
+		expect(editor).not.toContain("Editor preview");
+		expect(vi.getTimerCount()).toBe(0);
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		const copyFriendly = component.render(100).join("\n");
+		expect(copyFriendly).not.toBe(editor);
+		expect(harness.calls.editor).toEqual([{ style: "opencode-copy-friendly" }]);
+		selectLabel(component, "Editor colors");
+		component.handleInput(" ");
+		expect(component.render(100).join("\n")).not.toBe(copyFriendly);
+		selectLabel(component, "Editor viewport indicators");
+		component.handleInput(" ");
+		expect(component.render(100).join("\n")).not.toContain("↑ 2 more");
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		const minimalist = component.render(100).join("\n");
+		selectLabel(component, "Timer");
+		component.handleInput(" ");
+		expect(component.render(100).join("\n")).not.toBe(minimalist);
+		expect(harness.calls.minimalist).toEqual([{ showTimer: false }]);
+		expect(vi.getTimerCount()).toBe(0);
+		component.handleInput("\t");
+		const messageRows = component.render(100);
+		expectStackedPreview(messageRows, "Please review");
+		const messages = messageRows.join("\n");
+		expect(messages).toContain("Please review [this change] safely.");
+		expect(messages).not.toContain("User message preview");
+		expect(harness.calls.messages).toEqual([]);
+		expect(vi.getTimerCount()).toBe(0);
+		selectLabel(component, "Message style");
+		component.handleInput(" ");
+		const copyFriendlyMessage = component.render(100).join("\n");
+		expect(copyFriendlyMessage).not.toBe(messages);
+		selectLabel(component, "Message colors");
+		component.handleInput(" ");
+		expect(component.render(100).join("\n")).not.toBe(copyFriendlyMessage);
+		expect(harness.calls.messages).toEqual([
+			{ style: "framed-copy-friendly" },
+			{ colorSource: "terminal" },
+		]);
+		expect(vi.getTimerCount()).toBe(0);
+		component.handleInput("\t");
+		const workingRows = component.render(100);
+		expectStackedPreview(workingRows, "Sautéing…");
+		component.handleInput("\t");
+		for (const section of ["Footer", "Segments", "Git", "Extensions"] as const) {
+			expect(leadingEmptyRowCount(component.render(100)), section).toBe(0);
+			if (section !== "Extensions") component.handleInput("\t");
+		}
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("keeps disabled Editor and User-message previews visual, bounded, and focus-neutral", async () => {
+		const current = cloneConfig();
+		current.components.editor.enabled = false;
+		current.components.userMessages.enabled = false;
+		const harness = createHarness(current);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		expect(component.render(80).join("\n")).toContain("Explain this change safely.");
+		expect(component.render(80).join("\n")).not.toContain("Editor preview");
+		expect(component.render(4).every((line) => visibleWidth(line) <= 4)).toBe(true);
+		expect(focusedRow(component)).toContain("> Editor");
+		component.handleInput("\t");
+		expect(component.render(24).join("\n")).toContain("Please review");
+		expect(component.render(80).join("\n")).not.toContain("User message preview");
+		expect(focusedRow(component)).toContain("> User messages");
+		expect(harness.calls.editor).toEqual([]);
+		expect(harness.calls.messages).toEqual([]);
+	});
+
 	it("animates the preview and cleans its single timer on changes, exits, errors, and shutdown", async () => {
 		vi.useFakeTimers();
 		const harness = createHarness();
 		harness.sessionLifecycle.start();
 		await harness.command().handler("working-line", harness.ctx);
 		const component = harness.component();
-		const firstPreview = component.render(100)[3];
+		const animationWidth = 160;
+		const initialRows = component.render(animationWidth);
+		expectStackedPreview(initialRows, "Sautéing…");
+		expect(leadingEmptyRowCount(component.render(1))).toBe(0);
+		expect(component.render(1).every((line) => visibleWidth(line) <= 1)).toBe(true);
+		const firstPreviewIndex = previewRow(initialRows, "Sautéing…");
+		const firstPreview = initialRows[firstPreviewIndex];
 		expect(firstPreview).toContain("Sautéing…");
 		expect(firstPreview).toContain("read");
 		expect(harness.calls.workingLine).toEqual([]);
 		expect(vi.getTimerCount()).toBe(1);
 		vi.advanceTimersByTime(300);
-		expect(component.render(100)[3]).not.toBe(firstPreview);
+		expect(component.render(animationWidth)[firstPreviewIndex]).not.toBe(firstPreview);
 		selectLabel(component, "Custom messages");
 		component.handleInput(" ");
-		const fallbackPreview = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "");
+		const fallbackPreview = component
+			.render(animationWidth)
+			[firstPreviewIndex]?.replaceAll("[", "")
+			.replaceAll("]", "");
 		expect(fallbackPreview).toContain("Working…");
 		expect(fallbackPreview).toContain("read");
 		vi.advanceTimersByTime(1200);
-		const stablePreview = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "") ?? "";
+		const stablePreview =
+			component
+				.render(animationWidth)
+				[firstPreviewIndex]?.replaceAll("[", "")
+				.replaceAll("]", "") ?? "";
 		expect(stablePreview).toContain("Working…");
 		expect(stablePreview).toContain("read · 1m02s · thinking 10s · ↑1234 ↓56");
 		selectLabel(component, "Tool");
 		component.handleInput(" ");
-		const withoutTool = component.render(100)[3]?.replaceAll("[", "").replaceAll("]", "") ?? "";
+		const withoutTool =
+			component
+				.render(animationWidth)
+				[firstPreviewIndex]?.replaceAll("[", "")
+				.replaceAll("]", "") ?? "";
 		expect(withoutTool).not.toContain("read");
 		expect(withoutTool).toContain("1m02s · thinking 10s · ↑1234 ↓56");
 		selectLabel(component, "Spinner");
@@ -958,6 +1134,7 @@ describe("component-oriented /zentui settings", () => {
 		await failed.command().handler("working-line", failed.ctx);
 		failed.component().handleInput(" ");
 		expect(vi.getTimerCount()).toBe(0);
+		expect(leadingEmptyRowCount(failed.component().render(100))).toBe(0);
 		expect(failed.notifications).toContain(
 			"Could not update Zentui settings: read-only working line",
 		);
@@ -988,7 +1165,8 @@ describe("component-oriented /zentui settings", () => {
 						component.handleInput(" ");
 					} else {
 						expect(focusedRow(component)).toContain("> Message list");
-						reopenedPreview = component.render(100)[3] ?? "";
+						const rows = component.render(100);
+						reopenedPreview = rows[previewRow(rows, "Working…")] ?? "";
 						component.handleInput("\x1b");
 					}
 					return outcome;

--- a/test/settings-previews.test.ts
+++ b/test/settings-previews.test.ts
@@ -1,0 +1,263 @@
+import { stripVTControlCharacters } from "node:util";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+	defaultConfig,
+	type EditorStyle,
+	type PolishedTuiConfig,
+	type UserMessageStyle,
+} from "../extensions/zentui/config";
+import {
+	renderEditorSettingsPreview,
+	renderUserMessageSettingsPreview,
+	SETTINGS_PREVIEW_MAX_ROWS,
+	SETTINGS_PREVIEW_MAX_WIDTH,
+} from "../extensions/zentui/settings-previews";
+
+function theme(offset = 0): Theme {
+	return {
+		fg: (color: string, text: string) => {
+			const index =
+				([...color].reduce((total, character) => total + character.charCodeAt(0), 0) + offset) %
+				200;
+			return `\x1b[38;5;${index}m${text}\x1b[0m`;
+		},
+		bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+	} as Theme;
+}
+
+function config(): PolishedTuiConfig {
+	return structuredClone(defaultConfig);
+}
+
+function plain(lines: string[]): string {
+	return stripVTControlCharacters(lines.join("\n"));
+}
+
+function expectOnlyTrustedSgr(rows: string[], hostileText: readonly string[] = []): void {
+	for (const row of rows) {
+		expect(row).not.toMatch(/[\r\n]/);
+		for (let index = 0; index < row.length; ) {
+			const code = row.charCodeAt(index);
+			if (code === 0x1b) {
+				const sgr = /^\x1b\[[0-9:;]*m/.exec(row.slice(index));
+				expect(sgr, `unexpected terminal escape in ${JSON.stringify(row)}`).not.toBeNull();
+				index += sgr?.[0].length ?? 1;
+				continue;
+			}
+			expect(
+				code >= 0x20 && !(code >= 0x7f && code <= 0x9f),
+				`unexpected control U+${code.toString(16).padStart(4, "0")} in ${JSON.stringify(row)}`,
+			).toBe(true);
+			index += 1;
+		}
+	}
+	const raw = rows.join("");
+	for (const text of hostileText) expect(raw).not.toContain(text);
+}
+
+const widths = [0, 1, 4, 20, 60, 72, 100];
+
+describe("settings previews", () => {
+	it.each(widths)("bounds deterministic Editor output at width %i", (width) => {
+		const current = config();
+		const first = renderEditorSettingsPreview(current, theme(), width);
+		expect(first).toEqual(renderEditorSettingsPreview(current, theme(), width));
+		expect(first.length).toBeLessThanOrEqual(SETTINGS_PREVIEW_MAX_ROWS);
+		if (width <= 0) expect(first).toEqual([]);
+		if (first.length > 0) expect(visibleWidth(first.at(-1) ?? "")).toBeGreaterThan(0);
+		for (const row of first)
+			expect(visibleWidth(row)).toBeLessThanOrEqual(Math.min(width, SETTINGS_PREVIEW_MAX_WIDTH));
+	});
+
+	it.each(widths)("bounds deterministic User-message output at width %i", (width) => {
+		const current = config();
+		const first = renderUserMessageSettingsPreview(current, theme(), width);
+		expect(first).toEqual(renderUserMessageSettingsPreview(current, theme(), width));
+		expect(first.length).toBeLessThanOrEqual(SETTINGS_PREVIEW_MAX_ROWS);
+		if (width <= 0) expect(first).toEqual([]);
+		if (first.length > 0) expect(visibleWidth(first.at(-1) ?? "")).toBeGreaterThan(0);
+		for (const row of first)
+			expect(visibleWidth(row)).toBeLessThanOrEqual(Math.min(width, SETTINGS_PREVIEW_MAX_WIDTH));
+	});
+
+	it("renders the defining structure of all three Editor styles without status cues", () => {
+		const outputs = Object.fromEntries(
+			(["opencode", "opencode-copy-friendly", "minimalist"] as EditorStyle[]).map((style) => {
+				const current = config();
+				current.components.editor.style = style;
+				return [style, plain(renderEditorSettingsPreview(current, theme(), 72))];
+			}),
+		) as Record<EditorStyle, string>;
+		expect(new Set(Object.values(outputs)).size).toBe(3);
+		for (const output of Object.values(outputs)) {
+			expect(output).not.toContain("Editor preview");
+			expect(output).not.toContain("preview enabled");
+			expect(output).not.toContain("preview disabled");
+		}
+		expect(outputs.opencode).toContain("│ Explain this change safely.");
+		expect(outputs.opencode).toContain("─── ↑ 2 more");
+		expect(outputs["opencode-copy-friendly"]).toContain("\nExplain this change safely.");
+		expect(outputs["opencode-copy-friendly"]).toContain("\n sonnet-4");
+		expect(outputs["opencode-copy-friendly"]).not.toContain("│ Explain this change safely.");
+		expect(outputs.minimalist).toContain("╭─ ↑ 2 more");
+		expect(outputs.minimalist).toContain("╰─ ↓ 3 more");
+		expect(outputs.minimalist).toContain("feat/settings-previews");
+		const disabled = config();
+		disabled.components.editor.enabled = false;
+		const disabledOutput = plain(renderEditorSettingsPreview(disabled, theme(), 72));
+		expect(disabledOutput).toContain("Explain this change safely.");
+		expect(disabledOutput).not.toContain("preview");
+	});
+
+	it("responds to Editor visible settings and selected metadata format", () => {
+		const current = config();
+		const render = () => renderEditorSettingsPreview(current, theme(), 72).join("\n");
+		const baseline = render();
+		current.components.editor.colorSource = "terminal";
+		expect(render()).not.toBe(baseline);
+		current.components.editor.modelLabel = "name";
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).toContain("Sonnet 4");
+		current.components.editor.styles.opencode.metadataFormat = "$provider";
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).toContain("Anthropic");
+		current.components.editor.viewportIndicators = false;
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).not.toContain("↑ 2 more");
+		current.components.editor.viewportIndicators = true;
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).toContain("↑ 2 more");
+		const staticBorder = render();
+		current.components.editor.borderColorMode = "adaptive";
+		expect(render()).not.toBe(staticBorder);
+	});
+
+	it("responds to every applicable Minimalist setting and thresholds", () => {
+		const current = config();
+		current.components.editor.style = "minimalist";
+		const minimalist = current.components.editor.styles.minimalist;
+		const render = () => renderEditorSettingsPreview(current, theme(), 72).join("\n");
+		const changes = [
+			() => (minimalist.pathDisplay = "full"),
+			() => (minimalist.contextFormat = "percent-total"),
+			() => (minimalist.contextGauge = !minimalist.contextGauge),
+			() => (minimalist.showSessionName = !minimalist.showSessionName),
+			() => (minimalist.showTimer = !minimalist.showTimer),
+			() => (minimalist.showCost = !minimalist.showCost),
+			() => (minimalist.showGit = !minimalist.showGit),
+			() => (minimalist.contextThresholds = { warning: 80, error: 90 }),
+		];
+		for (const [index, change] of changes.entries()) {
+			const before = render();
+			change();
+			expect(render(), `Minimalist change ${index}`).not.toBe(before);
+		}
+	});
+
+	it("renders the defining structure of all four User-message styles without status cues", () => {
+		const outputs = Object.fromEntries(
+			(["framed", "framed-copy-friendly", "compact", "labeled"] as UserMessageStyle[]).map(
+				(style) => {
+					const current = config();
+					current.components.userMessages.style = style;
+					return [style, plain(renderUserMessageSettingsPreview(current, theme(), 72))];
+				},
+			),
+		) as Record<UserMessageStyle, string>;
+		expect(new Set(Object.values(outputs)).size).toBe(4);
+		for (const output of Object.values(outputs)) {
+			expect(output).not.toContain("User message preview");
+			expect(output).not.toContain("preview enabled");
+			expect(output).not.toContain("preview disabled");
+		}
+		expect(outputs.framed).toContain("│ Please review this change safely.");
+		expect(outputs.framed).toContain("────────────────");
+		const framed = config();
+		framed.components.userMessages.style = "framed";
+		const framedRows = plain(renderUserMessageSettingsPreview(framed, theme(), 72)).split("\n");
+		expect(framedRows.at(-1)).toMatch(/^─+$/);
+		expect(framedRows.at(-2)).toMatch(/^│ +$/);
+		expect(outputs["framed-copy-friendly"]).toContain("\n Please review this change safely.");
+		expect(outputs["framed-copy-friendly"]).not.toContain("│ Please review");
+		const copyFriendly = config();
+		copyFriendly.components.userMessages.style = "framed-copy-friendly";
+		const copyFriendlyRows = plain(
+			renderUserMessageSettingsPreview(copyFriendly, theme(), 72),
+		).split("\n");
+		expect(copyFriendlyRows.at(-1)).toMatch(/^─+$/);
+		expect(copyFriendlyRows.at(-2)).toBe("");
+		expect(outputs.compact).toContain("│ Please review this change safely.");
+		expect(outputs.compact).not.toContain("────────────────");
+		expect(outputs.labeled).toContain("╭─ User ─");
+		expect(outputs.labeled).toContain("╰────");
+		const current = config();
+		const terminal = renderUserMessageSettingsPreview(current, theme(), 72).join("\n");
+		current.components.userMessages.colorSource = "terminal";
+		expect(renderUserMessageSettingsPreview(current, theme(), 72).join("\n")).not.toBe(terminal);
+		current.components.userMessages.enabled = false;
+		const disabledOutput = plain(renderUserMessageSettingsPreview(current, theme(), 72));
+		expect(disabledOutput).toContain("Please review this change safely.");
+		expect(disabledOutput).not.toContain("preview");
+	});
+
+	it("sanitizes hostile source and configured icons before trusted preview styling", () => {
+		const current = config();
+		current.icons.rail = "\x1b]2;RAIL-OSC\x07│\u009b31m\u009dRAIL-C1\u009c\u009b0m";
+		current.icons.editorPrompt =
+			"❯\x1b]8;;https://PROMPT-OSC.evil.invalid\x07\x1b]8;;\x07\x1b]2;TRUNCATED-OSC";
+		current.icons.ahead = "↑\x1bP$qARROW-DCS\x1b\\";
+		current.icons.behind = "↓\u009dARROW-C1\u009c";
+
+		for (const style of ["opencode", "opencode-copy-friendly", "minimalist"] as EditorStyle[]) {
+			current.components.editor.style = style;
+			expectOnlyTrustedSgr(renderEditorSettingsPreview(current, theme(), 72), [
+				"RAIL-OSC",
+				"RAIL-C1",
+				"PROMPT-OSC",
+				"ARROW-DCS",
+				"ARROW-C1",
+				"evil.invalid",
+				"TRUNCATED-OSC",
+			]);
+		}
+		current.components.editor.style = "opencode";
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).toContain("│");
+		current.components.editor.style = "opencode-copy-friendly";
+		expect(plain(renderEditorSettingsPreview(current, theme(), 72))).toContain("❯");
+		expect(current.icons.rail).toContain("RAIL-OSC");
+		expect(current.icons.editorPrompt).toContain("TRUNCATED-OSC");
+
+		for (const style of [
+			"framed",
+			"framed-copy-friendly",
+			"compact",
+			"labeled",
+		] as UserMessageStyle[]) {
+			current.components.userMessages.style = style;
+			const rows = renderUserMessageSettingsPreview(
+				current,
+				theme(),
+				72,
+				"safe \x1b[31mred\x1b[0m \x1b]2;SOURCE-OSC\x07 title \u009b32mgreen\u009b0m\nnext",
+			);
+			expectOnlyTrustedSgr(rows, ["RAIL-OSC", "RAIL-C1", "SOURCE-OSC"]);
+			const rendered = plain(rows);
+			expect(rendered).toContain("safe red");
+			expect(rendered).toContain("green");
+			expect(rendered).toContain("next");
+		}
+	});
+
+	it("re-renders from the current theme without cached preview rows", () => {
+		const current = config();
+		const firstEditor = renderEditorSettingsPreview(current, theme(0), 72);
+		const secondEditor = renderEditorSettingsPreview(current, theme(37), 72);
+		const firstMessage = renderUserMessageSettingsPreview(current, theme(0), 72);
+		const secondMessage = renderUserMessageSettingsPreview(current, theme(37), 72);
+		expect(secondEditor).not.toEqual(firstEditor);
+		expect(secondMessage).not.toEqual(firstMessage);
+		expect(plain(secondEditor)).toBe(plain(firstEditor));
+		expect(plain(secondMessage)).toBe(plain(firstMessage));
+	});
+});


### PR DESCRIPTION
## Summary

Closes #83.

Adds representative previews to the **Editor** and **User messages** sections of `/zentui`:

- previews all three Editor styles and all four User-message styles;
- reflects applicable style, color, model, border, viewport, and Minimalist settings immediately;
- keeps disabled components configurable and previewable;
- uses deterministic synthetic content rather than session, prompt, transcript, or filesystem data;
- reuses the pure production Editor/User-message render paths without installing components or invoking the fragile User-message prototype patch;
- sanitizes configured glyphs and representative Markdown before trusted terminal styling;
- bounds previews to 72 columns and at most eight meaningful rows;
- places every preview above its settings with one blank row above and below;
- leaves Working line as the only animated/timer-owning settings preview.

## Screenshots / recordings

Manually validated in isolated live Pi sessions at 80 and 140 columns. Editor, User-message, and Working-line previews remained above their settings with the requested blank-row spacing and no preview status labels.

No recording is attached because the behavior is fully covered by deterministic rendering tests and isolated terminal captures.

## Testing

- [x] `npm run verify` — 1,070 tests across 32 files
- [x] `npm run pack:check` — 36 packaged files
- [x] Manual Pi test via `npm run pi:dev` at 80 and 140 columns
- [x] Added or updated tests where practical

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Independent correctness, security, lifecycle, width, and spacing review

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Updated `README.md` for the new settings previews.
- [x] Kept the diff surgical with no config schema, migration, dependency, or style-semantic changes.
- [x] `extensions/zentui/index.ts` remains orchestration-only and unchanged.
- [x] Used a conventional commit-style PR title.
