### PR TITLE
chore: release v0.20.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.20.1",
+			"version": "0.20.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.1",
+	"version": "0.20.2",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Bumps `pi-zentui` from `0.20.1` to `0.20.2` after merging the minimalist Editor color improvements in #92.

This keeps `package.json` and both root `package-lock.json` version fields synchronized. No dependency, source, config-schema, workflow, or generated artifact changes are included.

## Screenshots / recordings

N/A — release metadata only. Manual Pi TUI verification and the rendering tests are in #92.

## Testing

- [x] `npm ci`
- [x] `npm run verify` — 1,097 tests across 32 files
- [x] `npm run pack:check` — `pi-zentui@0.20.2`, 36 files
- [ ] Manual Pi test via `npm run pi:dev` (not applicable to metadata-only change)
- [ ] Added or updated tests where practical (not applicable)

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] All three release version fields asserted as `0.20.2`
- [x] Normalized lockfile SHA-256 matches `main`
- [x] Independent release-diff review — PASS

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no source changes).
- [x] README/config docs unchanged because this PR contains release metadata only.
- [x] Kept the diff surgical: no unrelated refactors, formatting, dependency, or workflow changes.
- [x] `extensions/zentui/index.ts` remains unchanged.
- [x] Used a conventional commit-style PR title.
