### PR TITLE
chore: release v0.22.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.2",
+	"version": "0.22.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.22.2",
+			"version": "0.22.3",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.2",
+	"version": "0.22.3",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary

Release `pi-zentui` v0.22.3.

Patch fix:
- parse GPT/OpenAI reasoning containing validated ANSI SGR styling in Rail and Tree
- strip styling before structural parsing while retaining fail-closed native fallback for all other terminal controls

## Testing

- [x] affected GPT Tree output manually verified
- [x] `npm run verify` — 1,383 passed, 1 skipped
- [x] `npm run pack:check`
- [x] five-version actual-TUI matrix
- [x] Pi 0.84.4 fullscreen smoke
- [x] version fields limited to package and lockfile
