### PR TITLE
fix: compact working line token counts

### DIFF
--- a/extensions/zentui/working-line.ts
+++ b/extensions/zentui/working-line.ts
@@ -7,6 +7,7 @@ import type {
 	WorkingLineTextAnimation,
 	ZentuiConfig,
 } from "./config";
+import { formatCount } from "./format";
 import {
 	isSafeSgrStylePrefix,
 	isSupportedColorSpec,
@@ -561,7 +562,7 @@ export function formatWorkingLineTokens(
 	) {
 		return undefined;
 	}
-	return `↑${tokens.input} ↓${tokens.output}`;
+	return `↑${formatCount(tokens.input)} ↓${formatCount(tokens.output)}`;
 }
 
 function truncateWithEllipsis(value: string, capacity: number): string {

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -79,12 +79,20 @@ function makeSessionContext(entries: unknown[], branch = entries) {
 }
 
 describe("usage formatting", () => {
-	it("formats large counts with compact M suffixes", () => {
+	it("formats counts at compact decimal boundaries", () => {
+		expect(formatCount(0)).toBe("0");
 		expect(formatCount(999)).toBe("999");
-		expect(formatCount(1_500)).toBe("1.5k");
+		expect(formatCount(1_000)).toBe("1.0k");
+		expect(formatCount(1_100)).toBe("1.1k");
+		expect(formatCount(9_999)).toBe("10.0k");
+		expect(formatCount(10_000)).toBe("10k");
+		expect(formatCount(27_000)).toBe("27k");
 		expect(formatCount(123_456)).toBe("123k");
+		expect(formatCount(999_999)).toBe("1000k");
+		expect(formatCount(1_000_000)).toBe("1.0M");
 		expect(formatCount(3_100_000)).toBe("3.1M");
 		expect(formatCount(44_000_000)).toBe("44M");
+		expect(formatCount(Number.MAX_SAFE_INTEGER)).toBe("9007199255M");
 	});
 
 	it("uses all session entries for totals instead of only the active branch", () => {
@@ -301,7 +309,7 @@ describe("usage formatting", () => {
 		expect(totals.latestCacheHitRate).toBeCloseTo(100 / 3);
 		expect(Number.isFinite(totals.latestCacheHitRate ?? Number.NaN)).toBe(true);
 		expect(buildTokenLabel(totals, cacheHitIcon)).toBe(
-			`↑${formatCount(Number.MAX_VALUE)} ↓${formatCount(Number.MAX_VALUE)} ${cacheHitIcon} 33.3%`,
+			`↑1.797693134862316e+302M ↓1.797693134862316e+302M ${cacheHitIcon} 33.3%`,
 		);
 		expect(buildCostLabel(totals)).toBe(`$${Number.MAX_VALUE.toFixed(3)}`);
 		expect(buildTokenLabel(totals, cacheHitIcon)).not.toMatch(/Infinity|NaN/);

--- a/test/interaction-summary.test.ts
+++ b/test/interaction-summary.test.ts
@@ -1295,16 +1295,16 @@ describe("thought duration tracking", () => {
 
 describe("turn summary entry", () => {
 	it("validates versioned numeric data and formats exact persistent text", () => {
-		const data = { version: 1 as const, durationMs: 42_999, input: 1234, output: 380 };
+		const data = { version: 1 as const, durationMs: 42_999, input: 27_000, output: 1_400 };
 		expect(isTurnSummaryData(data)).toBe(true);
-		expect(formatTurnSummary(data)).toBe(" Turn took 42s · ↑1.2k ↓380");
+		expect(formatTurnSummary(data)).toBe(" Turn took 42s · ↑27k ↓1.4k");
 		const rendered = renderTurnSummaryEntry(
 			{ data },
 			{},
 			{ fg: (_color: string, text: string) => `\x1b[2m${text}\x1b[0m` },
 		);
 		expect(stripTerminalSequences(rendered?.render(100).join("\n") ?? "").trimEnd()).toBe(
-			" Turn took 42s · ↑1.2k ↓380",
+			" Turn took 42s · ↑27k ↓1.4k",
 		);
 	});
 

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -1102,7 +1102,7 @@ describe("component-oriented /zentui settings", () => {
 				[firstPreviewIndex]?.replaceAll("[", "")
 				.replaceAll("]", "") ?? "";
 		expect(stablePreview).toContain("Working…");
-		expect(stablePreview).toContain("read · 1m02s · thinking 10s · ↑1234 ↓56");
+		expect(stablePreview).toContain("read · 1m02s · thinking 10s · ↑1.2k ↓56");
 		selectLabel(component, "Tool");
 		component.handleInput(" ");
 		const withoutTool =
@@ -1111,7 +1111,7 @@ describe("component-oriented /zentui settings", () => {
 				[firstPreviewIndex]?.replaceAll("[", "")
 				.replaceAll("]", "") ?? "";
 		expect(withoutTool).not.toContain("read");
-		expect(withoutTool).toContain("1m02s · thinking 10s · ↑1234 ↓56");
+		expect(withoutTool).toContain("1m02s · thinking 10s · ↑1.2k ↓56");
 		selectLabel(component, "Spinner");
 		component.handleInput(" ");
 		expect(vi.getTimerCount()).toBe(1);

--- a/test/working-line-lifecycle.integration.test.ts
+++ b/test/working-line-lifecycle.integration.test.ts
@@ -228,7 +228,63 @@ describe("working-line extension lifecycle integration", () => {
 		expect(current.forbidden).not.toHaveBeenCalled();
 	});
 
-	it("shows exact whole-interaction usage when the aggregate widens the row", async () => {
+	it("compacts live provider usage", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const message = (input: number, output: number) => ({
+			role: "assistant",
+			usage: { input, output },
+			content: [],
+			responseId: "reported",
+		});
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_update", current.ctx, { message: message(27_000, 1_400) });
+		expect(row()).toContain("↑27k ↓1.4k");
+		await emit(handlers, "message_end", current.ctx, { message: message(27_000, 1_400) });
+		expect(row()).toContain("↑27k ↓1.4k");
+	});
+
+	it("visibly reconciles an estimated 1.0k output to exact 999", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		const message = (output: number) => ({
+			role: "assistant",
+			usage: { input: 0, output },
+			content: [],
+			responseId: "estimated-boundary",
+		});
+
+		await emit(handlers, "session_start", current.ctx);
+		await emit(handlers, "agent_start", current.ctx);
+		await emit(handlers, "turn_start", current.ctx);
+		const partial = message(998);
+		await emit(handlers, "message_update", current.ctx, { message: partial });
+		await emit(handlers, "message_update", current.ctx, {
+			message: partial,
+			assistantMessageEvent: {
+				type: "text_delta",
+				contentIndex: 0,
+				delta: "abcdefgh",
+				partial: { content: [{ type: "text", text: "abcdefgh" }] },
+			},
+		});
+		expect(row()).toContain("↑0 ↓1.0k");
+		await emit(handlers, "message_end", current.ctx, { message: message(999) });
+		expect(row()).toContain("↑0 ↓999");
+	});
+
+	it("keeps cumulative billion-scale totals compact across continuations", async () => {
 		runtime.message = "Response usage stays visible here";
 		const handlers = loadExtension();
 		const current = harness();
@@ -254,10 +310,10 @@ describe("working-line extension lifecycle integration", () => {
 		await emit(handlers, "message_end", current.ctx, {
 			message: assistant(1_000_000_000, 1_000_000_000, "first"),
 		});
-		expect(row()).toContain("↑1000000000 ↓1000000000");
+		expect(row()).toContain("↑1000M ↓1000M");
 
 		await emit(handlers, "turn_start", current.ctx);
-		expect(row()).toContain("↑1000000000 ↓1000000000");
+		expect(row()).toContain("↑1000M ↓1000M");
 		await emit(handlers, "tool_execution_start", current.ctx, {
 			toolCallId: "wide",
 			toolName: "123456789012345678",
@@ -266,14 +322,20 @@ describe("working-line extension lifecycle integration", () => {
 		await emit(handlers, "message_update", current.ctx, {
 			message: assistant(12, 3, "second"),
 		});
-		expect(row()).toContain("↑1000000012 ↓1000000003");
-		expect(current.calls).toHaveLength(writesBeforeLiveUsage + 1);
+		expect(row()).toContain("↑1000M ↓1000M");
+		expect(current.calls).toHaveLength(writesBeforeLiveUsage);
 
 		await emit(handlers, "tool_execution_end", current.ctx, { toolCallId: "wide" });
 		await emit(handlers, "message_end", current.ctx, {
 			message: assistant(14, 5, "second"),
 		});
-		expect(row()).toContain("↑1000000014 ↓1000000005");
+		expect(row()).toContain("↑1000M ↓1000M");
+
+		await emit(handlers, "turn_start", current.ctx);
+		await emit(handlers, "message_end", current.ctx, {
+			message: assistant(499_986, 499_995, "third"),
+		});
+		expect(row()).toContain("↑1001M ↓1001M");
 	});
 
 	it("keeps committed tokens through retry lifecycle and initial zero usage, then accumulates final usage", async () => {

--- a/test/working-line.test.ts
+++ b/test/working-line.test.ts
@@ -93,18 +93,18 @@ function gcdForTest(left: number, right: number): number {
 
 describe("working-line token formatting", () => {
 	it("formats approximate and exact output identically while validating metadata", () => {
-		expect(formatWorkingLineTokens({ input: 123, output: 45, outputApproximate: false })).toBe(
-			"↑123 ↓45",
-		);
-		expect(formatWorkingLineTokens({ input: 123, output: 45, outputApproximate: true })).toBe(
-			"↑123 ↓45",
+		expect(
+			formatWorkingLineTokens({ input: 27_000, output: 1_400, outputApproximate: false }),
+		).toBe("↑27k ↓1.4k");
+		expect(formatWorkingLineTokens({ input: 27_000, output: 1_400, outputApproximate: true })).toBe(
+			"↑27k ↓1.4k",
 		);
 		expect(
 			formatWorkingLineTokens({ input: 1, output: 2, outputApproximate: "yes" } as never),
 		).toBeUndefined();
 	});
 
-	it("reserves the maximum-safe token label within the complete 80-cell row", () => {
+	it("reserves compact maximum-safe tokens within the complete 80-cell row", () => {
 		const current = config();
 		const composed = composeWorkingLineRow(current.components.workingLine, "x".repeat(43), {
 			tokens: {
@@ -113,7 +113,7 @@ describe("working-line token formatting", () => {
 				outputApproximate: true,
 			},
 		});
-		expect(composed.row).toContain(`↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`);
+		expect(composed.row).toContain("↑9007199255M ↓9007199255M");
 		expect(visibleWidth(composed.row)).toBeLessThanOrEqual(MAX_WORKING_LINE_FRAME_CELLS - 2);
 	});
 });
@@ -809,14 +809,14 @@ describe("working-line presets and frame generation", () => {
 			theme(),
 		);
 		for (const frame of strippedFrames(generated.frames)) {
-			expect(frame).toMatch(/^[·✦✧✶] Configured · read · ↑1234 ↓56$/);
+			expect(frame).toMatch(/^[·✦✧✶] Configured · read · ↑1.2k ↓56$/);
 			expect(frame).not.toContain("1m02s");
 		}
 		current.components.workingLine.messages.custom = false;
 		const fallback = strippedFrames(
 			buildWorkingLinePreviewFrames(current.components.workingLine, current.colors, theme()).frames,
 		);
-		expect(fallback.every((frame) => frame.includes(" Working… · read · ↑1234 ↓56"))).toBe(true);
+		expect(fallback.every((frame) => frame.includes(" Working… · read · ↑1.2k ↓56"))).toBe(true);
 	});
 });
 
@@ -953,7 +953,7 @@ describe("working-line row composition", () => {
 			elapsedMs: 62_000,
 			tokens: { input: 1234, output: 56 },
 		});
-		expect(all.row).toBe("Working… · read · 1m02s · ↑1234 ↓56");
+		expect(all.row).toBe("Working… · read · 1m02s · ↑1.2k ↓56");
 		expect(2 + visibleWidth(all.row) + 1 + 2).toBeLessThanOrEqual(MAX_WORKING_LINE_ROW_CELLS);
 		component.spinner = "pulse";
 		const constrained = composeWorkingLineRow(component, "x".repeat(43), {
@@ -961,10 +961,8 @@ describe("working-line row composition", () => {
 			elapsedMs: 360_000_000,
 			tokens: { input: Number.MAX_SAFE_INTEGER, output: Number.MAX_SAFE_INTEGER },
 		});
-		expect(constrained.row).toBe(
-			`${"x".repeat(34)}… · ↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`,
-		);
-		expect(workingLineSpinnerWidth("pulse") + 1 + visibleWidth(constrained.row)).toBe(
+		expect(constrained.row).toBe(`${"x".repeat(43)} · ↑9007199255M ↓9007199255M`);
+		expect(workingLineSpinnerWidth("pulse") + 1 + visibleWidth(constrained.row)).toBeLessThan(
 			MAX_WORKING_LINE_FRAME_CELLS,
 		);
 		expect(constrained.row).not.toContain("parallel");
@@ -1012,7 +1010,7 @@ describe("working-line thought segment", () => {
 			thought: { durationMs: 10_000, active: true },
 			tokens: { input: Number.MAX_SAFE_INTEGER, output: Number.MAX_SAFE_INTEGER },
 		});
-		expect(composed.row).toContain(`↑${Number.MAX_SAFE_INTEGER} ↓${Number.MAX_SAFE_INTEGER}`);
+		expect(composed.row).toContain("↑9007199255M ↓9007199255M");
 		expect(composed.row).toContain("thinking");
 		expect(composed.row).not.toContain("parallel-tool-label");
 		expect(


### PR DESCRIPTION
## Summary

Fixes live Working-line token totals displaying raw integers instead of Zentui's established compact count format.

Examples:

- `↑27000 ↓1400` → `↑27k ↓1.4k`
- `↑1234 ↓56` → `↑1.2k ↓56`
- `↑1000 ↓999` → `↑1.0k ↓999`

The fix reuses the same canonical `formatCount` helper already used by the footer and persistent turn summary. Internal accounting remains numeric and exact; provider usage, streamed estimates, retry/tool/continuation accumulation, and final reconciliation are unchanged.

Regression coverage includes compact thresholds, exact and estimated totals, a visible estimate-to-final boundary correction, billion-scale label collisions with retained raw state, final summaries, and the 80-cell Working-line budget.

## Screenshots / recordings

N/A — the change is deterministic token-label formatting. `/zentui` Working-line preview coverage confirms the representative total now renders as `↑1.2k ↓56`.

## Testing

- [x] `npm run verify` — 1,072 tests across 32 files
- [x] `npm run pack:check` — 36 packaged files
- [ ] Manual Pi test via `npm run pi:dev` (automated TUI capture was inconclusive; focused lifecycle and settings tests cover the visible behavior)
- [x] Added or updated tests where practical

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Independent correctness, lifecycle, rounding, and width review

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] README/config docs unchanged because the documented token semantics already imply compact counts.
- [x] Kept the production diff surgical: one formatter import and one formatted return expression.
- [x] `extensions/zentui/index.ts` remains unchanged.
- [x] Used a conventional commit-style PR title.
