### PR TITLE
chore: release v0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.2",
+	"version": "0.21.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.20.2",
+			"version": "0.21.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.20.2",
+	"version": "0.21.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Bumps `pi-zentui` from `0.20.2` to `0.21.0` after shipping:

- Accent Rail editor and composable completion palettes
- theme/terminal color refinements and adaptive thinking alignment
- guarded fullscreen Accent Rail layout integration
- refreshed and aligned editor showcase images
- streamlined README plus focused configuration/Footer documentation

This PR changes only the three npm version fields in `package.json` and `package-lock.json`. Dependencies and lock structure are unchanged.

## Testing

- [x] Clean `npm ci`
- [x] `npm run fmt`
- [x] `npm run verify` — 1,204 tests across 35 files; one intentional opt-in host probe skipped
- [x] `npm run pack:check` — `pi-zentui@0.21.0`, 39 files
- [x] All three release version fields asserted as `0.21.0`
- [x] Normalized lockfile SHA-256 matches `main`
- [x] Independent release-diff review — PASS
- [x] `git diff --check`

## Checklist

- [x] Release metadata only
- [x] No dependency/source/config/workflow changes
- [x] Generated release notes remain owned by the tag workflow
- [x] Conventional commit-style title
