### PR TITLE
chore: release v0.23.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.3",
+	"version": "0.23.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-zentui",
-			"version": "0.22.3",
+			"version": "0.23.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@biomejs/biome": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-zentui",
-	"version": "0.22.3",
+	"version": "0.23.0",
 	"description": "A Starship-inspired statusline and Opencode-style TUI for Pi.",
 	"type": "module",
 	"license": "MIT",


### PR DESCRIPTION
## Summary
- Bump package and lockfile versions to 0.23.0 for component presets (#121).
- Publication will use the existing tag-triggered npm/GitHub release workflow after CI passes.

## Testing
- Feature validation: 1588 tests passed, 1 skipped; formatting, packaging, live Pi smoke and independent review passed.
- Release CI and local verification will be checked before tagging.