### PR TITLE
chore: release v0.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.20.0",
+			"version": "0.20.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Bumps `pi-zentui` from `0.20.0` to `0.20.1` after merging compact live Working-line token labels in #88.

This keeps `package.json` and both root `package-lock.json` version fields synchronized. No dependency, source, config-schema, or generated artifact changes are included.

## Screenshots / recordings

N/A — release metadata only. The deterministic presentation fix and lifecycle coverage are in #88.

## Testing

- [x] `npm run verify` — 1,072 tests across 32 files
- [x] `npm run pack:check` — `pi-zentui@0.20.1`, 36 files
- [ ] Manual Pi test via `npm run pi:dev` (not applicable to metadata-only change)
- [ ] Added or updated tests where practical (not applicable)

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Independent release-diff review

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no source changes).
- [x] README/config docs unchanged because this PR contains release metadata only.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` remains unchanged.
- [x] Used a conventional commit-style PR title.
