### PR TITLE
chore: release v0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.19.0",
+			"version": "0.20.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Bumps `pi-zentui` from `0.19.0` to `0.20.0` after merging the Editor and User-message settings previews in #86.

This keeps `package.json` and both root `package-lock.json` version fields synchronized. No dependency, source, config-schema, or generated artifact changes are included.

## Screenshots / recordings

N/A — release metadata only. The user-facing settings previews were manually validated and reviewed in #86.

## Testing

- [x] `npm run verify` — 1,070 tests across 32 files
- [x] `npm run pack:check` — `pi-zentui@0.20.0`, 36 files
- [ ] Manual Pi test via `npm run pi:dev` (not applicable to metadata-only change; completed in #86)
- [ ] Added or updated tests where practical (not applicable)

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Independent release-diff review

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no source changes).
- [x] Updated `README.md` or config docs if user-facing behavior changed (handled in #86).
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration (no source changes).
- [x] Used a conventional commit-style PR title.
