### PR TITLE
feat: refresh minimalist editor colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Default config values — copy this and change any value you want:
 - `editorAccent` styles Editor and User-message accent rails and the labeled message label.
 - `editorPrompt` styles the `opencode-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
 - `editorBorder` styles the `framed` and `framed-copy-friendly` previous-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
+- `editorGitBranch` and `editorThinkingMax` are optional editor-owned overrides, omitted above so source-specific and adaptive defaults remain active. `editorGitBranch` owns the minimalist Editor branch color independently from Footer `gitBranch`; where Zentui resolves configured thinking colors, `max` falls back through `editorThinkingXhigh` and then `editorThinking`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: with `opencode-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -323,6 +323,7 @@ export type PolishedTuiColors = {
 	editorThinkingMedium?: ColorSpec;
 	editorThinkingHigh?: ColorSpec;
 	editorThinkingXhigh?: ColorSpec;
+	editorThinkingMax?: ColorSpec;
 	workingLineLow?: ColorSpec;
 	workingLineMid?: ColorSpec;
 	workingLineHigh?: ColorSpec;
@@ -719,6 +720,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		editorThinkingMedium: colorValue(record, "editorThinkingMedium"),
 		editorThinkingHigh: colorValue(record, "editorThinkingHigh"),
 		editorThinkingXhigh: colorValue(record, "editorThinkingXhigh"),
+		editorThinkingMax: colorValue(record, "editorThinkingMax"),
 		workingLineLow: colorValue(record, "workingLineLow"),
 		workingLineMid: colorValue(record, "workingLineMid"),
 		workingLineHigh: colorValue(record, "workingLineHigh"),

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -314,6 +314,7 @@ export type PolishedTuiColors = {
 	editorAccent?: ColorSpec;
 	editorPrompt?: ColorSpec;
 	editorBorder?: ColorSpec;
+	editorGitBranch?: ColorSpec;
 	editorModel?: ColorSpec;
 	editorProvider?: ColorSpec;
 	editorThinking?: ColorSpec;
@@ -709,6 +710,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		editorAccent: colorValue(record, "editorAccent"),
 		editorPrompt: colorValue(record, "editorPrompt"),
 		editorBorder: colorValue(record, "editorBorder"),
+		editorGitBranch: colorValue(record, "editorGitBranch"),
 		editorModel: colorValue(record, "editorModel"),
 		editorProvider: colorValue(record, "editorProvider"),
 		editorThinking: colorValue(record, "editorThinking"),
@@ -1425,13 +1427,20 @@ export function mergeConfig(parsed: unknown): PolishedTuiConfig {
 	const config = isRecord(parsed) ? parsed : {};
 	const iconsRecord = recordValue(config.icons);
 	const colorsRecord = recordValue(config.colors);
+	const colors = normalizeColors(colorsRecord);
 	const canonical: ZentuiConfig = {
 		projectRefreshIntervalMs: parseProjectRefreshIntervalMs(config.projectRefreshIntervalMs),
 		icons: resolveConfiguredIcons(
 			normalizeIconMode(iconsRecord.mode),
 			normalizeIconOverrides(iconsRecord),
 		),
-		colors: { ...defaultConfig.colors, ...normalizeColors(colorsRecord) },
+		colors: {
+			...defaultConfig.colors,
+			...colors,
+			...(colors.editorGitBranch === undefined && colors.gitBranch !== undefined
+				? { editorGitBranch: colors.gitBranch }
+				: {}),
+		},
 		components: resolveComponents(config),
 	};
 	const view = compatibilityView(canonical);

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -132,6 +132,12 @@ function editorThinkingStyle(config: ZentuiConfig, level: string): string | unde
 			return config.colors.editorThinkingHigh ?? config.colors.editorThinking;
 		case "xhigh":
 			return config.colors.editorThinkingXhigh ?? config.colors.editorThinking;
+		case "max":
+			return (
+				config.colors.editorThinkingMax ??
+				config.colors.editorThinkingXhigh ??
+				config.colors.editorThinking
+			);
 		default:
 			return config.colors.editorThinking;
 	}

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -21,6 +21,13 @@ import {
 	safeThemeFg,
 } from "./style";
 
+const MINIMALIST_MODEL_FALLBACK = {
+	theme: "syntaxKeyword",
+	terminal: EDITOR_ACCENT_FALLBACK.terminal,
+};
+const MINIMALIST_THINKING_FALLBACK = { theme: "warning", terminal: "muted" };
+const MINIMALIST_BRANCH_THEME_FALLBACK = "bold accent";
+
 export type MinimalistEditorMetadata = {
 	cwd: string;
 	projectRoot?: string;
@@ -173,7 +180,7 @@ function renderTopRight(
 				uiTheme,
 				source,
 				config.colors.editorModel,
-				EDITOR_ACCENT_FALLBACK,
+				MINIMALIST_MODEL_FALLBACK,
 				model,
 			),
 		);
@@ -185,7 +192,7 @@ function renderTopRight(
 				uiTheme,
 				source,
 				thinkingStyle(config, thinking),
-				"muted",
+				MINIMALIST_THINKING_FALLBACK,
 				thinking,
 			),
 		);
@@ -236,7 +243,15 @@ function renderBottomLeft(
 	const source = config.components.editor.colorSource;
 	const branch = sanitizeEditorMetadataText(metadata.branch ?? "");
 	const parts = branch
-		? [renderStyleForSource(uiTheme, source, config.colors.gitBranch, branch)]
+		? [
+				renderStyleForSourceOrFallback(
+					uiTheme,
+					source,
+					config.colors.editorGitBranch,
+					{ theme: MINIMALIST_BRANCH_THEME_FALLBACK, terminal: config.colors.gitBranch },
+					branch,
+				),
+			]
 		: [];
 	if (metadata.dirty) {
 		parts.push(renderStyleForSource(uiTheme, source, config.colors.gitStatus, "*"));

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -23,10 +23,10 @@ import {
 
 const MINIMALIST_MODEL_FALLBACK = {
 	theme: "syntaxKeyword",
-	terminal: EDITOR_ACCENT_FALLBACK.terminal,
+	terminal: "bold purple",
 };
-const MINIMALIST_THINKING_FALLBACK = { theme: "warning", terminal: "muted" };
-const MINIMALIST_BRANCH_THEME_FALLBACK = "bold accent";
+const MINIMALIST_THINKING_FALLBACK = { theme: "warning", terminal: "bold yellow" };
+const MINIMALIST_BRANCH_FALLBACK = { theme: "bold syntaxKeyword", terminal: "bold blue" };
 
 export type MinimalistEditorMetadata = {
 	cwd: string;
@@ -248,7 +248,7 @@ function renderBottomLeft(
 					uiTheme,
 					source,
 					config.colors.editorGitBranch,
-					{ theme: MINIMALIST_BRANCH_THEME_FALLBACK, terminal: config.colors.gitBranch },
+					MINIMALIST_BRANCH_FALLBACK,
 					branch,
 				),
 			]

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -26,6 +26,14 @@ const MINIMALIST_MODEL_FALLBACK = {
 	terminal: "bold purple",
 };
 const MINIMALIST_THINKING_FALLBACK = { theme: "warning", terminal: "bold yellow" };
+const MINIMALIST_ADAPTIVE_TERMINAL_THINKING_FALLBACKS: Record<string, string> = {
+	minimal: "bright-black",
+	low: "blue",
+	medium: "cyan",
+	high: "yellow",
+	xhigh: "red",
+	max: "bright-red",
+};
 const MINIMALIST_BRANCH_FALLBACK = { theme: "bold syntaxKeyword", terminal: "bold blue" };
 
 export type MinimalistEditorMetadata = {
@@ -107,6 +115,12 @@ function thinkingStyle(config: ZentuiConfig, level: string): string | undefined 
 			return config.colors.editorThinkingHigh ?? config.colors.editorThinking;
 		case "xhigh":
 			return config.colors.editorThinkingXhigh ?? config.colors.editorThinking;
+		case "max":
+			return (
+				config.colors.editorThinkingMax ??
+				config.colors.editorThinkingXhigh ??
+				config.colors.editorThinking
+			);
 		default:
 			return config.colors.editorThinking;
 	}
@@ -162,6 +176,7 @@ function renderTopRight(
 	config: ZentuiConfig,
 	availableWidth: number,
 	renderBorder: (text: string) => string,
+	renderThinking: (text: string) => string,
 ): string {
 	const source = config.components.editor.colorSource;
 	const parts: string[] = [];
@@ -187,15 +202,7 @@ function renderTopRight(
 	}
 	const thinking = sanitizeEditorMetadataText(metadata.thinkingLevel ?? "");
 	if (thinking && thinking.toLowerCase() !== "off") {
-		parts.push(
-			renderStyleForSourceOrFallback(
-				uiTheme,
-				source,
-				thinkingStyle(config, thinking),
-				MINIMALIST_THINKING_FALLBACK,
-				thinking,
-			),
-		);
+		parts.push(renderThinking(thinking));
 	}
 	if (metadata.contextPercent !== undefined && Number.isFinite(metadata.contextPercent)) {
 		const percent = Math.round(Math.max(0, Math.min(999, metadata.contextPercent)));
@@ -369,18 +376,31 @@ export function renderMinimalistFrame({
 }: MinimalistFrameOptions): string[] {
 	if (width <= 4) return clampLines(editorLines, width);
 	const contentWidth = Math.max(0, width - 4);
+	const source = config.components.editor.colorSource;
+	const adaptive = config.components.editor.borderColorMode === "adaptive";
+	const thinking = sanitizeEditorMetadataText(metadata.thinkingLevel ?? "");
+	const activeThinking = thinking && thinking.toLowerCase() !== "off" ? thinking : "";
 	const renderStaticBorder = (text: string) =>
 		renderStyleForSourceOrFallback(
 			uiTheme,
-			config.components.editor.colorSource,
+			source,
 			config.colors.editorBorder,
 			EDITOR_BORDER_FALLBACK,
 			text,
 		);
+	const terminalAdaptiveThinkingStyle = activeThinking
+		? (thinkingStyle(config, activeThinking) ??
+			MINIMALIST_ADAPTIVE_TERMINAL_THINKING_FALLBACKS[activeThinking.toLowerCase()] ??
+			MINIMALIST_THINKING_FALLBACK.terminal)
+		: undefined;
 	const renderBorder = (text: string) => {
-		if (config.components.editor.borderColorMode !== "adaptive" || !borderColor) {
-			return renderStaticBorder(text);
+		if (!adaptive) return renderStaticBorder(text);
+		if (source === "terminal") {
+			return terminalAdaptiveThinkingStyle
+				? renderStyleForSource(uiTheme, source, terminalAdaptiveThinkingStyle, text)
+				: renderStaticBorder(text);
 		}
+		if (!borderColor) return renderStaticBorder(text);
 		try {
 			const rendered = borderColor(text);
 			return typeof rendered === "string" ? rendered : renderStaticBorder(text);
@@ -388,6 +408,15 @@ export function renderMinimalistFrame({
 			return renderStaticBorder(text);
 		}
 	};
+	const renderStaticThinking = (text: string) =>
+		renderStyleForSourceOrFallback(
+			uiTheme,
+			source,
+			thinkingStyle(config, text),
+			MINIMALIST_THINKING_FALLBACK,
+			text,
+		);
+	const renderThinking = adaptive ? renderBorder : renderStaticThinking;
 	const separator = safeThemeFg(uiTheme, "muted", " · ");
 	const viewportLabel = (direction: "above" | "below", count: string | undefined) => {
 		if (!count || !/^[1-9]\d*$/.test(count)) return "";
@@ -406,7 +435,7 @@ export function renderMinimalistFrame({
 		width,
 		left: topLeft,
 		leftFallbacks: topFallbacks,
-		right: renderTopRight(metadata, uiTheme, config, topRightBudget, renderBorder),
+		right: renderTopRight(metadata, uiTheme, config, topRightBudget, renderBorder, renderThinking),
 		leftCorner: "╭",
 		rightCorner: "╮",
 		renderBorder,

--- a/extensions/zentui/style.ts
+++ b/extensions/zentui/style.ts
@@ -146,6 +146,7 @@ const themeColorTokens = new Set<ThemeColor>([
 	"thinkingMedium",
 	"thinkingHigh",
 	"thinkingXhigh",
+	"thinkingMax",
 	"bashMode",
 ]);
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1880,6 +1880,7 @@ describe("mergeConfig", () => {
 				editorThinkingMedium: "thinkingMedium",
 				editorThinkingHigh: "thinkingHigh",
 				editorThinkingXhigh: "thinkingXhigh",
+				editorThinkingMax: "thinkingMax",
 			},
 		});
 
@@ -1893,6 +1894,7 @@ describe("mergeConfig", () => {
 		expect(config.colors.editorThinkingMedium).toBe("thinkingMedium");
 		expect(config.colors.editorThinkingHigh).toBe("thinkingHigh");
 		expect(config.colors.editorThinkingXhigh).toBe("thinkingXhigh");
+		expect(config.colors.editorThinkingMax).toBe("thinkingMax");
 	});
 
 	it("ignores invalid known values at runtime instead of trusting zentui.json", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -173,6 +173,24 @@ describe("canonical config resolution", () => {
 		expect(defaultConfig.components).toEqual(config.components);
 	});
 
+	it("bridges explicit legacy branch colors into the independent Editor branch role", () => {
+		expect(mergeConfig({}).colors.editorGitBranch).toBeUndefined();
+
+		const legacyDefault = mergeConfig({ colors: { gitBranch: "bold purple" } }).colors;
+		expect(legacyDefault.gitBranch).toBe("bold purple");
+		expect(legacyDefault.editorGitBranch).toBe("bold purple");
+
+		const legacyCustom = mergeConfig({ colors: { gitBranch: "success" } }).colors;
+		expect(legacyCustom.gitBranch).toBe("success");
+		expect(legacyCustom.editorGitBranch).toBe("success");
+
+		const independent = mergeConfig({
+			colors: { gitBranch: "success", editorGitBranch: "accent" },
+		}).colors;
+		expect(independent.gitBranch).toBe("success");
+		expect(independent.editorGitBranch).toBe("accent");
+	});
+
 	it("ignores stale fixed-editor config forms without exposing runtime fields", () => {
 		const config = mergeConfig({
 			fixedEditor: { enabled: true, mouseScroll: false },

--- a/test/editor-metadata-format.test.ts
+++ b/test/editor-metadata-format.test.ts
@@ -107,6 +107,27 @@ describe("renderEditorMetadataFormat", () => {
 		).toBe("[thinkingText]low");
 	});
 
+	it.each([
+		[
+			{
+				editorThinking: "thinkingText",
+				editorThinkingXhigh: "thinkingXhigh",
+				editorThinkingMax: "thinkingMax",
+			},
+			"thinkingMax",
+		],
+		[{ editorThinking: "thinkingText", editorThinkingXhigh: "thinkingXhigh" }, "thinkingXhigh"],
+		[{ editorThinking: "thinkingText" }, "thinkingText"],
+	] as const)("resolves max thinking through its compatibility chain", (colors, expected) => {
+		const config = {
+			...defaultConfig,
+			colors: { ...defaultConfig.colors, ...colors },
+		};
+		expect(
+			renderEditorMetadataFormat("$thinking", { ...values, thinking: "max" }, makeTheme(), config),
+		).toBe(`[${expected}]max`);
+	});
+
 	it("sanitizes literals and values without collapsing ordinary spaces", () => {
 		const rendered = render(
 			"\u001b]8;;https://example.com/$provider\u0007lit\u001b]8;;\u0007  x\n\ty:$model",

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -141,7 +141,7 @@ function standalone(style: EditorStyle = "opencode"): PolishedEditor {
 	return editor;
 }
 
-const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+const thinkingLevels = ["off", "minimal", "low", "medium", "high", "xhigh", "max"] as const;
 type SemanticBorderState = (typeof thinkingLevels)[number] | "shell";
 
 const semanticBorderCodes: Record<SemanticBorderState, number> = {
@@ -151,6 +151,7 @@ const semanticBorderCodes: Record<SemanticBorderState, number> = {
 	medium: 33,
 	high: 34,
 	xhigh: 35,
+	max: 37,
 	shell: 36,
 };
 

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -124,10 +124,14 @@ describe("minimalist editor frame", () => {
 				{ color: "syntaxKeyword", text: "model-x" },
 				{ color: "warning", text: "high" },
 				{ color: "muted", text: "42%" },
-				{ color: "accent", text: "main" },
+				{ color: "syntaxKeyword", text: "main" },
 				{ color: "syntaxFunction", text: "project" },
 			]),
 		);
+		const branchColor = calls.find(({ text }) => text === "main")?.color;
+		const cwdColor = calls.find(({ text }) => text === "project")?.color;
+		expect(branchColor).toBe("syntaxKeyword");
+		expect(branchColor).not.toBe(cwdColor);
 		const chromeCalls = calls.filter(({ text }) => /^[╭╮╰╯─│ –]+$/.test(text));
 		expect(chromeCalls.length).toBeGreaterThan(0);
 		expect(new Set(chromeCalls.map(({ color }) => color))).toEqual(new Set(["borderMuted"]));
@@ -165,7 +169,7 @@ describe("minimalist editor frame", () => {
 		expect(calls).toContainEqual({ color, text: `${contextPercent}%` });
 	});
 
-	it("preserves custom theme roles and terminal-source colors", () => {
+	it("preserves custom theme roles", () => {
 		const calls: Array<{ color: string; text: string }> = [];
 		const colors = {
 			...defaultConfig.colors,
@@ -202,20 +206,61 @@ describe("minimalist editor frame", () => {
 				{ color: "accent", text: "project" },
 			]),
 		);
+	});
 
-		const defaultTerminal = renderMinimalistFrame({
-			width: 80,
+	it("uses the complete default terminal palette", () => {
+		const terminalConfig = config({
+			colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+		});
+		const output = renderMinimalistFrame({
+			width: 120,
 			editorLines: ["draft"],
 			inputText: "draft",
-			metadata: { cwd: "", branch: "main" },
+			metadata: {
+				cwd: "/tmp/project",
+				branch: "main",
+				costLabel: "$0.123",
+				modelLabel: "model-x",
+				thinkingLevel: "high",
+				contextPercent: 42,
+			},
 			uiTheme: theme(),
-			config: config({
-				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
-			}),
+			config: terminalConfig,
 		}).join("\n");
-		expect(defaultTerminal).toContain("\x1b[1;35mmain\x1b[0m");
 
-		const terminal = renderMinimalistFrame({
+		expect(output).toContain("\x1b[1;32m$0.123\x1b[0m");
+		expect(output).toContain("\x1b[1;35mmodel-x\x1b[0m");
+		expect(output).toContain("\x1b[1;33mhigh\x1b[0m");
+		expect(output).toContain("\x1b[90m42%\x1b[0m");
+		expect(output).toContain("\x1b[1;34mmain\x1b[0m");
+		expect(output).toContain("\x1b[1;36mproject\x1b[0m");
+		expect(output).toContain("\x1b[90m╭\x1b[0m");
+
+		for (const [contextPercent, expected] of [
+			[70, "\x1b[1;33m70%\x1b[0m"],
+			[90, "\x1b[1;31m90%\x1b[0m"],
+		] as const) {
+			const contextOutput = renderMinimalistFrame({
+				width: 80,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: "", contextPercent },
+				uiTheme: theme(),
+				config: terminalConfig,
+			}).join("\n");
+			expect(contextOutput).toContain(expected);
+		}
+	});
+
+	it("preserves custom terminal colors and legacy branch provenance", () => {
+		const legacyColors = mergeConfig({
+			colors: {
+				gitBranch: "cyan",
+				editorModel: "bright-purple",
+				editorThinkingHigh: "yellow",
+			},
+		}).colors;
+		const legacyOutput = renderMinimalistFrame({
 			width: 120,
 			editorLines: ["draft"],
 			inputText: "draft",
@@ -228,17 +273,27 @@ describe("minimalist editor frame", () => {
 			uiTheme: theme(),
 			config: config({
 				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
-				colors: {
-					...defaultConfig.colors,
-					gitBranch: "cyan",
-					editorModel: "bold purple",
-					editorThinkingHigh: "yellow",
-				},
+				colors: legacyColors,
 			}),
 		}).join("\n");
-		expect(terminal).toContain("\x1b[1;35mmodel-x\x1b[0m");
-		expect(terminal).toContain("\x1b[33mhigh\x1b[0m");
-		expect(terminal).toContain("\x1b[36mmain\x1b[0m");
+		expect(legacyOutput).toContain("\x1b[95mmodel-x\x1b[0m");
+		expect(legacyOutput).toContain("\x1b[33mhigh\x1b[0m");
+		expect(legacyOutput).toContain("\x1b[36mmain\x1b[0m");
+
+		const canonicalOutput = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", branch: "main" },
+			uiTheme: theme(),
+			config: config({
+				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+				colors: mergeConfig({
+					colors: { gitBranch: "cyan", editorGitBranch: "bright-green" },
+				}).colors,
+			}),
+		}).join("\n");
+		expect(canonicalOutput).toContain("\x1b[92mmain\x1b[0m");
 	});
 
 	it("puts complete viewport counts first on their matching borders", () => {

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -622,6 +622,126 @@ describe("minimalist editor frame", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 20)).toBe(true);
 	});
 
+	it("keeps adaptive theme borders and thinking labels on the same renderer", () => {
+		const colors = {
+			...defaultConfig.colors,
+			editorBorder: "error",
+			editorThinkingHigh: "success",
+		};
+		const adaptiveConfig = config({ colors, editorBorderColorMode: "adaptive" });
+		const renderWith = (uiTheme: Theme, borderColor?: (text: string) => string) =>
+			renderMinimalistFrame({
+				width: 80,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: "", thinkingLevel: "high" },
+				uiTheme,
+				config: adaptiveConfig,
+				borderColor,
+			}).join("\n");
+
+		const adaptive = renderWith(theme(), (text) => `\x1b[36m${text}\x1b[0m`);
+		expect(adaptive).toContain("\x1b[36m╭\x1b[0m");
+		expect(adaptive).toContain("\x1b[36mhigh\x1b[0m");
+
+		for (const failedBorderColor of [
+			undefined,
+			() => {
+				throw new Error("adaptive color failed");
+			},
+			(() => 42) as unknown as (text: string) => string,
+		]) {
+			const calls: Array<{ color: string; text: string }> = [];
+			renderWith(recordingTheme(calls), failedBorderColor);
+			expect(calls).toContainEqual({ color: "error", text: "╭" });
+			expect(calls).toContainEqual({ color: "error", text: "high" });
+			expect(calls).not.toContainEqual({ color: "success", text: "high" });
+		}
+
+		const staticCalls: Array<{ color: string; text: string }> = [];
+		renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", thinkingLevel: "high" },
+			uiTheme: recordingTheme(staticCalls),
+			config: config({ colors, editorBorderColorMode: "static" }),
+			borderColor: (text) => `\x1b[36m${text}\x1b[0m`,
+		});
+		expect(staticCalls).toContainEqual({ color: "error", text: "╭" });
+		expect(staticCalls).toContainEqual({ color: "success", text: "high" });
+	});
+
+	it.each([
+		["minimal", "\x1b[90m"],
+		["low", "\x1b[34m"],
+		["medium", "\x1b[36m"],
+		["high", "\x1b[33m"],
+		["xhigh", "\x1b[31m"],
+		["max", "\x1b[91m"],
+	] as const)("uses the terminal adaptive color for %s borders and labels", (level, ansi) => {
+		const output = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", thinkingLevel: level },
+			uiTheme: theme(),
+			config: config({
+				editorBorderColorMode: "adaptive",
+				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+			}),
+			borderColor: (text) => `[theme]${text}`,
+		}).join("\n");
+		expect(output).toContain(`${ansi}╭\x1b[0m`);
+		expect(output).toContain(`${ansi}${level}\x1b[0m`);
+		expect(output).not.toContain("[theme]");
+	});
+
+	it.each([
+		[{ editorThinkingMax: "bright-purple" }, "max", "\x1b[95m"],
+		[{ editorThinkingXhigh: "bright-cyan" }, "max", "\x1b[96m"],
+		[{ editorThinking: "bright-green" }, "low", "\x1b[92m"],
+	] as const)(
+		"uses configured terminal adaptive thinking colors for both border and %s label",
+		(colors, level, ansi) => {
+			const output = renderMinimalistFrame({
+				width: 80,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: "", thinkingLevel: level },
+				uiTheme: theme(),
+				config: config({
+					colors: { ...defaultConfig.colors, ...colors },
+					editorBorderColorMode: "adaptive",
+					colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+				}),
+			}).join("\n");
+			expect(output).toContain(`${ansi}╭\x1b[0m`);
+			expect(output).toContain(`${ansi}${level}\x1b[0m`);
+		},
+	);
+
+	it.each([undefined, "", "off"])(
+		"keeps terminal adaptive borders static and omits an inactive thinking level %s",
+		(thinkingLevel) => {
+			const output = renderMinimalistFrame({
+				width: 80,
+				editorLines: ["draft"],
+				inputText: "draft",
+				metadata: { cwd: "", thinkingLevel },
+				uiTheme: theme(),
+				config: config({
+					editorBorderColorMode: "adaptive",
+					colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+				}),
+				borderColor: (text) => `[theme]${text}`,
+			}).join("\n");
+			expect(output).toContain("\x1b[90m╭\x1b[0m");
+			expect(output).not.toContain("[theme]");
+			expect(output).not.toContain("off");
+		},
+	);
+
 	it("colors every separator in the full top-right sequence with the resolved border color", () => {
 		const top = renderMinimalistFrame({
 			width: 100,
@@ -640,7 +760,7 @@ describe("minimalist editor frame", () => {
 		})[0];
 
 		expect(top).toContain(
-			"$0.000\x1b[36m – \x1b[0mgpt-5.6-terra\x1b[36m – \x1b[0mminimal\x1b[36m – \x1b[0m0%",
+			"$0.000\x1b[36m – \x1b[0mgpt-5.6-terra\x1b[36m – \x1b[0m\x1b[36mminimal\x1b[0m\x1b[36m – \x1b[0m0%",
 		);
 		expect(top.match(/\x1b\[36m – \x1b\[0m/g)).toHaveLength(3);
 		expect(top).not.toContain("\x1b[36m$0.000");
@@ -651,12 +771,12 @@ describe("minimalist editor frame", () => {
 		[
 			"without cost",
 			{ cwd: "", modelLabel: "model", thinkingLevel: "low", contextPercent: 12 },
-			"model\x1b[36m – \x1b[0mlow\x1b[36m – \x1b[0m12%",
+			"model\x1b[36m – \x1b[0m\x1b[36mlow\x1b[0m\x1b[36m – \x1b[0m12%",
 		],
 		[
 			"without model",
 			{ cwd: "", costLabel: "$1", thinkingLevel: "high", contextPercent: 25 },
-			"$1\x1b[36m – \x1b[0mhigh\x1b[36m – \x1b[0m25%",
+			"$1\x1b[36m – \x1b[0m\x1b[36mhigh\x1b[0m\x1b[36m – \x1b[0m25%",
 		],
 		[
 			"without thinking",
@@ -666,7 +786,7 @@ describe("minimalist editor frame", () => {
 		[
 			"without context",
 			{ cwd: "", costLabel: "$3", modelLabel: "model", thinkingLevel: "xhigh" },
-			"$3\x1b[36m – \x1b[0mmodel\x1b[36m – \x1b[0mxhigh",
+			"$3\x1b[36m – \x1b[0mmodel\x1b[36m – \x1b[0m\x1b[36mxhigh\x1b[0m",
 		],
 	] satisfies Array<[string, MinimalistEditorMetadata, string]>)(
 		"uses the resolved border separator %s",

--- a/test/minimalist-editor.test.ts
+++ b/test/minimalist-editor.test.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
-import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+import { defaultConfig, mergeConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
 import { installFooter } from "../extensions/zentui/footer";
 import { emptyGitStatus } from "../extensions/zentui/git";
 import {
@@ -22,6 +22,16 @@ function theme(): Theme {
 		underline: (text: string) => text,
 		strikethrough: (text: string) => text,
 		inverse: (text: string) => text,
+	} as Theme;
+}
+
+function recordingTheme(calls: Array<{ color: string; text: string }>): Theme {
+	return {
+		...theme(),
+		fg(color: string, text: string) {
+			calls.push({ color, text });
+			return text;
+		},
 	} as Theme;
 }
 
@@ -87,6 +97,148 @@ describe("minimalist editor frame", () => {
 		expect(lines.at(-1)).toContain("feature/minimalist * ↑2 ↓1");
 		expect(lines.at(-1)).toContain("project");
 		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
+	});
+
+	it("uses distinct theme roles for default minimalist metadata", () => {
+		const calls: Array<{ color: string; text: string }> = [];
+		const lines = renderMinimalistFrame({
+			width: 120,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: {
+				cwd: "/tmp/project",
+				branch: "main",
+				costLabel: "$0.123",
+				modelLabel: "model-x",
+				thinkingLevel: "high",
+				contextPercent: 42,
+			},
+			uiTheme: recordingTheme(calls),
+			config: config(),
+		});
+
+		expect(lines.join("\n")).toContain("main");
+		expect(calls).toEqual(
+			expect.arrayContaining([
+				{ color: "success", text: "$0.123" },
+				{ color: "syntaxKeyword", text: "model-x" },
+				{ color: "warning", text: "high" },
+				{ color: "muted", text: "42%" },
+				{ color: "accent", text: "main" },
+				{ color: "syntaxFunction", text: "project" },
+			]),
+		);
+		const chromeCalls = calls.filter(({ text }) => /^[╭╮╰╯─│ –]+$/.test(text));
+		expect(chromeCalls.length).toBeGreaterThan(0);
+		expect(new Set(chromeCalls.map(({ color }) => color))).toEqual(new Set(["borderMuted"]));
+	});
+
+	it.each([
+		["bold purple", "syntaxKeyword"],
+		["success", "success"],
+	] as const)("preserves an explicit legacy gitBranch color %s", (gitBranch, expectedColor) => {
+		const calls: Array<{ color: string; text: string }> = [];
+		renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", branch: "main" },
+			uiTheme: recordingTheme(calls),
+			config: config({ colors: mergeConfig({ colors: { gitBranch } }).colors }),
+		});
+		expect(calls).toContainEqual({ color: expectedColor, text: "main" });
+	});
+
+	it.each([
+		[70, "warning"],
+		[90, "error"],
+	] as const)("keeps %i%% context on the %s semantic tier", (contextPercent, color) => {
+		const calls: Array<{ color: string; text: string }> = [];
+		renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", contextPercent },
+			uiTheme: recordingTheme(calls),
+			config: config(),
+		});
+		expect(calls).toContainEqual({ color, text: `${contextPercent}%` });
+	});
+
+	it("preserves custom theme roles and terminal-source colors", () => {
+		const calls: Array<{ color: string; text: string }> = [];
+		const colors = {
+			...defaultConfig.colors,
+			cwd: "accent",
+			gitBranch: "bold purple",
+			editorGitBranch: "success",
+			cost: "warning",
+			contextNormal: "dim",
+			editorModel: "text",
+			editorThinkingHigh: "thinkingHigh",
+		};
+		renderMinimalistFrame({
+			width: 120,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: {
+				cwd: "/tmp/project",
+				branch: "main",
+				costLabel: "$0.123",
+				modelLabel: "model-x",
+				thinkingLevel: "high",
+				contextPercent: 42,
+			},
+			uiTheme: recordingTheme(calls),
+			config: config({ colors }),
+		});
+		expect(calls).toEqual(
+			expect.arrayContaining([
+				{ color: "warning", text: "$0.123" },
+				{ color: "text", text: "model-x" },
+				{ color: "thinkingHigh", text: "high" },
+				{ color: "muted", text: "42%" },
+				{ color: "success", text: "main" },
+				{ color: "accent", text: "project" },
+			]),
+		);
+
+		const defaultTerminal = renderMinimalistFrame({
+			width: 80,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: { cwd: "", branch: "main" },
+			uiTheme: theme(),
+			config: config({
+				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+			}),
+		}).join("\n");
+		expect(defaultTerminal).toContain("\x1b[1;35mmain\x1b[0m");
+
+		const terminal = renderMinimalistFrame({
+			width: 120,
+			editorLines: ["draft"],
+			inputText: "draft",
+			metadata: {
+				cwd: "",
+				branch: "main",
+				modelLabel: "model-x",
+				thinkingLevel: "high",
+			},
+			uiTheme: theme(),
+			config: config({
+				colorSources: { ...defaultConfig.colorSources, editor: "terminal" },
+				colors: {
+					...defaultConfig.colors,
+					gitBranch: "cyan",
+					editorModel: "bold purple",
+					editorThinkingHigh: "yellow",
+				},
+			}),
+		}).join("\n");
+		expect(terminal).toContain("\x1b[1;35mmodel-x\x1b[0m");
+		expect(terminal).toContain("\x1b[33mhigh\x1b[0m");
+		expect(terminal).toContain("\x1b[36mmain\x1b[0m");
 	});
 
 	it("puts complete viewport counts first on their matching borders", () => {


### PR DESCRIPTION
## Summary

- gives the minimalist Editor distinct theme and terminal color roles for model, thinking, Git branch, cwd, context, and chrome
- makes adaptive thinking labels follow the actual adaptive border color
- adds first-class `max` thinking support, including a distinct terminal adaptive color
- preserves static-mode customization, explicit/legacy color overrides, and Footer/Editor ownership boundaries

The branch color now uses an Editor-owned override/fallback, so Footer `gitBranch` styling remains independent. Theme and terminal rendering paths have dedicated regression coverage.

## Screenshots / recordings

Manual Pi TUI verification was performed from the worktree using the development extension entry point. No recording is attached.

## Testing

- [x] `npm run verify` — 1,097 tests across 32 files
- [x] `npm run pack:check` — `pi-zentui@0.20.1`, 36 files
- [x] Manual Pi test via the worktree development extension
- [x] Added or updated focused tests for theme, terminal, adaptive, fallback, override, and `max` behavior

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Impeccable detector — no findings
- [x] Two independent final reviews — PASS

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Documented the new optional Editor-owned color overrides.
- [x] Kept the diff surgical with no unrelated refactors or dependency changes.
- [x] `extensions/zentui/index.ts` remains orchestration-only and unchanged.
- [x] Used a conventional commit-style PR title.
