### PR TITLE
feat: add editor metadata zones

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -338,7 +338,13 @@ Each Opencode variant owns an independent `metadataFormat`:
 }
 ```
 
-The syntax supports `$variable`, `${variable}`, literal text, spaces, and conditional groups `( ... )` that disappear when every variable inside is empty. Unknown variables and `$fill` render empty; `$fill` never creates an Editor layout zone because the right side remains reserved for structural Vim status.
+The syntax supports `$variable`, `${variable}`, literal text, spaces, conditional groups `( ... )` that disappear when every variable inside is empty, and the Footer's top-level `$fill` grammar. With no fill, metadata keeps its existing left-aligned layout. One fill creates left/right zones; two fills create left/middle/right zones; additional fills are ignored. For example:
+
+```text
+$model( · $provider)$fill($session_name)$fill($context · $tokens · $cache_hit)
+```
+
+The configured right zone and Pi's operational right status are right-aligned together, with the operational status kept first when space is limited. Configured left content is kept next, then configured right content. The middle zone is centered within the remaining gap between those sides, not at the terminal's absolute center, and is omitted completely if it cannot fit with one-cell separation. Narrow layouts truncate configured left/right content without an ellipsis. `$fill` inside a conditional group remains non-structural and renders empty.
 
 | Token | Renders |
 | --- | --- |

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -24,6 +24,12 @@ type RenderedTokens = {
 	hasNonEmptyDynamic: boolean;
 };
 
+export type EditorMetadataZones = {
+	left: string;
+	middle: string;
+	right: string;
+};
+
 const ESC = 0x1b;
 const BEL = 0x07;
 const CAN = 0x18;
@@ -263,6 +269,41 @@ function renderTokens(
 	}
 
 	return { styled, hasDynamic, hasNonEmptyDynamic };
+}
+
+export function renderEditorMetadataFormatSplit(
+	format: string,
+	values: EditorMetadataValues,
+	uiTheme: Theme,
+	config: ZentuiConfig,
+): EditorMetadataZones {
+	const tokens = parseFooterFormat(sanitizeEditorMetadataText(format));
+	const fillIndices: number[] = [];
+	for (let index = 0; index < tokens.length; index++) {
+		if (tokens[index]?.kind === "fill") fillIndices.push(index);
+	}
+
+	const first = fillIndices[0];
+	const second = fillIndices[1];
+	if (first === undefined) {
+		return {
+			left: renderTokens(tokens, values, uiTheme, config).styled,
+			middle: "",
+			right: "",
+		};
+	}
+	if (second === undefined) {
+		return {
+			left: renderTokens(tokens.slice(0, first), values, uiTheme, config).styled,
+			middle: "",
+			right: renderTokens(tokens.slice(first + 1), values, uiTheme, config).styled,
+		};
+	}
+	return {
+		left: renderTokens(tokens.slice(0, first), values, uiTheme, config).styled,
+		middle: renderTokens(tokens.slice(first + 1, second), values, uiTheme, config).styled,
+		right: renderTokens(tokens.slice(second + 1), values, uiTheme, config).styled,
+	};
 }
 
 export function renderEditorMetadataFormat(

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -11,7 +11,10 @@ import {
 import { ACCENT_RAIL_CHROME_WIDTH, renderAccentRailEditorFrame } from "./accent-rail-editor";
 import { renderCompletionPalette } from "./completion-menu";
 import type { EditorStyle, ZentuiConfig } from "./config";
-import { renderEditorMetadataFormat } from "./editor-metadata-format";
+import {
+	type EditorMetadataZones,
+	renderEditorMetadataFormatSplit,
+} from "./editor-metadata-format";
 import { type MinimalistEditorMetadata, renderMinimalistFrame } from "./minimalist-editor";
 import {
 	EDITOR_ACCENT_FALLBACK,
@@ -361,16 +364,60 @@ function getEditorChromeWidths(config: ZentuiConfig, uiTheme: Theme, reset: stri
 	};
 }
 
-function composeMetadataLine(left: string, right: string | undefined, width: number): string {
-	if (!right) return left;
+export function composeEditorMetadataLine(
+	{ left, middle, right }: EditorMetadataZones,
+	rightStatus: string | undefined,
+	width: number,
+): string {
 	const maxWidth = Math.max(0, width);
-	const rightWidth = visibleWidth(right);
-	if (rightWidth >= maxWidth) return truncateToWidth(right, maxWidth, "");
 
-	const leftWidth = Math.max(0, maxWidth - rightWidth - 1);
-	const leftText = truncateToWidth(left, leftWidth, "");
-	const gap = " ".repeat(Math.max(1, maxWidth - visibleWidth(leftText) - rightWidth));
-	return `${leftText}${gap}${right}`;
+	// Preserve the legacy no-fill path exactly, including deferring left-only
+	// truncation to the style-specific frame clamp below.
+	if (!middle && !right) {
+		if (!rightStatus) return left;
+		const rightStatusWidth = visibleWidth(rightStatus);
+		if (rightStatusWidth >= maxWidth) return truncateToWidth(rightStatus, maxWidth, "");
+
+		const leftBudget = Math.max(0, maxWidth - rightStatusWidth - 1);
+		const leftText = truncateToWidth(left, leftBudget, "");
+		const gap = " ".repeat(Math.max(1, maxWidth - visibleWidth(leftText) - rightStatusWidth));
+		return `${leftText}${gap}${rightStatus}`;
+	}
+
+	const statusText = rightStatus ? truncateToWidth(rightStatus, maxWidth, "") : "";
+	const statusWidth = visibleWidth(statusText);
+	const leftBudget = Math.max(0, maxWidth - statusWidth - (statusText && left ? 1 : 0));
+	const leftText = truncateToWidth(left, leftBudget, "");
+	const leftWidth = visibleWidth(leftText);
+
+	const rightBudget = Math.max(
+		0,
+		maxWidth - leftWidth - statusWidth - (leftText ? 1 : 0) - (statusText ? 1 : 0),
+	);
+	const configuredRight = truncateToWidth(right, rightBudget, "");
+	const rightText =
+		configuredRight && statusText
+			? `${configuredRight} ${statusText}`
+			: configuredRight || statusText;
+	const rightWidth = visibleWidth(rightText);
+	const gapWidth = Math.max(0, maxWidth - leftWidth - rightWidth);
+	const middleWidth = visibleWidth(middle);
+	const minimumMiddleGap = (leftText ? 1 : 0) + (rightText ? 1 : 0);
+
+	if (!middle || middleWidth + minimumMiddleGap > gapWidth) {
+		return `${leftText}${" ".repeat(gapWidth)}${rightText}`;
+	}
+
+	const availablePadding = gapWidth - middleWidth;
+	const minimumLeftPadding = leftText ? 1 : 0;
+	const maximumLeftPadding = availablePadding - (rightText ? 1 : 0);
+	const leftPadding = Math.min(
+		maximumLeftPadding,
+		Math.max(minimumLeftPadding, Math.floor(availablePadding / 2)),
+	);
+	return `${leftText}${" ".repeat(leftPadding)}${middle}${" ".repeat(
+		availablePadding - leftPadding,
+	)}${rightText}`;
 }
 
 function ansiStrippedText(line: string): string {
@@ -726,7 +773,7 @@ export function renderPolishedEditorFrame({
 	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
 	const innerWidth = Math.max(0, width - railWidth);
 	const lowRailContinuation = " ".repeat(promptWidth);
-	const meta = renderEditorMetadataFormat(
+	const metadataZones = renderEditorMetadataFormatSplit(
 		selectedPolishedConfig(config)?.metadataFormat ??
 			config.components.editor.styles.opencode.metadataFormat,
 		{
@@ -745,8 +792,8 @@ export function renderPolishedEditorFrame({
 		uiTheme,
 		config,
 	);
-	const lowRailMeta = composeMetadataLine(meta, rightStatus, Math.max(0, width - 1));
-	const railedMeta = composeMetadataLine(meta, rightStatus, innerWidth);
+	const lowRailMeta = composeEditorMetadataLine(metadataZones, rightStatus, Math.max(0, width - 1));
+	const railedMeta = composeEditorMetadataLine(metadataZones, rightStatus, innerWidth);
 
 	const renderStaticBorder = (text: string) =>
 		renderStyleForSourceOrFallback(

--- a/test/editor-metadata-format.test.ts
+++ b/test/editor-metadata-format.test.ts
@@ -1,17 +1,37 @@
+import { stripVTControlCharacters } from "node:util";
 import type { Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { defaultConfig } from "../extensions/zentui/config";
 import {
 	type EditorMetadataValues,
 	renderEditorMetadataFormat,
+	renderEditorMetadataFormatSplit,
 	sanitizeEditorMetadataText,
 } from "../extensions/zentui/editor-metadata-format";
-import { renderPolishedEditorFrame } from "../extensions/zentui/ui";
+import { composeEditorMetadataLine, renderPolishedEditorFrame } from "../extensions/zentui/ui";
 
 function makeTheme(): Theme {
 	return {
 		fg(color: string, text: string) {
 			return `[${color}]${text}`;
+		},
+		bold(text: string) {
+			return text;
+		},
+		italic(text: string) {
+			return text;
+		},
+		underline(text: string) {
+			return text;
+		},
+	} as unknown as Theme;
+}
+
+function makeAnsiTheme(): Theme {
+	return {
+		fg(_color: string, text: string) {
+			return `\x1b[31m${text}\x1b[39m`;
 		},
 		bold(text: string) {
 			return text;
@@ -192,6 +212,148 @@ describe("renderEditorMetadataFormat", () => {
 		expect(rendered).toBe("[border]lit  x y:[accent]bad   model");
 		expect(rendered).not.toMatch(/[\u0000-\u001f\u007f-\u009f]/);
 	});
+});
+
+describe("editor metadata zones", () => {
+	it("keeps no-fill rendering byte-for-byte equivalent", () => {
+		const format = "$model( · $provider)(nested $fill)";
+		const legacy = renderEditorMetadataFormat(format, values, makeTheme(), defaultConfig);
+		const zones = renderEditorMetadataFormatSplit(format, values, makeTheme(), defaultConfig);
+		expect(zones).toEqual({ left: legacy, middle: "", right: "" });
+		expect(composeEditorMetadataLine(zones, undefined, 5)).toBe(legacy);
+	});
+
+	it("keeps nested fill non-structural when a top-level fill creates zones", () => {
+		expect(
+			renderEditorMetadataFormatSplit(
+				"$model$fill(nested $fill)",
+				values,
+				makeTheme(),
+				defaultConfig,
+			),
+		).toEqual({ left: "[accent]Model Label", middle: "", right: "" });
+	});
+
+	it("aligns one-fill left and right zones", () => {
+		expect(
+			composeEditorMetadataLine({ left: "left", middle: "", right: "right" }, undefined, 12),
+		).toBe("left   right");
+	});
+
+	it("centers the middle within the available gap", () => {
+		expect(
+			composeEditorMetadataLine({ left: "LLLLLLLLLL", middle: "MMM", right: "R" }, undefined, 20),
+		).toBe("LLLLLLLLLL   MMM   R");
+	});
+
+	it("drops conditional empty zones and keeps content after extra fills on the right", () => {
+		const conditional = renderEditorMetadataFormatSplit(
+			"$model$fill( · $session_name)$fill($context)",
+			{ ...values, sessionName: "" },
+			makeTheme(),
+			defaultConfig,
+		);
+		expect(conditional).toEqual({
+			left: "[accent]Model Label",
+			middle: "",
+			right: "[border]26.8%/272k",
+		});
+
+		const extra = renderEditorMetadataFormatSplit(
+			"$model$fill$provider$fill$thinking$fill$session_name",
+			values,
+			makeTheme(),
+			defaultConfig,
+		);
+		expect(extra).toEqual({
+			left: "[accent]Model Label",
+			middle: "[text]Provider",
+			right: "[muted]high[border]Session",
+		});
+	});
+
+	it("omits an unfittable middle instead of truncating it", () => {
+		const line = composeEditorMetadataLine(
+			{ left: "left", middle: "middle", right: "right" },
+			undefined,
+			11,
+		);
+		expect(line).toBe("left  right");
+		expect(line).not.toContain("middle");
+	});
+
+	it("reserves operational right status, then configured left, then configured right", () => {
+		const wide = composeEditorMetadataLine(
+			{ left: "left", middle: "", right: "right" },
+			"INSERT",
+			24,
+		);
+		expect(visibleWidth(wide)).toBe(24);
+		expect(wide.endsWith("right INSERT")).toBe(true);
+
+		expect(
+			stripVTControlCharacters(
+				composeEditorMetadataLine(
+					{ left: "left-long", middle: "middle", right: "configured-right" },
+					"INSERT",
+					12,
+				),
+			),
+		).toBe("left- INSERT");
+		expect(
+			stripVTControlCharacters(
+				composeEditorMetadataLine({ left: "left", middle: "", right: "right" }, "INSERT", 4),
+			),
+		).toBe("INSE");
+	});
+
+	it("keeps ANSI, CJK, combining marks, and emoji within the cell budget", () => {
+		const line = composeEditorMetadataLine(
+			{
+				left: "\x1b[31m界e\u0301👩‍💻abcdef\x1b[0m",
+				middle: "中🙂",
+				right: "右🙂tail",
+			},
+			"INSERT",
+			22,
+		);
+		expect(visibleWidth(line)).toBeLessThanOrEqual(22);
+		const plain = stripVTControlCharacters(line);
+		expect(plain).toContain("界e\u0301👩‍💻");
+		expect(plain).toContain("INSERT");
+		expect(plain).not.toContain("�");
+	});
+
+	it.each([
+		["opencode", 2, "regular-left", "regular-right"],
+		["opencode-copy-friendly", 1, "copy-left", "copy-right"],
+	] as const)(
+		"uses the %s metadata format and its chrome budget",
+		(style, chromeWidth, expectedLeft, expectedRight) => {
+			const config = structuredClone(defaultConfig);
+			config.components.editor.style = style;
+			config.components.editor.styles.opencode.metadataFormat =
+				"regular-left$" + "{fill}regular-right";
+			config.components.editor.styles["opencode-copy-friendly"].metadataFormat =
+				"copy-left$" + "{fill}copy-right";
+			const width = 40;
+			const frame = renderPolishedEditorFrame({
+				width,
+				editorLines: ["draft"],
+				uiTheme: makeAnsiTheme(),
+				config,
+				modelMeta: { modelLabel: "model", providerLabel: "provider" },
+			});
+			const metadata = frame.find(
+				(line) => line.includes(expectedLeft) && line.includes(expectedRight),
+			);
+			expect(metadata).toBeDefined();
+			expect(visibleWidth(metadata ?? "")).toBe(width);
+			const plain = stripVTControlCharacters(metadata ?? "");
+			expect(plain.indexOf(expectedLeft)).toBe(chromeWidth);
+			expect(plain.endsWith(expectedRight)).toBe(true);
+		},
+	);
 });
 
 describe("sanitizeEditorMetadataText", () => {


### PR DESCRIPTION
## Summary

- support left, middle, and right Opencode metadata zones through the existing top-level `$fill` grammar
- preserve legacy no-fill rendering and operational right-status priority
- add display-width, narrow-layout, nested-fill, and both-style regression coverage

Stacked on #104.

## Screenshots / recordings

Manually inspected the three-zone Opencode editor in a local Pi session via Herdr.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via `npm run pi:dev`
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Updated configuration documentation.
- [x] Kept the diff surgical.
- [x] Left Footer and orchestration ownership unchanged.
- [x] Used a conventional commit-style PR title.
