### PR TITLE
feat: add editor usage metadata

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -348,8 +348,13 @@ The syntax supports `$variable`, `${variable}`, literal text, spaces, and condit
 | `$provider` | formatted provider label |
 | `$thinking` | current level; empty when `off` |
 | `$session_name` | current Pi session name; empty when unnamed |
+| `$context` | compact current context usage and window, for example `26.8%/272k` |
+| `$tokens` | cumulative session input/output tokens only, for example `↑76k ↓1.6k` |
+| `$cache_hit` | latest assistant prompt cache-hit rate to one decimal; `0.0%` when unavailable |
 
-Model variables use `editorModel`, provider uses `editorProvider`, and thinking uses the matching level style. Literal text and session name use the neutral editor-border theme style. ANSI/VT sequences, controls, and line-breaking whitespace are sanitized without collapsing ordinary spaces.
+`$context` uses Pi's current context snapshot and the live assistant context override, refreshing on the existing 250 ms streaming render cadence. `$tokens` and `$cache_hit` use authoritative persisted session snapshots, so they update at normal session synchronization boundaries rather than estimating in-progress totals. These variables are independent of Footer visibility, style, color source, and configuration.
+
+Model variables use `editorModel`, provider uses `editorProvider`, and thinking uses the matching level style. Literal text, session name, and usage metadata use the neutral editor-border theme style. ANSI/VT sequences, controls, and line-breaking whitespace are sanitized without collapsing ordinary spaces.
 
 Missing, non-string, or empty values use `$model  $provider(  $thinking)`. A non-empty format that resolves to no metadata preserves the normal blank spacer and metadata rows. This option is JSON-only; `/zentui format` controls the Footer.
 

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -1,6 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import type { ZentuiConfig } from "./config";
 import { type FormatToken, parseFooterFormat } from "./footer-format";
+import { buildSessionTokenLabel, formatCacheHitRate, formatContextPercentLabel } from "./format";
 import { EDITOR_ACCENT_FALLBACK, renderStyleForSourceOrFallback, safeThemeFg } from "./style";
 
 export type EditorMetadataValues = {
@@ -10,6 +11,11 @@ export type EditorMetadataValues = {
 	provider: string;
 	thinking: string;
 	sessionName: string;
+	contextPercent?: number;
+	contextWindow?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheHitRate?: number;
 };
 
 type RenderedTokens = {
@@ -164,7 +170,16 @@ function renderVariable(
 							? thinking
 							: name === "session_name"
 								? values.sessionName
-								: "";
+								: name === "context"
+									? formatContextPercentLabel(values.contextPercent, values.contextWindow)
+									: name === "tokens"
+										? buildSessionTokenLabel({
+												input: values.inputTokens ?? 0,
+												output: values.outputTokens ?? 0,
+											})
+										: name === "cache_hit"
+											? formatCacheHitRate(values.cacheHitRate)
+											: "";
 	const plain = sanitizeEditorMetadataText(raw);
 	if (!plain) return { plain: "", styled: "" };
 
@@ -204,7 +219,7 @@ function renderVariable(
 			),
 		};
 	}
-	if (name === "session_name") {
+	if (name === "session_name" || name === "context" || name === "tokens" || name === "cache_hit") {
 		return { plain, styled: safeThemeFg(uiTheme, "border", plain) };
 	}
 	return { plain: "", styled: "" };

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -35,6 +35,7 @@ import {
 	formatRuntimeSegment,
 	formatTimeLabel,
 	formatUsernameHostLabel,
+	resolveContextUsage,
 } from "./format";
 import { resolveRuntimeSymbol } from "./icons";
 import type { LiveContextOverride } from "./live-context";
@@ -282,14 +283,10 @@ export function installFooter(
 							config.components.footer.styles.starship.gitBranch.maxLength,
 						)
 					: undefined;
-				const contextUsage = ctx.getContextUsage();
-				const liveContext = hooks.getLiveContext?.();
-				const contextWindow = ctx.model?.contextWindow ?? contextUsage?.contextWindow;
-				const useLiveContext =
-					liveContext !== undefined && contextWindow !== undefined && contextWindow > 0;
-				const contextPercent = useLiveContext
-					? (liveContext.tokens / contextWindow) * 100
-					: contextUsage?.percent;
+				const { percent: contextPercent, contextWindow } = resolveContextUsage(
+					ctx,
+					hooks.getLiveContext?.(),
+				);
 				const contextLabel = buildContextDisplayLabel({
 					percent: contextPercent,
 					contextWindow,

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -294,17 +294,24 @@ export function buildCacheWriteLabel(cacheWrite: number): string {
 	return cacheWrite > 0 ? `W${formatCount(cacheWrite)}` : "";
 }
 
-export function buildTokenLabel(totals: UsageTotals, cacheHitIcon = "󰆼"): string {
+export function buildSessionTokenLabel(totals: Pick<UsageTotals, "input" | "output">): string {
 	const parts: string[] = [];
 	if (totals.input) parts.push(`↑${formatCount(totals.input)}`);
 	if (totals.output) parts.push(`↓${formatCount(totals.output)}`);
-
-	const hasCacheTokens = totals.cacheRead > 0 || totals.cacheWrite > 0;
-	if (hasCacheTokens && totals.latestCacheHitRate !== undefined) {
-		const cacheHitRate = `${totals.latestCacheHitRate.toFixed(1)}%`;
-		parts.push(cacheHitIcon ? `${cacheHitIcon} ${cacheHitRate}` : cacheHitRate);
-	}
 	return parts.length > 0 ? parts.join(" ") : "↑0 ↓0";
+}
+
+export function formatCacheHitRate(rate: number | undefined): string {
+	return `${rate !== undefined && Number.isFinite(rate) ? rate.toFixed(1) : "0.0"}%`;
+}
+
+export function buildTokenLabel(totals: UsageTotals, cacheHitIcon = "󰆼"): string {
+	const tokenLabel = buildSessionTokenLabel(totals);
+	const hasCacheTokens = totals.cacheRead > 0 || totals.cacheWrite > 0;
+	if (!hasCacheTokens || totals.latestCacheHitRate === undefined) return tokenLabel;
+
+	const cacheHitRate = formatCacheHitRate(totals.latestCacheHitRate);
+	return `${tokenLabel} ${cacheHitIcon ? `${cacheHitIcon} ` : ""}${cacheHitRate}`;
 }
 
 export function buildCostLabel(totals: UsageTotals): string {
@@ -372,10 +379,29 @@ export function buildContextDisplayLabel(options: {
 	return text;
 }
 
-export function buildContextLabel(ctx: ExtensionContext): string {
+export type ContextUsageSnapshot = {
+	percent: number | undefined;
+	contextWindow: number | undefined;
+};
+
+export function resolveContextUsage(
+	ctx: Pick<ExtensionContext, "model" | "getContextUsage">,
+	live?: { tokens: number },
+): ContextUsageSnapshot {
 	const usage = ctx.getContextUsage();
 	const contextWindow = ctx.model?.contextWindow ?? usage?.contextWindow;
-	return formatContextPercentLabel(usage?.percent, contextWindow);
+	return {
+		percent:
+			live && contextWindow && contextWindow > 0
+				? (live.tokens / contextWindow) * 100
+				: (usage?.percent ?? undefined),
+		contextWindow,
+	};
+}
+
+export function buildContextLabel(ctx: ExtensionContext): string {
+	const { percent, contextWindow } = resolveContextUsage(ctx);
+	return formatContextPercentLabel(percent, contextWindow);
 }
 
 export function formatRuntimeSegment(

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -60,7 +60,11 @@ import {
 } from "./editor-transfer";
 import { installFooter, installHiddenFooter } from "./footer";
 import { collectFooterFormatReferences, parseFooterFormat } from "./footer-format";
-import { buildSessionDurationLabel, invalidateUsageTotalsCache } from "./format";
+import {
+	buildSessionDurationLabel,
+	invalidateUsageTotalsCache,
+	resolveContextUsage,
+} from "./format";
 import { emptyGitStatus, readGitStatus } from "./git";
 import {
 	InteractionMetricsTracker,
@@ -296,15 +300,25 @@ export default function (pi: ExtensionAPI) {
 		Date.now,
 		() => interactionMetrics.currentThought(),
 	);
+	const getContextSnapshot = (ctx: ExtensionContext) => resolveContextUsage(ctx, liveContext.get());
 	const getContextWindow = (ctx: ExtensionContext): number | undefined =>
-		ctx.model?.contextWindow ?? ctx.getContextUsage()?.contextWindow;
-	const getContextPercent = (ctx: ExtensionContext): number | undefined => {
-		const usage = ctx.getContextUsage();
-		const contextWindow = getContextWindow(ctx);
-		const live = liveContext.get();
-		return live && contextWindow && contextWindow > 0
-			? (live.tokens / contextWindow) * 100
-			: (usage?.percent ?? undefined);
+		getContextSnapshot(ctx).contextWindow;
+	const getContextPercent = (ctx: ExtensionContext): number | undefined =>
+		getContextSnapshot(ctx).percent;
+	const getEditorMeta = (ctx: ExtensionContext) => {
+		const context = getContextSnapshot(ctx);
+		return {
+			modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
+			modelId: state.modelId,
+			modelName: state.modelName,
+			providerLabel: state.providerLabel,
+			sessionName: ctx.sessionManager.getSessionName() ?? "",
+			contextPercent: context.percent,
+			contextWindow: context.contextWindow,
+			inputTokens: state.usageTotals.input,
+			outputTokens: state.usageTotals.output,
+			cacheHitRate: state.usageTotals.latestCacheHitRate,
+		};
 	};
 	const getAgentDurationMs = () => agentDurationClock.elapsedMs();
 	const getThinkingLevel = () =>
@@ -689,13 +703,7 @@ export default function (pi: ExtensionAPI) {
 					keybindings,
 					sessionTheme,
 					getCurrentConfig,
-					() => ({
-						modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
-						modelId: state.modelId,
-						modelName: state.modelName,
-						providerLabel: state.providerLabel,
-						sessionName: ctx.sessionManager.getSessionName() ?? "",
-					}),
+					() => getEditorMeta(ctx),
 					getThinkingLevel,
 					() => ({
 						cwd: ctx.cwd,
@@ -734,13 +742,7 @@ export default function (pi: ExtensionAPI) {
 					baseFactory(tui, theme, keybindings),
 					sessionTheme,
 					getCurrentConfig,
-					() => ({
-						modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
-						modelId: state.modelId,
-						modelName: state.modelName,
-						providerLabel: state.providerLabel,
-						sessionName: ctx.sessionManager.getSessionName() ?? "",
-					}),
+					() => getEditorMeta(ctx),
 					getThinkingLevel,
 					() => ({
 						cwd: ctx.cwd,

--- a/extensions/zentui/state.ts
+++ b/extensions/zentui/state.ts
@@ -8,6 +8,7 @@ import {
 	buildTokenLabel,
 	formatProviderLabel,
 	getUsageTotals,
+	type UsageTotals,
 } from "./format";
 import type { GitStatusSummary } from "./git";
 import type { PackageVersionResult } from "./package-version";
@@ -24,6 +25,7 @@ export type FooterState = GitStatusSummary & {
 	cacheReadLabel: string;
 	cacheWriteLabel: string;
 	costLabel: string;
+	usageTotals: UsageTotals;
 	subscription: boolean;
 	autoCompaction: boolean;
 	runtime?: RuntimeInfo;
@@ -42,6 +44,14 @@ export function createInitialState(gitDefaults: GitStatusSummary): FooterState {
 		cacheReadLabel: "",
 		cacheWriteLabel: "",
 		costLabel: "$0.000",
+		usageTotals: {
+			input: 0,
+			output: 0,
+			cacheRead: 0,
+			cacheWrite: 0,
+			latestCacheHitRate: undefined,
+			cost: 0,
+		},
 		subscription: false,
 		autoCompaction: false,
 		runtime: undefined,
@@ -78,6 +88,7 @@ export function syncState(
 	state.cacheReadLabel = buildCacheReadLabel(totals.cacheRead);
 	state.cacheWriteLabel = buildCacheWriteLabel(totals.cacheWrite);
 	state.costLabel = buildCostLabel(totals);
+	state.usageTotals = totals;
 	state.subscription = telemetry.subscription === true;
 	state.autoCompaction = telemetry.autoCompaction === true;
 }

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -83,6 +83,11 @@ export type EditorMeta = {
 	modelName?: string;
 	providerLabel: string;
 	sessionName?: string;
+	contextPercent?: number;
+	contextWindow?: number;
+	inputTokens?: number;
+	outputTokens?: number;
+	cacheHitRate?: number;
 };
 
 export type PolishedEditorFrameOptions = {
@@ -731,6 +736,11 @@ export function renderPolishedEditorFrame({
 			provider: modelMeta.providerLabel,
 			thinking: thinkingLevel ?? "",
 			sessionName: modelMeta.sessionName ?? "",
+			contextPercent: modelMeta.contextPercent,
+			contextWindow: modelMeta.contextWindow,
+			inputTokens: modelMeta.inputTokens,
+			outputTokens: modelMeta.outputTokens,
+			cacheHitRate: modelMeta.cacheHitRate,
 		},
 		uiTheme,
 		config,

--- a/test/editor-metadata-format.test.ts
+++ b/test/editor-metadata-format.test.ts
@@ -6,6 +6,7 @@ import {
 	renderEditorMetadataFormat,
 	sanitizeEditorMetadataText,
 } from "../extensions/zentui/editor-metadata-format";
+import { renderPolishedEditorFrame } from "../extensions/zentui/ui";
 
 function makeTheme(): Theme {
 	return {
@@ -31,6 +32,11 @@ const values: EditorMetadataValues = {
 	provider: "Provider",
 	thinking: "high",
 	sessionName: "Session",
+	contextPercent: 26.8,
+	contextWindow: 272_000,
+	inputTokens: 76_000,
+	outputTokens: 1_600,
+	cacheHitRate: 73.4,
 };
 
 function render(format: string, overrides: Partial<EditorMetadataValues> = {}): string {
@@ -46,6 +52,26 @@ describe("renderEditorMetadataFormat", () => {
 	it("renders all supported variables in both syntaxes", () => {
 		expect(render(`$model|\${model_id}|$model_name|\${provider}|$thinking|\${session_name}`)).toBe(
 			"[accent]Model Label[border]|[accent]model-id[border]|[accent]Model Name[border]|[text]Provider[border]|[muted]high[border]|[border]Session",
+		);
+	});
+
+	it("renders usage variables in both syntaxes without duplicating cache metadata", () => {
+		expect(render(`$context | \${tokens} | $cache_hit`)).toBe(
+			"[border]26.8%/272k[border] | [border]↑76k ↓1.6k[border] | [border]73.4%",
+		);
+		expect(render(`\${context} | $tokens | \${cache_hit}`)).toBe(
+			"[border]26.8%/272k[border] | [border]↑76k ↓1.6k[border] | [border]73.4%",
+		);
+		expect(render("$tokens")).not.toContain("73.4%");
+		expect(render("$cache_hit")).not.toMatch(/[↑↓]/);
+		expect(render("($context)( · $tokens)( · $cache_hit)")).toBe(
+			"[border]26.8%/272k[border] · [border]↑76k ↓1.6k[border] · [border]73.4%",
+		);
+	});
+
+	it("renders unavailable cache-hit metadata as zero", () => {
+		expect(render("before( · $cache_hit)", { cacheHitRate: undefined })).toBe(
+			"[border]before[border] · [border]0.0%",
 		);
 	});
 
@@ -127,6 +153,34 @@ describe("renderEditorMetadataFormat", () => {
 			renderEditorMetadataFormat("$thinking", { ...values, thinking: "max" }, makeTheme(), config),
 		).toBe(`[${expected}]max`);
 	});
+
+	it.each(["opencode", "opencode-copy-friendly"] as const)(
+		"plumbs usage metadata through the %s frame",
+		(style) => {
+			const config = structuredClone(defaultConfig);
+			config.components.editor.style = style;
+			config.components.editor.styles[style].metadataFormat = "$context $tokens $cache_hit";
+			const frame = renderPolishedEditorFrame({
+				width: 120,
+				editorLines: ["typed text"],
+				uiTheme: makeTheme(),
+				config,
+				modelMeta: {
+					modelLabel: values.model,
+					providerLabel: values.provider,
+					contextPercent: values.contextPercent,
+					contextWindow: values.contextWindow,
+					inputTokens: values.inputTokens,
+					outputTokens: values.outputTokens,
+					cacheHitRate: values.cacheHitRate,
+				},
+			});
+			const rendered = frame.join("\n");
+			expect(rendered).toContain("26.8%/272k");
+			expect(rendered).toContain("↑76k ↓1.6k");
+			expect(rendered).toContain("73.4%");
+		},
+	);
 
 	it("sanitizes literals and values without collapsing ordinary spaces", () => {
 		const rendered = render(

--- a/test/live-context-integration.test.ts
+++ b/test/live-context-integration.test.ts
@@ -9,6 +9,19 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 		loadConfig: () => ({
 			...actual.defaultConfig,
 			projectRefreshIntervalMs: 0,
+			components: {
+				...actual.defaultConfig.components,
+				editor: {
+					...actual.defaultConfig.components.editor,
+					styles: {
+						...actual.defaultConfig.components.editor.styles,
+						opencode: {
+							...actual.defaultConfig.components.editor.styles.opencode,
+							metadataFormat: "$context $tokens $cache_hit",
+						},
+					},
+				},
+			},
 			features: { ...actual.defaultConfig.features, editor: false, statusLine: true },
 		}),
 	};
@@ -40,6 +53,8 @@ import zentui from "../extensions/zentui/index";
 type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
 type Footer = { render(width: number): string[]; dispose?: () => void };
 type FooterFactory = (...args: unknown[]) => Footer;
+type Editor = { render(width: number): string[]; setText(text: string): void };
+type EditorFactory = (...args: unknown[]) => Editor;
 
 function makeTheme(): Theme {
 	return {
@@ -72,10 +87,10 @@ function assistant(totalTokens: number, stopReason = "stop") {
 		provider: "anthropic",
 		model: "test",
 		usage: {
-			input: 0,
-			output: 0,
-			cacheRead: 0,
-			cacheWrite: 0,
+			input: totalTokens === 0 ? 0 : 101,
+			output: totalTokens === 0 ? 0 : 202,
+			cacheRead: totalTokens === 0 ? 0 : 303,
+			cacheWrite: totalTokens === 0 ? 0 : 404,
 			totalTokens,
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
 		},
@@ -84,7 +99,14 @@ function assistant(totalTokens: number, stopReason = "stop") {
 	};
 }
 
-function persistedEntry(id: string, input: number, output: number, cost: number) {
+function persistedEntry(
+	id: string,
+	input: number,
+	output: number,
+	cost: number,
+	cacheRead = 0,
+	cacheWrite = 0,
+) {
 	return {
 		type: "message",
 		id,
@@ -93,8 +115,8 @@ function persistedEntry(id: string, input: number, output: number, cost: number)
 			usage: {
 				input,
 				output,
-				cacheRead: 0,
-				cacheWrite: 0,
+				cacheRead,
+				cacheWrite,
 				totalTokens: input + output,
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
 			},
@@ -132,8 +154,10 @@ function createHarness(
 	} = {},
 ) {
 	let footerFactory: FooterFactory | undefined;
-	let editorFactory: unknown;
+	let editorFactory: EditorFactory | undefined;
+	let editorText = "";
 	const requestRender = vi.fn();
+	const editorRequestRender = vi.fn();
 	const entries = [persistedEntry("old", 5, 6, 0.123)];
 	const state = {
 		model:
@@ -161,10 +185,16 @@ function createHarness(
 		getContextUsage: () => state.contextUsage,
 		ui: {
 			theme,
+			getEditorText() {
+				return editorText;
+			},
+			setEditorText(text: string) {
+				editorText = text;
+			},
 			setFooter(factory: FooterFactory | undefined) {
 				footerFactory = factory;
 			},
-			setEditorComponent(factory: unknown) {
+			setEditorComponent(factory: EditorFactory | undefined) {
 				editorFactory = factory;
 			},
 			getEditorComponent() {
@@ -177,6 +207,7 @@ function createHarness(
 		entries,
 		state,
 		requestRender,
+		editorRequestRender,
 		createFooter() {
 			if (!footerFactory) throw new Error("footer was not installed");
 			return footerFactory({ requestRender }, theme, {
@@ -184,11 +215,25 @@ function createHarness(
 				getExtensionStatuses: () => new Map<string, string>(),
 			});
 		},
+		createEditor() {
+			if (!editorFactory) throw new Error("editor was not installed");
+			const editor = editorFactory(
+				{ requestRender: editorRequestRender, terminal: { rows: 24, cols: 160 } },
+				{ borderColor: (text: string) => text, selectList: {} },
+				{},
+			);
+			editor.setText("typed text");
+			return editor;
+		},
 	};
 }
 
 function rendered(footer: Footer): string {
 	return footer.render(160).join("\n");
+}
+
+function renderedEditor(editor: Editor): string {
+	return editor.render(160).join("\n");
 }
 
 async function settleProjectRefresh(): Promise<void> {
@@ -210,7 +255,10 @@ describe("live streaming context event integration", () => {
 		await emit(handlers, "session_start", harness.ctx);
 		await settleProjectRefresh();
 		const footer = harness.createFooter();
+		const editor = harness.createEditor();
+		expect(renderedEditor(editor)).toContain("10.0%/10k ↑5 ↓6 0.0%");
 		harness.requestRender.mockClear();
+		harness.editorRequestRender.mockClear();
 
 		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_000) });
 		await emit(handlers, "message_update", harness.ctx, { message: assistant(1_100) });
@@ -218,22 +266,28 @@ describe("live streaming context event integration", () => {
 		expect(harness.requestRender).not.toHaveBeenCalled();
 		vi.advanceTimersByTime(1);
 		expect(harness.requestRender).toHaveBeenCalledTimes(1);
+		expect(harness.editorRequestRender).toHaveBeenCalledTimes(1);
 		expect(rendered(footer)).toContain("11.0%/10k");
 		expect(rendered(footer)).toContain("↑5 ↓6");
 		expect(rendered(footer)).toContain("$0.123");
+		expect(renderedEditor(editor)).toContain("11.0%/10k ↑5 ↓6 0.0%");
 
 		await emit(handlers, "message_end", harness.ctx, { message: assistant(1_100) });
 		expect(rendered(footer)).toContain("11.0%/10k");
 		expect(rendered(footer)).toContain("↑5 ↓6");
 		expect(rendered(footer)).toContain("$0.123");
+		expect(renderedEditor(editor)).toContain("11.0%/10k ↑5 ↓6 0.0%");
 
 		harness.state.contextUsage = { tokens: 1_200, contextWindow: 10_000, percent: 12 };
-		harness.entries.push(persistedEntry("new", 7, 8, 0.2));
+		harness.entries.push(persistedEntry("new", 7, 8, 0.2, 21, 2));
 		await emit(handlers, "agent_end", harness.ctx);
 		const finalized = rendered(footer);
 		expect(finalized).toContain("12.0%/10k");
 		expect(finalized).toContain("↑12 ↓14");
 		expect(finalized).toContain("$0.323");
+		const finalizedEditor = renderedEditor(editor);
+		expect(finalizedEditor).toContain("12.0%/10k ↑12 ↓14 70.0%");
+		expect(finalizedEditor.match(/70\.0%/g)).toHaveLength(1);
 
 		footer.dispose?.();
 		await emit(handlers, "session_shutdown", harness.ctx);


### PR DESCRIPTION
## Summary

- add `$context`, `$tokens`, and `$cache_hit` to Opencode editor metadata formats
- keep context live while tokens and cache-hit values follow authoritative session snapshots
- preserve independent Editor/Footer ownership and document the new variables

Closes #91

## Screenshots / recordings

Manually inspected the updated Opencode editor in a local Pi session via Herdr.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev`
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Updated configuration documentation.
- [x] Kept the diff surgical.
- [x] Kept `extensions/zentui/index.ts` orchestration-focused.
- [x] Used a conventional commit-style PR title.
