### PR TITLE
chore: release v0.22.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.1",
+	"version": "0.22.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.22.1",
+			"version": "0.22.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.1",
+	"version": "0.22.2",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Release `pi-zentui` v0.22.2.

Patch fix:
- apply Streaming → Tree/Rail and Rail ↔ Tree mode changes live in active Thinking sessions
- retain restart gating when entering Streaming, first enabling, or re-enabling after disable
- harden timer/input cleanup, status reporting, and actual-TUI transition coverage

## Testing

- [x] `npm run verify` — 1,341 passed, 1 skipped
- [x] `npm run pack:check`
- [x] Five-version actual-TUI matrix
- [x] Pi 0.84.4 fullscreen smoke
- [x] Version fields limited to package and lockfile
