### PR TITLE
feat: add accent rail editor and completion palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A Starship-inspired statusline and Opencode-style TUI for [Pi](https://pi.dev).
 
 Zentui styles four major Pi surfaces independently:
 
-- **Editor** — selectable opencode, low-rail opencode, and minimalist input frames inspired by [Opencode](https://github.com/opencode-ai/opencode)
+- **Editor** — selectable Opencode, Accent Rail, and Minimalist input treatments inspired by [Opencode](https://github.com/opencode-ai/opencode), Oh My Pi, and pi-custom-input
 - **User messages** — selectable framed, framed copy-friendly, compact, and labeled transcript messages
 - **Working line** — optional ownership and styling of Pi's complete in-progress row
 - **[Starship](https://starship.rs/) footer** — current directory, Git, runtime, context, tokens, cost, and other configurable segments
@@ -32,14 +32,15 @@ Editor, User messages, Working line, and selector borders use independent `enabl
 - Third-party Pi extension statuses from `ctx.ui.setStatus()` can be shown on the left,
   middle, or right side, or hidden per status key from `/zentui`
 
-### Editor (Opencode-inspired)
+### Editor
 
 - `opencode` (default) keeps an accent rail on every interior row
 - `opencode-copy-friendly` (**Opencode (copy-friendly)** in `/zentui`) preserves the low-rail rendering for clean terminal selection
+- `accent-rail` (**Accent Rail** in `/zentui`) uses a filled compact input surface, one editor-owned rail on every input row, and no frame or metadata
 - `minimalist` moves session name, cost, model, thinking, context, Git, configurable path, Bash state, and turn duration into a rounded frame
 - The selected model label and provider appear inside both Opencode editor variants; the model ID is used by default, while `components.editor.modelLabel: "name"` uses the display name with ID fallback.
-- Opencode autocomplete rows retain Pi's original unframed trailing layout; Minimalist keeps autocomplete inside its rounded frame
-- Configurable model, provider, thinking-level, accent, and border colors
+- Accent Rail autocomplete keeps Pi's native menu content on the same filled surface, replacing only the selected `→` with the configured rail; transparent mode removes its owned input and menu backgrounds. Both Opencode variants default to a transparent full-width completion palette and can independently restore Pi's native trailing list; Minimalist keeps autocomplete inside its rounded frame
+- Configurable model, provider, thinking-level, accent, rail, and border colors
 
 Editor styles:
 
@@ -50,6 +51,14 @@ Editor styles:
 <h4 align="center"><code>opencode-copy-friendly</code></h4>
 
 ![Zentui copy-friendly Opencode editor with model metadata, Nerd Font Git branch, and Starship footer.](./assets/screenshots/editor-opencode-copy-friendly.png)
+
+<h4 align="center"><code>accent-rail</code></h4>
+
+```text
+▎ Ask anything, edit files, run tools
+▎ settings     Open settings
+  files        Search files
+```
 
 <h4 align="center"><code>minimalist</code></h4>
 
@@ -244,10 +253,17 @@ Default config values — copy this and change any value you want:
 			"viewportIndicators": true,
 			"styles": {
 				"opencode": {
-					"metadataFormat": "$model  $provider(  $thinking)"
+					"metadataFormat": "$model  $provider(  $thinking)",
+					"completionMenu": "palette"
 				},
 				"opencode-copy-friendly": {
-					"metadataFormat": "$model  $provider(  $thinking)"
+					"metadataFormat": "$model  $provider(  $thinking)",
+					"completionMenu": "palette"
+				},
+				"accent-rail": {
+					"rail": "▎",
+					"asciiRail": "|",
+					"transparent": false
 				},
 				"minimalist": {
 					"pathDisplay": "compact",
@@ -425,7 +441,7 @@ Default config values — copy this and change any value you want:
 
 - Style values can be Starship/terminal strings (`bold purple`, `fg:202`, `#89b` / `#89b4fa`, `bg:blue fg:bright-green`) or Pi theme tokens (`accent`, `borderMuted`, `thinkingHigh`). Short `#rgb` hex values expand to `#rrggbb`.
 - `projectRefreshIntervalMs`: project status polling interval; `0` disables polling. Values `1..4999` clamp up to `5000` (minimum 5s); invalid/non-finite values fall back to `30000`.
-- `components.editor`: owns editor enablement, `opencode | opencode-copy-friendly | minimalist` style selection, color source, border mode, model label, viewport indicators, and all three editor-style configurations.
+- `components.editor`: owns editor enablement, `opencode | opencode-copy-friendly | accent-rail | minimalist` style selection, color source, border mode, model label, viewport indicators, and all four editor-style configurations.
 - `components.userMessages`: owns message enablement, `framed | framed-copy-friendly | compact | labeled` style selection, and color source. `framed-copy-friendly` remains Zentui-rendered; disabling the component delegates to Pi's native renderer.
 - `components.workingLine`: `enabled` is the sole ownership switch. While enabled, Zentui owns both the Working-row message and indicator and renders the full row. It configures `braille | star-bloom | pinwheel | claude-inspired | pulse`, independent spinner/text speeds, optional Classic/KITT spinner-color participation, `classic | kitt | disabled` text animation, color source, the default-on `messages.custom` toggle and editable 16-value list, plus Tool/Elapsed/Thinking/Tokens segments. Thinking only controls the live row; measurement and final summaries continue while it is hidden. Custom-off and empty-list fallback both render owned `Working…`; Static keeps glyph motion but ignores text speed and spinner-color participation.
 - Optional `colors.workingLineLow`, `colors.workingLineMid`, and `colors.workingLineHigh` override its palette. Without overrides, theme mode uses `dim`, `muted`, and `bold accent`; terminal mode uses `bright-black`, `cyan`, and `bold cyan`.
@@ -438,13 +454,20 @@ Default config values — copy this and change any value you want:
 - The flat properties returned by `mergeConfig`, `loadConfig`, and save helpers are deprecated compatibility output and will remain available until at least the next major release. This output deprecation is separate from accepted legacy flat JSON input.
 - `polished` and `polished-copy-friendly` remain read-only migration aliases for `opencode` and `opencode-copy-friendly`. Legacy `features.copyFriendly` and the old nested Editor/message `copyFriendly` fields are read-only migration inputs: message copy-friendly `true` selects `framed-copy-friendly` rather than disabling custom rendering. Explicit Editor or User-message style saves remove only the corresponding obsolete nested flag; raw released feature keys, unknown fields, and unknown style data remain preserved as user-owned migration data.
 - The shown `editor*` values match the default `theme` source. Omit those keys to keep Zentui's source-aware defaults when switching between `theme` and `terminal`.
-- `editorAccent` styles Editor and User-message accent rails and the labeled message label.
+- `editorAccent` styles Opencode Editor and User-message accent rails plus the labeled message label.
+- Optional `editorRail` styles only the Accent Rail editor. When omitted, theme mode uses warm `syntaxNumber` and terminal mode uses portable color 215; it never inherits `editorAccent`.
 - `editorPrompt` styles the `opencode-copy-friendly` Editor prompt glyph. Omit it to use `editorAccent`, then the default accent fallback.
 - `editorBorder` styles the `framed` and `framed-copy-friendly` previous-message top/bottom borders and the active editor in static border color mode; the border glyph stays `─`.
 - `editorGitBranch` and `editorThinkingMax` are optional editor-owned overrides, omitted above so source-specific and adaptive defaults remain active. `editorGitBranch` owns the minimalist Editor branch color independently from Footer `gitBranch`; where Zentui resolves configured thinking colors, `max` falls back through `editorThinkingXhigh` and then `editorThinking`.
 - `editorModel`, `editorProvider`, and `editorThinking*` style the editor metadata. `editorThinking` applies to every non-`off` thinking level unless a level-specific key is set.
 
 Tip: with `opencode-copy-friendly`, setting Pi's `editorPaddingX` to `1` in `~/.pi/agent/settings.json` keeps a small left gutter without copying a rail glyph.
+
+## Accent Rail editor style
+
+Set `components.editor.style` to `accent-rail` or select **Accent Rail** from the `/zentui` **Editor** tab. Each rendered input row uses the style-owned `rail` glyph (`▎`, or `asciiRail` in ASCII icon mode), one blank cell before text, and Pi's neutral filled surface. It intentionally has no prompt glyph, metadata, enclosing border, or blank chrome row. Viewport counts appear only while content is clipped. Known autocomplete rows keep Pi's native text, descriptions, and scrolling on the same full-width surface; the selected native `→` becomes the configured rail marker without replacing Pi's selected-text color. Unknown third-party editor layouts fail open without decoration using the already-rendered native rows.
+
+`components.editor.styles["accent-rail"].transparent` defaults to `false`. Set it to `true`, or choose **Transparent** from the Accent Rail surface control in `/zentui`, to remove only Zentui-owned input and autocomplete backgrounds while preserving geometry, rail/text colors, and native autocomplete backgrounds. The rail and gap are rendered decoration, not part of the underlying prompt text. Terminal drag or rectangular selection can still include visible decoration; choose `opencode-copy-friendly` when selection must avoid a rail entirely.
 
 ## Minimalist editor style
 
@@ -455,6 +478,12 @@ The Minimalist editor is inspired by [pi-custom-input](https://github.com/VinhLe
 While `minimalist` is selected, the `/zentui` **Editor** area shows its focused controls without repeating the style name on every row. Path examples are `src` (`compact`), `zentui/src` (`project`), and `~/Projects/zentui/src` (`full`). Context can render as `11%`, `11%/372k`, or—with the gauge enabled and enough room—`[█░░░░] 11%/372k`. The gauge shortens or disappears before the context text at narrow widths. Session name, timer, cost, and Git can be hidden independently; model, thinking, and context remain structurally stable.
 
 Footer visibility is controlled by `components.footer.style`: use `starship`, `native`, or `hidden`. Minimalist editor decoration and the Starship Footer may be shown together, including at narrow widths or after decoration fallback. Minimalist style does not remove Pi's header.
+
+## Opencode completion menu
+
+Both Opencode variants default to `completionMenu: "palette"`, configurable independently in JSON or through the active style's **Completion menu** control in `/zentui`. The transparent palette keeps Pi's captured native result rows and any native embedded backgrounds, removes only a recognized selected `→` while preserving native selected-text emphasis, omits a narrowly recognized trailing native count row such as `(1/47)`, fills the available width without adding a menu background, and adds a bottom separator plus `↑↓ Navigate   Enter Use   Esc Close`. It intentionally has no results header, range, category column, selected background, or side borders because Pi does not expose that structured data through a stable public completion API.
+
+Set one variant to `"native"` to preserve Pi's trailing rows byte-for-byte. Palette mode adds full-width padding and help text to visible terminal output, so `opencode-copy-friendly` users who prioritize clean rectangular selection may prefer its independent Native setting. If autocomplete capture or frame provenance is ambiguous after rendering, Zentui returns those same native rows unchanged rather than rendering the editor again; Accent Rail and framed styles may therefore retain their reduced probe width on this rare fail-open path. Once compatible string rows are captured, Palette applies its surface to them; selected prefixes and trailing count rows are rewritten only when they match the narrow native patterns, while unrecognized forms remain visible.
 
 ## Editor Metadata Format
 
@@ -596,7 +625,7 @@ You can also select fullscreen from Pi's `/settings` UI or start Pi with `--tui-
 
 ## Acknowledgments
 
-The minimalist frame's information hierarchy was inspired by [VinhLe1410/pi-custom-input](https://github.com/VinhLe1410/pi-custom-input) and is integrated with Zentui's existing editor, state, configuration, and compatibility layers.
+The Accent Rail editor is inspired by Oh My Pi, with an independent implementation in Zentui. The Minimalist frame's information hierarchy was inspired by [VinhLe1410/pi-custom-input](https://github.com/VinhLe1410/pi-custom-input) and is integrated with Zentui's existing editor, state, configuration, and compatibility layers.
 
 ## Requirements
 

--- a/extensions/zentui/accent-rail-editor.ts
+++ b/extensions/zentui/accent-rail-editor.ts
@@ -1,0 +1,99 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import {
+	applyOwnedSurfaceBackground,
+	fillTerminalLine,
+	renderCompletionRows,
+} from "./completion-menu";
+import type { ZentuiConfig } from "./config";
+import { sanitizeEditorMetadataText } from "./editor-metadata-format";
+import { renderStyleForSourceOrFallback, type SourceStyleFallback } from "./style";
+
+export const ACCENT_RAIL_CHROME_WIDTH = 2;
+
+const ACCENT_RAIL_FALLBACK: SourceStyleFallback = {
+	theme: "syntaxNumber",
+	terminal: "fg:215",
+};
+
+export type AccentRailViewport = {
+	above?: string;
+	below?: string;
+};
+
+export type AccentRailEditorFrameOptions = {
+	width: number;
+	editorLines: string[];
+	autocompleteLines?: string[];
+	viewport?: AccentRailViewport;
+	uiTheme: Theme;
+	config: ZentuiConfig;
+};
+
+function clampLines(lines: string[], width: number): string[] {
+	const maxWidth = Math.max(0, width);
+	return lines.map((line) => truncateToWidth(line, maxWidth, ""));
+}
+
+function selectedRail(config: ZentuiConfig): string {
+	const style = config.components.editor.styles["accent-rail"];
+	const fallback = config.icons.mode === "ascii" ? "|" : "▎";
+	const configured = config.icons.mode === "ascii" ? style.asciiRail : style.rail;
+	const sanitized = sanitizeEditorMetadataText(configured);
+	const glyph = truncateToWidth(sanitized, 1, "");
+	return visibleWidth(glyph) === 1 ? glyph : fallback;
+}
+
+function viewportLabel(
+	direction: "above" | "below",
+	count: string | undefined,
+): string | undefined {
+	if (!count || !/^[1-9]\d*$/.test(count)) return undefined;
+	return `${direction === "above" ? "↑" : "↓"} ${count} more`;
+}
+
+/** Pure compact accent-rail composition shared by live rendering and settings previews. */
+export function renderAccentRailEditorFrame({
+	width,
+	editorLines,
+	autocompleteLines = [],
+	viewport = {},
+	uiTheme,
+	config,
+}: AccentRailEditorFrameOptions): string[] {
+	if (width < ACCENT_RAIL_CHROME_WIDTH + 1) {
+		return clampLines([...editorLines, ...autocompleteLines], width);
+	}
+
+	const contentWidth = width - ACCENT_RAIL_CHROME_WIDTH;
+	const rail = renderStyleForSourceOrFallback(
+		uiTheme,
+		config.components.editor.colorSource,
+		config.colors.editorRail,
+		ACCENT_RAIL_FALLBACK,
+		selectedRail(config),
+	);
+	const above = config.components.editor.viewportIndicators
+		? viewportLabel("above", viewport.above)
+		: undefined;
+	const below = config.components.editor.viewportIndicators
+		? viewportLabel("below", viewport.below)
+		: undefined;
+	const rows = [...(above ? [above] : []), ...editorLines, ...(below ? [below] : [])];
+	const transparent = config.components.editor.styles["accent-rail"].transparent;
+	const surface = rows.map((line) => {
+		const railCell = transparent ? rail : applyOwnedSurfaceBackground(uiTheme, rail);
+		const bodyText = ` ${fillTerminalLine(line, contentWidth)}`;
+		const body = transparent ? bodyText : applyOwnedSurfaceBackground(uiTheme, bodyText);
+		return `${railCell}${body}`;
+	});
+	const autocompleteSurface = renderCompletionRows({
+		lines: autocompleteLines,
+		width,
+		theme: uiTheme,
+		selectedPrefix: `${rail} `,
+		ownedBackground: !transparent,
+	});
+
+	return clampLines([...surface, ...autocompleteSurface], width);
+}

--- a/extensions/zentui/completion-menu.ts
+++ b/extensions/zentui/completion-menu.ts
@@ -1,0 +1,157 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+export type CompletionRowsOptions = {
+	lines: string[];
+	width: number;
+	theme: Theme;
+	selectedPrefix: string;
+	ownedBackground: boolean;
+};
+
+export type CompletionPaletteOptions = {
+	lines: string[];
+	width: number;
+	theme: Theme;
+	renderSeparator: (text: string) => string;
+	ownedBackground: boolean;
+};
+
+const SGR_SEQUENCE = /(?:\x1b\[|\u009b)([0-9:;]*)m/g;
+
+function normalizeC1Csi(content: string): string {
+	return content.replace(/\u009b([0-?]*[ -/]*[@-~])/g, "\x1b[$1");
+}
+
+function sgrBackgroundAction(parameters: string): "reset" | "set" | undefined {
+	let action: "reset" | "set" | undefined;
+	const values = (parameters || "0").split(";");
+	for (let index = 0; index < values.length; index++) {
+		const parameter = values[index] ?? "";
+		const primary = parameter === "" ? 0 : Number.parseInt(parameter.split(":", 1)[0] ?? "", 10);
+		if (primary === 38 || primary === 48 || primary === 58) {
+			if (primary === 48) action = "set";
+			if (!parameter.includes(":")) {
+				const mode = Number.parseInt(values[index + 1] ?? "", 10);
+				if (mode === 5) index += 2;
+				else if (mode === 2) index += 4;
+			}
+			continue;
+		}
+		if (primary === 0 || primary === 49) action = "reset";
+		else if ((primary >= 40 && primary <= 47) || (primary >= 100 && primary <= 107)) action = "set";
+	}
+	return action;
+}
+
+function restoresOwnedBackground(sequence: string): boolean {
+	const parameters = sequence.slice(sequence.startsWith("\u009b") ? 1 : 2, -1);
+	return sgrBackgroundAction(parameters) === "reset";
+}
+
+function truncateTerminalLine(content: string, width: number): string {
+	const safeWidth = Math.max(0, width);
+	const normalized = normalizeC1Csi(content);
+	return visibleWidth(normalized) <= safeWidth
+		? content
+		: truncateToWidth(normalized, safeWidth, "");
+}
+
+export function fillTerminalLine(content: string, width: number): string {
+	const truncated = truncateTerminalLine(content, width);
+	const renderedWidth = visibleWidth(normalizeC1Csi(truncated));
+	return `${truncated}${" ".repeat(Math.max(0, width - renderedWidth))}`;
+}
+
+export function applyOwnedSurfaceBackground(theme: Theme, text: string): string {
+	try {
+		const background = theme.getBgAnsi("userMessageBg");
+		const restored = text.replace(SGR_SEQUENCE, (sequence) =>
+			restoresOwnedBackground(sequence) ? `${sequence}${background}` : sequence,
+		);
+		return `${background}${restored}\x1b[49m`;
+	} catch {
+		try {
+			let cursor = 0;
+			let rendered = "";
+			for (const match of text.matchAll(SGR_SEQUENCE)) {
+				if (!restoresOwnedBackground(match[0])) continue;
+				const before = text.slice(cursor, match.index);
+				if (before) rendered += theme.bg("userMessageBg", before);
+				rendered += match[0];
+				cursor = (match.index ?? 0) + match[0].length;
+			}
+			const trailing = text.slice(cursor);
+			if (trailing) rendered += theme.bg("userMessageBg", trailing);
+			return rendered || theme.bg("userMessageBg", text);
+		} catch {
+			return text;
+		}
+	}
+}
+
+export function replaceNativeSelectedPrefix(line: string, replacement: string): string {
+	const selectedPrefix = /^((?:(?:\x1b\[|\u009b)[0-9:;]*m)*)→ /;
+	const match = line.match(selectedPrefix);
+	if (!match) return line;
+	return `${replacement}${match[1]}${line.slice(match[0].length)}`;
+}
+
+export function isNativeCompletionCountRow(line: string): boolean {
+	const withoutSgr = line.replace(/(?:\x1b\[|\u009b)[0-?]*[ -/]*m/g, "");
+	return /^\s*\(\d+\/\d+\)\s*$/.test(withoutSgr);
+}
+
+export function omitTrailingNativeCompletionCountRow(lines: string[]): string[] {
+	return lines.length > 0 && isNativeCompletionCountRow(lines.at(-1) ?? "")
+		? lines.slice(0, -1)
+		: lines;
+}
+
+export function renderCompletionRows({
+	lines,
+	width,
+	theme,
+	selectedPrefix,
+	ownedBackground,
+}: CompletionRowsOptions): string[] {
+	return lines.map((line) => {
+		const content = fillTerminalLine(replaceNativeSelectedPrefix(line, selectedPrefix), width);
+		const surfaced = ownedBackground ? applyOwnedSurfaceBackground(theme, content) : content;
+		return truncateTerminalLine(surfaced, width);
+	});
+}
+
+function helpLabel(width: number): string {
+	const labels = [
+		" ↑↓ Navigate   Enter Use   Esc Close",
+		" ↑↓ Nav   Enter Use   Esc",
+		" ↑↓   Enter   Esc",
+	];
+	return labels.find((label) => visibleWidth(label) <= width) ?? labels.at(-1) ?? "";
+}
+
+/** Full-width, provenance-preserving completion shell for Opencode editor styles. */
+export function renderCompletionPalette({
+	lines,
+	width,
+	theme,
+	renderSeparator,
+	ownedBackground,
+}: CompletionPaletteOptions): string[] {
+	const resultLines = omitTrailingNativeCompletionCountRow(lines);
+	if (resultLines.length === 0) return [];
+	const safeWidth = Math.max(0, width);
+	const rows = renderCompletionRows({
+		lines: resultLines,
+		width: safeWidth,
+		theme,
+		selectedPrefix: "  ",
+		ownedBackground,
+	});
+	const separator = renderSeparator("─".repeat(safeWidth));
+	if (safeWidth < 3) return [...rows, truncateToWidth(separator, safeWidth, "")];
+	const helpText = fillTerminalLine(helpLabel(safeWidth), safeWidth);
+	const help = ownedBackground ? applyOwnedSurfaceBackground(theme, helpText) : helpText;
+	return [...rows, truncateToWidth(separator, safeWidth, ""), truncateToWidth(help, safeWidth, "")];
+}

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -35,7 +35,7 @@ export type { IconMode } from "./icons";
 export type ContextStyle = "text" | "gauge" | "text+gauge";
 export type SeparatorStyle = "pipe" | "dot" | "chevron" | "none";
 export type ModelLabelSource = "id" | "name";
-export type EditorStyle = "opencode" | "opencode-copy-friendly" | "minimalist";
+export type EditorStyle = "opencode" | "opencode-copy-friendly" | "accent-rail" | "minimalist";
 export type UserMessageStyle = "framed" | "framed-copy-friendly" | "compact" | "labeled";
 export type SelectorBorderStyle = "zentui";
 export type FooterStyle = "native" | "starship" | "hidden";
@@ -50,6 +50,7 @@ export type ComponentStyleOwner = "editor" | "userMessages" | "selectorBorders" 
 export type MinimalistPathDisplayMode = "compact" | "project" | "full";
 export type MinimalistContextFormat = "percent" | "percent-total";
 export type EditorBorderColorMode = "static" | "adaptive";
+export type CompletionMenuStyle = "native" | "palette";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
 
 export const DEFAULT_COMPACT_FOOTER_FORMAT =
@@ -108,10 +109,18 @@ export type FooterSegmentsConfig = {
 
 export type PolishedEditorStyleConfig = {
 	metadataFormat: string;
+	completionMenu: CompletionMenuStyle;
 };
 
 export type PolishedCopyFriendlyEditorStyleConfig = {
 	metadataFormat: string;
+	completionMenu: CompletionMenuStyle;
+};
+
+export type AccentRailEditorStyleConfig = {
+	rail: string;
+	asciiRail: string;
+	transparent: boolean;
 };
 
 export type MinimalistEditorStyleConfig = {
@@ -142,6 +151,7 @@ export type EditorComponentConfig = {
 	styles: {
 		opencode: PolishedEditorStyleConfig;
 		"opencode-copy-friendly": PolishedCopyFriendlyEditorStyleConfig;
+		"accent-rail": AccentRailEditorStyleConfig;
 		minimalist: MinimalistEditorStyleConfig;
 	};
 };
@@ -312,6 +322,7 @@ export type PolishedTuiColors = {
 	time: ColorSpec;
 	os: ColorSpec;
 	editorAccent?: ColorSpec;
+	editorRail?: ColorSpec;
 	editorPrompt?: ColorSpec;
 	editorBorder?: ColorSpec;
 	editorGitBranch?: ColorSpec;
@@ -427,6 +438,14 @@ const defaultFooterSegments: FooterSegmentsConfig = {
 	packageVersion: false,
 };
 
+const DEFAULT_COMPLETION_MENU: CompletionMenuStyle = "palette";
+
+const defaultAccentRailStyle: AccentRailEditorStyleConfig = {
+	rail: "▎",
+	asciiRail: "|",
+	transparent: false,
+};
+
 const defaultMinimalistStyle: MinimalistEditorStyleConfig = {
 	pathDisplay: "compact",
 	contextFormat: "percent",
@@ -463,8 +482,15 @@ const defaultComponents: ComponentsConfig = {
 		modelLabel: "id",
 		viewportIndicators: true,
 		styles: {
-			opencode: { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
-			"opencode-copy-friendly": { metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT },
+			opencode: {
+				metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+				completionMenu: DEFAULT_COMPLETION_MENU,
+			},
+			"opencode-copy-friendly": {
+				metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+				completionMenu: DEFAULT_COMPLETION_MENU,
+			},
+			"accent-rail": defaultAccentRailStyle,
 			minimalist: defaultMinimalistStyle,
 		},
 	},
@@ -582,7 +608,12 @@ function parseEditorModelLabel(
 }
 
 function parseEditorStyle(value: unknown): EditorStyle {
-	if (value === "opencode" || value === "opencode-copy-friendly" || value === "minimalist") {
+	if (
+		value === "opencode" ||
+		value === "opencode-copy-friendly" ||
+		value === "accent-rail" ||
+		value === "minimalist"
+	) {
 		return value;
 	}
 	if (value === "polished") return "opencode";
@@ -593,6 +624,10 @@ function parseEditorStyle(value: unknown): EditorStyle {
 function parseEditorBorderColorMode(value: unknown): EditorBorderColorMode {
 	if (value === "static" || value === "adaptive") return value;
 	return defaultConfig.editorBorderColorMode;
+}
+
+function parseCompletionMenuStyle(value: unknown): CompletionMenuStyle {
+	return value === "native" || value === "palette" ? value : DEFAULT_COMPLETION_MENU;
 }
 
 export function isSeparatorStyle(value: unknown): value is SeparatorStyle {
@@ -709,6 +744,7 @@ function normalizeColors(record: Record<string, unknown>): Partial<PolishedTuiCo
 		time: colorValue(record, "time"),
 		os: colorValue(record, "os"),
 		editorAccent: colorValue(record, "editorAccent"),
+		editorRail: colorValue(record, "editorRail"),
 		editorPrompt: colorValue(record, "editorPrompt"),
 		editorBorder: colorValue(record, "editorBorder"),
 		editorGitBranch: colorValue(record, "editorGitBranch"),
@@ -1065,6 +1101,7 @@ function resolveEditorStyle(
 	if (
 		rawStyle === "opencode" ||
 		rawStyle === "opencode-copy-friendly" ||
+		rawStyle === "accent-rail" ||
 		rawStyle === "minimalist"
 	) {
 		return rawStyle;
@@ -1146,6 +1183,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 	const polished = recordValue(editorStyles.polished);
 	const opencodeCopyFriendly = recordValue(editorStyles["opencode-copy-friendly"]);
 	const polishedCopyFriendly = recordValue(editorStyles["polished-copy-friendly"]);
+	const accentRail = recordValue(editorStyles["accent-rail"]);
 	const minimalist = recordValue(editorStyles.minimalist);
 	const userMessages = recordValue(components.userMessages);
 	const userMessageStyles = recordValue(userMessages.styles);
@@ -1206,12 +1244,19 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			styles: {
 				opencode: {
 					metadataFormat: parseNonEmptyString(metadataFormat, DEFAULT_EDITOR_METADATA_FORMAT),
+					completionMenu: parseCompletionMenuStyle(opencode.completionMenu),
 				},
 				"opencode-copy-friendly": {
 					metadataFormat: parseNonEmptyString(
 						lowRailMetadataFormat,
 						DEFAULT_EDITOR_METADATA_FORMAT,
 					),
+					completionMenu: parseCompletionMenuStyle(opencodeCopyFriendly.completionMenu),
+				},
+				"accent-rail": {
+					rail: parseNonEmptyString(accentRail.rail, defaultAccentRailStyle.rail),
+					asciiRail: parseNonEmptyString(accentRail.asciiRail, defaultAccentRailStyle.asciiRail),
+					transparent: parseBoolean(accentRail.transparent, defaultAccentRailStyle.transparent),
 				},
 				minimalist: {
 					pathDisplay:
@@ -1397,6 +1442,7 @@ const knownComponentStyleIds: Record<ComponentStyleOwner, ReadonlySet<string>> =
 	editor: new Set([
 		"opencode",
 		"opencode-copy-friendly",
+		"accent-rail",
 		"minimalist",
 		"polished",
 		"polished-copy-friendly",
@@ -1618,6 +1664,7 @@ export function savePolishedEditorStylePatch(
 	return saveComponentsMutation((components) => {
 		const style = components.editor.styles.opencode;
 		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
+		if (patch.completionMenu !== undefined) style.completionMenu = patch.completionMenu;
 	}, path);
 }
 
@@ -1628,6 +1675,19 @@ export function savePolishedCopyFriendlyEditorStylePatch(
 	return saveComponentsMutation((components) => {
 		const style = components.editor.styles["opencode-copy-friendly"];
 		if (patch.metadataFormat !== undefined) style.metadataFormat = patch.metadataFormat;
+		if (patch.completionMenu !== undefined) style.completionMenu = patch.completionMenu;
+	}, path);
+}
+
+export function saveAccentRailEditorStylePatch(
+	patch: Partial<AccentRailEditorStyleConfig>,
+	path = configPath,
+): PolishedTuiConfig {
+	return saveComponentsMutation((components) => {
+		const style = components.editor.styles["accent-rail"];
+		if (patch.rail !== undefined) style.rail = patch.rail;
+		if (patch.asciiRail !== undefined) style.asciiRail = patch.asciiRail;
+		if (patch.transparent !== undefined) style.transparent = patch.transparent;
 	}, path);
 }
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -8,6 +8,7 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
 import {
+	type AccentRailEditorStyleConfig,
 	type ContextStyle,
 	type EditorComponentConfig,
 	type ExtensionStatusColorMode,
@@ -24,9 +25,12 @@ import {
 	loadConfig,
 	type MinimalistConfig,
 	type PathDisplayConfig,
+	type PolishedCopyFriendlyEditorStyleConfig,
+	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
+	saveAccentRailEditorStylePatch,
 	saveEditorComponentPatch,
 	saveExtensionStatusColorMode,
 	saveExtensionStatusDefaultPlacement,
@@ -34,6 +38,8 @@ import {
 	saveFooterComponentPatch,
 	saveIconsModePatch,
 	saveMinimalistEditorStylePatch,
+	savePolishedCopyFriendlyEditorStylePatch,
+	savePolishedEditorStylePatch,
 	saveSelectorBordersComponentPatch,
 	saveStarshipFooterStylePatch,
 	saveUserMessagesComponentPatch,
@@ -1124,6 +1130,21 @@ export default function (pi: ExtensionAPI) {
 				applied: !result || result.ok,
 				reason: result && !result.ok ? result.reason : undefined,
 			};
+		},
+		setPolished(patch: Partial<PolishedEditorStyleConfig>, _ctx: ExtensionContext) {
+			currentConfig = savePolishedEditorStylePatch(patch);
+			refresh();
+		},
+		setPolishedCopyFriendly(
+			patch: Partial<PolishedCopyFriendlyEditorStyleConfig>,
+			_ctx: ExtensionContext,
+		) {
+			currentConfig = savePolishedCopyFriendlyEditorStylePatch(patch);
+			refresh();
+		},
+		setAccentRail(patch: Partial<AccentRailEditorStyleConfig>, _ctx: ExtensionContext) {
+			currentConfig = saveAccentRailEditorStylePatch(patch);
+			refresh();
 		},
 		setMinimalist(patch: Partial<MinimalistConfig>, ctx: ExtensionContext) {
 			currentConfig = saveMinimalistEditorStylePatch(patch);

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -11,8 +11,10 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import {
+	type AccentRailEditorStyleConfig,
 	type ColorSource,
 	type CompactFooterMaxLines,
+	type CompletionMenuStyle,
 	type ContextStyle,
 	type EditorBorderColorMode,
 	type EditorComponentConfig,
@@ -38,6 +40,8 @@ import {
 	type MinimalistConfig,
 	type ModelLabelSource,
 	type PathDisplayConfig,
+	type PolishedCopyFriendlyEditorStyleConfig,
+	type PolishedEditorStyleConfig,
 	type PolishedTuiConfig,
 	type SelectorBordersComponentConfig,
 	type SeparatorStyle,
@@ -81,6 +85,7 @@ const modelLabelValues: ModelLabelSource[] = ["id", "name"];
 const editorStyleLabels: Record<EditorStyle, string> = {
 	opencode: "Opencode",
 	"opencode-copy-friendly": "Opencode (copy-friendly)",
+	"accent-rail": "Accent Rail",
 	minimalist: "Minimalist",
 };
 const editorStyleValues = Object.values(editorStyleLabels);
@@ -97,6 +102,8 @@ const footerStyleLabels: Record<FooterStyle, string> = {
 	hidden: "Hidden",
 };
 const footerStyleValues = Object.values(footerStyleLabels);
+const completionMenuValues: CompletionMenuStyle[] = ["palette", "native"];
+const accentRailSurfaceValues = ["filled", "transparent"];
 const minimalistPathDisplayValues = ["compact", "project", "full"];
 const minimalistContextFormatValues = ["percent", "percent-total"];
 const editorBorderColorModeValues: EditorBorderColorMode[] = ["static", "adaptive"];
@@ -161,6 +168,12 @@ type SettingsCommandDeps = {
 	sessionLifecycle: SessionLifecycle;
 	getConfig: () => PolishedTuiConfig;
 	setEditorComponent: (patch: EditorPatch, ctx: ExtensionContext) => ApplyResult;
+	setPolished: (patch: Partial<PolishedEditorStyleConfig>, ctx: ExtensionContext) => void;
+	setPolishedCopyFriendly: (
+		patch: Partial<PolishedCopyFriendlyEditorStyleConfig>,
+		ctx: ExtensionContext,
+	) => void;
+	setAccentRail: (patch: Partial<AccentRailEditorStyleConfig>, ctx: ExtensionContext) => void;
 	setMinimalist: (patch: Partial<MinimalistConfig>, ctx: ExtensionContext) => void;
 	setUserMessagesComponent: (patch: UserMessagesPatch, ctx: ExtensionContext) => void;
 	setWorkingLineComponent: (patch: WorkingLineComponentPatch, ctx: ExtensionContext) => ApplyResult;
@@ -451,7 +464,7 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 		{
 			id: "editorStyle",
 			label: "Editor style",
-			description: "Use Opencode rails or a compact minimalist frame.",
+			description: "Use Opencode, Accent Rail, or a compact Minimalist frame.",
 			currentValue: editorStyleLabel(editor.style),
 			values: editorStyleValues,
 		},
@@ -482,6 +495,36 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 			description: "Show Pi's native wrapped-row counts in editor borders.",
 			currentValue: featureValue(editor.viewportIndicators),
 			values: featureStateValues,
+		},
+	];
+}
+
+function buildPolishedEditorStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	const editor = config.components.editor;
+	const style =
+		editor.style === "opencode-copy-friendly"
+			? editor.styles["opencode-copy-friendly"]
+			: editor.styles.opencode;
+	return [
+		{
+			id: "opencodeCompletionMenu",
+			label: "Completion menu",
+			description: "Use Pi's native list or the full-width Opencode palette shell.",
+			currentValue: style.completionMenu,
+			values: completionMenuValues,
+		},
+	];
+}
+
+function buildAccentRailEditorStyleItems(config: PolishedTuiConfig): SettingItem[] {
+	const accentRail = config.components.editor.styles["accent-rail"];
+	return [
+		{
+			id: "accentRailSurface",
+			label: "Accent Rail surface",
+			description: "Fill input and autocomplete surfaces or keep them transparent.",
+			currentValue: accentRail.transparent ? "transparent" : "filled",
+			values: accentRailSurfaceValues,
 		},
 	];
 }
@@ -921,6 +964,13 @@ function buildSectionItems(
 		case "editor":
 			return [
 				...buildEditorItems(config),
+				...(config.components.editor.style === "opencode" ||
+				config.components.editor.style === "opencode-copy-friendly"
+					? buildPolishedEditorStyleItems(config)
+					: []),
+				...(config.components.editor.style === "accent-rail"
+					? buildAccentRailEditorStyleItems(config)
+					: []),
 				...(config.components.editor.style === "minimalist"
 					? buildMinimalistEditorStyleItems(config)
 					: []),
@@ -1230,6 +1280,28 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 										setEditor({ viewportIndicators: enabled }, ctx);
 										settingsList.updateValue(id, newValue);
 										notifyChange("Editor viewport indicators", newValue);
+										return;
+									}
+									if (
+										id === "opencodeCompletionMenu" &&
+										(newValue === "native" || newValue === "palette")
+									) {
+										const style = deps.getConfig().components.editor.style;
+										if (style === "opencode") deps.setPolished({ completionMenu: newValue }, ctx);
+										else if (style === "opencode-copy-friendly")
+											deps.setPolishedCopyFriendly({ completionMenu: newValue }, ctx);
+										else return;
+										settingsList.updateValue(id, newValue);
+										notifyChange("Completion menu", newValue);
+										return;
+									}
+									if (
+										id === "accentRailSurface" &&
+										(newValue === "filled" || newValue === "transparent")
+									) {
+										deps.setAccentRail({ transparent: newValue === "transparent" }, ctx);
+										settingsList.updateValue(id, newValue);
+										notifyChange("Accent Rail surface", newValue);
 										return;
 									}
 									if (id.startsWith("minimalist")) {

--- a/extensions/zentui/settings-previews.ts
+++ b/extensions/zentui/settings-previews.ts
@@ -1,5 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { renderAccentRailEditorFrame } from "./accent-rail-editor";
 import type { PolishedTuiConfig } from "./config";
 import { sanitizeEditorMetadataText } from "./editor-metadata-format";
 import { renderMinimalistFrame } from "./minimalist-editor";
@@ -8,7 +9,7 @@ import { renderPolishedEditorFrame } from "./ui";
 import { renderUserMessageStyle } from "./user-message-styles";
 
 export const SETTINGS_PREVIEW_MAX_WIDTH = 72;
-export const SETTINGS_PREVIEW_MAX_ROWS = 8;
+export const SETTINGS_PREVIEW_MAX_ROWS = 10;
 export const EDITOR_PREVIEW_INPUT = "Explain this change safely.";
 export const USER_MESSAGE_PREVIEW_MARKDOWN = "Please review **this change** safely.";
 
@@ -49,50 +50,67 @@ export function renderEditorSettingsPreview(
 	const borderColor = adaptiveBorder(theme);
 	const modelLabel = editor.modelLabel === "name" ? "Sonnet 4" : "sonnet-4";
 	const editorLines = [EDITOR_PREVIEW_INPUT];
+	const autocompleteLines = [
+		safeThemeFg(theme, "accent", "→ settings     Open settings"),
+		"  files        Search files",
+		safeThemeFg(theme, "muted", "  (1/47)"),
+	];
 	const viewport = editor.viewportIndicators ? { above: "2", below: "3" } : undefined;
-	const frame =
-		editor.style === "minimalist"
-			? renderMinimalistFrame({
-					width: previewWidth,
-					editorLines,
-					viewport,
-					inputText: EDITOR_PREVIEW_INPUT,
-					metadata: {
-						cwd: "/workspace/zentui/src",
-						projectRoot: "/workspace/zentui",
-						branch: "feat/settings-previews",
-						dirty: true,
-						ahead: 2,
-						behind: 1,
-						costLabel: "$.12",
-						modelLabel,
-						thinkingLevel: "high",
-						contextPercent: 75,
-						contextWindow: 372_000,
-						sessionName: "Preview",
-						agentDurationMs: 12_000,
-						agentActive: true,
-					},
-					uiTheme: theme,
-					config: safeConfig,
-					borderColor,
-				})
-			: renderPolishedEditorFrame({
-					width: previewWidth,
-					editorLines,
-					viewport,
-					uiTheme: theme,
-					config: safeConfig,
-					modelMeta: {
-						modelLabel,
-						modelId: "sonnet-4",
-						modelName: "Sonnet 4",
-						providerLabel: "Anthropic",
-						sessionName: "Preview",
-					},
-					thinkingLevel: "high",
-					borderColor,
-				});
+	let frame: string[];
+	if (editor.style === "accent-rail") {
+		frame = renderAccentRailEditorFrame({
+			width: previewWidth,
+			editorLines,
+			autocompleteLines,
+			viewport,
+			uiTheme: theme,
+			config: safeConfig,
+		});
+	} else if (editor.style === "minimalist") {
+		frame = renderMinimalistFrame({
+			width: previewWidth,
+			editorLines,
+			viewport,
+			inputText: EDITOR_PREVIEW_INPUT,
+			metadata: {
+				cwd: "/workspace/zentui/src",
+				projectRoot: "/workspace/zentui",
+				branch: "feat/settings-previews",
+				dirty: true,
+				ahead: 2,
+				behind: 1,
+				costLabel: "$.12",
+				modelLabel,
+				thinkingLevel: "high",
+				contextPercent: 75,
+				contextWindow: 372_000,
+				sessionName: "Preview",
+				agentDurationMs: 12_000,
+				agentActive: true,
+			},
+			uiTheme: theme,
+			config: safeConfig,
+			borderColor,
+		});
+	} else {
+		frame = renderPolishedEditorFrame({
+			width: previewWidth,
+			editorLines,
+			autocompleteLines,
+			viewport,
+			uiTheme: theme,
+			config: safeConfig,
+			modelMeta: {
+				modelLabel,
+				modelId: "sonnet-4",
+				modelName: "Sonnet 4",
+				providerLabel: "Anthropic",
+				sessionName: "Preview",
+			},
+			thinkingLevel: "high",
+			borderColor,
+		});
+	}
 	return boundedRows(frame, previewWidth);
 }
 

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -8,6 +8,8 @@ import {
 	truncateToWidth,
 	visibleWidth,
 } from "@earendil-works/pi-tui";
+import { ACCENT_RAIL_CHROME_WIDTH, renderAccentRailEditorFrame } from "./accent-rail-editor";
+import { renderCompletionPalette } from "./completion-menu";
 import type { EditorStyle, ZentuiConfig } from "./config";
 import { renderEditorMetadataFormat } from "./editor-metadata-format";
 import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
@@ -116,6 +118,17 @@ type PolishedFrameResult = {
 	decorated: boolean;
 };
 
+type AccentRailFrameAdapterOptions = {
+	width: number;
+	baseRendered: string[];
+	autocompleteSource: AutocompleteEditorInternals;
+	autocompleteCapture?: AutocompleteCapture;
+	uiTheme: Theme;
+	config: ZentuiConfig;
+	ownedFrame?: PolishedFrameSplit;
+	trustedBaseFrame?: boolean;
+};
+
 type MinimalistFrameAdapterOptions = {
 	width: number;
 	baseRendered: string[];
@@ -155,10 +168,14 @@ function isPolishedFrameSplit(value: unknown, baseLineCount: number): value is P
 	);
 }
 
+function stripNativeRightPadding(value: string): string {
+	return value.replace(/ +$/, "");
+}
+
 function autocompleteCount(
 	source: AutocompleteEditorInternals,
 	capture: AutocompleteCapture | undefined,
-	baseLineCount: number,
+	baseRendered: string[],
 ): AutocompleteCount {
 	try {
 		const showing = source.isShowingAutocomplete;
@@ -167,7 +184,18 @@ function autocompleteCount(
 			!capture?.compatible ||
 			capture.called !== 1 ||
 			capture.rows.length <= 0 ||
-			capture.rows.length >= baseLineCount
+			capture.rows.length >= baseRendered.length
+		)
+			return { known: false };
+		const suffix = baseRendered.slice(-capture.rows.length);
+		if (
+			!suffix.every((line, index) => {
+				const captured = capture.rows[index];
+				return (
+					captured !== undefined &&
+					(line === captured || stripNativeRightPadding(line) === stripNativeRightPadding(captured))
+				);
+			})
 		)
 			return { known: false };
 		return { known: true, count: capture.rows.length };
@@ -257,7 +285,7 @@ export function renderWithAutocompleteCapture<T>(
 				capture.compatible = false;
 			try {
 				if (own) Object.defineProperty(list, "render", own);
-				else Reflect.deleteProperty(list, "render");
+				else if (!Reflect.deleteProperty(list, "render")) capture.compatible = false;
 			} catch {
 				capture.compatible = false;
 			}
@@ -289,6 +317,7 @@ function selectedPolishedConfig(config: ZentuiConfig) {
 			return config.components.editor.styles.opencode;
 		case "opencode-copy-friendly":
 			return config.components.editor.styles["opencode-copy-friendly"];
+		case "accent-rail":
 		case "minimalist":
 			return undefined;
 	}
@@ -477,6 +506,65 @@ function readVimStatus(editor: WrappedEditor, uiTheme: Theme): string | undefine
 	return safeThemeFg(uiTheme, vimModeColor(normalized), label);
 }
 
+function renderAccentRailFrameFromBase({
+	width,
+	baseRendered,
+	autocompleteSource,
+	autocompleteCapture,
+	uiTheme,
+	config,
+	ownedFrame,
+	trustedBaseFrame = false,
+}: AccentRailFrameAdapterOptions): PolishedFrameResult {
+	if (width < ACCENT_RAIL_CHROME_WIDTH + 1 || baseRendered.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	if (ownedFrame && !isPolishedFrameSplit(ownedFrame, baseRendered.length)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const autocomplete = ownedFrame
+		? { known: true as const, count: ownedFrame.trailingLines.length }
+		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered);
+	if (!autocomplete.known) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const editorFrame =
+		!ownedFrame && autocomplete.count > 0
+			? baseRendered.slice(0, -autocomplete.count)
+			: baseRendered;
+	const autocompleteLines = ownedFrame
+		? ownedFrame.trailingLines
+		: autocomplete.count > 0
+			? baseRendered.slice(-autocomplete.count)
+			: [];
+	if (editorFrame.length < 2) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const parsedTop = parseEditorBorder(editorFrame[0] ?? "", "above");
+	const parsedBottom = parseEditorBorder(editorFrame.at(-1) ?? "", "below");
+	if (!ownedFrame && !trustedBaseFrame && (!parsedTop || !parsedBottom)) {
+		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
+	}
+	const editorLines = ownedFrame?.editorLines ?? editorFrame.slice(1, -1);
+	const viewport = ownedFrame?.viewport ?? {
+		above: parsedTop?.count,
+		below: parsedBottom?.count,
+	};
+	const lines = renderAccentRailEditorFrame({
+		width,
+		editorLines,
+		autocompleteLines,
+		viewport,
+		uiTheme,
+		config,
+	});
+	POLISHED_FRAME_SPLITS.set(lines, {
+		rows: Object.freeze([...lines]),
+		split: { editorLines, trailingLines: autocompleteLines, viewport },
+	});
+	return { lines, decorated: true };
+}
+
 function renderMinimalistFrameFromBase({
 	width,
 	baseRendered,
@@ -498,7 +586,7 @@ function renderMinimalistFrameFromBase({
 	}
 	const autocomplete = ownedFrame
 		? { known: true as const, count: ownedFrame.trailingLines.length }
-		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered.length);
+		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered);
 	if (!autocomplete.known) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
@@ -564,7 +652,7 @@ function renderPolishedFrame({
 
 	const autocomplete = ownedFrame
 		? { known: true, count: ownedFrame.trailingLines.length }
-		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered.length);
+		: autocompleteCount(autocompleteSource, autocompleteCapture, baseRendered);
 	if (!autocomplete.known) {
 		return { lines: clampRenderedLines(baseRendered, width), decorated: false };
 	}
@@ -686,6 +774,16 @@ export function renderPolishedEditorFrame({
 			config.components.editor.viewportIndicators ? viewport.below : undefined,
 		),
 	);
+	const completionLines =
+		selectedPolishedConfig(config)?.completionMenu === "palette"
+			? renderCompletionPalette({
+					lines: autocompleteLines,
+					width,
+					theme: uiTheme,
+					renderSeparator: renderBorder,
+					ownedBackground: false,
+				})
+			: autocompleteLines;
 	const lines = ["", ...editorLines, "", railedMeta];
 	const renderedLines = isLowRailPolishedStyle(config.components.editor.style)
 		? [
@@ -698,13 +796,13 @@ export function renderPolishedEditorFrame({
 				"",
 				` ${truncateToWidth(lowRailMeta, Math.max(0, width - 1), "")}`,
 				bottom,
-				...autocompleteLines,
+				...completionLines,
 			]
 		: [
 				top,
 				...lines.map((line) => `${rail}${fillLine(line, innerWidth)}`),
 				bottom,
-				...autocompleteLines,
+				...completionLines,
 			];
 
 	return clampRenderedLines(renderedLines, width);
@@ -749,16 +847,52 @@ export class PolishedEditor extends CustomEditor {
 			this.reportMinimalistDecoration(false);
 			return clampRenderedLines(super.render(width), width);
 		}
+		if (config.components.editor.style === "accent-rail") {
+			this.reportMinimalistDecoration(false);
+			if (width < ACCENT_RAIL_CHROME_WIDTH + 1) {
+				return clampRenderedLines(super.render(width), width);
+			}
+			let captured: { value: string[]; capture?: AutocompleteCapture };
+			try {
+				captured = renderWithAutocompleteCapture(
+					this as unknown as AutocompleteEditorInternals,
+					() => super.render(width - ACCENT_RAIL_CHROME_WIDTH),
+				);
+			} catch {
+				return clampRenderedLines(super.render(width), width);
+			}
+			try {
+				const result = renderAccentRailFrameFromBase({
+					width,
+					baseRendered: captured.value,
+					autocompleteSource: this as unknown as AutocompleteEditorInternals,
+					autocompleteCapture: captured.capture,
+					uiTheme: this.uiTheme,
+					config,
+					trustedBaseFrame: true,
+				});
+				if (result.decorated) return result.lines;
+			} catch {
+				// Decoration is optional; preserve the completed same-render rows below.
+			}
+			return clampRenderedLines(captured.value, width);
+		}
 		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
 				return clampRenderedLines(super.render(width), width);
 			}
+			let captured: { value: string[]; capture?: AutocompleteCapture };
 			try {
-				const captured = renderWithAutocompleteCapture(
+				captured = renderWithAutocompleteCapture(
 					this as unknown as AutocompleteEditorInternals,
 					() => super.render(Math.max(0, width - 4)),
 				);
+			} catch {
+				this.reportMinimalistDecoration(false);
+				return clampRenderedLines(super.render(width), width);
+			}
+			try {
 				const result = renderMinimalistFrameFromBase({
 					width,
 					baseRendered: captured.value,
@@ -775,7 +909,7 @@ export class PolishedEditor extends CustomEditor {
 				return result.lines;
 			} catch {
 				this.reportMinimalistDecoration(false);
-				return clampRenderedLines(super.render(width), width);
+				return clampRenderedLines(captured.value, width);
 			}
 		}
 		this.reportMinimalistDecoration(false);
@@ -785,11 +919,15 @@ export class PolishedEditor extends CustomEditor {
 
 		const { railWidth } = getEditorChromeWidths(config, this.uiTheme, "\x1b[0m");
 		const innerWidth = Math.max(0, width - railWidth);
+		let captured: { value: string[]; capture?: AutocompleteCapture };
 		try {
-			const captured = renderWithAutocompleteCapture(
-				this as unknown as AutocompleteEditorInternals,
-				() => super.render(innerWidth),
+			captured = renderWithAutocompleteCapture(this as unknown as AutocompleteEditorInternals, () =>
+				super.render(innerWidth),
 			);
+		} catch {
+			return clampRenderedLines(super.render(width), width);
+		}
+		try {
 			const result = renderPolishedFrame({
 				width,
 				baseRendered: captured.value,
@@ -802,13 +940,11 @@ export class PolishedEditor extends CustomEditor {
 				trustedBaseFrame: true,
 				borderColor: this.borderColor,
 			});
-			if (result.decorated) {
-				return result.lines;
-			}
+			if (result.decorated) return result.lines;
 		} catch {
-			// Decoration is optional; re-render the base at the caller's width below.
+			// Decoration is optional; preserve the completed same-render rows below.
 		}
-		return clampRenderedLines(super.render(width), width);
+		return clampRenderedLines(captured.value, width);
 	}
 }
 
@@ -932,6 +1068,43 @@ export class WrappedPolishedEditor implements EditorComponent {
 			this.reportMinimalistDecoration(false);
 			return clampRenderedLines(this.base.render(width), width);
 		}
+		if (config.components.editor.style === "accent-rail") {
+			this.reportMinimalistDecoration(false);
+			if (width < ACCENT_RAIL_CHROME_WIDTH + 1) {
+				return clampRenderedLines(this.base.render(width), width);
+			}
+			let captured: { value: string[]; capture?: AutocompleteCapture };
+			try {
+				captured = renderWithAutocompleteCapture(this.base, () =>
+					this.base.render(width - ACCENT_RAIL_CHROME_WIDTH),
+				);
+			} catch {
+				return clampRenderedLines(this.base.render(width), width);
+			}
+			try {
+				const provenance = inspectPolishedFrameProvenance(
+					this.base,
+					captured.value,
+					config,
+					this.uiTheme,
+				);
+				if (provenance.safe) {
+					const result = renderAccentRailFrameFromBase({
+						width,
+						baseRendered: captured.value,
+						autocompleteSource: this.base,
+						autocompleteCapture: captured.capture,
+						uiTheme: this.uiTheme,
+						config,
+						ownedFrame: provenance.ownedFrame,
+					});
+					if (result.decorated) return result.lines;
+				}
+			} catch {
+				// Decoration is optional; preserve the completed same-render rows below.
+			}
+			return clampRenderedLines(captured.value, width);
+		}
 		if (config.components.editor.style === "minimalist") {
 			if (width <= 4) {
 				this.reportMinimalistDecoration(false);
@@ -972,10 +1145,10 @@ export class WrappedPolishedEditor implements EditorComponent {
 					}
 				}
 			} catch {
-				// Decoration is optional; re-render the base at the caller's width below.
+				// Decoration is optional; preserve the completed same-render rows below.
 			}
 			this.reportMinimalistDecoration(false);
-			return clampRenderedLines(this.base.render(width), width);
+			return clampRenderedLines(captured.value, width);
 		}
 		this.reportMinimalistDecoration(false);
 		if (width <= 2) return clampRenderedLines(this.base.render(width), width);
@@ -1012,12 +1185,10 @@ export class WrappedPolishedEditor implements EditorComponent {
 				});
 			}
 		} catch {
-			// Decoration is optional; re-render the base at the caller's width below.
+			// Decoration is optional; preserve the completed same-render rows below.
 		}
-		if (result?.decorated) {
-			return result.lines;
-		}
-		return clampRenderedLines(this.base.render(width), width);
+		if (result?.decorated) return result.lines;
+		return clampRenderedLines(captured.value, width);
 	}
 
 	invalidate(): void {

--- a/test/accent-rail-editor.test.ts
+++ b/test/accent-rail-editor.test.ts
@@ -1,0 +1,230 @@
+import { stripVTControlCharacters } from "node:util";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { renderAccentRailEditorFrame } from "../extensions/zentui/accent-rail-editor";
+import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+
+function theme(calls: Array<{ color: string; text: string }> = []): Theme {
+	return {
+		fg(color: string, text: string) {
+			calls.push({ color, text });
+			return `\x1b[38;5;215m${text}\x1b[39m`;
+		},
+		bg(_color: string, text: string) {
+			return `\x1b[48;5;234m${text}\x1b[49m`;
+		},
+		getBgAnsi() {
+			return "\x1b[48;5;234m";
+		},
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+	} as unknown as Theme;
+}
+
+function config(overrides: Partial<PolishedTuiConfig["colors"]> = {}): PolishedTuiConfig {
+	const current = structuredClone(defaultConfig);
+	current.components.editor.style = "accent-rail";
+	current.colors = { ...current.colors, ...overrides };
+	return current;
+}
+
+function plain(value: string): string {
+	return stripVTControlCharacters(value);
+}
+
+describe("accent rail editor frame", () => {
+	it("renders a full-width filled rail surface for every input row", () => {
+		const rows = renderAccentRailEditorFrame({
+			width: 20,
+			editorLines: ["Ask anything", "continuation"],
+			uiTheme: theme(),
+			config: config(),
+		});
+
+		expect(rows.map(plain)).toEqual(["▎ Ask anything      ", "▎ continuation      "]);
+		for (const row of rows) {
+			expect(visibleWidth(row)).toBe(20);
+			expect(row).toContain("\x1b[48;5;234m");
+		}
+	});
+
+	it("fills autocomplete and replaces only the native selected prefix", () => {
+		const selected = "\x1b[38;5;39m→ settings\x1b[0m";
+		const unusual = "\x1b]8;;https://example.com\x07→ linked\x1b]8;;\x07";
+		const rows = renderAccentRailEditorFrame({
+			width: 20,
+			editorLines: ["draft"],
+			autocompleteLines: [selected, "  files", unusual],
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(rows).toHaveLength(4);
+		expect(rows.slice(1).map(plain)).toEqual([
+			"▎ settings          ",
+			"  files             ",
+			"→ linked            ",
+		]);
+		expect(rows[1]).toContain("\x1b[38;5;215m▎\x1b[39m \x1b[38;5;39msettings");
+		for (const row of rows.slice(1)) {
+			expect(row).toContain("\x1b[48;5;234m");
+			expect(visibleWidth(row)).toBe(20);
+		}
+	});
+
+	it("replaces C1 SGR selection while preserving control-CSI rows unchanged", () => {
+		const c1Selected = "\u009b38;5;39m→ settings\u009b0m";
+		const erased = "\x1b[2K→ unsafe";
+		const c1Erased = "\u009b2K→ c1-unsafe";
+		const rows = renderAccentRailEditorFrame({
+			width: 20,
+			editorLines: ["draft"],
+			autocompleteLines: [c1Selected, erased, c1Erased],
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(rows[1]).toContain("\x1b[38;5;215m▎\x1b[39m \u009b38;5;39msettings\u009b0m");
+		expect(rows[2]).toContain(erased);
+		expect(plain(rows[2] ?? "")).toContain("→ unsafe");
+		expect(rows[3]).toContain(c1Erased);
+		expect(plain(rows[3] ?? "")).toContain("→ c1-unsafe");
+	});
+
+	it("fails open at width two and decorates one content cell at width three", () => {
+		const narrow = renderAccentRailEditorFrame({
+			width: 2,
+			editorLines: ["draft"],
+			autocompleteLines: ["pick"],
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(narrow.map(plain)).toEqual(["dr", "pi"]);
+
+		const minimum = renderAccentRailEditorFrame({
+			width: 3,
+			editorLines: ["draft"],
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(minimum.map(plain)).toEqual(["▎ d"]);
+	});
+
+	it("keeps ANSI, combining text, and emoji within the requested width", () => {
+		const rows = renderAccentRailEditorFrame({
+			width: 12,
+			editorLines: ["\x1b[1mé\u0301dit\x1b[0m 🧠 data"],
+			uiTheme: theme(),
+			config: config(),
+		});
+		expect(plain(rows[0] ?? "")).toContain("▎ é\u0301dit");
+		expect(visibleWidth(rows[0] ?? "")).toBe(12);
+		expect(rows[0]).toContain("\x1b[0m\x1b[48;5;234m");
+	});
+
+	it.each([
+		["an unavailable getBgAnsi", undefined],
+		[
+			"a throwing getBgAnsi",
+			() => {
+				throw new Error("background unavailable");
+			},
+		],
+	] as const)("reapplies the theme.bg fallback after resets with %s", (_name, getBgAnsi) => {
+		for (const reset of ["\x1b[0m", "\x1b[m", "\x1b[49m"]) {
+			const fallbackTheme = { ...theme(), getBgAnsi } as unknown as Theme;
+			const [row] = renderAccentRailEditorFrame({
+				width: 14,
+				editorLines: [`draft${reset}█`],
+				uiTheme: fallbackTheme,
+				config: config(),
+			});
+
+			expect(visibleWidth(row ?? "")).toBe(14);
+			expect(row).toContain(`${reset}\x1b[48;5;234m█`);
+			expect(row).toMatch(/\x1b\[48;5;234m█ +\x1b\[49m$/);
+		}
+	});
+
+	it("uses the style-owned ASCII rail", () => {
+		const current = config();
+		current.icons.mode = "ascii";
+		current.components.editor.styles["accent-rail"].asciiRail = "!";
+		const rows = renderAccentRailEditorFrame({
+			width: 10,
+			editorLines: ["draft"],
+			autocompleteLines: ["→ pick"],
+			uiTheme: theme(),
+			config: current,
+		});
+		expect(rows.map(plain)).toEqual(["! draft   ", "! pick    "]);
+	});
+
+	it("uses source-specific rail defaults and an explicit editor-only override", () => {
+		const themeCalls: Array<{ color: string; text: string }> = [];
+		renderAccentRailEditorFrame({
+			width: 10,
+			editorLines: ["draft"],
+			uiTheme: theme(themeCalls),
+			config: config(),
+		});
+		expect(themeCalls).toContainEqual({ color: "syntaxNumber", text: "▎" });
+
+		const terminal = config();
+		terminal.components.editor.colorSource = "terminal";
+		const [terminalRow] = renderAccentRailEditorFrame({
+			width: 10,
+			editorLines: ["draft"],
+			uiTheme: theme(),
+			config: terminal,
+		});
+		expect(terminalRow).toContain("\x1b[38;5;215m▎\x1b[0m");
+
+		const overrideCalls: Array<{ color: string; text: string }> = [];
+		const independent = config({ editorRail: "success", editorAccent: "error" });
+		independent.components.userMessages.enabled = false;
+		independent.components.userMessages.style = "labeled";
+		independent.components.userMessages.colorSource = "terminal";
+		renderAccentRailEditorFrame({
+			width: 10,
+			editorLines: ["draft"],
+			uiTheme: theme(overrideCalls),
+			config: independent,
+		});
+		expect(overrideCalls).toContainEqual({ color: "success", text: "▎" });
+		expect(overrideCalls).not.toContainEqual({ color: "error", text: "▎" });
+	});
+
+	it("removes only owned backgrounds in transparent mode", () => {
+		const current = config();
+		current.components.editor.styles["accent-rail"].transparent = true;
+		const nativeBackground = "\x1b[48;5;52m  warning\x1b[49m";
+		const rows = renderAccentRailEditorFrame({
+			width: 16,
+			editorLines: ["draft"],
+			autocompleteLines: [nativeBackground],
+			uiTheme: theme(),
+			config: current,
+		});
+		expect(rows.map(plain)).toEqual(["▎ draft         ", "  warning       "]);
+		expect(rows[0]).not.toContain("\x1b[48;5;234m");
+		expect(rows[1]).not.toContain("\x1b[48;5;234m");
+		expect(rows[1]).toContain("\x1b[48;5;52m");
+	});
+
+	it("renders compact viewport indicators only when enabled", () => {
+		const current = config();
+		const render = () =>
+			renderAccentRailEditorFrame({
+				width: 16,
+				editorLines: ["draft"],
+				viewport: { above: "2", below: "3" },
+				uiTheme: theme(),
+				config: current,
+			}).map(plain);
+		expect(render()).toEqual(["▎ ↑ 2 more      ", "▎ draft         ", "▎ ↓ 3 more      "]);
+		current.components.editor.viewportIndicators = false;
+		expect(render()).toEqual(["▎ draft         "]);
+	});
+});

--- a/test/completion-menu.test.ts
+++ b/test/completion-menu.test.ts
@@ -1,0 +1,265 @@
+import { stripVTControlCharacters } from "node:util";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import {
+	applyOwnedSurfaceBackground,
+	isNativeCompletionCountRow,
+	omitTrailingNativeCompletionCountRow,
+	renderCompletionPalette,
+	renderCompletionRows,
+	replaceNativeSelectedPrefix,
+} from "../extensions/zentui/completion-menu";
+
+function theme(): Theme {
+	return {
+		bg: (_color: string, text: string) => `\x1b[48;5;234m${text}\x1b[49m`,
+		getBgAnsi: () => "\x1b[48;5;234m",
+	} as unknown as Theme;
+}
+
+function plain(value: string): string {
+	return stripVTControlCharacters(value);
+}
+
+function terminalWidth(value: string): number {
+	return visibleWidth(value.replace(/\u009b([0-?]*[ -/]*[@-~])/g, "\x1b[$1"));
+}
+
+describe("completion menu surfaces", () => {
+	it("renders a transparent full-width palette shell without a results header or native count row", () => {
+		const rows = renderCompletionPalette({
+			lines: ["\x1b[38;5;39m→ settings\x1b[0m", "  files", "\x1b[90m  (1/47)  \x1b[0m"],
+			width: 40,
+			theme: theme(),
+			renderSeparator: (text) => `\x1b[90m${text}\x1b[0m`,
+			ownedBackground: false,
+		});
+		expect(rows.map(plain)).toEqual([
+			"  settings                              ",
+			"  files                                 ",
+			"────────────────────────────────────────",
+			" ↑↓ Navigate   Enter Use   Esc Close    ",
+		]);
+		expect(rows.join("\n")).not.toContain("Results");
+		expect(rows.join("\n")).not.toContain("\x1b[48;5;234m");
+		expect(rows[0]).toContain("  \x1b[38;5;39msettings");
+		expect(rows.slice(0, 2).every((row) => visibleWidth(row) === 40)).toBe(true);
+	});
+
+	it("preserves native embedded row backgrounds in a transparent palette", () => {
+		const rows = renderCompletionPalette({
+			lines: ["\x1b[48;5;52m→ warning\x1b[49m"],
+			width: 24,
+			theme: theme(),
+			renderSeparator: (text) => text,
+			ownedBackground: false,
+		});
+		expect(rows[0]).toContain("\x1b[48;5;52m");
+		expect(rows.join("\n")).not.toContain("\x1b[48;5;234m");
+	});
+
+	it.each([
+		[
+			"ESC CSI",
+			"\x1b[48;5;52m  warning\x1b[49m next\x1b[0m",
+			"\x1b[48;5;52m",
+			"\x1b[49m\x1b[48;5;234m next",
+			"\x1b[0m\x1b[48;5;234m",
+		],
+		[
+			"C1 CSI",
+			"\u009b48;5;52m  warning\u009b49m next\u009b0m",
+			"\u009b48;5;52m",
+			"\u009b49m\x1b[48;5;234m next",
+			"\u009b0m\x1b[48;5;234m",
+		],
+	] as const)(
+		"restores owned background after %s native resets while retaining embedded backgrounds",
+		(_name, embedded, nativeBackground, restoredDefault, restoredReset) => {
+			const [row] = renderCompletionRows({
+				lines: [embedded],
+				width: 24,
+				theme: theme(),
+				selectedPrefix: "  ",
+				ownedBackground: true,
+			});
+			expect(row).toContain(nativeBackground);
+			expect(row).toContain(restoredDefault);
+			expect(row).toContain(restoredReset);
+			expect(row).toMatch(/(?:\x1b\[0m|\u009b0m)\x1b\[48;5;234m +\x1b\[49m$/);
+			expect(terminalWidth(row ?? "")).toBe(24);
+		},
+	);
+
+	it.each([
+		["ESC SGR", "\x1b[1;38;5;39m→ help\x1b[0m", "  \x1b[1;38;5;39mhelp\x1b[0m"],
+		["C1 SGR", "\u009b1;38;5;39m→ help\u009b0m", "  \u009b1;38;5;39mhelp\u009b0m"],
+	] as const)(
+		"changes a native selected prefix preceded by %s only",
+		(_name, selected, expected) => {
+			expect(replaceNativeSelectedPrefix(selected, "  ")).toBe(expected);
+		},
+	);
+
+	it.each([
+		["cursor movement", "\x1b[1G→ help"],
+		["erase", "\x1b[2K→ help"],
+		["C1 erase", "\u009b2K→ help"],
+		["mode", "\x1b[?25l→ help"],
+		["private m-final CSI", "\x1b[>4;2m→ help"],
+		["private C1 m-final CSI", "\u009b>4;2m→ help"],
+		["SGR followed by private m-final CSI", "\x1b[1m\x1b[>4;2m→ help"],
+		["SGR followed by cursor movement", "\x1b[1m\x1b[1G→ help"],
+		["OSC", "\x1b]8;;https://example.com\x07→ help\x1b]8;;\x07"],
+	] as const)("leaves a selected-looking row with leading %s unchanged", (_name, line) => {
+		expect(replaceNativeSelectedPrefix(line, "  ")).toBe(line);
+	});
+
+	it.each([
+		["ESC reset plus foreground", "\x1b[0;39m", true],
+		["ESC foreground plus background reset", "\x1b[31;49m", true],
+		["ESC reset then explicit background", "\x1b[0;41m", false],
+		["ESC background then reset", "\x1b[41;49m", true],
+		["ESC extended black background", "\x1b[0;48;2;0;0;0m", false],
+		["ESC colon extended black background", "\x1b[0;48:2::0:0:0m", false],
+		["ESC extended background then reset", "\x1b[48;5;0;49m", true],
+		["C1 reset plus foreground", "\u009b0;39m", true],
+		["C1 reset then explicit background", "\u009b0;101m", false],
+		["C1 background then reset", "\u009b101;49m", true],
+	] as const)("respects ordered background semantics for %s", (_name, sequence, restores) => {
+		const background = "\x1b[48;5;234m";
+		const primary = applyOwnedSurfaceBackground(theme(), `before${sequence}tail   `);
+		expect(primary).toContain(sequence);
+		expect(primary.includes(`${sequence}${background}tail`)).toBe(restores);
+		expect(terminalWidth(primary)).toBe(13);
+
+		const fallbackTheme = {
+			...theme(),
+			getBgAnsi() {
+				throw new Error("unavailable");
+			},
+		} as unknown as Theme;
+		const fallback = applyOwnedSurfaceBackground(fallbackTheme, `before${sequence}tail   `);
+		expect(fallback).toContain(sequence);
+		expect(fallback.includes(`${sequence}${background}tail`)).toBe(restores);
+		expect(terminalWidth(fallback)).toBe(13);
+	});
+
+	it.each(["\u009b0m", "\u009bm", "\u009b49m"])(
+		"reapplies the theme.bg fallback after C1 reset %j through trailing padding",
+		(reset) => {
+			const fallbackTheme = {
+				...theme(),
+				getBgAnsi() {
+					throw new Error("unavailable");
+				},
+			} as unknown as Theme;
+			const row = applyOwnedSurfaceBackground(fallbackTheme, `item${reset}█   `);
+			expect(row).toContain(`${reset}\x1b[48;5;234m█   \x1b[49m`);
+		},
+	);
+
+	it.each(["\u009b0m", "\u009bm", "\u009b49m"])(
+		"reapplies getBgAnsi background after direct C1 reset %j",
+		(reset) => {
+			const row = applyOwnedSurfaceBackground(theme(), `item${reset}tail`);
+			expect(row).toContain(`${reset}\x1b[48;5;234mtail`);
+		},
+	);
+
+	it("leaves combined C1 resets and embedded backgrounds authoritative in transparent rows", () => {
+		const embedded = "\u009b48;5;52m→ warning\u009b31;49m next\u009b0;39m";
+		const [row] = renderCompletionRows({
+			lines: [embedded],
+			width: 20,
+			theme: theme(),
+			selectedPrefix: "  ",
+			ownedBackground: false,
+		});
+		expect(row).toContain("\u009b48;5;52m");
+		expect(row).toContain("\u009b31;49m next\u009b0;39m");
+		expect(row).not.toContain("\x1b[48;5;234m");
+		expect(terminalWidth(row ?? "")).toBe(20);
+	});
+
+	it("preserves SGR-only selection replacement and fails open for control CSI in a palette", () => {
+		const c1Selected = "\u009b1;38;5;39m→ settings\u009b0m";
+		const cursorControlled = "\x1b[2K→ unsafe";
+		const c1CursorControlled = "\u009b2K→ c1-unsafe";
+		const rows = renderCompletionPalette({
+			lines: [c1Selected, cursorControlled, c1CursorControlled],
+			width: 24,
+			theme: theme(),
+			renderSeparator: (text) => text,
+			ownedBackground: false,
+		});
+		expect(rows[0]).toContain("  \u009b1;38;5;39msettings\u009b0m");
+		expect(rows[1]).toContain(cursorControlled);
+		expect(rows[1]).not.toContain(`  ${cursorControlled}`);
+		expect(rows[2]).toContain(c1CursorControlled);
+		expect(rows[2]).not.toContain(`  ${c1CursorControlled}`);
+	});
+
+	it("omits only a trailing standalone native count row", () => {
+		expect(isNativeCompletionCountRow(" \x1b[90m(6/47)\x1b[0m ")).toBe(true);
+		expect(isNativeCompletionCountRow("(6/47) details")).toBe(false);
+		expect(isNativeCompletionCountRow("\x1b]8;;https://example.com\x07(6/47)\x1b]8;;\x07")).toBe(
+			false,
+		);
+		expect(
+			omitTrailingNativeCompletionCountRow(["  (1/47)", "  item", "\u009b90m (2/47) \u009b0m"]),
+		).toEqual(["  (1/47)", "  item"]);
+		expect(omitTrailingNativeCompletionCountRow(["  item", "  (1/47) details"])).toEqual([
+			"  item",
+			"  (1/47) details",
+		]);
+	});
+
+	it("keeps Unicode and combining rows width-safe", () => {
+		const rows = renderCompletionRows({
+			lines: ["→ é\u0301dit 😀 界"],
+			width: 9,
+			theme: theme(),
+			selectedPrefix: "  ",
+			ownedBackground: true,
+		});
+		expect(plain(rows[0] ?? "")).toContain("  é\u0301dit");
+		expect(visibleWidth(rows[0] ?? "")).toBe(9);
+	});
+
+	it("compacts help and fails safely at narrow widths", () => {
+		const compact = renderCompletionPalette({
+			lines: ["→ item"],
+			width: 18,
+			theme: theme(),
+			renderSeparator: (text) => text,
+			ownedBackground: false,
+		});
+		expect(compact.map(plain)).toEqual([
+			"  item            ",
+			"──────────────────",
+			" ↑↓   Enter   Esc ",
+		]);
+		const tiny = renderCompletionPalette({
+			lines: ["→ item"],
+			width: 2,
+			theme: theme(),
+			renderSeparator: (text) => text,
+			ownedBackground: false,
+		});
+		expect(tiny.map(plain)).toEqual(["  ", "──"]);
+	});
+
+	it("falls back without corruption when theme background APIs fail", () => {
+		const unavailable = {
+			getBgAnsi() {
+				throw new Error("unavailable");
+			},
+			bg() {
+				throw new Error("unavailable");
+			},
+		} as unknown as Theme;
+		expect(applyOwnedSurfaceBackground(unavailable, "safe\x1b[0m text")).toBe("safe\x1b[0m text");
+	});
+});

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -26,6 +26,7 @@ import {
 	getExtensionStatusPlacement,
 	hasUnsupportedComponentStyle,
 	mergeConfig,
+	saveAccentRailEditorStylePatch,
 	saveColorSourcesPatch,
 	saveContextStylePatch,
 	saveContextThresholdsPatch,
@@ -102,9 +103,16 @@ describe("canonical config resolution", () => {
 				styles: {
 					opencode: {
 						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+						completionMenu: "palette",
 					},
 					"opencode-copy-friendly": {
 						metadataFormat: DEFAULT_EDITOR_METADATA_FORMAT,
+						completionMenu: "palette",
+					},
+					"accent-rail": {
+						rail: "▎",
+						asciiRail: "|",
+						transparent: false,
 					},
 					minimalist: {
 						pathDisplay: "compact",
@@ -171,6 +179,56 @@ describe("canonical config resolution", () => {
 		expect(config.icons.cacheHit).toBe("󰆼");
 		expect(config.colors).toEqual(defaultConfig.colors);
 		expect(defaultConfig.components).toEqual(config.components);
+	});
+
+	it("normalizes Opencode completion menus independently", () => {
+		const config = mergeConfig({
+			components: {
+				editor: {
+					styles: {
+						opencode: { completionMenu: "native" },
+						"opencode-copy-friendly": { completionMenu: "invalid" },
+					},
+				},
+			},
+		});
+		expect(config.components.editor.styles.opencode.completionMenu).toBe("native");
+		expect(config.components.editor.styles["opencode-copy-friendly"].completionMenu).toBe(
+			"palette",
+		);
+	});
+
+	it("normalizes the canonical accent-rail style and its editor-owned roles", () => {
+		const config = mergeConfig({
+			colors: { editorRail: "bright-green", editorAccent: "error" },
+			components: {
+				editor: {
+					style: "accent-rail",
+					styles: { "accent-rail": { rail: "!", asciiRail: ":", transparent: true } },
+				},
+			},
+		});
+		expect(config.components.editor.style).toBe("accent-rail");
+		expect(config.components.editor.styles["accent-rail"]).toEqual({
+			rail: "!",
+			asciiRail: ":",
+			transparent: true,
+		});
+		expect(config.colors.editorRail).toBe("bright-green");
+		expect(config.colors.editorAccent).toBe("error");
+
+		const invalid = mergeConfig({
+			components: {
+				editor: {
+					styles: { "accent-rail": { rail: "", asciiRail: 1, transparent: "yes" } },
+				},
+			},
+		});
+		expect(invalid.components.editor.styles["accent-rail"]).toEqual({
+			rail: "▎",
+			asciiRail: "|",
+			transparent: false,
+		});
 	});
 
 	it("bridges explicit legacy branch colors into the independent Editor branch role", () => {
@@ -1164,8 +1222,12 @@ describe("canonical snapshot persistence", () => {
 
 	it("supports every typed component saver without discarding inactive styles", () => {
 		withConfig(undefined, (path) => {
-			savePolishedEditorStylePatch({ metadataFormat: "$provider" }, path);
-			savePolishedCopyFriendlyEditorStylePatch({ metadataFormat: "$model" }, path);
+			savePolishedEditorStylePatch({ metadataFormat: "$provider", completionMenu: "native" }, path);
+			savePolishedCopyFriendlyEditorStylePatch(
+				{ metadataFormat: "$model", completionMenu: "palette" },
+				path,
+			);
+			saveAccentRailEditorStylePatch({ transparent: true }, path);
 			saveMinimalistEditorStylePatch({ showGit: false, contextGauge: true }, path);
 			saveUserMessagesComponentPatch({ enabled: false, colorSource: "terminal" }, path);
 			saveSelectorBordersComponentPatch({ enabled: false, colorSource: "terminal" }, path);
@@ -1177,9 +1239,14 @@ describe("canonical snapshot persistence", () => {
 			const config = mergeConfig(readRaw(path));
 			expect(config.components.editor.styles.opencode).toEqual({
 				metadataFormat: "$provider",
+				completionMenu: "native",
 			});
 			expect(config.components.editor.styles["opencode-copy-friendly"]).toEqual({
 				metadataFormat: "$model",
+				completionMenu: "palette",
+			});
+			expect(config.components.editor.styles["accent-rail"]).toMatchObject({
+				transparent: true,
 			});
 			expect(config.components.editor.styles.minimalist).toMatchObject({
 				showGit: false,
@@ -1347,6 +1414,7 @@ describe("mergeConfig", () => {
 		expect(config.colors.tokens).toBe("bright-black");
 		expect(config.colors.extensionStatus).toBe("bright-black");
 		expect(config.colors.editorAccent).toBeUndefined();
+		expect(config.colors.editorRail).toBeUndefined();
 		expect(config.colors.editorPrompt).toBeUndefined();
 		expect(config.colors.editorBorder).toBeUndefined();
 		expect(config.colorSources).toEqual({
@@ -1615,6 +1683,16 @@ describe("mergeConfig", () => {
 			expect(raw.editorStyle).toBeUndefined();
 			expect(raw.components.editor.style).toBe("minimalist");
 			expect(minimalist.editorStyle).toBe("minimalist");
+
+			const accentRail = saveEditorStyle("accent-rail", path);
+			raw = JSON.parse(readFileSync(path, "utf8"));
+			expect(accentRail.editorStyle).toBe("accent-rail");
+			expect(raw.components.editor.style).toBe("accent-rail");
+			expect(raw.components.editor.styles["accent-rail"]).toEqual({
+				rail: "▎",
+				asciiRail: "|",
+				transparent: false,
+			});
 
 			const polished = saveEditorStyle("opencode", path);
 			raw = JSON.parse(readFileSync(path, "utf8"));

--- a/test/editor-viewport-indicators.test.ts
+++ b/test/editor-viewport-indicators.test.ts
@@ -25,7 +25,10 @@ function theme(): Theme {
 	} as Theme;
 }
 
-type EditorOptions = Partial<PolishedTuiConfig["features"]> & { style?: EditorStyle };
+type EditorOptions = Partial<PolishedTuiConfig["features"]> & {
+	style?: EditorStyle;
+	completionMenu?: "native" | "palette";
+};
 
 function config(
 	options: EditorOptions = {},
@@ -41,6 +44,17 @@ function config(
 				borderColorMode: editorBorderColorMode,
 				viewportIndicators:
 					options.viewportIndicators ?? defaultConfig.components.editor.viewportIndicators,
+				styles: {
+					...defaultConfig.components.editor.styles,
+					opencode: {
+						...defaultConfig.components.editor.styles.opencode,
+						...(options.completionMenu ? { completionMenu: options.completionMenu } : {}),
+					},
+					"opencode-copy-friendly": {
+						...defaultConfig.components.editor.styles["opencode-copy-friendly"],
+						...(options.completionMenu ? { completionMenu: options.completionMenu } : {}),
+					},
+				},
 			},
 		},
 		features: {
@@ -317,17 +331,150 @@ describe("editor viewport indicators", () => {
 	});
 
 	it.each(["opencode", "opencode-copy-friendly"] as const)(
-		"keeps ANSI and Unicode autocomplete rows raw after the terminal bottom border in %s",
+		"renders one completion palette through nested %s wrappers",
 		(style) => {
-			const suggestions = ["\x1b[31msuggestion-one\x1b[0m", "emoji 😀 e\u0301 界"];
-			const lines = wrapped(baseEditor({ below: 5, autocomplete: suggestions }), { style }).render(
-				80,
-			);
+			const base = baseEditor({ autocomplete: ["→ suggestion-one", "  suggestion-two"] });
+			const renderAutocomplete = base.autocompleteList.render;
+			let calls = 0;
+			base.autocompleteList.render = (width) => {
+				calls += 1;
+				return renderAutocomplete(width);
+			};
+			const inner = wrapped(base, { style });
+			const lines = wrapped(inner, { style }).render(50);
+			const rendered = lines.join("\n");
+			expect(calls).toBe(1);
+			expect(rendered.match(/suggestion-one/g)).toHaveLength(1);
+			expect(rendered.match(/suggestion-two/g)).toHaveLength(1);
+			expect(rendered.match(/↑↓ Navigate/g)).toHaveLength(1);
+			expect(rendered).not.toContain("→ suggestion-one");
+		},
+	);
+
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"keeps ANSI, Unicode, and native count autocomplete rows raw after the terminal bottom border in %s",
+		(style) => {
+			const suggestions = [
+				"\x1b[31msuggestion-one\x1b[0m",
+				"emoji 😀 e\u0301 界",
+				"\x1b[90m (1/47) \x1b[0m",
+			];
+			const lines = wrapped(baseEditor({ below: 5, autocomplete: suggestions }), {
+				style,
+				completionMenu: "native",
+			}).render(80);
 			const bottom = lines.findIndex((line) => line.includes("↓ 5 more"));
 			expect(lines.some((line) => line.includes("├") || line.includes("┤"))).toBe(false);
 			expect(bottom).toBe(lines.length - suggestions.length - 1);
 			expect(lines.slice(bottom + 1)).toEqual(suggestions);
 			expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
+		},
+	);
+
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"renders the default completion palette once without the native count row in %s",
+		(style) => {
+			const suggestions = ["\x1b[1m→ settings\x1b[0m", "  files", "\x1b[90m (1/47) \x1b[0m"];
+			const lines = wrapped(baseEditor({ autocomplete: suggestions }), { style }).render(40);
+			const plain = lines.map((line) => line.replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, ""));
+			expect(plain).toContain("  settings".padEnd(40));
+			expect(plain).toContain("  files".padEnd(40));
+			expect(plain.some((line) => line.includes("→"))).toBe(false);
+			expect(plain.some((line) => line.includes("(1/47)"))).toBe(false);
+			expect(plain.at(-1)).toContain("↑↓ Navigate");
+			expect(plain.filter((line) => /^─+$/.test(line.trim()))).toHaveLength(3);
+			expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+		},
+	);
+
+	it.each(["opencode", "accent-rail"] as const)(
+		"fails open from the same render when a third-party %s editor rewrites captured autocomplete rows",
+		(style) => {
+			for (const mutation of ["replace", "reorder"] as const) {
+				const suggestions = ["→ original-one", "  original-two"];
+				const base = baseEditor({ autocomplete: suggestions });
+				const nativeRender = base.render.bind(base);
+				const widths: number[] = [];
+				let lastOutput: string[] = [];
+				base.render = (width: number) => {
+					widths.push(width);
+					const rendered = nativeRender(width);
+					const editorRows = rendered.slice(0, -suggestions.length);
+					const autocompleteRows = rendered.slice(-suggestions.length);
+					const mutatedRows =
+						mutation === "replace"
+							? ["replacement-one", "replacement-two"]
+							: [...autocompleteRows].reverse();
+					lastOutput = [...editorRows, ...mutatedRows];
+					return lastOutput;
+				};
+
+				const lines = wrapped(base, { style }).render(40);
+				expect(lines).toEqual(lastOutput);
+				expect(widths).toHaveLength(1);
+				expect(widths[0]).toBeLessThan(40);
+				expect(lines.join("\n")).not.toContain("↑↓ Navigate");
+				expect(lines.some((line) => line.startsWith("▎"))).toBe(false);
+			}
+		},
+	);
+
+	it.each([
+		["ASCII spaces", "   ", true],
+		["a tab", "\t", false],
+		["a newline", "\n", false],
+		["a non-breaking space", "\u00a0", false],
+		["a Unicode em space", "\u2003", false],
+	] as const)("treats trailing %s as %s autocomplete padding", (_label, trailing, accepted) => {
+		const suggestions = ["→ original-one", "  original-two"];
+		const base = baseEditor({ autocomplete: suggestions });
+		const nativeRender = base.render.bind(base);
+		const widths: number[] = [];
+		let sameRenderRows: string[] = [];
+		base.render = (width: number) => {
+			widths.push(width);
+			const rendered = nativeRender(width);
+			const editorRows = rendered.slice(0, -suggestions.length);
+			sameRenderRows = [
+				...editorRows,
+				...rendered.slice(-suggestions.length).map((line) => `${line}${trailing}`),
+			];
+			return sameRenderRows;
+		};
+
+		const lines = wrapped(base, { style: "opencode" }).render(40);
+		expect(widths).toHaveLength(1);
+		if (accepted) {
+			expect(lines.join("\n")).toContain("↑↓ Navigate");
+		} else {
+			expect(lines).toEqual(sameRenderRows);
+			expect(lines.join("\n")).not.toContain("↑↓ Navigate");
+		}
+	});
+
+	it.each(["opencode", "accent-rail"] as const)(
+		"preserves same-render %s rows when autocomplete ownership changes during rendering",
+		(style) => {
+			const suggestions = ["→ original-one", "  original-two"];
+			const base = baseEditor({ autocomplete: suggestions });
+			const nativeRender = base.render.bind(base);
+			const replacement = vi.fn(() => ["replacement"]);
+			const widths: number[] = [];
+			let sameRenderRows: string[] = [];
+			base.render = (width: number) => {
+				widths.push(width);
+				sameRenderRows = nativeRender(width);
+				base.autocompleteList.render = replacement;
+				return sameRenderRows;
+			};
+
+			const lines = wrapped(base, { style }).render(40);
+			expect(lines).toEqual(sameRenderRows);
+			expect(widths).toHaveLength(1);
+			expect(replacement).not.toHaveBeenCalled();
+			expect(base.autocompleteList.render).toBe(replacement);
+			expect(lines.join("\n")).not.toContain("↑↓ Navigate");
+			expect(lines.some((line) => line.startsWith("▎"))).toBe(false);
 		},
 	);
 
@@ -349,9 +496,10 @@ describe("editor viewport indicators", () => {
 		"keeps raw trailing autocomplete width-safe at widths 5 and 4 in %s",
 		(style) => {
 			for (const width of [5, 4]) {
-				const lines = wrapped(baseEditor({ autocomplete: ["界😀e\u0301"] }), { style }).render(
-					width,
-				);
+				const lines = wrapped(baseEditor({ autocomplete: ["界😀e\u0301"] }), {
+					style,
+					completionMenu: "native",
+				}).render(width);
 				expect(lines.some((line) => line.includes("├") || line.includes("┤"))).toBe(false);
 				expect(lines.at(-2)).toMatch(/^─+$/);
 				expect(visibleWidth(lines.at(-1) ?? "")).toBeLessThanOrEqual(width);
@@ -398,6 +546,37 @@ describe("editor viewport indicators", () => {
 		expect(lines.some((line) => line.includes("caller-width-suggestion"))).toBe(true);
 		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
+
+	it.each(["opencode", "accent-rail"] as const)(
+		"keeps standalone %s autocomplete to one render when ownership changes",
+		(style) => {
+			const editor = standalone(style);
+			const replacement = vi.fn(() => ["replacement"]);
+			let calls = 0;
+			const autocompleteList = {
+				filteredItems: [{ value: "original" }],
+				selectedIndex: 0,
+				maxVisible: 1,
+				render() {
+					calls += 1;
+					autocompleteList.render = replacement;
+					return ["→ original"];
+				},
+			};
+			Object.assign(editor as unknown as Record<string, unknown>, {
+				autocompleteState: {},
+				autocompleteList,
+			});
+
+			const lines = editor.render(80);
+			expect(calls).toBe(1);
+			expect(replacement).not.toHaveBeenCalled();
+			expect(autocompleteList.render).toBe(replacement);
+			expect(lines.some((line) => line.includes("→ original"))).toBe(true);
+			expect(lines.join("\n")).not.toContain("↑↓ Navigate");
+			expect(lines.some((line) => line.startsWith("▎"))).toBe(false);
+		},
+	);
 
 	it.each([
 		"── ↑ 7 more ─────────",
@@ -512,11 +691,11 @@ describe("editor viewport indicators", () => {
 			[Symbol.for("pi-zentui.polished-frame")]: spoofedSplit,
 		};
 		expect(wrapped(base as never).render(80)).toEqual([
-			nativeBorder(80, "above"),
+			nativeBorder(78, "above"),
 			"typed text",
-			nativeBorder(80, "below"),
+			nativeBorder(78, "below"),
 		]);
-		expect(widths).toEqual([78, 80]);
+		expect(widths).toEqual([78]);
 		expect(spoofedSplit).not.toHaveBeenCalled();
 	});
 
@@ -575,7 +754,7 @@ describe("editor viewport indicators", () => {
 		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
 
-	it("re-renders unknown third-party output at the caller width before failing open", () => {
+	it("returns unknown third-party output from the completed same-width probe", () => {
 		const widths: number[] = [];
 		const base = {
 			render(width: number) {
@@ -589,9 +768,9 @@ describe("editor viewport indicators", () => {
 		};
 
 		const lines = wrapped(base as never).render(80);
-		expect(widths).toEqual([78, 80]);
-		expect(lines[0]).toBe("header-80");
-		expect(lines.at(-1)).toBe("help-80");
+		expect(widths).toEqual([78]);
+		expect(lines[0]).toBe("header-78");
+		expect(lines.at(-1)).toBe("help-78");
 		expect(lines.every((line) => visibleWidth(line) <= 80)).toBe(true);
 	});
 
@@ -719,6 +898,57 @@ describe("same-render autocomplete capture", () => {
 		expect(predecessor).toHaveBeenCalledTimes(1);
 	});
 
+	it.each(["opencode", "accent-rail"] as const)(
+		"fails open from one %s render when inherited-renderer cleanup is rejected",
+		(style) => {
+			const predecessor = vi.fn((_width: number) => ["→ original"]);
+			const target = Object.assign(
+				Object.create({ render: predecessor }) as {
+					render: (width: number) => string[];
+					filteredItems: Array<{ value: string }>;
+					selectedIndex: number;
+					maxVisible: number;
+				},
+				{
+					filteredItems: [{ value: "original" }],
+					selectedIndex: 0,
+					maxVisible: 1,
+				},
+			);
+			const autocompleteList = new Proxy(target, {
+				deleteProperty: () => false,
+			});
+			let renderCalls = 0;
+			let sameRenderRows: string[] = [];
+			const base = {
+				render(width: number) {
+					renderCalls++;
+					sameRenderRows = [
+						nativeBorder(width, "above"),
+						"typed text",
+						nativeBorder(width, "below"),
+						...autocompleteList.render(width),
+					];
+					return sameRenderRows;
+				},
+				invalidate() {},
+				handleInput() {},
+				getText: () => "typed text",
+				setText() {},
+				isShowingAutocomplete: () => true,
+				autocompleteList,
+			};
+
+			const lines = wrapped(base as never, { style }).render(40);
+			expect(lines).toEqual(sameRenderRows);
+			expect(renderCalls).toBe(1);
+			expect(predecessor).toHaveBeenCalledTimes(1);
+			expect(Object.hasOwn(target, "render")).toBe(true);
+			expect(lines.join("\n")).not.toContain("↑↓ Navigate");
+			expect(lines.some((line) => line.startsWith("▎"))).toBe(false);
+		},
+	);
+
 	it("restores after throwing and supports nested capture without extra renders", () => {
 		const predecessor = vi.fn(() => ["one"]);
 		const autocomplete = source(predecessor);
@@ -741,6 +971,33 @@ describe("same-render autocomplete capture", () => {
 		expect(outer.capture).toMatchObject({ compatible: true, called: 1 });
 		expect(outer.value.capture).toMatchObject({ compatible: true, called: 1 });
 		expect(autocomplete.autocompleteList.render).toBe(original);
+	});
+});
+
+describe("accent rail editor integration", () => {
+	it("decorates trusted wrapped input and autocomplete rows", () => {
+		const editor = wrapped(baseEditor({ autocomplete: ["one", "two"] }), {
+			style: "accent-rail",
+		});
+		const lines = editor.render(24);
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toMatch(/^▎ typed text/);
+		expect(lines.every((line) => visibleWidth(line) === 24)).toBe(true);
+		expect(lines.slice(1).map((line) => line.trimEnd())).toEqual(["one", "two"]);
+	});
+
+	it("fails open from the reduced same-render rows for untrusted third-party output", () => {
+		const base = baseEditor({ malformedTop: "third-party header" });
+		const editor = wrapped(base, { style: "accent-rail" });
+		const lines = editor.render(24);
+		expect(lines).toEqual(base.render(22));
+		expect(lines.join("\n")).not.toContain("▎");
+	});
+
+	it("renders the standalone editor with the same accent rail", () => {
+		const lines = standalone("accent-rail").render(24);
+		expect(lines.some((line) => line.startsWith("▎ "))).toBe(true);
+		expect(lines.every((line) => visibleWidth(line) <= 24)).toBe(true);
 	});
 });
 
@@ -795,19 +1052,29 @@ describe("minimalist editor integration", () => {
 		const polished = editor.render(40);
 		current = withEditorStyle(current, "opencode-copy-friendly");
 		const lowRail = editor.render(40);
+		current = withEditorStyle(current, "accent-rail");
+		const accentRail = editor.render(40);
 		current = withEditorStyle(current, "minimalist");
 		const minimalist = editor.render(40);
 		current = withEditorStyle(current, "opencode");
 		const polishedAgain = editor.render(40);
 
-		expect(rawWidths).toEqual([36, 38, 34, 36]);
+		expect(rawWidths).toEqual([36, 38, 36, 34, 36]);
 		expect(polished.join("\n").match(/provider/g)).toHaveLength(1);
 		expect(lowRail.join("\n").match(/provider/g)).toHaveLength(1);
+		expect(accentRail[0]).toMatch(/^▎ typed text/);
+		expect(accentRail.join("\n")).not.toContain("provider");
 		expect(minimalist[0]).toMatch(/^╭.*╮$/);
 		expect(minimalist.at(-1)).toMatch(/^╰.*╯$/);
 		expect(polishedAgain.join("\n").match(/provider/g)).toHaveLength(1);
 		expect(polishedAgain.join("\n")).not.toContain("╭");
-		expect(decoration.mock.calls.map(([active]) => active)).toEqual([false, false, true, false]);
+		expect(decoration.mock.calls.map(([active]) => active)).toEqual([
+			false,
+			false,
+			false,
+			true,
+			false,
+		]);
 	});
 
 	it("places native viewport counts at the far left before minimalist metadata", () => {
@@ -864,7 +1131,7 @@ describe("minimalist editor integration", () => {
 		expect(lines.at(-1)).toMatch(/^╰.*╯$/);
 	});
 
-	it("fails open at caller width for unknown third-party output", () => {
+	it("fails open from the reduced same-render rows for unknown third-party output", () => {
 		const widths: number[] = [];
 		const decoration = vi.fn();
 		const base = {
@@ -886,8 +1153,8 @@ describe("minimalist editor integration", () => {
 			() => ({ cwd: "/tmp" }),
 			decoration,
 		);
-		expect(editor.render(40)).toEqual(["header-40", "body", "help-40"]);
-		expect(widths).toEqual([36, 40]);
+		expect(editor.render(40)).toEqual(["header-36", "body", "help-36"]);
+		expect(widths).toEqual([36]);
 		expect(decoration).toHaveBeenLastCalledWith(false);
 	});
 

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -95,6 +95,9 @@ const settingsCommandDefaults: SettingsCommandDeps = {
 	sessionLifecycle: inactiveSessionLifecycle,
 	getConfig: () => defaultConfig,
 	setEditorComponent: () => ({ applied: true }),
+	setPolished() {},
+	setPolishedCopyFriendly() {},
+	setAccentRail() {},
 	setMinimalist() {},
 	setUserMessagesComponent() {},
 	setWorkingLineComponent: () => ({ applied: true }),
@@ -1345,6 +1348,7 @@ describe("Pi docs compliance", () => {
 					settings.handleInput("\x1b[B");
 					settings.handleInput(" ");
 					settings.handleInput(" ");
+					settings.handleInput(" ");
 				},
 			},
 		});
@@ -1463,7 +1467,7 @@ describe("Pi docs compliance", () => {
 				keybindings as never,
 			);
 			const activeRender = activeEditor.render(80);
-			expect(activeRender).toContain("third-party:80");
+			expect(activeRender).toContain("third-party:78");
 			expect(zentuiLayers(activeRender)).toBe(1);
 			expect(zentuiLayers(opaqueEditor.render(80))).toBe(1);
 			activeEditor.handleInput("x");
@@ -2029,6 +2033,10 @@ describe("Pi docs compliance", () => {
 		["opencode-copy-friendly", "framed-copy-friendly"],
 		["opencode-copy-friendly", "compact"],
 		["opencode-copy-friendly", "labeled"],
+		["accent-rail", "framed"],
+		["accent-rail", "framed-copy-friendly"],
+		["accent-rail", "compact"],
+		["accent-rail", "labeled"],
 		["minimalist", "framed"],
 		["minimalist", "framed-copy-friendly"],
 		["minimalist", "compact"],
@@ -2058,6 +2066,7 @@ describe("Pi docs compliance", () => {
 
 		if (editorStyle === "opencode") expect(editorRendered).toContain("│");
 		else if (editorStyle === "opencode-copy-friendly") expect(editorRendered).not.toContain("│");
+		else if (editorStyle === "accent-rail") expect(editorRendered).toContain("▎ draft");
 		else expect(editorRendered).toContain("╭");
 		const plainMessage = stripPromptMarks(messageRendered);
 		if (messageStyle === "framed") expect(plainMessage).toContain("────");
@@ -3291,7 +3300,7 @@ describe("Pi docs compliance", () => {
 			getExtensionStatuses: () => new Map<string, string>(),
 		});
 
-		expect(editor.render(80)).toEqual(["third-party-80", "draft", "help"]);
+		expect(editor.render(80)).toEqual(["third-party-76", "draft", "help"]);
 		expect(footer?.render(80).length).toBeGreaterThan(0);
 
 		footer?.dispose?.();
@@ -4949,8 +4958,11 @@ describe("Pi docs compliance", () => {
 		assertSingleFrame(third);
 	});
 
-	it("preserves every autocomplete row outside multiply wrapped branded frames", () => {
-		const config = { ...defaultConfig, editorMetadataFormat: "autocomplete-meta" };
+	it("preserves every native autocomplete row outside multiply wrapped branded frames", () => {
+		const config = structuredClone(defaultConfig);
+		config.editorMetadataFormat = "autocomplete-meta";
+		config.components.editor.styles.opencode.metadataFormat = "autocomplete-meta";
+		config.components.editor.styles.opencode.completionMenu = "native";
 		const base = new PolishedEditor(
 			{ requestRender() {}, terminal: { rows: 24, cols: 120 } } as never,
 			{ borderColor: (text: string) => text, selectList: {} } as never,

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -108,6 +108,9 @@ function createHarness(
 	const sessionLifecycle = new SessionLifecycle();
 	const calls = {
 		editor: [] as Partial<EditorComponentConfig>[],
+		polished: [] as Array<Record<string, unknown>>,
+		polishedCopyFriendly: [] as Array<Record<string, unknown>>,
+		accentRail: [] as Array<Record<string, unknown>>,
 		messages: [] as Partial<UserMessagesComponentConfig>[],
 		workingLine: [] as WorkingLineComponentPatch[],
 		renders: { shared: 0, local: 0 },
@@ -127,6 +130,18 @@ function createHarness(
 			calls.editor.push(patch);
 			Object.assign(config.components.editor, patch);
 			return { applied: true };
+		},
+		setPolished(patch: Record<string, unknown>) {
+			calls.polished.push(patch);
+			Object.assign(config.components.editor.styles.opencode, patch);
+		},
+		setPolishedCopyFriendly(patch: Record<string, unknown>) {
+			calls.polishedCopyFriendly.push(patch);
+			Object.assign(config.components.editor.styles["opencode-copy-friendly"], patch);
+		},
+		setAccentRail(patch: Record<string, unknown>) {
+			calls.accentRail.push(patch);
+			Object.assign(config.components.editor.styles["accent-rail"], patch);
 		},
 		setMinimalist(patch: Record<string, unknown>) {
 			calls.minimalist.push(patch);
@@ -302,6 +317,7 @@ describe("component-oriented /zentui settings", () => {
 			"Editor model label",
 			"Editor border color",
 			"Editor viewport indicators",
+			"Completion menu",
 		]);
 
 		component.handleInput("\t");
@@ -531,11 +547,66 @@ describe("component-oriented /zentui settings", () => {
 		expect(focusedRow(component)).toContain("Opencode (copy-friendly)");
 		component.handleInput(" ");
 		expect(focusedRow(component)).toContain("> Editor style");
+		expect(focusedRow(component)).toContain("Accent Rail");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("> Editor style");
 		expect(focusedRow(component)).toContain("Minimalist");
 		expect(harness.calls.editor).toEqual([
 			{ style: "opencode-copy-friendly" },
+			{ style: "accent-rail" },
 			{ style: "minimalist" },
 		]);
+	});
+
+	it("configures Opencode completion menus independently", async () => {
+		const current = cloneConfig();
+		const harness = createHarness(current);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Completion menu");
+		expect(focusedRow(component)).toContain("palette");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("native");
+		expect(harness.calls.polished).toEqual([{ completionMenu: "native" }]);
+		expect(harness.calls.polishedCopyFriendly).toEqual([]);
+
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		selectLabel(component, "Completion menu");
+		expect(focusedRow(component)).toContain("palette");
+		component.handleInput(" ");
+		expect(harness.calls.polishedCopyFriendly).toEqual([{ completionMenu: "native" }]);
+		expect(current.components.editor.styles.opencode.completionMenu).toBe("native");
+		expect(current.components.editor.styles["opencode-copy-friendly"].completionMenu).toBe(
+			"native",
+		);
+
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		expect(component.render(100).join("\n")).not.toContain("Completion menu");
+	});
+
+	it("shows and persists the Accent Rail surface control only for that style", async () => {
+		const current = cloneConfig();
+		current.components.editor.style = "accent-rail";
+		const harness = createHarness(current);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Accent Rail surface");
+		expect(focusedRow(component)).toContain("filled");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("transparent");
+		expect(harness.calls.accentRail).toEqual([{ transparent: true }]);
+		expect(harness.calls.editor).toEqual([]);
+		expect(current.components.editor.styles.minimalist).toEqual(
+			defaultConfig.components.editor.styles.minimalist,
+		);
+
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		expect(component.render(80).join("\n")).not.toContain("Accent Rail surface");
 	});
 
 	it("shows friendly message style labels and restores focus after rebuild", async () => {
@@ -1009,6 +1080,10 @@ describe("component-oriented /zentui settings", () => {
 		selectLabel(component, "Editor viewport indicators");
 		component.handleInput(" ");
 		expect(component.render(100).join("\n")).not.toContain("↑ 2 more");
+		selectLabel(component, "Editor style");
+		component.handleInput(" ");
+		const accentRail = component.render(100).join("\n");
+		expect(accentRail).not.toBe(copyFriendly);
 		selectLabel(component, "Editor style");
 		component.handleInput(" ");
 		const minimalist = component.render(100).join("\n");

--- a/test/settings-previews.test.ts
+++ b/test/settings-previews.test.ts
@@ -23,11 +23,13 @@ function theme(offset = 0): Theme {
 				200;
 			return `\x1b[38;5;${index}m${text}\x1b[0m`;
 		},
+		bg: (_color: string, text: string) => `\x1b[48;5;234m${text}\x1b[49m`,
+		getBgAnsi: () => "\x1b[48;5;234m",
 		bold: (text: string) => `\x1b[1m${text}\x1b[0m`,
 		italic: (text: string) => text,
 		underline: (text: string) => text,
 		strikethrough: (text: string) => text,
-	} as Theme;
+	} as unknown as Theme;
 }
 
 function config(): PolishedTuiConfig {
@@ -85,15 +87,17 @@ describe("settings previews", () => {
 			expect(visibleWidth(row)).toBeLessThanOrEqual(Math.min(width, SETTINGS_PREVIEW_MAX_WIDTH));
 	});
 
-	it("renders the defining structure of all three Editor styles without status cues", () => {
+	it("renders the defining structure of all four Editor styles without status cues", () => {
 		const outputs = Object.fromEntries(
-			(["opencode", "opencode-copy-friendly", "minimalist"] as EditorStyle[]).map((style) => {
-				const current = config();
-				current.components.editor.style = style;
-				return [style, plain(renderEditorSettingsPreview(current, theme(), 72))];
-			}),
+			(["opencode", "opencode-copy-friendly", "accent-rail", "minimalist"] as EditorStyle[]).map(
+				(style) => {
+					const current = config();
+					current.components.editor.style = style;
+					return [style, plain(renderEditorSettingsPreview(current, theme(), 72))];
+				},
+			),
 		) as Record<EditorStyle, string>;
-		expect(new Set(Object.values(outputs)).size).toBe(3);
+		expect(new Set(Object.values(outputs)).size).toBe(4);
 		for (const output of Object.values(outputs)) {
 			expect(output).not.toContain("Editor preview");
 			expect(output).not.toContain("preview enabled");
@@ -101,9 +105,16 @@ describe("settings previews", () => {
 		}
 		expect(outputs.opencode).toContain("│ Explain this change safely.");
 		expect(outputs.opencode).toContain("─── ↑ 2 more");
+		expect(outputs.opencode).toContain("↑↓ Navigate");
+		expect(outputs.opencode).not.toContain("→ settings");
 		expect(outputs["opencode-copy-friendly"]).toContain("\nExplain this change safely.");
+		expect(outputs["opencode-copy-friendly"]).toContain("↑↓ Navigate");
 		expect(outputs["opencode-copy-friendly"]).toContain("\n sonnet-4");
 		expect(outputs["opencode-copy-friendly"]).not.toContain("│ Explain this change safely.");
+		expect(outputs["accent-rail"]).toContain("▎ Explain this change safely.");
+		expect(outputs["accent-rail"]).toContain("▎ settings     Open settings");
+		expect(outputs["accent-rail"]).toContain("  files        Search files");
+		expect(outputs["accent-rail"]).not.toContain("sonnet-4");
 		expect(outputs.minimalist).toContain("╭─ ↑ 2 more");
 		expect(outputs.minimalist).toContain("╰─ ↓ 3 more");
 		expect(outputs.minimalist).toContain("feat/settings-previews");
@@ -112,6 +123,61 @@ describe("settings previews", () => {
 		const disabledOutput = plain(renderEditorSettingsPreview(disabled, theme(), 72));
 		expect(disabledOutput).toContain("Explain this change safely.");
 		expect(disabledOutput).not.toContain("preview");
+	});
+
+	it("previews transparent palette and native completion menus independently for both Opencode styles", () => {
+		const current = config();
+		const renderRows = () => renderEditorSettingsPreview(current, theme(), 72);
+		const render = () => plain(renderRows());
+		expect(render()).toContain("↑↓ Navigate");
+		expect(render()).not.toContain("→ settings");
+		expect(render()).not.toContain("(1/47)");
+		expect(renderRows().join("\n")).not.toContain("\x1b[48;5;234m");
+
+		current.components.editor.styles.opencode.completionMenu = "native";
+		expect(render()).not.toContain("↑↓ Navigate");
+		expect(render()).toContain("→ settings");
+		expect(render()).toContain("(1/47)");
+		expect(current.components.editor.styles["opencode-copy-friendly"].completionMenu).toBe(
+			"palette",
+		);
+
+		current.components.editor.style = "opencode-copy-friendly";
+		expect(render()).toContain("↑↓ Navigate");
+		expect(render()).not.toContain("(1/47)");
+		current.components.editor.styles["opencode-copy-friendly"].completionMenu = "native";
+		expect(render()).not.toContain("↑↓ Navigate");
+		expect(render()).toContain("→ settings");
+		expect(render()).toContain("(1/47)");
+	});
+
+	it("passes enabled and disabled viewport indicators through the Accent Rail preview", () => {
+		const current = config();
+		current.components.editor.style = "accent-rail";
+		const render = () => plain(renderEditorSettingsPreview(current, theme(), 72));
+
+		current.components.editor.viewportIndicators = true;
+		expect(render()).toContain("▎ ↑ 2 more");
+		expect(render()).toContain("▎ ↓ 3 more");
+
+		current.components.editor.viewportIndicators = false;
+		expect(render()).not.toContain("↑ 2 more");
+		expect(render()).not.toContain("↓ 3 more");
+		expect(render()).toContain("▎ Explain this change safely.");
+	});
+
+	it("previews filled and transparent Accent Rail surfaces", () => {
+		const current = config();
+		current.components.editor.style = "accent-rail";
+		const render = () => renderEditorSettingsPreview(current, theme(), 72).join("\n");
+		const filled = render();
+		expect(filled).toContain("\x1b[48;5;234m");
+		expect(plain(filled.split("\n"))).toContain("▎ settings     Open settings");
+
+		current.components.editor.styles["accent-rail"].transparent = true;
+		const transparent = render();
+		expect(transparent).not.toContain("\x1b[48;5;234m");
+		expect(plain(transparent.split("\n"))).toContain("▎ settings     Open settings");
 	});
 
 	it("responds to Editor visible settings and selected metadata format", () => {
@@ -209,7 +275,15 @@ describe("settings previews", () => {
 		current.icons.ahead = "↑\x1bP$qARROW-DCS\x1b\\";
 		current.icons.behind = "↓\u009dARROW-C1\u009c";
 
-		for (const style of ["opencode", "opencode-copy-friendly", "minimalist"] as EditorStyle[]) {
+		current.components.editor.styles["accent-rail"].rail =
+			"▎\x1b]2;ACCENT-RAIL-OSC\x07\u009b31m\u009dACCENT-RAIL-C1\u009c\u009b0m";
+
+		for (const style of [
+			"opencode",
+			"opencode-copy-friendly",
+			"accent-rail",
+			"minimalist",
+		] as EditorStyle[]) {
 			current.components.editor.style = style;
 			expectOnlyTrustedSgr(renderEditorSettingsPreview(current, theme(), 72), [
 				"RAIL-OSC",
@@ -219,6 +293,8 @@ describe("settings previews", () => {
 				"ARROW-C1",
 				"evil.invalid",
 				"TRUNCATED-OSC",
+				"ACCENT-RAIL-OSC",
+				"ACCENT-RAIL-C1",
 			]);
 		}
 		current.components.editor.style = "opencode";


### PR DESCRIPTION
## Summary

- adds an independently selectable `accent-rail` Editor with dedicated rail color/glyph ownership, Filled/Transparent surfaces, compact multiline rails, and native autocomplete preservation
- adds a reusable ANSI-safe completion renderer and independently configurable Native/Palette menus for Opencode and Opencode Copy Friendly
- adds live `/zentui` controls, shared production/settings previews, canonical config persistence, documentation, and compatibility-safe fail-open behavior

Opencode Palette defaults on, keeps native result data/emphasis, removes native arrows/count rows, adds transparent separators/help, and never reconstructs private suggestions. Native mode remains available per Opencode variant.

## Screenshots / recordings

Manual Pi TUI validation was performed from the worktree against the supplied Accent Rail and Opencode palette references. Filled/Transparent Accent Rail, Native/Palette Opencode variants, autocomplete selection, and terminal-width behavior were confirmed by the requester.

## Testing

- [x] `npm run verify` — 1,176 tests across 34 files
- [x] `npm run pack:check` — 38 packaged files
- [x] Manual Pi test via worktree development extension
- [x] Added focused renderer, ANSI/provenance, config, settings, preview, lifecycle, and compatibility tests

Additional validation:

- [x] `npm run fmt`
- [x] `git diff --check`
- [x] Impeccable detector — no findings
- [x] Fresh correctness, visual-contract, ownership, ANSI, provenance, and final focused reviews

## Checklist

- [x] Preserved Nerd Font/private-use glyph behavior with ASCII fallback.
- [x] Documented new editor styles, completion modes, copy behavior, colors, and fallbacks.
- [x] Kept component ownership independent; no Footer/User-message/Working-line/selector settings are changed.
- [x] `extensions/zentui/index.ts` remains orchestration-only.
- [x] Used a conventional commit-style PR title.
