### PR TITLE
feat: compose extension segments into working line

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Editor, User messages, Thinking (Experimental), Working line, and selector borde
 
 The Starship Footer shows directory, Git, runtime, context, tokens, and cost. Optional segments include model/provider, package version, session duration, `user@host`, time, OS, Git commit, Git metrics, and third-party extension statuses. The layout is segment-driven by default and supports a complete Starship-style format template.
 
+When the Working line is enabled, third-party extensions can publish keyed text segments through Pi's shared event bus. Zentui composes those segments into the owned row so Classic and KITT animate across them with the built-in content. See the [Working-line extension integration](https://github.com/lmilojevicc/pi-zentui/blob/main/docs/configuration.md#working-line-extension-integration) reference.
+
 Zentui detects a broad set of runtime and language modules, preserves Nerd Font icons with an ASCII mode, and can source colors from the active Pi theme or directly from the terminal palette.
 
 ## Screenshots

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -428,7 +428,36 @@ Classic and KITT move color across message and segments. **Animate spinner color
 
 Both speeds accept `30..1000` ms. Classic/KITT combine both cadences through one Pi Loader interval; exact cycles are used within 1024-frame/512-KiB limits. Pathological custom pairs use a bounded evenly distributed schedule with at most half a spinner-cycle and half a text-step rounding. Legacy `intervalMs` is accepted only as migration input for `spinnerIntervalMs` when the canonical field is absent.
 
-Content reserves the complete Tokens label first, then Message, Thought, Elapsed, and Tool allocation, while preserving visual order **Message · Tool · Elapsed · Thought · Tokens** within the 80-column Loader-row contract. Active thought starts as `thinking 0s`; completed positive thought becomes `thought for Ns`. Rebuilds preserve spinner and visible color phase. Pi's working-row APIs are global and unkeyed, so another extension may win by writing last.
+Content reserves the complete Tokens label and active extension segments first, then Message, Thought, Elapsed, and Tool allocation, while preserving visual order **Message · Tool · Elapsed · Thought · Tokens · Extensions** within the 80-column Loader-row contract. Active thought starts as `thinking 0s`; completed positive thought becomes `thought for Ns`. Rebuilds preserve spinner and visible color phase. Pi's working-row APIs are global and unkeyed, so another extension may win by writing last.
+
+### Working-line extension integration
+
+Third-party extensions can add dynamic text to Zentui's owned Working line through Pi's shared event bus. Keyed segments are sanitized, ordered by key, width-bounded, and included in the same Classic/KITT animation frames as Zentui's built-in content.
+
+Probe the capability when an interaction starts so an extension can fall back to Pi's public `setWorkingMessage()` slot when Zentui's Working line is unavailable:
+
+```typescript
+const capability = { supported: false, active: false };
+pi.events.emit("zentui:working-line-segment-capability", capability);
+
+if (capability.active) {
+  pi.events.emit("zentui:working-line-segment", {
+    key: "my-extension",
+    text: "24.3 tok/s · TTFT 820ms",
+  });
+}
+```
+
+Update a segment by emitting the same key with new text. Remove it when the interaction settles or the extension shuts down:
+
+```typescript
+pi.events.emit("zentui:working-line-segment", {
+  key: "my-extension",
+  text: undefined,
+});
+```
+
+`text: ""` also removes a segment. Zentui accepts at most 16 unique keys, keys up to 64 code units, and values up to 256 code units. Extra segments are omitted or truncated when the complete row reaches its fixed width. `supported` reports whether this Zentui version understands the protocol; `active` additionally requires an enabled Working line in an active TUI session.
 
 ## Git status icons
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -432,7 +432,7 @@ Content reserves the complete Tokens label and active extension segments first, 
 
 ### Working-line extension integration
 
-Third-party extensions can add dynamic text to Zentui's owned Working line through Pi's shared event bus. Keyed segments are sanitized, ordered by key, width-bounded, and included in the same Classic/KITT animation frames as Zentui's built-in content.
+Third-party extensions can add dynamic text to Zentui's owned Working line through Pi's shared event bus. Protocol version 1 uses keyed segments that are sanitized, ordered by key, width-bounded, and included in the same Classic/KITT animation frames as Zentui's built-in content.
 
 Probe the capability when an interaction starts so an extension can fall back to Pi's public `setWorkingMessage()` slot when Zentui's Working line is unavailable:
 
@@ -442,22 +442,24 @@ pi.events.emit("zentui:working-line-segment-capability", capability);
 
 if (capability.active) {
   pi.events.emit("zentui:working-line-segment", {
-    key: "my-extension",
+    key: "@scope/my-extension:throughput",
     text: "24.3 tok/s · TTFT 820ms",
   });
 }
 ```
 
-Update a segment by emitting the same key with new text. Remove it when the interaction settles or the extension shuts down:
+Update a segment by emitting the same key with new text. Remove it when the interaction settles or the publishing extension shuts down:
 
 ```typescript
 pi.events.emit("zentui:working-line-segment", {
-  key: "my-extension",
+  key: "@scope/my-extension:throughput",
   text: undefined,
 });
 ```
 
-`text: ""` also removes a segment. Zentui accepts at most 16 unique keys, keys up to 64 code units, and values up to 256 code units. Extra segments are omitted or truncated when the complete row reaches its fixed width. `supported` reports whether this Zentui version understands the protocol; `active` additionally requires an enabled Working line in an active TUI session.
+All publishers share one global key namespace. Collisions are last-update-wins, and removal by either publisher removes the value for that key. Publishers must therefore use stable, package-qualified keys such as `@scope/package:segment`; each publisher owns removal and lifecycle cleanup for its keys. `text: ""` also removes a segment. Published state is scoped to the current session and Working-row ownership: Zentui discards it on a new session, disable, shutdown, or ownership release. Positive updates while capability is inactive are ignored rather than retained, so publishers must probe again and republish their current value after capability becomes active.
+
+Zentui accepts at most 16 unique keys, keys up to 64 code units, and values up to 256 code units. Extra segments are omitted or truncated when the complete row reaches its fixed width. `supported` reports whether this Zentui version understands the protocol. Zentui also adds `version: 1` to the mutable capability response; probes that initialize only `supported` and `active`, as above, remain compatible. `active` additionally requires an enabled Working line in an active TUI session where Zentui successfully installed and still claims both required Pi working-row surfaces. Pi's unkeyed, last-writer-wins APIs provide no way to prove that another extension has not overwritten a surface after installation, so publishers should probe at each interaction and retain their normal fallback.
 
 ## Git status icons
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -294,6 +294,7 @@ export default function (pi: ExtensionAPI) {
 	const liveContext = new LiveContextController(sessionLifecycle, refresh);
 	const getActiveTheme = () => activeTheme;
 	const getCurrentConfig = () => currentConfig;
+	let invalidateWorkingLinePublisherState = () => {};
 	const workingLine = new WorkingLineController(
 		getCurrentConfig,
 		() => activeTheme as Theme,
@@ -301,19 +302,29 @@ export default function (pi: ExtensionAPI) {
 		Math.random,
 		Date.now,
 		() => interactionMetrics.currentThought(),
+		() => invalidateWorkingLinePublisherState(),
 	);
+	let workingLineSessionReady = false;
 	const workingLineExtensions = new WorkingLineExtensionSegments(
 		pi.events,
 		() =>
+			workingLineSessionReady &&
 			sessionLifecycle.isCurrent() &&
 			currentConfig.components.workingLine.enabled &&
-			activeTuiContext !== undefined,
+			activeTuiContext !== undefined &&
+			workingLine.isAvailable(),
 		(segments) => {
 			if (activeTuiContext && sessionLifecycle.isCurrent()) {
-				workingLine.updateExtensionSegments(segments, activeTuiContext);
+				const applied = workingLine.updateExtensionSegments(segments, activeTuiContext);
+				if (!applied && !workingLine.isAvailable()) {
+					workingLine.invalidateExtensionSegments();
+				}
+				return applied;
 			}
+			return false;
 		},
 	);
+	invalidateWorkingLinePublisherState = () => workingLineExtensions.invalidate();
 	const getContextSnapshot = (ctx: ExtensionContext) => resolveContextUsage(ctx, liveContext.get());
 	const getContextWindow = (ctx: ExtensionContext): number | undefined =>
 		getContextSnapshot(ctx).contextWindow;
@@ -1160,6 +1171,12 @@ export default function (pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		const lifecycleGeneration = sessionLifecycle.start();
+		// A new generation must not expose or route extension segments through the previous
+		// session while asynchronous TUI startup is still pending.
+		workingLineSessionReady = false;
+		workingLineExtensions.invalidate();
+		if (activeTuiContext) workingLine.dispose(activeTuiContext);
+		else workingLine.invalidateExtensionSegments();
 		// Reload synchronously so private ownership uses this session's disk snapshot before
 		// any await or transcript restoration.
 		currentConfig = loadConfig();
@@ -1186,7 +1203,7 @@ export default function (pi: ExtensionAPI) {
 		if (!sessionLifecycle.isCurrent(lifecycleGeneration)) return;
 		liveContext.clear();
 		interactionMetrics.shutdown();
-		workingLineExtensions.clear();
+		workingLineExtensions.invalidate();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		resetAgentTimer();
@@ -1195,6 +1212,7 @@ export default function (pi: ExtensionAPI) {
 		repositoryRoots.reset();
 		installUi(ctx);
 		workingLine.startSession(ctx);
+		workingLineSessionReady = true;
 		scheduleEditorReconciliation(ctx);
 	});
 
@@ -1341,11 +1359,12 @@ export default function (pi: ExtensionAPI) {
 	});
 
 	pi.on("session_shutdown", async (_event, ctx) => {
+		workingLineSessionReady = false;
 		thinkingExperimental.shutdown();
 		liveContext.clear();
 		interactionMetrics.shutdown();
 		workingLine.dispose(ctx);
-		workingLineExtensions.clear();
+		workingLineExtensions.invalidate();
 		cleanupUi(ctx);
 	});
 

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -97,6 +97,7 @@ import {
 	snapshotWorkingLineHighStyle,
 	WorkingLineController,
 } from "./working-line";
+import { WorkingLineExtensionSegments } from "./working-line-extension-segments";
 
 const ZENTUI_EDITOR_FACTORY = Symbol.for("pi-zentui.editor-factory");
 const ZENTUI_EDITOR_BASE_FACTORY = Symbol.for("pi-zentui.editor-base-factory");
@@ -300,6 +301,18 @@ export default function (pi: ExtensionAPI) {
 		Math.random,
 		Date.now,
 		() => interactionMetrics.currentThought(),
+	);
+	const workingLineExtensions = new WorkingLineExtensionSegments(
+		pi.events,
+		() =>
+			sessionLifecycle.isCurrent() &&
+			currentConfig.components.workingLine.enabled &&
+			activeTuiContext !== undefined,
+		(segments) => {
+			if (activeTuiContext && sessionLifecycle.isCurrent()) {
+				workingLine.updateExtensionSegments(segments, activeTuiContext);
+			}
+		},
 	);
 	const getContextSnapshot = (ctx: ExtensionContext) => resolveContextUsage(ctx, liveContext.get());
 	const getContextWindow = (ctx: ExtensionContext): number | undefined =>
@@ -1173,6 +1186,7 @@ export default function (pi: ExtensionAPI) {
 		if (!sessionLifecycle.isCurrent(lifecycleGeneration)) return;
 		liveContext.clear();
 		interactionMetrics.shutdown();
+		workingLineExtensions.clear();
 		state.sessionStartEpoch = Date.now();
 		invalidateUsageTotalsCache();
 		resetAgentTimer();
@@ -1241,6 +1255,7 @@ export default function (pi: ExtensionAPI) {
 		},
 		setWorkingLineComponent(patch: WorkingLineComponentPatch, ctx: ExtensionContext) {
 			currentConfig = saveWorkingLineComponentPatch(patch);
+			if (patch.enabled === false) workingLineExtensions.clear();
 			return workingLine.reconcile(ctx);
 		},
 		setSelectorBordersComponent(
@@ -1330,6 +1345,7 @@ export default function (pi: ExtensionAPI) {
 		liveContext.clear();
 		interactionMetrics.shutdown();
 		workingLine.dispose(ctx);
+		workingLineExtensions.clear();
 		cleanupUi(ctx);
 	});
 

--- a/extensions/zentui/working-line-extension-segments.ts
+++ b/extensions/zentui/working-line-extension-segments.ts
@@ -3,6 +3,7 @@ import type { EventBus } from "@earendil-works/pi-coding-agent";
 export const ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT =
 	"zentui:working-line-segment-capability";
 export const ZENTUI_WORKING_LINE_SEGMENT_EVENT = "zentui:working-line-segment";
+export const ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION = 1;
 
 export const MAX_WORKING_LINE_EXTENSION_SEGMENTS = 16;
 export const MAX_WORKING_LINE_EXTENSION_KEY_CODE_UNITS = 64;
@@ -11,6 +12,8 @@ export const MAX_WORKING_LINE_EXTENSION_TEXT_CODE_UNITS = 256;
 export type WorkingLineSegmentCapability = {
 	supported: boolean;
 	active: boolean;
+	/** Present in protocol version 1 and later. */
+	version?: number;
 };
 
 export type WorkingLineSegmentUpdate = {
@@ -49,11 +52,12 @@ function segmentUpdate(value: unknown): WorkingLineSegmentUpdate | undefined {
 /** Collects keyed third-party segments and publishes deterministic snapshots to the Working line. */
 export class WorkingLineExtensionSegments {
 	private readonly segments = new Map<string, string>();
+	private publishDirty = false;
 
 	constructor(
 		events: EventBus | undefined,
 		private readonly isActive: () => boolean,
-		private readonly onChange: (segments: readonly string[]) => void,
+		private readonly onChange: (segments: readonly string[]) => boolean | undefined,
 	) {
 		if (!events) return;
 		events.on(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, (value) => {
@@ -61,37 +65,51 @@ export class WorkingLineExtensionSegments {
 			if (!capability) return;
 			capability.supported = true;
 			capability.active = this.isActive();
+			capability.version = ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION;
 		});
 		events.on(ZENTUI_WORKING_LINE_SEGMENT_EVENT, (value) => {
 			const update = segmentUpdate(value);
 			if (!update) return;
 			if (update.text !== undefined && update.text.length > 0 && !this.isActive()) return;
 			if (update.text === undefined || update.text.length === 0) {
-				if (!this.segments.delete(update.key)) return;
+				if (!this.segments.delete(update.key) && !this.publishDirty) return;
 			} else {
 				if (
 					!this.segments.has(update.key) &&
 					this.segments.size >= MAX_WORKING_LINE_EXTENSION_SEGMENTS
 				)
 					return;
-				if (this.segments.get(update.key) === update.text) return;
+				if (this.segments.get(update.key) === update.text && !this.publishDirty) return;
 				this.segments.set(update.key, update.text);
 			}
+			this.publishDirty = true;
 			this.publish();
 		});
 	}
 
 	clear(): void {
-		if (this.segments.size === 0) return;
+		if (this.segments.size === 0 && !this.publishDirty) return;
 		this.segments.clear();
+		this.publishDirty = true;
 		this.publish();
 	}
 
+	/** Drops session-scoped publisher state without attempting a Working-row write. */
+	invalidate(): void {
+		this.segments.clear();
+		this.publishDirty = false;
+	}
+
 	private publish(): void {
-		this.onChange(
+		const applied = this.onChange(
 			[...this.segments.entries()]
 				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
 				.map(([, text]) => text),
 		);
+		if (applied === false && !this.isActive()) {
+			this.invalidate();
+			return;
+		}
+		this.publishDirty = applied === false;
 	}
 }

--- a/extensions/zentui/working-line-extension-segments.ts
+++ b/extensions/zentui/working-line-extension-segments.ts
@@ -1,0 +1,97 @@
+import type { EventBus } from "@earendil-works/pi-coding-agent";
+
+export const ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT =
+	"zentui:working-line-segment-capability";
+export const ZENTUI_WORKING_LINE_SEGMENT_EVENT = "zentui:working-line-segment";
+
+export const MAX_WORKING_LINE_EXTENSION_SEGMENTS = 16;
+export const MAX_WORKING_LINE_EXTENSION_KEY_CODE_UNITS = 64;
+export const MAX_WORKING_LINE_EXTENSION_TEXT_CODE_UNITS = 256;
+
+export type WorkingLineSegmentCapability = {
+	supported: boolean;
+	active: boolean;
+};
+
+export type WorkingLineSegmentUpdate = {
+	key: string;
+	text?: string;
+};
+
+type EventRecord = Record<string, unknown>;
+
+function eventRecord(value: unknown): EventRecord | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as EventRecord)
+		: undefined;
+}
+
+function segmentUpdate(value: unknown): WorkingLineSegmentUpdate | undefined {
+	const record = eventRecord(value);
+	if (!record) return undefined;
+	if (
+		typeof record.key !== "string" ||
+		record.key.length === 0 ||
+		record.key.length > MAX_WORKING_LINE_EXTENSION_KEY_CODE_UNITS
+	) {
+		return undefined;
+	}
+	if (
+		record.text !== undefined &&
+		(typeof record.text !== "string" ||
+			record.text.length > MAX_WORKING_LINE_EXTENSION_TEXT_CODE_UNITS)
+	) {
+		return undefined;
+	}
+	return { key: record.key, text: record.text as string | undefined };
+}
+
+/** Collects keyed third-party segments and publishes deterministic snapshots to the Working line. */
+export class WorkingLineExtensionSegments {
+	private readonly segments = new Map<string, string>();
+
+	constructor(
+		events: EventBus | undefined,
+		private readonly isActive: () => boolean,
+		private readonly onChange: (segments: readonly string[]) => void,
+	) {
+		if (!events) return;
+		events.on(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, (value) => {
+			const capability = eventRecord(value);
+			if (!capability) return;
+			capability.supported = true;
+			capability.active = this.isActive();
+		});
+		events.on(ZENTUI_WORKING_LINE_SEGMENT_EVENT, (value) => {
+			const update = segmentUpdate(value);
+			if (!update) return;
+			if (update.text !== undefined && update.text.length > 0 && !this.isActive()) return;
+			if (update.text === undefined || update.text.length === 0) {
+				if (!this.segments.delete(update.key)) return;
+			} else {
+				if (
+					!this.segments.has(update.key) &&
+					this.segments.size >= MAX_WORKING_LINE_EXTENSION_SEGMENTS
+				)
+					return;
+				if (this.segments.get(update.key) === update.text) return;
+				this.segments.set(update.key, update.text);
+			}
+			this.publish();
+		});
+	}
+
+	clear(): void {
+		if (this.segments.size === 0) return;
+		this.segments.clear();
+		this.publish();
+	}
+
+	private publish(): void {
+		this.onChange(
+			[...this.segments.entries()]
+				.sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+				.map(([, text]) => text),
+		);
+	}
+}

--- a/extensions/zentui/working-line.ts
+++ b/extensions/zentui/working-line.ts
@@ -494,6 +494,7 @@ export type WorkingLineRuntimeSegments = {
 	elapsedMs?: number;
 	thought?: { durationMs: number; active: boolean };
 	tokens?: { input: number; output: number; outputApproximate?: boolean };
+	extensions?: readonly string[];
 };
 
 export type WorkingLineFrameState = {
@@ -573,6 +574,26 @@ function truncateWithEllipsis(value: string, capacity: number): string {
 	return prefix ? `${prefix}…` : "";
 }
 
+function fitWorkingLineExtensionSegments(
+	values: readonly string[],
+	budget: number,
+	delimiter: string,
+): string[] {
+	const fitted: string[] = [];
+	let used = 0;
+	for (const value of values) {
+		const normalized = normalizeWorkingLineMessage(value);
+		const remaining = budget - used - visibleWidth(delimiter);
+		if (!normalized || remaining <= 0) continue;
+		const text = truncateWithEllipsis(normalized, remaining);
+		if (!text) continue;
+		fitted.push(text);
+		used += visibleWidth(delimiter) + visibleWidth(text);
+		if (text !== normalized) break;
+	}
+	return fitted;
+}
+
 export type ComposedWorkingLine = { message: string; row: string };
 
 /** Validate and measure the fixed visible width shared by every frame in a preset. */
@@ -596,7 +617,17 @@ export function composeWorkingLineRow(
 		MAX_WORKING_LINE_FRAME_CELLS - workingLineSpinnerWidth(config.spinner) - visibleWidth(" ");
 	const delimiter = " · ";
 	const tokens = config.segments.tokens ? formatWorkingLineTokens(runtime.tokens) : undefined;
-	const mandatoryWidth = tokens ? visibleWidth(delimiter) + visibleWidth(tokens) : 0;
+	const tokenWidth = tokens ? visibleWidth(delimiter) + visibleWidth(tokens) : 0;
+	const extensions = fitWorkingLineExtensionSegments(
+		runtime.extensions ?? [],
+		Math.max(0, maximumRowCells - tokenWidth - 1),
+		delimiter,
+	);
+	const extensionWidth = extensions.reduce(
+		(width, value) => width + visibleWidth(delimiter) + visibleWidth(value),
+		0,
+	);
+	const mandatoryWidth = tokenWidth + extensionWidth;
 	const messageCapacity = maximumRowCells - mandatoryWidth;
 	const fittedMessage = truncateWithEllipsis(normalized, messageCapacity);
 	const segments: string[] = [fittedMessage];
@@ -630,6 +661,7 @@ export function composeWorkingLineRow(
 	if (accepted.has("elapsed") && elapsed) segments.push(elapsed);
 	if (accepted.has("thought") && thought) segments.push(thought);
 	if (tokens) segments.push(tokens);
+	segments.push(...extensions);
 	return { message: normalized, row: segments.filter(Boolean).join(delimiter) };
 }
 
@@ -1022,6 +1054,7 @@ export class WorkingLineController {
 	private installedIndicatorOptions: WorkingIndicatorOptions | undefined;
 	private tokens: WorkingLineRuntimeSegments["tokens"];
 	private thought: WorkingLineRuntimeSegments["thought"];
+	private extensionSegments: readonly string[] = [];
 	private readonly activeTools = new Map<string, string>();
 	private elapsedUpdatesActive = false;
 	private elapsedUpdatesContext: WorkingLineContext | undefined;
@@ -1080,6 +1113,17 @@ export class WorkingLineController {
 
 	updateTokens(tokens: WorkingLineRuntimeSegments["tokens"], ctx: WorkingLineContext): void {
 		this.updateMetrics(tokens, this.getThought(), ctx);
+	}
+
+	updateExtensionSegments(segments: readonly string[], ctx: WorkingLineContext): void {
+		if (
+			this.extensionSegments.length === segments.length &&
+			this.extensionSegments.every((value, index) => value === segments[index])
+		) {
+			return;
+		}
+		this.extensionSegments = [...segments];
+		this.updateIndicator(ctx);
 	}
 
 	startTool(toolCallId: string, toolName: string, ctx: WorkingLineContext): void {
@@ -1201,6 +1245,7 @@ export class WorkingLineController {
 			elapsedMs: this.agentActive ? this.durationClock.elapsedMs() : undefined,
 			thought,
 			tokens: this.tokens,
+			extensions: this.extensionSegments,
 		};
 	}
 
@@ -1429,5 +1474,6 @@ export class WorkingLineController {
 		this.activeTools.clear();
 		this.tokens = undefined;
 		this.thought = undefined;
+		this.extensionSegments = [];
 	}
 }

--- a/extensions/zentui/working-line.ts
+++ b/extensions/zentui/working-line.ts
@@ -1055,6 +1055,7 @@ export class WorkingLineController {
 	private tokens: WorkingLineRuntimeSegments["tokens"];
 	private thought: WorkingLineRuntimeSegments["thought"];
 	private extensionSegments: readonly string[] = [];
+	private extensionSegmentsDirty = false;
 	private readonly activeTools = new Map<string, string>();
 	private elapsedUpdatesActive = false;
 	private elapsedUpdatesContext: WorkingLineContext | undefined;
@@ -1068,6 +1069,7 @@ export class WorkingLineController {
 		private readonly random: () => number = Math.random,
 		private readonly now: () => number = Date.now,
 		private readonly getThought: () => WorkingLineRuntimeSegments["thought"] = () => this.thought,
+		private readonly onUnavailable: () => void = () => {},
 	) {}
 
 	startSession(ctx: WorkingLineContext): WorkingLineReconcileResult {
@@ -1115,15 +1117,22 @@ export class WorkingLineController {
 		this.updateMetrics(tokens, this.getThought(), ctx);
 	}
 
-	updateExtensionSegments(segments: readonly string[], ctx: WorkingLineContext): void {
-		if (
+	updateExtensionSegments(segments: readonly string[], ctx: WorkingLineContext): boolean {
+		const unchanged =
 			this.extensionSegments.length === segments.length &&
-			this.extensionSegments.every((value, index) => value === segments[index])
-		) {
-			return;
+			this.extensionSegments.every((value, index) => value === segments[index]);
+		if (unchanged && !this.extensionSegmentsDirty) return true;
+		if (!unchanged) {
+			this.extensionSegments = [...segments];
+			this.extensionSegmentsDirty = true;
 		}
-		this.extensionSegments = [...segments];
-		this.updateIndicator(ctx);
+		return this.updateIndicator(ctx);
+	}
+
+	/** Drops extension state that is no longer valid for the current owned Working row. */
+	invalidateExtensionSegments(): void {
+		this.extensionSegments = [];
+		this.extensionSegmentsDirty = false;
 	}
 
 	startTool(toolCallId: string, toolName: string, ctx: WorkingLineContext): void {
@@ -1180,6 +1189,16 @@ export class WorkingLineController {
 		return this.selectedMessage;
 	}
 
+	/** Whether this controller currently claims both required public Working-row surfaces. */
+	isAvailable(): boolean {
+		return (
+			this.getConfig().components.workingLine.enabled &&
+			this.installed &&
+			this.ownsIndicator &&
+			this.ownsMessage
+		);
+	}
+
 	private install(
 		ctx: WorkingLineContext,
 		forceIndicator = false,
@@ -1190,6 +1209,7 @@ export class WorkingLineController {
 		if (!ui) {
 			this.installed = false;
 			this.deactivateElapsedUpdates();
+			this.invalidateUnavailableExtensionSegments();
 			return { applied: false, reason: "Working line requires a newer Pi TUI" };
 		}
 		const rootConfig = this.getConfig();
@@ -1257,7 +1277,10 @@ export class WorkingLineController {
 		rebase = false,
 	): void {
 		const key = this.makeFrameKey(rootConfig, selectedMessage);
-		if (!force && this.installed && this.frameKey === key) return;
+		if (!force && this.installed && this.frameKey === key) {
+			this.extensionSegmentsDirty = false;
+			return;
+		}
 		const config = rootConfig.components.workingLine;
 		const sampledAtMs = this.now();
 		let spinnerTick = 0;
@@ -1329,19 +1352,22 @@ export class WorkingLineController {
 		this.installed = true;
 		this.frameKey = key;
 		this.installedIndicatorOptions = indicatorOptions;
+		this.extensionSegmentsDirty = false;
 	}
 
-	private updateIndicator(ctx: WorkingLineContext): void {
+	private updateIndicator(ctx: WorkingLineContext): boolean {
 		const rootConfig = this.getConfig();
-		if (!rootConfig.components.workingLine.enabled || !this.installed) return;
+		if (!rootConfig.components.workingLine.enabled || !this.installed) return false;
 		const ui = workingLineUi(ctx);
-		if (!ui) return;
+		if (!ui) return false;
 		const snapshot = this.installationSnapshot();
 		try {
 			this.applyIndicator(ui, rootConfig);
+			return !this.extensionSegmentsDirty;
 		} catch {
 			// A transient last-writer/public-API failure must not break the agent turn.
 			this.recoverOrReleaseAfterFailure(ui, snapshot);
+			return false;
 		}
 	}
 
@@ -1418,6 +1444,15 @@ export class WorkingLineController {
 		}
 	}
 
+	private invalidateUnavailableExtensionSegments(): void {
+		this.invalidateExtensionSegments();
+		try {
+			this.onUnavailable();
+		} catch {
+			// Availability cleanup is fail-open like the public Working-row release.
+		}
+	}
+
 	private releaseAfterFailure(ui: WorkingLineUi): void {
 		this.deactivateElapsedUpdates();
 		if (this.ownsIndicator) {
@@ -1440,6 +1475,7 @@ export class WorkingLineController {
 		this.frameKey = undefined;
 		this.installedPhase = undefined;
 		this.installedIndicatorOptions = undefined;
+		this.invalidateUnavailableExtensionSegments();
 	}
 
 	private reset(ctx: WorkingLineContext): void {
@@ -1474,6 +1510,6 @@ export class WorkingLineController {
 		this.activeTools.clear();
 		this.tokens = undefined;
 		this.thought = undefined;
-		this.extensionSegments = [];
+		this.invalidateExtensionSegments();
 	}
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"tui"
 	],
 	"files": [
-		"extensions"
+		"extensions",
+		"docs/configuration.md"
 	],
 	"scripts": {
 		"lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	"scripts": {
 		"lint": "biome check .",
 		"typecheck": "tsc --noEmit",
-		"test": "vitest run",
+		"test": "vitest run --testTimeout=30000",
 		"test:thinking-experimental-tui": "node test/thinking-experimental-tui.mjs",
 		"test:thinking-experimental-diagnostics": "node test/thinking-experimental-loader-diagnostics.mjs",
 		"pi:dev": "${PI_BIN:-/opt/homebrew/bin/pi} --no-extensions -e ./extensions/zentui/index.ts",

--- a/test/package-contents.mjs
+++ b/test/package-contents.mjs
@@ -15,6 +15,7 @@ assert.equal(packages.length, 1, "npm pack must report exactly one package");
 const files = packages[0]?.files;
 assert.ok(Array.isArray(files), "npm pack must report its package file list");
 for (const required of [
+	"docs/configuration.md",
 	"extensions/zentui/thinking-steps.ts",
 	"extensions/zentui/thinking-experimental.ts",
 	"extensions/zentui/thinking-status.ts",

--- a/test/working-line-extension-segments.test.ts
+++ b/test/working-line-extension-segments.test.ts
@@ -7,6 +7,7 @@ import {
 	WorkingLineExtensionSegments,
 	ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT,
 	ZENTUI_WORKING_LINE_SEGMENT_EVENT,
+	ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
 } from "../extensions/zentui/working-line-extension-segments";
 
 function eventBus(): EventBus {
@@ -31,14 +32,22 @@ describe("working-line extension segments", () => {
 		new WorkingLineExtensionSegments(
 			events,
 			() => active,
-			() => {},
+			() => undefined,
 		);
 		const capability = { supported: false, active: false };
 		events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
-		expect(capability).toEqual({ supported: true, active: false });
+		expect(capability).toEqual({
+			supported: true,
+			active: false,
+			version: ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
+		});
 		active = true;
 		events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
-		expect(capability).toEqual({ supported: true, active: true });
+		expect(capability).toEqual({
+			supported: true,
+			active: true,
+			version: ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
+		});
 	});
 
 	it("ignores segment values while the Working line is inactive", () => {
@@ -65,6 +74,40 @@ describe("working-line extension segments", () => {
 		expect(onChange).toHaveBeenLastCalledWith(["updated"]);
 		segments.clear();
 		expect(onChange).toHaveBeenLastCalledWith([]);
+	});
+
+	it("retries an identical keyed snapshot after its first publication is rejected", () => {
+		const events = eventBus();
+		const onChange = vi.fn().mockReturnValueOnce(false).mockReturnValue(true);
+		new WorkingLineExtensionSegments(events, () => true, onChange);
+		const update = { key: "@scope/publisher:queue", text: "queue 2" };
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		expect(onChange).toHaveBeenCalledTimes(2);
+		expect(onChange).toHaveBeenNthCalledWith(1, ["queue 2"]);
+		expect(onChange).toHaveBeenNthCalledWith(2, ["queue 2"]);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		expect(onChange).toHaveBeenCalledTimes(2);
+	});
+
+	it("invalidates keyed state when a rejected publication makes the integration inactive", () => {
+		const events = eventBus();
+		let active = true;
+		const onChange = vi.fn(() => {
+			active = false;
+			return false;
+		});
+		new WorkingLineExtensionSegments(events, () => active, onChange);
+		const update = { key: "@scope/publisher:queue", text: "queue 2" };
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		expect(onChange).toHaveBeenCalledTimes(1);
+
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		expect(onChange).toHaveBeenCalledTimes(1);
+		active = true;
+		onChange.mockReturnValue(true);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		expect(onChange).toHaveBeenCalledTimes(2);
 	});
 
 	it("rejects malformed and over-limit updates and bounds unique keys", () => {

--- a/test/working-line-extension-segments.test.ts
+++ b/test/working-line-extension-segments.test.ts
@@ -1,0 +1,96 @@
+import type { EventBus } from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+	MAX_WORKING_LINE_EXTENSION_KEY_CODE_UNITS,
+	MAX_WORKING_LINE_EXTENSION_SEGMENTS,
+	MAX_WORKING_LINE_EXTENSION_TEXT_CODE_UNITS,
+	WorkingLineExtensionSegments,
+	ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT,
+	ZENTUI_WORKING_LINE_SEGMENT_EVENT,
+} from "../extensions/zentui/working-line-extension-segments";
+
+function eventBus(): EventBus {
+	const handlers = new Map<string, Set<(data: unknown) => void>>();
+	return {
+		emit(channel, data) {
+			for (const handler of handlers.get(channel) ?? []) handler(data);
+		},
+		on(channel, handler) {
+			const current = handlers.get(channel) ?? new Set();
+			current.add(handler);
+			handlers.set(channel, current);
+			return () => current.delete(handler);
+		},
+	};
+}
+
+describe("working-line extension segments", () => {
+	it("reports support and whether the integration is currently active", () => {
+		const events = eventBus();
+		let active = false;
+		new WorkingLineExtensionSegments(
+			events,
+			() => active,
+			() => {},
+		);
+		const capability = { supported: false, active: false };
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
+		expect(capability).toEqual({ supported: true, active: false });
+		active = true;
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
+		expect(capability).toEqual({ supported: true, active: true });
+	});
+
+	it("ignores segment values while the Working line is inactive", () => {
+		const events = eventBus();
+		const onChange = vi.fn();
+		new WorkingLineExtensionSegments(events, () => false, onChange);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "inactive", text: "hidden" });
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it("publishes keyed segments in deterministic order and supports update, removal, and clear", () => {
+		const events = eventBus();
+		const onChange = vi.fn();
+		const segments = new WorkingLineExtensionSegments(events, () => true, onChange);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "zeta", text: "second" });
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "alpha", text: "first" });
+		expect(onChange).toHaveBeenLastCalledWith(["first", "second"]);
+		const calls = onChange.mock.calls.length;
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "alpha", text: "first" });
+		expect(onChange).toHaveBeenCalledTimes(calls);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "alpha", text: "updated" });
+		expect(onChange).toHaveBeenLastCalledWith(["updated", "second"]);
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "zeta" });
+		expect(onChange).toHaveBeenLastCalledWith(["updated"]);
+		segments.clear();
+		expect(onChange).toHaveBeenLastCalledWith([]);
+	});
+
+	it("rejects malformed and over-limit updates and bounds unique keys", () => {
+		const events = eventBus();
+		const onChange = vi.fn();
+		new WorkingLineExtensionSegments(events, () => true, onChange);
+		for (const value of [
+			null,
+			{},
+			{ key: "" },
+			{ key: "x".repeat(MAX_WORKING_LINE_EXTENSION_KEY_CODE_UNITS + 1), text: "value" },
+			{ key: "wrong-text", text: 1 },
+			{
+				key: "long-text",
+				text: "x".repeat(MAX_WORKING_LINE_EXTENSION_TEXT_CODE_UNITS + 1),
+			},
+		]) {
+			events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, value);
+		}
+		expect(onChange).not.toHaveBeenCalled();
+		for (let index = 0; index < MAX_WORKING_LINE_EXTENSION_SEGMENTS + 1; index += 1) {
+			events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+				key: `segment-${index}`,
+				text: `${index}`,
+			});
+		}
+		expect(onChange).toHaveBeenCalledTimes(MAX_WORKING_LINE_EXTENSION_SEGMENTS);
+	});
+});

--- a/test/working-line-lifecycle.integration.test.ts
+++ b/test/working-line-lifecycle.integration.test.ts
@@ -1,5 +1,5 @@
 import { stripVTControlCharacters } from "node:util";
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { EventBus, Theme } from "@earendil-works/pi-coding-agent";
 import { Loader, visibleWidth } from "@earendil-works/pi-tui";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -40,6 +40,10 @@ vi.mock("../extensions/zentui/config", async (importOriginal) => {
 });
 
 import zentui from "../extensions/zentui/index";
+import {
+	ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT,
+	ZENTUI_WORKING_LINE_SEGMENT_EVENT,
+} from "../extensions/zentui/working-line-extension-segments";
 
 type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
 
@@ -73,11 +77,27 @@ function loaderPhase(rendered: string): [string, number | undefined] {
 	];
 }
 
-function loadExtension() {
-	const handlers = new Map<string, Handler[]>();
+type LoadedHandlers = Map<string, Handler[]> & { events: EventBus };
+
+function loadExtension(): LoadedHandlers {
+	const handlers = new Map<string, Handler[]>() as LoadedHandlers;
+	const eventHandlers = new Map<string, Set<(data: unknown) => void>>();
+	const events: EventBus = {
+		emit(channel, data) {
+			for (const handler of eventHandlers.get(channel) ?? []) handler(data);
+		},
+		on(channel, handler) {
+			const current = eventHandlers.get(channel) ?? new Set();
+			current.add(handler);
+			eventHandlers.set(channel, current);
+			return () => current.delete(handler);
+		},
+	};
+	handlers.events = events;
 	zentui({
 		registerEntryRenderer() {},
 		appendEntry() {},
+		events,
 		on(name: string, handler: Handler) {
 			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
 		},
@@ -226,6 +246,33 @@ describe("working-line extension lifecycle integration", () => {
 			["message", undefined],
 		]);
 		expect(current.forbidden).not.toHaveBeenCalled();
+	});
+
+	it("composes keyed extension segments into the owned animated row", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const row = () => {
+			const indicator = current.calls.at(-1)?.[1] as { frames?: string[] } | undefined;
+			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
+		};
+		await emit(handlers, "session_start", current.ctx);
+		const capability = { supported: false, active: false };
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
+		expect(capability).toEqual({ supported: true, active: true });
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "tps",
+			text: "24.3 tok/s · TTFT 820ms",
+		});
+		expect(row()).toContain("Stable · 24.3 tok/s · TTFT 820ms");
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "queue",
+			text: "queue 2",
+		});
+		expect(row()).toContain("queue 2 · 24.3 tok/s · TTFT 820ms");
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "tps" });
+		expect(row()).toContain("Stable · queue 2");
+		expect(row()).not.toContain("tok/s");
+		await emit(handlers, "session_shutdown", current.ctx);
 	});
 
 	it("compacts live provider usage", async () => {

--- a/test/working-line-lifecycle.integration.test.ts
+++ b/test/working-line-lifecycle.integration.test.ts
@@ -14,6 +14,24 @@ const runtime = vi.hoisted(() => ({
 	textIntervalMs: 60,
 }));
 
+const startupGate = vi.hoisted(() => ({
+	pending: undefined as Promise<void> | undefined,
+}));
+
+vi.mock("../extensions/zentui/accent-rail-layout-patch", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../extensions/zentui/accent-rail-layout-patch")>();
+	return {
+		...actual,
+		async retainAccentRailLayoutPatchInstallation(
+			...args: Parameters<typeof actual.retainAccentRailLayoutPatchInstallation>
+		) {
+			if (startupGate.pending) await startupGate.pending;
+			return actual.retainAccentRailLayoutPatchInstallation(...args);
+		},
+	};
+});
+
 vi.mock("../extensions/zentui/config", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../extensions/zentui/config")>();
 	return {
@@ -43,6 +61,7 @@ import zentui from "../extensions/zentui/index";
 import {
 	ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT,
 	ZENTUI_WORKING_LINE_SEGMENT_EVENT,
+	ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
 } from "../extensions/zentui/working-line-extension-segments";
 
 type Handler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
@@ -116,6 +135,12 @@ async function emit(
 	for (const handler of handlers.get(name) ?? []) await handler(event, ctx);
 }
 
+function capability(handlers: LoadedHandlers) {
+	const result = { supported: false, active: false };
+	handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, result);
+	return result as typeof result & { version: number };
+}
+
 function harness() {
 	const calls: Array<[string, unknown?]> = [];
 	const forbidden = vi.fn();
@@ -172,6 +197,7 @@ beforeEach(() => {
 	runtime.spinner = "star-bloom";
 	runtime.spinnerIntervalMs = 100;
 	runtime.textIntervalMs = 60;
+	startupGate.pending = undefined;
 });
 
 describe("working-line extension lifecycle integration", () => {
@@ -256,9 +282,11 @@ describe("working-line extension lifecycle integration", () => {
 			return stripTerminalSequences(indicator?.frames?.[0] ?? "");
 		};
 		await emit(handlers, "session_start", current.ctx);
-		const capability = { supported: false, active: false };
-		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_CAPABILITY_EVENT, capability);
-		expect(capability).toEqual({ supported: true, active: true });
+		expect(capability(handlers)).toEqual({
+			supported: true,
+			active: true,
+			version: ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
+		});
 		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
 			key: "tps",
 			text: "24.3 tok/s · TTFT 820ms",
@@ -272,6 +300,165 @@ describe("working-line extension lifecycle integration", () => {
 		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "tps" });
 		expect(row()).toContain("Stable · queue 2");
 		expect(row()).not.toContain("tok/s");
+		await emit(handlers, "session_shutdown", current.ctx);
+		expect(capability(handlers).active).toBe(false);
+	});
+
+	it("suspends capability and routing synchronously while a replacement session starts", async () => {
+		const handlers = loadExtension();
+		const first = harness();
+		await emit(handlers, "session_start", first.ctx);
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "@scope/publisher:session",
+			text: "session A",
+		});
+		expect(capability(handlers).active).toBe(true);
+
+		let releaseStartup = () => {};
+		startupGate.pending = new Promise<void>((resolve) => {
+			releaseStartup = resolve;
+		});
+		const second = harness();
+		const starting = emit(handlers, "session_start", second.ctx);
+		expect(capability(handlers).active).toBe(false);
+		const firstCallsAfterSuspension = first.calls.length;
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "@scope/publisher:session",
+			text: "must not reach session A",
+		});
+		expect(first.calls).toHaveLength(firstCallsAfterSuspension);
+		expect(second.calls).toEqual([]);
+
+		releaseStartup();
+		await starting;
+		startupGate.pending = undefined;
+		expect(capability(handlers).active).toBe(true);
+		const installed = second.calls
+			.filter(([name, value]) => name === "indicator" && value !== undefined)
+			.at(-1)?.[1] as { frames?: string[] } | undefined;
+		expect(stripTerminalSequences(installed?.frames?.[0] ?? "")).not.toContain("session A");
+		expect(stripTerminalSequences(installed?.frames?.[0] ?? "")).not.toContain("must not reach");
+		await emit(handlers, "session_shutdown", second.ctx);
+	});
+
+	it("reports inactive across missing APIs, disable, re-enable, and session boundaries", async () => {
+		const handlers = loadExtension();
+		const missingApi = harness();
+		(missingApi.ctx.ui as { setWorkingIndicator?: unknown }).setWorkingIndicator = undefined;
+		await emit(handlers, "session_start", missingApi.ctx);
+		expect(capability(handlers)).toEqual({
+			supported: true,
+			active: false,
+			version: ZENTUI_WORKING_LINE_SEGMENT_PROTOCOL_VERSION,
+		});
+		await emit(handlers, "session_shutdown", missingApi.ctx);
+		expect(capability(handlers).active).toBe(false);
+
+		const enabled = harness();
+		await emit(handlers, "session_start", enabled.ctx);
+		expect(capability(handlers).active).toBe(true);
+		await emit(handlers, "session_shutdown", enabled.ctx);
+		expect(capability(handlers).active).toBe(false);
+
+		runtime.enabled = false;
+		const disabled = harness();
+		await emit(handlers, "session_start", disabled.ctx);
+		expect(capability(handlers).active).toBe(false);
+		await emit(handlers, "session_shutdown", disabled.ctx);
+
+		runtime.enabled = true;
+		const reenabled = harness();
+		await emit(handlers, "session_start", reenabled.ctx);
+		expect(capability(handlers).active).toBe(true);
+		await emit(handlers, "session_shutdown", reenabled.ctx);
+		expect(capability(handlers).active).toBe(false);
+	});
+
+	it("reports inactive when the initial indicator setter fails", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		const setIndicator = current.ctx.ui.setWorkingIndicator.bind(current.ctx.ui);
+		let fail = true;
+		current.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			if (value !== undefined && fail) {
+				fail = false;
+				throw new Error("indicator unavailable");
+			}
+			setIndicator(value);
+		};
+		await emit(handlers, "session_start", current.ctx);
+		expect(capability(handlers).active).toBe(false);
+		await emit(handlers, "session_shutdown", current.ctx);
+	});
+
+	it("invalidates released state, ignores inactive updates, and accepts a current republish", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		await emit(handlers, "session_start", current.ctx);
+		expect(capability(handlers).active).toBe(true);
+		const setIndicator = current.ctx.ui.setWorkingIndicator.bind(current.ctx.ui);
+		let failures = 2;
+		current.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			if (value !== undefined && failures > 0) {
+				failures -= 1;
+				throw new Error("indicator unavailable");
+			}
+			setIndicator(value);
+		};
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "@scope/publisher:queue",
+			text: "stale queue 2",
+		});
+		expect(capability(handlers).active).toBe(false);
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "@scope/publisher:queue",
+			text: "current queue 3",
+		});
+
+		await emit(handlers, "agent_start", current.ctx);
+		expect(capability(handlers).active).toBe(true);
+		const reinstalled = current.calls
+			.filter(([name, value]) => name === "indicator" && value !== undefined)
+			.at(-1)?.[1] as { frames?: string[] } | undefined;
+		expect(stripTerminalSequences(reinstalled?.frames?.[0] ?? "")).not.toContain("stale queue");
+		expect(stripTerminalSequences(reinstalled?.frames?.[0] ?? "")).not.toContain("current queue");
+
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "@scope/publisher:queue",
+			text: "current queue 3",
+		});
+		const republished = current.calls
+			.filter(([name, value]) => name === "indicator" && value !== undefined)
+			.at(-1)?.[1] as { frames?: string[] } | undefined;
+		expect(stripTerminalSequences(republished?.frames?.[0] ?? "")).toContain("current queue 3");
+		await emit(handlers, "session_shutdown", current.ctx);
+	});
+
+	it("renders an identical keyed replay after a transient segment update failure", async () => {
+		const handlers = loadExtension();
+		const current = harness();
+		await emit(handlers, "session_start", current.ctx);
+		const setIndicator = current.ctx.ui.setWorkingIndicator.bind(current.ctx.ui);
+		let fail = true;
+		current.ctx.ui.setWorkingIndicator = (value?: unknown) => {
+			if (value !== undefined && fail) {
+				fail = false;
+				throw new Error("transient indicator failure");
+			}
+			setIndicator(value);
+		};
+		const update = { key: "@scope/publisher:queue", text: "queue 2" };
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		const afterFailure = current.calls
+			.filter(([name, value]) => name === "indicator" && value !== undefined)
+			.at(-1)?.[1] as { frames?: string[] } | undefined;
+		expect(stripTerminalSequences(afterFailure?.frames?.[0] ?? "")).not.toContain("queue 2");
+		handlers.events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, update);
+		const afterReplay = current.calls
+			.filter(([name, value]) => name === "indicator" && value !== undefined)
+			.at(-1)?.[1] as { frames?: string[] } | undefined;
+		expect(stripTerminalSequences(afterReplay?.frames?.[0] ?? "")).toContain("queue 2");
+		expect(capability(handlers).active).toBe(true);
 		await emit(handlers, "session_shutdown", current.ctx);
 	});
 

--- a/test/working-line.test.ts
+++ b/test/working-line.test.ts
@@ -968,6 +968,42 @@ describe("working-line row composition", () => {
 		expect(constrained.row).not.toContain("parallel");
 	});
 
+	it("composes sanitized extension segments into every animated frame", () => {
+		const current = config();
+		const component = current.components.workingLine;
+		const runtime = {
+			tokens: { input: 12, output: 3 },
+			extensions: ["24.3 tok/s · TTFT 820ms", "\x1b[31mqueue 2\x1b[0m"],
+		};
+		const composed = composeWorkingLineRow(component, "Working…", runtime);
+		expect(composed.row).toBe("Working… · ↑12 ↓3 · 24.3 tok/s · TTFT 820ms · queue 2");
+		const generated = buildWorkingLineFrames(
+			component,
+			current.colors,
+			theme(),
+			"Working…",
+			runtime,
+		);
+		expect(strippedFrames(generated.frames).every((frame) => frame.includes(composed.row))).toBe(
+			true,
+		);
+	});
+
+	it("bounds extension segments inside the complete Working-line row", () => {
+		const component = config().components.workingLine;
+		component.spinner = "pulse";
+		const composed = composeWorkingLineRow(component, "Working…", {
+			tokens: { input: Number.MAX_SAFE_INTEGER, output: Number.MAX_SAFE_INTEGER },
+			extensions: ["extension ".repeat(50), "must-not-fit"],
+		});
+		expect(composed.row).toContain("extension");
+		expect(composed.row).toContain("…");
+		expect(composed.row).not.toContain("must-not-fit");
+		expect(
+			workingLineSpinnerWidth(component.spinner) + 1 + visibleWidth(composed.row) + 3,
+		).toBeLessThanOrEqual(MAX_WORKING_LINE_ROW_CELLS);
+	});
+
 	it("reserves exact Tokens, then allocates Message, Elapsed, and truncated Tool within 80 cells", () => {
 		const component = config().components.workingLine;
 		const composed = composeWorkingLineRow(component, "x".repeat(43), {

--- a/test/working-line.test.ts
+++ b/test/working-line.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { stripVTControlCharacters } from "node:util";
-import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { EventBus, Theme } from "@earendil-works/pi-coding-agent";
 import { Loader, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import { defaultConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
@@ -35,6 +35,10 @@ import {
 	WorkingLineController,
 	workingLineSpinnerWidth,
 } from "../extensions/zentui/working-line";
+import {
+	WorkingLineExtensionSegments,
+	ZENTUI_WORKING_LINE_SEGMENT_EVENT,
+} from "../extensions/zentui/working-line-extension-segments";
 
 function theme(): Theme {
 	return {
@@ -1097,6 +1101,7 @@ describe("working-line runtime ownership", () => {
 		harness.controller.finishAgent(harness.ctx);
 		harness.controller.dispose(harness.ctx);
 		harness.clock.reset();
+		expect(harness.controller.isAvailable()).toBe(false);
 		expect(harness.calls).toEqual([]);
 	});
 
@@ -1105,6 +1110,7 @@ describe("working-line runtime ownership", () => {
 		for (const ui of [{ setWorkingMessage: vi.fn() }, { setWorkingIndicator: vi.fn() }]) {
 			const result = harness.controller.startSession({ hasUI: true, mode: "tui", ui });
 			expect(result.applied).toBe(false);
+			expect(harness.controller.isAvailable()).toBe(false);
 			expect(Object.values(ui).every((fn) => !fn.mock.calls.length)).toBe(true);
 		}
 		expect(harness.calls).toEqual([]);
@@ -1133,6 +1139,42 @@ describe("working-line runtime ownership", () => {
 			["indicator", undefined],
 			["message", undefined],
 		]);
+	});
+
+	it("accepts render-equivalent extension text and deduplicates its identical replay", () => {
+		const harness = runtime(true);
+		harness.controller.startSession(harness.ctx);
+		const eventHandlers = new Map<string, Set<(data: unknown) => void>>();
+		const events: EventBus = {
+			emit(channel, data) {
+				for (const handler of eventHandlers.get(channel) ?? []) handler(data);
+			},
+			on(channel, handler) {
+				const current = eventHandlers.get(channel) ?? new Set();
+				current.add(handler);
+				eventHandlers.set(channel, current);
+				return () => current.delete(handler);
+			},
+		};
+		const publish = vi.fn((segments: readonly string[]) =>
+			harness.controller.updateExtensionSegments(segments, harness.ctx),
+		);
+		new WorkingLineExtensionSegments(events, () => harness.controller.isAvailable(), publish);
+
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, { key: "publisher:value", text: "queue 2" });
+		const indicatorWrites = harness.calls.filter(([name]) => name === "indicator").length;
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "publisher:value",
+			text: "  queue   2  ",
+		});
+		expect(harness.calls.filter(([name]) => name === "indicator")).toHaveLength(indicatorWrites);
+		expect(publish).toHaveBeenCalledTimes(2);
+
+		events.emit(ZENTUI_WORKING_LINE_SEGMENT_EVENT, {
+			key: "publisher:value",
+			text: "  queue   2  ",
+		});
+		expect(publish).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not rewrite Static frames for text-speed or spinner-color participation changes", () => {
@@ -1749,6 +1791,7 @@ describe("working-line runtime ownership", () => {
 		};
 		const controller = new WorkingLineController(() => current, theme);
 		expect(controller.startSession(ctx).applied).toBe(true);
+		expect(controller.isAvailable()).toBe(true);
 		current.components.workingLine.spinnerIntervalMs += 1;
 		failureSets = 2;
 		expect(controller.reconcile(ctx).applied).toBe(false);
@@ -1760,10 +1803,12 @@ describe("working-line runtime ownership", () => {
 		]);
 		expect(indicatorSurface).toBeUndefined();
 		expect(messageSurface).toBeUndefined();
+		expect(controller.isAvailable()).toBe(false);
 		const afterRelease = calls.length;
 		controller.updateTokens({ input: 1, output: 1 }, ctx);
 		expect(calls).toHaveLength(afterRelease);
 		expect(controller.reconcile(ctx).applied).toBe(true);
+		expect(controller.isAvailable()).toBe(true);
 		expect(calls.slice(-2)).toEqual(["message-set", "indicator-set"]);
 	});
 
@@ -2009,14 +2054,25 @@ describe("working-line runtime ownership", () => {
 		harness.controller.startTurn(harness.ctx);
 		harness.current.components.workingLine.enabled = true;
 		expect(harness.controller.reconcile(harness.ctx).applied).toBe(true);
+		expect(harness.controller.isAvailable()).toBe(true);
 		expect(harness.controller.currentMessage()).toBe("B");
 		harness.current.components.workingLine.enabled = false;
+		expect(harness.controller.isAvailable()).toBe(false);
 		harness.controller.reconcile(harness.ctx);
+		expect(harness.controller.isAvailable()).toBe(false);
+		harness.current.components.workingLine.enabled = true;
+		expect(harness.controller.reconcile(harness.ctx).applied).toBe(true);
+		expect(harness.controller.isAvailable()).toBe(true);
 		harness.controller.dispose(harness.ctx);
+		expect(harness.controller.isAvailable()).toBe(false);
 		harness.controller.dispose(harness.ctx);
 		expect(
 			harness.calls.map(([name, value]) => [name, value === undefined ? "reset" : "set"]),
 		).toEqual([
+			["message", "set"],
+			["indicator", "set"],
+			["indicator", "reset"],
+			["message", "reset"],
 			["message", "set"],
 			["indicator", "set"],
 			["indicator", "reset"],


### PR DESCRIPTION
## Summary

Let third-party extensions publish keyed text segments into `pi-zentui`'s owned Working line through Pi's shared event bus.

Previously, extensions had to use Pi's separate `setWorkingMessage()` slot. Their text appeared after Zentui's row but did not participate in Classic or KITT animation. Zentui now sanitizes, orders,
width-bounds, and composes published segments into the same animated frames as its built-in content.

The protocol includes capability detection so extensions can check whether integration is supported and active before publishing, then fall back to Pi's public Working-message slot when necessary.

## Screenshots / recordings

I have a few custom extensions that use the `pi-zentui` extension capabilities, one of which being a TPS/TTFT meter.
The following demonstrates KITT animation continuing through the TPS and TTFT segments with the PR applied:

[Screencast_20260902_151745.webm](https://github.com/user-attachments/assets/24019a7a-2c8c-44fc-ad61-9c39e31a4e25)

## Testing

- [x] `npm run verify` : the default parallel run hit local five-second timeouts in performance-heavy Working-line and settings tests
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Full test suite run serially: 1,390 passed, 1 skipped
- [x] `npm run pack:check`
- [x] Manual Pi test with a TPS/TTFT consumer; recording captured
- [x] Added or updated tests where practical

## Checklist

- [x] Preserved Nerd Font / private-use icon glyphs (no empty strings or replaced characters).
- [x] Updated `README.md` and configuration documentation.
- [x] Kept the diff surgical: no unrelated refactors, formatting, or dependency churn.
- [x] `extensions/zentui/index.ts` stays mostly orchestration; event-bus logic lives in a focused module.
- [x] Used a conventional commit-style PR title.
