### PR TITLE
feat: add repository-relative footer paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Detailed reference:
 - [Configuration, component styles, defaults, runtime detection, and compatibility](https://github.com/lmilojevicc/pi-zentui/blob/main/docs/configuration.md)
 - [Footer format template and variables](https://github.com/lmilojevicc/pi-zentui/blob/main/docs/footer-format.md)
 
+The Starship Footer path defaults to `basename`. Opt into `components.footer.styles.starship.pathDisplay.mode: "repository"` to omit the repository directory itself: the repository root renders `.`, while `/repo/extensions/zentui` renders `extensions/zentui`. `depth` keeps the final N components in `full` and `repository` modes; `0` is unlimited. Until a current, safely contained repository root is available, repository mode silently uses the unlimited `full` path with `~` home abbreviation.
+
 Useful shortcuts:
 
 ```text

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -274,6 +274,14 @@ Copy this example and change only the values you need. Optional editor source-aw
 - Active third-party statuses from `ctx.ui.setStatus()` can be placed left, middle, or right, hidden per key, and assigned independent color modes.
 - The shown `editor*` colors match the default `theme` source. Omit them to preserve source-aware defaults when switching between `theme` and `terminal`.
 
+### Footer path display
+
+`components.footer.styles.starship.pathDisplay.mode` accepts `basename`, `full`, or the opt-in `repository`; the unchanged default is `basename`. Repository mode removes the repository directory name: at `/repo` it renders `.`, and at `/repo/extensions/zentui` it renders `extensions/zentui`. Zentui finds the nearest ancestor with a `.git` directory or worktree `.git` file without starting an extra Git process.
+
+For `full` and `repository`, `depth` is the number of final components to retain. `0` is unlimited. Repository mode first creates the path relative to the repository root, then applies depth, so `/repo/packages/core/src` with `depth: 2` renders `…/core/src`; repository root remains `.` at every depth. `/zentui` exposes **Repository** as a separate Footer path-display choice and keeps the depth control for both modes.
+
+Repository roots are associated with the cwd that produced them. While the current root is missing, stale, outside the cwd, still being refreshed, or unavailable after a lookup failure or Git-to-non-Git transition, Zentui silently renders the unlimited `full` path, including `~` home abbreviation. Built-in and custom `$cwd` layouts use the same result at wide and compact widths. These options belong only to the Starship Footer; Minimalist Editor path semantics are unchanged.
+
 ### Color ownership
 
 - `editorAccent` styles Opencode Editor and User-message accent rails plus the Labeled message label.

--- a/docs/footer-format.md
+++ b/docs/footer-format.md
@@ -89,6 +89,18 @@ The released flat `footerFormat` and `footerSegments` keys remain accepted only 
 
 Each variable renders its core value without prose prefixes such as `on` or `via`; add those words as literals.
 
+### `$cwd` path modes
+
+`$cwd`, the built-in wide directory segment, and responsive compact/final fallback all use `components.footer.styles.starship.pathDisplay`. Its unchanged default is `{ "mode": "basename", "depth": 0 }`.
+
+- `basename` renders only the current directory name.
+- `full` renders the full path with `~` home abbreviation.
+- Opt-in `repository` excludes the repository directory name: repository root renders `.`, while `/repo/extensions/zentui` renders `extensions/zentui`.
+
+For `full` and `repository`, `depth` keeps the final N components and `0` is unlimited. Repository mode forms the repository-relative path first and then applies depth; for example, `/repo/packages/core/src` at depth `2` renders `…/core/src`. Root always remains `.`. Separator normalization matches the existing cwd formatter.
+
+Repository mode recognizes normal repositories and `.git` file worktrees. If the root is missing, stale, unsafe for the current cwd, or unavailable during a cwd/repository transition or failed lookup, `$cwd` silently uses the unlimited `full` path until current root state is safe. This fallback retains `~` abbreviation and never emits a relative path from a stale root.
+
 ### Compact-only structural tokens
 
 `components.footer.styles.starship.compactFormat` also supports:

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -61,11 +61,11 @@ export type ContextThresholds = {
 	error: number;
 };
 
-export type PathDisplayMode = "basename" | "full";
+export type PathDisplayMode = "basename" | "full" | "repository";
 
 export type PathDisplayConfig = {
 	mode: PathDisplayMode;
-	/** Trailing directories to show in full mode. 0 = unlimited; clamped to 0..5. */
+	/** Final components to show in full/repository mode. 0 = unlimited; clamped to 0..5. */
 	depth: number;
 };
 
@@ -665,7 +665,10 @@ function parseContextThresholds(
 function parsePathDisplay(value: unknown): PathDisplayConfig {
 	const defaults = defaultConfig.pathDisplay;
 	if (!isRecord(value)) return { ...defaults };
-	const mode = value.mode === "full" || value.mode === "basename" ? value.mode : defaults.mode;
+	const mode =
+		value.mode === "full" || value.mode === "basename" || value.mode === "repository"
+			? value.mode
+			: defaults.mode;
 	const rawDepth = value.depth;
 	const depth =
 		typeof rawDepth === "number" && Number.isFinite(rawDepth) && rawDepth >= 0

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -188,6 +188,7 @@ export function installFooter(
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
 		getLiveContext?: () => LiveContextOverride | undefined;
+		getRepositoryRoot?: (cwd: string) => string | undefined;
 		onDispose?: () => void;
 	},
 ): void {
@@ -228,10 +229,13 @@ export function installFooter(
 				);
 				const colorSource = config.components.footer.colorSource;
 				const iconMode = config.icons.mode;
+				const pathDisplay = config.components.footer.styles.starship.pathDisplay;
 				const formattedCwd = sanitizeEditorMetadataText(
 					formatCwdLabel(ctx.cwd, config.icons.cwd, {
-						mode: config.components.footer.styles.starship.pathDisplay.mode,
-						depth: config.components.footer.styles.starship.pathDisplay.depth,
+						mode: pathDisplay.mode,
+						depth: pathDisplay.depth,
+						repositoryRoot:
+							pathDisplay.mode === "repository" ? hooks.getRepositoryRoot?.(ctx.cwd) : undefined,
 					}),
 				);
 				const branch = sanitizeEditorMetadataText(state.branch ?? "") || undefined;
@@ -728,18 +732,7 @@ export function installFooter(
 				if (reflowed) return frameRows(reflowed);
 
 				const chunkBudget = compactChunkBudget(innerWidth);
-				const compactCwdLabel = truncateToWidth(
-					renderStyleForSource(
-						theme,
-						colorSource,
-						config.colors.cwd,
-						sanitizeEditorMetadataText(
-							formatCwdLabel(ctx.cwd, config.icons.cwd, { mode: "basename", depth: 0 }),
-						),
-					),
-					chunkBudget,
-					"…",
-				);
+				const compactCwdLabel = truncateToWidth(cwdLabel, chunkBudget, "…");
 				const compactSessionNameLabel = truncateToWidth(
 					sessionNameLabel,
 					Math.max(1, chunkBudget - visibleWidth("in ")),

--- a/extensions/zentui/format.ts
+++ b/extensions/zentui/format.ts
@@ -443,9 +443,10 @@ export function formatPackageVersionSegment(
 
 export type FormatCwdOptions = {
 	mode?: PathDisplayMode;
-	/** Trailing directory components to keep in full mode. 0 = unlimited. */
+	/** Final path components to keep in full/repository mode. 0 = unlimited. */
 	depth?: number;
 	home?: string;
+	repositoryRoot?: string;
 };
 
 function normalizeDisplayPath(cwd: string): string {
@@ -488,8 +489,7 @@ function applyPathDepth(path: string, depth: number): string {
 export function formatCwdLabel(cwd: string, cwdIcon: string, options?: FormatCwdOptions): string {
 	const mode = options?.mode ?? "basename";
 	const normalized = normalizeDisplayPath(cwd);
-	let pathText: string;
-	if (mode === "full") {
+	const fullPath = (depth = options?.depth ?? 0) => {
 		const home =
 			options?.home ??
 			(() => {
@@ -499,7 +499,25 @@ export function formatCwdLabel(cwd: string, cwdIcon: string, options?: FormatCwd
 					return "";
 				}
 			})();
-		pathText = applyPathDepth(toHomePath(normalized, home), options?.depth ?? 0);
+		return applyPathDepth(toHomePath(normalized, home), depth);
+	};
+	let pathText: string;
+	if (mode === "full") {
+		pathText = fullPath();
+	} else if (mode === "repository") {
+		const root = options?.repositoryRoot ? normalizeDisplayPath(options.repositoryRoot) : undefined;
+		if (!root) {
+			pathText = fullPath(0);
+		} else {
+			const rootPrefix = root === "/" ? "/" : `${root}/`;
+			if (normalized !== root && !normalized.startsWith(rootPrefix)) {
+				// Unsafe roots fail open to the existing unlimited full path.
+				pathText = fullPath(0);
+			} else {
+				const relative = normalized === root ? "." : normalized.slice(rootPrefix.length);
+				pathText = relative === "." ? relative : applyPathDepth(relative, options?.depth ?? 0);
+			}
+		}
 	} else if (normalized === "/") {
 		pathText = "/";
 	} else {

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -1,5 +1,3 @@
-import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
 import type {
 	ExtensionAPI,
 	ExtensionContext,
@@ -81,6 +79,7 @@ import {
 	startProjectRefreshInterval,
 } from "./project-refresh";
 import { applyProjectRefreshToState } from "./project-state";
+import { RepositoryRootController, type RepositoryRootRequest } from "./repository-root";
 import { readRuntimeInfo } from "./runtime";
 import { installSelectorBorderStyle, removeSelectorBorderStyle } from "./selector-border";
 import { SessionLifecycle } from "./session-lifecycle";
@@ -167,16 +166,6 @@ export function activeFooterReferences(config: ZentuiConfig): Set<string> {
 	return references;
 }
 
-function findRepositoryRoot(cwd: string): string | undefined {
-	let current = resolve(cwd);
-	while (true) {
-		if (existsSync(join(current, ".git"))) return current;
-		const parent = dirname(current);
-		if (parent === current) return undefined;
-		current = parent;
-	}
-}
-
 function isTuiContext(ctx: ExtensionContext): boolean {
 	try {
 		const mode = (ctx as ExtensionContext & { mode?: string }).mode;
@@ -228,11 +217,11 @@ export default function (pi: ExtensionAPI) {
 	let sessionTimerRequirements = "";
 	let lastDurationLabel = "";
 	let lastProjectCwd: string | undefined;
-	let requestedProjectCwd: string | undefined;
 	const agentDurationClock = new AgentDurationClock();
 	const interactionMetrics = new InteractionMetricsTracker();
 	let agentRunActive = false;
 	let minimalistProjectRoot: string | undefined;
+	const repositoryRoots = new RepositoryRootController();
 	let projectRefreshActive = false;
 	let activeTuiContext: ExtensionContext | undefined;
 	let cleanupAccentRailLayoutPatch: () => void = () => {};
@@ -336,12 +325,22 @@ export default function (pi: ExtensionAPI) {
 			? activeFooterReferences(currentConfig)
 			: new Set<string>();
 
-	type ProjectRefreshTarget = { cwd: string; generation: number };
+	type ProjectRefreshTarget = {
+		repository: RepositoryRootRequest;
+		sessionGeneration: number;
+	};
 	const refreshProjectState = async (
-		{ cwd, generation }: ProjectRefreshTarget,
+		{ repository, sessionGeneration }: ProjectRefreshTarget,
 		run: ProjectRefreshRun,
 	) => {
-		if (!run.isCurrent() || !sessionLifecycle.isCurrent(generation)) return;
+		const { cwd } = repository;
+		if (
+			!run.isCurrent() ||
+			!sessionLifecycle.isCurrent(sessionGeneration) ||
+			!repositoryRoots.isCurrent(repository)
+		) {
+			return;
+		}
 		const starship = currentConfig.components.footer.styles.starship;
 		const gitCommitConfig = starship.gitCommit;
 		const gitMetricsConfig = starship.gitMetrics;
@@ -367,12 +366,12 @@ export default function (pi: ExtensionAPI) {
 		]);
 		if (
 			!run.isCurrent() ||
-			!sessionLifecycle.isCurrent(generation) ||
-			requestedProjectCwd !== cwd
+			!sessionLifecycle.isCurrent(sessionGeneration) ||
+			!repositoryRoots.isCurrent(repository)
 		) {
 			return;
 		}
-		minimalistProjectRoot = git.kind === "ok" ? findRepositoryRoot(cwd) : undefined;
+		minimalistProjectRoot = repositoryRoots.update(repository, git.kind === "ok");
 		lastProjectCwd = applyProjectRefreshToState(state, {
 			cwd,
 			previousCwd: lastProjectCwd,
@@ -387,11 +386,11 @@ export default function (pi: ExtensionAPI) {
 		ctx: ExtensionContext,
 		options?: ScheduleProjectRefreshOptions,
 	) => {
-		const generation = sessionLifecycle.currentGeneration();
-		if (!sessionLifecycle.isCurrent(generation)) return;
-		const cwd = ctx.cwd;
-		requestedProjectCwd = cwd;
-		projectRefreshScheduler.schedule({ cwd, generation }, options);
+		const sessionGeneration = sessionLifecycle.currentGeneration();
+		if (!sessionLifecycle.isCurrent(sessionGeneration)) return;
+		const repository = repositoryRoots.request(ctx.cwd);
+		minimalistProjectRoot = repositoryRoots.cachedRootForCwd(ctx.cwd);
+		projectRefreshScheduler.schedule({ repository, sessionGeneration }, options);
 	};
 
 	const minimalistProjectRequired = () => {
@@ -911,6 +910,7 @@ export default function (pi: ExtensionAPI) {
 					getActiveExtensionStatuses = fn ?? (() => new Map());
 				},
 				getLiveContext: () => liveContext.get(),
+				getRepositoryRoot: (cwd) => repositoryRoots.rootForCwd(cwd),
 				onDispose: () => clearFooterOwnership(ctx, token),
 			});
 			installedFooterKind = "starship";
@@ -1162,8 +1162,8 @@ export default function (pi: ExtensionAPI) {
 		invalidateUsageTotalsCache();
 		resetAgentTimer();
 		lastProjectCwd = undefined;
-		requestedProjectCwd = undefined;
 		minimalistProjectRoot = undefined;
+		repositoryRoots.reset();
 		installUi(ctx);
 		workingLine.startSession(ctx);
 		scheduleEditorReconciliation(ctx);

--- a/extensions/zentui/repository-root.ts
+++ b/extensions/zentui/repository-root.ts
@@ -1,0 +1,98 @@
+import { existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+export type RepositoryRootState = {
+	/** The cwd whose repository lookup produced this state. */
+	cwd: string;
+	root?: string;
+};
+
+export type RepositoryRootRequest = {
+	cwd: string;
+	generation: number;
+};
+
+/** Find the nearest ancestor containing either a .git directory or worktree .git file. */
+export function findRepositoryRoot(cwd: string): string | undefined {
+	let current = resolve(cwd);
+	while (true) {
+		if (existsSync(join(current, ".git"))) return current;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+export function updateRepositoryRootState(
+	cwd: string,
+	isRepository: boolean,
+	findRoot: (cwd: string) => string | undefined = findRepositoryRoot,
+): RepositoryRootState {
+	if (!isRepository) return { cwd };
+	try {
+		return { cwd, root: findRoot(cwd) };
+	} catch {
+		return { cwd };
+	}
+}
+
+/** Return only a current, still-present root produced for this exact cwd. */
+export function repositoryRootForCwd(
+	state: RepositoryRootState | undefined,
+	cwd: string,
+	markerExists: (path: string) => boolean = existsSync,
+): string | undefined {
+	if (!state?.root || state.cwd !== cwd) return undefined;
+	try {
+		return markerExists(join(state.root, ".git")) ? state.root : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/** Own repository-root request generations so returning to an older cwd cannot revive old state. */
+export class RepositoryRootController {
+	private generation = 0;
+	private requestedCwd: string | undefined;
+	private state: RepositoryRootState | undefined;
+
+	request(cwd: string): RepositoryRootRequest {
+		if (cwd !== this.requestedCwd) {
+			this.generation += 1;
+			this.requestedCwd = cwd;
+			this.state = undefined;
+		}
+		return { cwd, generation: this.generation };
+	}
+
+	isCurrent(request: RepositoryRootRequest): boolean {
+		return request.cwd === this.requestedCwd && request.generation === this.generation;
+	}
+
+	update(
+		request: RepositoryRootRequest,
+		isRepository: boolean,
+		findRoot: (cwd: string) => string | undefined = findRepositoryRoot,
+	): string | undefined {
+		if (!this.isCurrent(request)) return undefined;
+		this.state = updateRepositoryRootState(request.cwd, isRepository, findRoot);
+		return this.state.root;
+	}
+
+	cachedRootForCwd(cwd: string): string | undefined {
+		return this.state?.cwd === cwd ? this.state.root : undefined;
+	}
+
+	rootForCwd(
+		cwd: string,
+		markerExists: (path: string) => boolean = existsSync,
+	): string | undefined {
+		return repositoryRootForCwd(this.state, cwd, markerExists);
+	}
+
+	reset(): void {
+		this.generation += 1;
+		this.requestedCwd = undefined;
+		this.state = undefined;
+	}
+}

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -77,7 +77,7 @@ const extensionStatusPlacementValues: ExtensionStatusPlacement[] = [
 const extensionStatusColorModeValues: ExtensionStatusColorMode[] = ["zentui", "original"];
 const contextStyleValues: ContextStyle[] = ["text", "gauge", "text+gauge"];
 const separatorStyleValues: SeparatorStyle[] = ["pipe", "dot", "chevron", "none"];
-const pathDisplayModeValues = ["basename", "full"];
+const pathDisplayModeValues: PathDisplayConfig["mode"][] = ["basename", "repository", "full"];
 const pathDepthValues = ["0", "1", "2", "3", "4", "5"];
 const branchLengthPresetValues = ["full", "10", "20", "30", "40", "50"];
 const iconModeValues: IconMode[] = ["auto", "nerd", "ascii"];
@@ -789,14 +789,14 @@ function buildStarshipFooterStyleItems(config: PolishedTuiConfig): SettingItem[]
 		{
 			id: "pathDisplay",
 			label: "Path display",
-			description: "Show cwd as basename or full path.",
+			description: "Show cwd as basename, repository-relative, or full path.",
 			currentValue: footer.pathDisplay.mode,
 			values: pathDisplayModeValues,
 		},
 		{
 			id: "pathDepth",
 			label: "Path depth",
-			description: "Trailing directories in full mode (0 = all).",
+			description: "Final component count for Full and Repository (0 = unlimited).",
 			currentValue: String(footer.pathDisplay.depth),
 			values: pathDepthValues,
 		},
@@ -1558,7 +1558,10 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 										notifyChange("Separator", newValue);
 										return;
 									}
-									if (id === "pathDisplay" && pathDisplayModeValues.includes(newValue as never)) {
+									if (
+										id === "pathDisplay" &&
+										pathDisplayModeValues.includes(newValue as PathDisplayConfig["mode"])
+									) {
 										deps.setPathDisplay({ mode: newValue as PathDisplayConfig["mode"] });
 										settingsList.updateValue(id, newValue);
 										notifyChange("Path display", newValue);

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1750,6 +1750,15 @@ describe("mergeConfig", () => {
 			mode: "full",
 			depth: 3,
 		});
+		expect(mergeConfig({ pathDisplay: { mode: "repository", depth: 2 } }).pathDisplay).toEqual({
+			mode: "repository",
+			depth: 2,
+		});
+		expect(
+			mergeConfig({
+				components: { footer: { styles: { starship: { pathDisplay: { mode: "repository" } } } } },
+			}).components.footer.styles.starship.pathDisplay,
+		).toEqual({ mode: "repository", depth: 0 });
 		expect(mergeConfig({ pathDisplay: { mode: "fish", depth: -3 } }).pathDisplay).toEqual({
 			mode: "basename",
 			depth: 0,

--- a/test/footer-repository-path.test.ts
+++ b/test/footer-repository-path.test.ts
@@ -1,0 +1,123 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import { defaultConfig } from "../extensions/zentui/config";
+import { installFooter } from "../extensions/zentui/footer";
+import { emptyGitStatus } from "../extensions/zentui/git";
+import { createInitialState } from "../extensions/zentui/state";
+
+type FooterFactory = (
+	tui: { requestRender(): void },
+	theme: Theme,
+	data: {
+		onBranchChange(callback: () => void): () => void;
+		getExtensionStatuses(): Map<string, string>;
+	},
+) => { render(width: number): string[] };
+
+function theme(): Theme {
+	return {
+		fg: (_color: string, text: string) => text,
+		bold: (text: string) => text,
+		italic: (text: string) => text,
+		underline: (text: string) => text,
+		strikethrough: (text: string) => text,
+		getThinkingBorderColor: () => (text: string) => text,
+	} as unknown as Theme;
+}
+
+describe("Footer repository path rendering", () => {
+	it("uses the same repository cwd in built-in, custom, and final responsive fallback output", () => {
+		let footerFactory: FooterFactory | undefined;
+		const cwd = "/repo/extensions/zentui";
+		const context = {
+			cwd,
+			model: { contextWindow: 100_000 },
+			getContextUsage: () => ({ percent: 10, tokens: 10_000, contextWindow: 100_000 }),
+			sessionManager: { getSessionName: () => undefined },
+			ui: {
+				setFooter(factory: FooterFactory | undefined) {
+					footerFactory = factory;
+				},
+			},
+		};
+		const config = structuredClone(defaultConfig);
+		config.icons.cwd = "";
+		config.components.footer.styles.starship.pathDisplay = {
+			mode: "repository",
+			depth: 0,
+		};
+		const render = (width: number) => {
+			installFooter(context as never, createInitialState(emptyGitStatus()), () => config, {
+				setRequestRender() {},
+				scheduleProjectRefresh() {},
+				getRepositoryRoot: () => "/repo",
+			});
+			const footer = footerFactory?.({ requestRender() {} }, theme(), {
+				onBranchChange: () => () => {},
+				getExtensionStatuses: () => new Map(),
+			});
+			return footer?.render(width).join("\n") ?? "";
+		};
+
+		const starship = config.components.footer.styles.starship;
+		starship.responsive = false;
+		starship.format = "";
+		const builtIn = render(160);
+		expect(builtIn).toMatch(/(?:^|\s)extensions\/zentui(?:\s|$)/);
+		expect(builtIn).not.toContain("/repo/extensions/zentui");
+
+		starship.format = "$cwd";
+		const custom = render(160);
+		expect(custom.trim()).toBe("extensions/zentui");
+		expect(custom).not.toContain("/repo/extensions/zentui");
+
+		starship.responsive = true;
+		starship.format = "X".repeat(100);
+		starship.compactFormat = "$cwd";
+		const compact = render(50);
+		expect(compact.trim()).toBe("extensions/zentui");
+		expect(compact).not.toContain("/repo/extensions/zentui");
+	});
+
+	it("only asks for a repository root in repository mode", () => {
+		let footerFactory: FooterFactory | undefined;
+		const config = structuredClone(defaultConfig);
+		config.icons.cwd = "";
+		const getRepositoryRoot = vi.fn(() => "/repo");
+		installFooter(
+			{
+				cwd: "/repo/extensions/zentui",
+				model: { contextWindow: 100_000 },
+				getContextUsage: () => ({ percent: 10, tokens: 10_000, contextWindow: 100_000 }),
+				sessionManager: { getSessionName: () => undefined },
+				ui: {
+					setFooter(factory: FooterFactory | undefined) {
+						footerFactory = factory;
+					},
+				},
+			} as never,
+			createInitialState(emptyGitStatus()),
+			() => config,
+			{
+				setRequestRender() {},
+				scheduleProjectRefresh() {},
+				getRepositoryRoot,
+			},
+		);
+		const footer = footerFactory?.({ requestRender() {} }, theme(), {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map(),
+		});
+
+		config.components.footer.styles.starship.pathDisplay.mode = "basename";
+		footer?.render(160);
+		config.components.footer.styles.starship.pathDisplay.mode = "full";
+		footer?.render(160);
+		expect(getRepositoryRoot).not.toHaveBeenCalled();
+
+		config.components.footer.styles.starship.pathDisplay.mode = "repository";
+		footer?.render(160);
+		expect(getRepositoryRoot).toHaveBeenCalledTimes(1);
+		expect(getRepositoryRoot).toHaveBeenCalledWith("/repo/extensions/zentui");
+	});
+});

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -459,6 +459,51 @@ describe("formatCwdLabel", () => {
 			}),
 		).toBe("󰝰 …/zentui");
 	});
+
+	it("renders safe repository-relative paths and falls back to unlimited full paths", () => {
+		const repositoryRoot = "/Users/me/Projects/zentui";
+		expect(
+			formatCwdLabel(`${repositoryRoot}/extensions/zentui`, "", {
+				mode: "repository",
+				repositoryRoot,
+				home,
+				depth: 0,
+			}),
+		).toBe("extensions/zentui");
+		expect(
+			formatCwdLabel(repositoryRoot, "", { mode: "repository", repositoryRoot, home, depth: 2 }),
+		).toBe(".");
+		expect(
+			formatCwdLabel(`${repositoryRoot}/packages/core/src`, "", {
+				mode: "repository",
+				repositoryRoot,
+				home,
+				depth: 2,
+			}),
+		).toBe("…/core/src");
+		expect(
+			formatCwdLabel("C:\\repo\\extensions\\zentui\\", "", {
+				mode: "repository",
+				repositoryRoot: "C:\\repo\\",
+				depth: 0,
+			}),
+		).toBe("extensions/zentui");
+		expect(
+			formatCwdLabel("/Users/me/Projects/other/src", "", {
+				mode: "repository",
+				repositoryRoot,
+				home,
+				depth: 1,
+			}),
+		).toBe("~/Projects/other/src");
+		expect(
+			formatCwdLabel(`${repositoryRoot}/extensions`, "", {
+				mode: "repository",
+				home,
+				depth: 1,
+			}),
+		).toBe("~/Projects/zentui/extensions");
+	});
 });
 
 describe("formatGitBranchText", () => {

--- a/test/repository-root.test.ts
+++ b/test/repository-root.test.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	findRepositoryRoot,
+	RepositoryRootController,
+	repositoryRootForCwd,
+	updateRepositoryRootState,
+} from "../extensions/zentui/repository-root";
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve = () => {};
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
+
+describe("repository root discovery", () => {
+	it.each(["directory", "file"] as const)("finds the nearest .git %s", (markerKind) => {
+		const parent = mkdtempSync(join(tmpdir(), "zentui-repository-root-"));
+		const root = join(parent, "repo");
+		const nested = join(root, "extensions", "zentui");
+		try {
+			mkdirSync(nested, { recursive: true });
+			if (markerKind === "directory") mkdirSync(join(root, ".git"));
+			else writeFileSync(join(root, ".git"), "gitdir: ../worktrees/repo\n");
+			expect(findRepositoryRoot(nested)).toBe(root);
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("repository root state", () => {
+	it("keeps A invalid through A→B→A until the fresh A generation completes", async () => {
+		const parent = mkdtempSync(join(tmpdir(), "zentui-repository-transition-"));
+		const rootA = join(parent, "repo-a");
+		const cwdA = join(rootA, "src");
+		const rootB = join(parent, "repo-b");
+		const cwdB = join(rootB, "lib");
+		const controller = new RepositoryRootController();
+		try {
+			mkdirSync(join(rootA, ".git"), { recursive: true });
+			mkdirSync(cwdA, { recursive: true });
+			mkdirSync(join(rootB, ".git"), { recursive: true });
+			mkdirSync(cwdB, { recursive: true });
+
+			const initialA = controller.request(cwdA);
+			expect(controller.update(initialA, true)).toBe(rootA);
+			expect(controller.rootForCwd(cwdA)).toBe(rootA);
+
+			const oldAResult = deferred();
+			const oldARequest = controller.request(cwdA);
+			const oldARefresh = oldAResult.promise.then(() => controller.update(oldARequest, true));
+			const bResult = deferred();
+			const bRequest = controller.request(cwdB);
+			const bRefresh = bResult.promise.then(() => controller.update(bRequest, true));
+			const freshAResult = deferred();
+			const freshARequest = controller.request(cwdA);
+			const freshARefresh = freshAResult.promise.then(() => controller.update(freshARequest, true));
+
+			expect(controller.rootForCwd(cwdA)).toBeUndefined();
+			bResult.resolve();
+			expect(await bRefresh).toBeUndefined();
+			expect(controller.rootForCwd(cwdA)).toBeUndefined();
+			oldAResult.resolve();
+			expect(await oldARefresh).toBeUndefined();
+			expect(controller.rootForCwd(cwdA)).toBeUndefined();
+
+			freshAResult.resolve();
+			expect(await freshARefresh).toBe(rootA);
+			expect(controller.rootForCwd(cwdA)).toBe(rootA);
+			expect(controller.rootForCwd(cwdB)).toBeUndefined();
+		} finally {
+			rmSync(parent, { recursive: true, force: true });
+		}
+	});
+
+	it("updates and clears roots across repository and cwd transitions", () => {
+		let state = updateRepositoryRootState("/repo-a/src", true, () => "/repo-a");
+		expect(repositoryRootForCwd(state, "/repo-a/src", () => true)).toBe("/repo-a");
+		expect(repositoryRootForCwd(state, "/repo-b/lib", () => true)).toBeUndefined();
+
+		state = updateRepositoryRootState("/repo-b/lib", true, () => "/repo-b");
+		expect(repositoryRootForCwd(state, "/repo-b/lib", () => true)).toBe("/repo-b");
+
+		state = updateRepositoryRootState("/tmp", false);
+		expect(repositoryRootForCwd(state, "/tmp", () => true)).toBeUndefined();
+	});
+
+	it("clears missing roots and lookup failures instead of reusing stale state", () => {
+		const failed = updateRepositoryRootState("/repo/src", true, () => {
+			throw new Error("lookup failed");
+		});
+		expect(failed).toEqual({ cwd: "/repo/src" });
+		expect(repositoryRootForCwd(failed, "/repo/src", () => true)).toBeUndefined();
+
+		const missing = updateRepositoryRootState("/repo/src", true, () => "/repo");
+		expect(repositoryRootForCwd(missing, "/repo/src", () => false)).toBeUndefined();
+		expect(
+			repositoryRootForCwd(missing, "/repo/src", () => {
+				throw new Error("marker lookup failed");
+			}),
+		).toBeUndefined();
+	});
+});

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -117,6 +117,7 @@ function createHarness(
 		selectors: [] as Partial<SelectorBordersComponentConfig>[],
 		footer: [] as Partial<FooterComponentConfig>[],
 		minimalist: [] as Array<Record<string, unknown>>,
+		pathDisplay: [] as Array<Record<string, unknown>>,
 		segments: [] as Array<Record<string, boolean>>,
 		gitCommit: [] as Array<Record<string, boolean>>,
 		gitMetrics: [] as Array<Record<string, boolean>>,
@@ -176,7 +177,10 @@ function createHarness(
 		setIconMode() {},
 		setContextStyle() {},
 		setSeparator() {},
-		setPathDisplay() {},
+		setPathDisplay(patch: Record<string, unknown>) {
+			calls.pathDisplay.push(patch);
+			Object.assign(config.components.footer.styles.starship.pathDisplay, patch);
+		},
 		setGitBranch() {},
 		setGitCommit(patch: Record<string, boolean>) {
 			calls.gitCommit.push(patch);
@@ -629,6 +633,25 @@ describe("component-oriented /zentui settings", () => {
 			{ style: "compact" },
 			{ style: "labeled" },
 		]);
+	});
+
+	it("offers and routes repository Footer paths with clarified depth semantics", async () => {
+		const harness = createHarness();
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Footer");
+		selectLabel(component, "Path display");
+		expect(focusedRow(component)).toContain("basename");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("repository");
+		expect(component.render(160).join("\n")).toContain("repository-relative");
+		selectLabel(component, "Path depth");
+		const depthRows = component.render(160).join("\n");
+		expect(depthRows).toContain("Final component count for Full and Repository");
+		expect(depthRows).toContain("0 = unlimited");
+		component.handleInput(" ");
+		expect(focusedRow(component)).toContain("1");
+		expect(harness.calls.pathDisplay).toEqual([{ mode: "repository" }, { depth: 1 }]);
 	});
 
 	it("routes color and model rows to separate component dependencies", async () => {


### PR DESCRIPTION
## Summary

- add an opt-in repository-relative Starship Footer path mode
- render `.` at repository root and apply adapted Starship depth semantics to nested relative paths
- safely fall back to the unlimited abbreviated full path while repository state is missing, stale, unsafe, or refreshing
- expose the mode through `/zentui` and document configuration and `$cwd` behavior

Closes #89

## Screenshots / recordings

Manually inspected `extensions/zentui` rendering as `extensions/zentui` in a local Pi TUI session using the issue branch.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi test via local extension loading
- [x] Added focused config, formatting, repository lifecycle, Footer rendering, and settings tests

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs.
- [x] Updated README and configuration/Footer documentation.
- [x] Kept the diff scoped to repository-relative Footer paths.
- [x] Kept `extensions/zentui/index.ts` orchestration-focused.
- [x] Used a conventional commit-style PR title.
