### PR TITLE
chore: release v0.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.21.0",
+			"version": "0.22.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.21.0",
+	"version": "0.22.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Release `pi-zentui` v0.22.0.

Included since v0.21.0:
- editor usage metadata variables and left/middle/right metadata zones
- repository-relative Footer path display
- opt-in Thinking (Experimental) component with Rail, Tree, and Streaming modes
- `/zentui` Thinking previews and restart/capability messaging
- Pi 0.80.5–0.84.4 compatibility and actual-TUI coverage

## Screenshots / recordings

Thinking previews and runtime behavior were manually inspected in Pi 0.84.4. The actual-TUI CI matrix covers all Thinking modes across supported Pi versions.

## Testing

- [x] `npm run verify`
- [x] `npm run pack:check`
- [x] Manual Pi testing completed for the Thinking UI
- [x] Version fields limited to `package.json` and `package-lock.json`

## Checklist

- [x] Version is `0.22.0` in package and lockfile.
- [x] Conventional release title used.
- [x] Release remains compatible with the existing tag-triggered npm/GitHub workflow.
