### PR TITLE
feat: add opt-in codex quota to editor and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ Streaming retains Pi's host-rendered final five rows under `Thinking 7.1s`, fold
 
 Pi 0.84 also provides a native fullscreen TUI with a sticky editor and Footer. Pi 0.84.4 is covered by a fullscreen live-transition PTY smoke in addition to the standard matrix. Zentui does not enable fullscreen automatically; select it from Pi's `/settings`, set `"tuiMode": "fullscreen"` in Pi settings, or launch Pi with `--tui-mode fullscreen`.
 
+**Codex quota (opt-in):** Show remaining 5-hour/weekly quota for `openai-codex` through independent Editor and Starship Footer settings, both off by default. See [configuration and private-endpoint limitations](./docs/configuration.md#codex-account-quota), including `$codex_quota` for custom templates.
+
 ## Requirements
 
 - [Pi](https://pi.dev) coding agent 0.80.5 or newer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,11 +38,11 @@ Native releases Zentui's ownership; Hidden deliberately installs a zero-row Foot
 The interactive `/zentui` menu is split into six component-oriented sections. Use `Tab` and `Shift+Tab` to switch sections. Selection/Change/Back/Close hints follow injected host keybindings (with older-host defaults when unavailable). Narrow help retains Change, Sections, and Back (on child pages) or Close guidance:
 
 1. **Appearance** — component Preset; selector-border enablement, informational fixed style, and colors; icon mode.
-2. **Editor** — enablement, style, colors, model label, border behavior, viewport indicators, settings for the selected editor style, and a static synthetic preview.
+2. **Editor** — enablement, style, colors, Codex quota, model label, border behavior, viewport indicators, settings for the selected editor style, and a static synthetic preview.
 3. **User messages** — enablement, style, colors, and a static synthetic Markdown preview.
 4. **Thinking (Experimental)** — private Rail, Tree, or Streaming rendering; active Streaming can switch live to Rail or Tree, Rail and Tree can switch live between each other, and the private renderer may break after Pi updates.
 5. **Working line** — ownership, settled Turn summary, spinner and text speeds, optional spinner-color motion, text animation, color source, custom messages, Tool/Elapsed/Thinking time/Tokens segments, and animated preview.
-6. **Footer** — Native, Starship, or Hidden. Starship additionally exposes colors, model label, responsive layout, separator, context style, and path display.
+6. **Footer** — Native, Starship, or Hidden. Starship additionally exposes colors, Codex quota, model label, responsive layout, separator, context style, and path display.
    - **Segments →** — visibility toggles for non-Git Starship segments.
    - **Git →** — Starship Footer Git segment and probe controls, not Editor Git controls.
    - **Extension statuses →** — Starship placement and color controls for active published keyed Footer statuses; not extension management or Working line integrations.
@@ -144,6 +144,7 @@ Reference only—not a starter file. Prefer the minimal overrides above. Optiona
   "components": {
     "editor": {
       "enabled": true,
+      "codexQuota": false,
       "style": "opencode",
       "colorSource": "theme",
       "borderColorMode": "static",
@@ -151,11 +152,11 @@ Reference only—not a starter file. Prefer the minimal overrides above. Optiona
       "viewportIndicators": true,
       "styles": {
         "opencode": {
-          "metadataFormat": "$model  $provider(  $thinking)",
+          "metadataFormat": "$model  $provider(  $thinking)(  $codex_quota)",
           "completionMenu": "palette"
         },
         "opencode-copy-friendly": {
-          "metadataFormat": "$model  $provider(  $thinking)",
+          "metadataFormat": "$model  $provider(  $thinking)(  $codex_quota)",
           "completionMenu": "palette"
         },
         "accent-rail": {
@@ -237,13 +238,14 @@ Reference only—not a starter file. Prefer the minimal overrides above. Optiona
     },
     "footer": {
       "style": "starship",
+      "codexQuota": false,
       "colorSource": "theme",
       "modelLabel": "id",
       "styles": {
         "starship": {
           "format": "",
           "responsive": true,
-          "compactFormat": "$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens",
+          "compactFormat": "$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens$wrap_sep($codex_quota)",
           "compactMaxLines": 2,
           "separator": "pipe",
           "contextStyle": "text",
@@ -359,7 +361,7 @@ Reference only—not a starter file. Prefer the minimal overrides above. Optiona
 ## Core configuration
 
 - Style values accept Starship/terminal strings such as `bold purple`, `fg:202`, `#89b`, `#89b4fa`, and `bg:blue fg:bright-green`, or Pi theme tokens such as `accent`, `borderMuted`, and `thinkingHigh`. Short `#rgb` values expand to `#rrggbb`.
-- `projectRefreshIntervalMs` controls project-status polling. `0` disables polling. Values `1..4999` clamp to the five-second minimum; invalid or non-finite values use `30000`.
+- `projectRefreshIntervalMs` controls project-status polling, not opt-in quota refresh. `0` disables project polling. Values `1..4999` clamp to the five-second minimum; invalid or non-finite values use `30000`.
 - `components.editor` owns Editor enablement, `opencode | opencode-copy-friendly | accent-rail | minimalist` style selection, color source, border mode, model label, viewport indicators, and all four style configurations.
 - Editor `modelLabel` uses `id` by default; `name` uses the display name with ID fallback. Footer has an independent `modelLabel` control.
 - `components.userMessages` owns User-message enablement, `framed | framed-copy-friendly | compact | labeled` style selection, and color source. Disabling it delegates byte-for-byte to Pi's native renderer.
@@ -371,6 +373,35 @@ Reference only—not a starter file. Prefer the minimal overrides above. Optiona
 - Starship's package-version segment reads the project manifest and is distinct from the runtime segment, which reports the installed toolchain.
 - Active third-party statuses from `ctx.ui.setStatus()` can be placed left, middle, or right, hidden per key, and assigned independent color modes.
 - The shown `editor*` colors match the default `theme` source. Omit them to preserve source-aware defaults when switching between `theme` and `terminal`.
+
+### Codex account quota
+
+`components.editor.codexQuota` and `components.footer.codexQuota` are independent booleans, both `false` by default. Enable either from its **Codex quota** settings row, or merge these leaves into your existing file:
+
+```json
+{
+  "components": {
+    "editor": { "codexQuota": true },
+    "footer": { "codexQuota": false }
+  }
+}
+```
+
+This example enables only Editor quota, without changing any component's style or enablement. Minimalist with Hidden Footer is supported. Footer quota requires Starship. Neither toggle enables another surface or changes a color source, and presets preserve both choices.
+
+- Only the exact active provider `openai-codex` is eligible, not `openai`, proxies, or similarly named models. Use Pi's existing ChatGPT/Codex login; API billing balances are not supported.
+- Values are **remaining**, rounded percentages: `5h 80% | week 60%`. Only exact 18,000-second and 604,800-second windows are recognized, independently of response ordering. Other durations stay unknown rather than acquiring incorrect labels.
+- `--` means unavailable, including a missing window, unsupported auth API/account, or no successful request. `0%` means exhausted. A newer partial response replaces the previous snapshot completely.
+- Transient HTTP/network/schema failures and refresh deadlines (including slow authentication lookups) retain successful values with a textual `stale` warning. Values older than two minutes also become stale. Missing, failed, or rejected authentication clears the cache, as do account changes, provider changes, loss of all consumers, and teardown. Credentials and quota are never persisted by Zentui.
+- One shared poller refreshes roughly every minute, including idle time, only in a TUI session with an owned, enabled eligible consumer. Both toggles off means no quota auth lookup or request. Editor templates without `$codex_quota` do not create demand; Footer considers both wide and responsive compact paths. HTTP 429 can delay the next request via `Retry-After`. Each refresh has a ten-second deadline; late uncancelable auth results are ignored.
+- Opencode variants include quota conditionally in their shipped metadata defaults. Minimalist adds it beside context when space allows. Accent Rail adds one editor-owned row beneath input and viewport indicators, before autocomplete. At narrow widths quota is omitted as a unit rather than clipping away labels or `stale`. Input text and Working line are unaffected.
+- Quota reuses the selected component's `contextNormal`, `contextWarning`, and `contextError` color roles. Remaining quota at or below 50% uses warning, at or below 20% uses error; stale values use at least warning. Editor never borrows Footer overrides. Settings previews use synthetic values only.
+
+**Custom templates remain authoritative.** Saved nonempty formats, including copies of old defaults, are never rewritten or augmented outside the template. Add `(  $codex_quota)` to either Opencode variant's `metadataFormat`, `($sep$codex_quota)` to a Footer wide `format`, or `$wrap_sep($codex_quota)` to `compactFormat`. Tokens remain empty when the corresponding quota toggle is off or the provider is ineligible. Unlike ordinary Footer `segments` flags, quota consent cannot be bypassed by a template.
+
+**Compatibility and privacy:** Zentui uses only Pi's public `modelRegistry.getProviderAuth("openai-codex")`, available on tested Pi 0.84.0 and 0.85.1. Hosts without that capability show placeholders without falling back to private storage or older credential APIs; the overall Pi minimum is unchanged. Auth is sent only to `https://chatgpt.com/backend-api/wham/usage`, with redirects rejected. JWT decoding is limited to the account-routing claim and is not identity verification. An opaque credential change invalidates cached data conservatively.
+
+The endpoint is undocumented and may change or reject some plans. Its path and seconds-based window field are corroborated by [OpenAI's Codex client](https://github.com/openai/codex/blob/rust-v0.98.0/codex-rs/backend-client/src/client.rs); this is not a public API guarantee. Automated verification uses synthetic responses, not a live account. No reset times, countdowns, alerts, or quota history are provided.
 
 ### Footer layout authority
 
@@ -410,7 +441,7 @@ Empty strings and whitespace-only strings mean deliberately **unstyled**, not mi
 | Owner | Local keys | Historical shared fallback |
 | --- | --- | --- |
 | `footer` | `cwd`, `sessionName`, `gitBranch`, `gitStatus`, `contextNormal`, `contextWarning`, `contextError`, `cost`, `sessionDuration`, `tokens`, `separator`, `runtimePrefix`, `extensionStatus`, `packageVersion`, `gitCommit`, `gitMetricsAdded`, `gitMetricsDeleted`, `username`, `time`, `os` | Same-named shared key |
-| `editor` | `cwd`, `sessionName`, `gitStatus`, `contextNormal`, `contextWarning`, `contextError`, `cost`, `sessionDuration` | Same-named shared key; these are Minimalist metadata roles |
+| `editor` | `cwd`, `sessionName`, `gitStatus`, `contextNormal`, `contextWarning`, `contextError`, `cost`, `sessionDuration` | Same-named shared key; used by Minimalist metadata and quota |
 | `editor` | `gitBranch` | `editorGitBranch`, then explicitly configured shared `gitBranch` / `git`; never the generated Footer branch default |
 | `editor` | `accent`, `border`, `prompt`, `rail`, `model`, `provider`, `thinking`, `thinkingMinimal`, `thinkingLow`, `thinkingMedium`, `thinkingHigh`, `thinkingXhigh`, `thinkingMax` | `editorAccent`, `editorBorder`, `editorPrompt`, `editorRail`, `editorModel`, `editorProvider`, `editorThinking`, and matching `editorThinking*` level keys |
 | `userMessages` | `accent`, `border` | `editorAccent`, `editorBorder` |
@@ -431,7 +462,7 @@ Role-specific defaults and chains remain intact:
 
 ### Accent Rail
 
-Set `components.editor.style` to `accent-rail` or select **Accent Rail** in `/zentui`. Each input row uses its style-owned `rail` glyph (`▎`, or `asciiRail` in ASCII mode), one blank cell before text, and Pi's neutral filled surface. It intentionally has no prompt glyph, metadata, enclosing border, or blank chrome row. Viewport counts appear only while content is clipped.
+Set `components.editor.style` to `accent-rail` or select **Accent Rail** in `/zentui`. Each input row uses its style-owned `rail` glyph (`▎`, or `asciiRail` in ASCII mode), one blank cell before text, and Pi's neutral filled surface. By default it has no prompt glyph, metadata, enclosing border, or blank chrome row. Opt-in eligible Codex quota is the sole metadata exception, adding a separate row beneath input when it fits. Viewport counts appear only while content is clipped.
 
 Known autocomplete rows retain Pi's native text, descriptions, and scrolling on the same full-width surface. The selected native `→` becomes the configured rail without replacing Pi's selected-text color. Ambiguous third-party editor layouts fail open using already-rendered native rows.
 
@@ -499,12 +530,13 @@ The configured right zone and Pi's operational right status are right-aligned to
 | `$context` | compact current context usage and window, for example `26.8%/272k` |
 | `$tokens` | cumulative session input/output tokens only, for example `↑76k ↓1.6k` |
 | `$cache_hit` | latest assistant prompt cache-hit rate to one decimal; `0.0%` when unavailable |
+| `$codex_quota` | remaining 5-hour/weekly account quota; requires Editor quota consent and active `openai-codex` |
 
 `$context` uses Pi's current context snapshot and the live assistant context override, refreshing on the existing 250 ms streaming render cadence. `$tokens` and `$cache_hit` use authoritative persisted session snapshots, so they update at normal session synchronization boundaries rather than estimating in-progress totals. These variables are independent of Footer visibility, style, color source, and configuration.
 
 Model variables use Editor `colors.model` (legacy `editorModel`), provider uses `colors.provider` (legacy `editorProvider`), and thinking uses the matching Editor level style. Literal text, session name, and usage metadata use the neutral editor-border theme style. ANSI/VT sequences, controls, and line-breaking whitespace are sanitized without collapsing ordinary spaces.
 
-Missing, non-string, or empty values use `$model  $provider(  $thinking)`. A non-empty format that resolves to no metadata preserves the normal blank spacer and metadata rows. This option is JSON-only; `/zentui format` controls the Footer.
+Missing, non-string, or empty values use `$model  $provider(  $thinking)(  $codex_quota)`, with identical spacing while quota is off. A non-empty format that resolves to no metadata preserves the normal blank spacer and metadata rows. This option is JSON-only; `/zentui format` controls the Footer.
 
 ## User-message styles
 

--- a/docs/footer-format.md
+++ b/docs/footer-format.md
@@ -9,7 +9,7 @@ Set `components.footer.styles.starship.format` for complete control over the Sta
 - conditional groups `( ... )` that disappear when every nested variable is empty
 - `$fill` layout boundaries
 
-A custom format overrides `components.footer.styles.starship.segments` for the wide layout. Empty or omitted format uses the segment layout. Responsive mode first reflows wide content, then uses the independent `compactFormat` template; compact variables do not follow built-in segment toggles. `compactMaxLines` limits compact rows, not segment selection. No settings toggle rewrites either template.
+A custom format overrides `components.footer.styles.starship.segments` for the wide layout. Empty or omitted format uses the segment layout. Responsive mode first reflows wide content, then uses the independent `compactFormat` template; compact variables do not follow built-in segment toggles. `compactMaxLines` limits compact rows, not segment selection. No settings toggle rewrites either template. `$codex_quota` is an exception to segment-toggle bypass: it always requires the independent Footer quota consent toggle and active `openai-codex` provider.
 
 ## Examples
 
@@ -78,6 +78,7 @@ The released flat `footerFormat` and `footerSegments` keys remain accepted only 
 | `$os` | | operating-system icon |
 | `$time` | | current time `HH:MM` |
 | `$context` | | context usage; finite percentages use one decimal |
+| `$codex_quota` | | remaining account quota, for example `5h 80% | week 60%`; gated by `components.footer.codexQuota` |
 | `$tokens` | | input/output totals and existing cache-hit percentage |
 | `$cache_read` | | cache-read total (`R1.2k`); empty at zero or when unavailable |
 | `$cache_write` | | cache-write total (`W300`); empty at zero or when unavailable |
@@ -88,6 +89,12 @@ The released flat `footerFormat` and `footerSegments` keys remain accepted only 
 | `$fill` | — | wide-format layout boundary |
 
 Each variable renders its core value without prose prefixes such as `on` or `via`; add those words as literals.
+
+### `$codex_quota` consent and freshness
+
+Set `components.footer.codexQuota: true` and select Starship to opt in. The built-in wide layout and shipped compact default include quota conditionally. Saved custom formats are unchanged; add `($sep$codex_quota)` to `format` and `$wrap_sep($codex_quota)` to `compactFormat` where desired. Templates without the token never have quota appended outside them.
+
+The token is empty when consent is off or the active provider is not exactly `openai-codex`. With consent, missing values use `--`; exhausted quota uses `0%`; retained values after a transient failure carry `stale`. Quota is omitted as a unit if it cannot fit safely. Editor has its own independent consent toggle. See [quota configuration](./configuration.md#codex-account-quota) for background polling, public auth capability requirements, and private-endpoint limitations.
 
 ### `$cwd` path modes
 

--- a/extensions/zentui/accent-rail-editor.ts
+++ b/extensions/zentui/accent-rail-editor.ts
@@ -1,5 +1,7 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { CodexQuota } from "./codex-quota";
+import { renderCodexQuota } from "./codex-quota-display";
 import {
 	applyOwnedSurfaceBackground,
 	fillTerminalLine,
@@ -23,6 +25,7 @@ export type AccentRailViewport = {
 };
 
 export type AccentRailEditorFrameOptions = {
+	codexQuota?: CodexQuota;
 	width: number;
 	editorLines: string[];
 	autocompleteLines?: string[];
@@ -55,6 +58,7 @@ function viewportLabel(
 
 /** Pure compact accent-rail composition shared by live rendering and settings previews. */
 export function renderAccentRailEditorFrame({
+	codexQuota,
 	width,
 	editorLines,
 	autocompleteLines = [],
@@ -80,7 +84,13 @@ export function renderAccentRailEditorFrame({
 	const below = config.components.editor.viewportIndicators
 		? viewportLabel("below", viewport.below)
 		: undefined;
-	const rows = [...(above ? [above] : []), ...editorLines, ...(below ? [below] : [])];
+	const quota = renderCodexQuota(codexQuota, uiTheme, config, "editor");
+	const rows = [
+		...(above ? [above] : []),
+		...editorLines,
+		...(below ? [below] : []),
+		...(quota && visibleWidth(quota) <= contentWidth ? [quota] : []),
+	];
 	const transparent = config.components.editor.styles["accent-rail"].transparent;
 	const surface = rows.map((line) => {
 		const railCell = transparent ? rail : applyOwnedSurfaceBackground(uiTheme, rail);

--- a/extensions/zentui/codex-quota-display.ts
+++ b/extensions/zentui/codex-quota-display.ts
@@ -1,0 +1,34 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { CodexQuota } from "./codex-quota";
+import { componentColor } from "./component-colors";
+import type { ZentuiConfig } from "./config";
+import { renderStyleForSourceOrFallback } from "./style";
+
+export function codexQuotaText(quota: CodexQuota | undefined): string {
+	if (!quota) return "";
+	const percent = (value: number | undefined) => (value === undefined ? "--" : `${value}%`);
+	return `5h ${percent(quota.fiveHour)} | week ${percent(quota.week)}${quota.stale ? " stale" : ""}`;
+}
+
+export function renderCodexQuota(
+	quota: CodexQuota | undefined,
+	theme: Theme,
+	config: ZentuiConfig,
+	owner: "editor" | "footer",
+): string {
+	if (!config.components[owner].codexQuota || !quota) return "";
+	const remaining = Math.min(quota.fiveHour ?? 100, quota.week ?? 100);
+	const tier =
+		remaining <= 20
+			? "contextError"
+			: quota.stale || remaining <= 50
+				? "contextWarning"
+				: "contextNormal";
+	return renderStyleForSourceOrFallback(
+		theme,
+		config.components[owner].colorSource,
+		componentColor(config, owner, tier),
+		tier === "contextError" ? "error" : tier === "contextWarning" ? "warning" : "muted",
+		codexQuotaText(quota),
+	);
+}

--- a/extensions/zentui/codex-quota.ts
+++ b/extensions/zentui/codex-quota.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ZentuiConfig } from "./config";
+import { sanitizeEditorMetadataText } from "./editor-metadata-format";
+import { collectFooterFormatReferences, parseFooterFormat } from "./footer-format";
+
+const INTERVAL = 60_000;
+const TIMEOUT = 10_000;
+const ENDPOINT = "https://chatgpt.com/backend-api/wham/usage";
+
+export type CodexQuota = {
+	fiveHour?: number;
+	week?: number;
+	lastSuccess?: number;
+	stale?: boolean;
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+/** Durations are seconds, not positions: unexpected windows must not inherit a label. */
+export function parseCodexQuota(value: unknown): CodexQuota | undefined {
+	const limits = record(record(value)?.rate_limit);
+	if (!limits) return undefined;
+	const result: CodexQuota = {};
+	for (const raw of [limits.primary_window, limits.secondary_window]) {
+		const window = record(raw);
+		if (!window) continue;
+		const used = window.used_percent;
+		if (typeof used !== "number" || !Number.isFinite(used) || used < 0 || used > 100) continue;
+		const key =
+			window.limit_window_seconds === 18_000
+				? "fiveHour"
+				: window.limit_window_seconds === 604_800
+					? "week"
+					: undefined;
+		if (key) result[key] = Math.round(100 - used);
+	}
+	return result.fiveHour !== undefined || result.week !== undefined ? result : undefined;
+}
+
+export function editorWantsCodexQuota(config: ZentuiConfig): boolean {
+	const editor = config.components.editor;
+	if (!editor.enabled || !editor.codexQuota) return false;
+	return (
+		editor.style === "minimalist" ||
+		editor.style === "accent-rail" ||
+		collectFooterFormatReferences(
+			parseFooterFormat(sanitizeEditorMetadataText(editor.styles[editor.style].metadataFormat)),
+		).has("codex_quota")
+	);
+}
+
+/** No fallback to private storage or older credential APIs. */
+export async function resolveCodexToken(
+	registry: ExtensionContext["modelRegistry"],
+): Promise<string | undefined> {
+	if (typeof registry.getProviderAuth !== "function") return undefined;
+	const result = await registry.getProviderAuth("openai-codex");
+	return typeof result?.auth.apiKey === "string" && result.auth.apiKey
+		? result.auth.apiKey
+		: undefined;
+}
+
+function accountId(token: string): string | undefined {
+	try {
+		// Unverified JWT decoding is used only for routing/cache isolation, never authorization.
+		const payload = record(
+			JSON.parse(Buffer.from(token.split(".")[1] ?? "", "base64url").toString("utf8")),
+		);
+		const id = record(payload?.["https://api.openai.com/auth"])?.chatgpt_account_id;
+		return typeof id === "string" && /^[a-zA-Z0-9_-]{1,256}$/.test(id) ? id : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function retryDelay(value: string | null): number {
+	if (!value) return INTERVAL;
+	const seconds = /^\d+(?:\.\d+)?$/.test(value) ? Number(value) : undefined;
+	const delay = seconds === undefined ? Date.parse(value) - Date.now() : seconds * 1000;
+	return Number.isFinite(delay) ? Math.max(INTERVAL, delay) : INTERVAL;
+}
+
+/** One session-scoped poller, with demand rechecked before every refresh and publication. */
+export class CodexQuotaCollector {
+	private active = false;
+	private timer?: ReturnType<typeof setTimeout>;
+	private request?: AbortController;
+	private generation = 0;
+	private identity?: string;
+	private value: CodexQuota = {};
+	private nextRefresh = 0;
+
+	constructor(
+		private readonly getContext: () => ExtensionContext | undefined,
+		private readonly changed: () => void,
+		private readonly fetchUsage: typeof fetch = fetch,
+	) {}
+
+	get(): CodexQuota | undefined {
+		if (!this.active) return undefined;
+		return {
+			...this.value,
+			stale:
+				this.value.stale ||
+				(this.value.lastSuccess !== undefined &&
+					Date.now() - this.value.lastSuccess >= 2 * INTERVAL),
+		};
+	}
+
+	reconcile(): void {
+		if (!this.getContext()) {
+			this.stop();
+			return;
+		}
+		if (this.active) return;
+		this.active = true;
+		void this.refresh();
+	}
+
+	stop(): void {
+		this.active = false;
+		this.generation++;
+		clearTimeout(this.timer);
+		this.timer = undefined;
+		this.request?.abort();
+		this.request = undefined;
+		this.identity = undefined;
+		this.value = {};
+		this.nextRefresh = 0;
+	}
+
+	private async refresh(): Promise<void> {
+		const ctx = this.getContext();
+		if (!this.active || !ctx) {
+			this.stop();
+			return;
+		}
+		if (this.request) return;
+		const generation = this.generation;
+		const controller = new AbortController();
+		this.request = controller;
+		const current = () =>
+			this.active &&
+			generation === this.generation &&
+			!controller.signal.aborted &&
+			Boolean(this.getContext());
+		let delay = INTERVAL;
+		let authResolved = false;
+		// Pi's auth lookup cannot be canceled. Bound waiting and ignore its late result.
+		let timedOut = false;
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			controller.abort();
+		}, TIMEOUT);
+		const aborted = new Promise<never>((_, reject) => {
+			controller.signal.addEventListener(
+				"abort",
+				() => reject(new Error("Quota refresh canceled")),
+				{ once: true },
+			);
+		});
+		try {
+			this.changed(); // Age-based stale state is visible while refreshing after sleep.
+			await Promise.race([
+				aborted,
+				(async () => {
+					const token = await resolveCodexToken(ctx.modelRegistry);
+					if (!current()) return;
+					authResolved = true;
+					if (!token) {
+						this.identity = undefined;
+						this.value = {};
+						return;
+					}
+					const account = accountId(token);
+					const identity = account
+						? `account:${account}`
+						: `token:${createHash("sha256").update(token).digest("hex")}`;
+					if (identity !== this.identity) {
+						this.identity = identity;
+						this.value = {};
+						this.changed();
+					}
+					const response = await this.fetchUsage(ENDPOINT, {
+						headers: {
+							Authorization: `Bearer ${token}`,
+							Accept: "application/json",
+							originator: "pi",
+							...(account ? { "ChatGPT-Account-Id": account } : {}),
+						},
+						redirect: "error",
+						signal: controller.signal,
+					});
+					if (!current()) return;
+					if (!response.ok) void response.body?.cancel().catch(() => {});
+					if (response.status === 401 || response.status === 403) {
+						this.identity = undefined;
+						this.value = {};
+						return;
+					}
+					if (response.status === 429) delay = retryDelay(response.headers.get("retry-after"));
+					if (!response.ok) throw new Error("Quota unavailable");
+					const parsed = parseCodexQuota(await response.json());
+					if (!current()) return;
+					if (!parsed) throw new Error("Invalid quota response");
+					this.value = { ...parsed, lastSuccess: Date.now(), stale: false };
+				})(),
+			]);
+		} catch {
+			if (generation !== this.generation) return;
+			// A deadline is transient, not evidence of invalid or missing authentication.
+			if (!authResolved && !timedOut) {
+				this.identity = undefined;
+				this.value = {};
+			} else this.value = { ...this.value, stale: this.value.lastSuccess !== undefined };
+		} finally {
+			clearTimeout(timeout);
+			if (generation === this.generation) {
+				this.request = undefined;
+				if (!this.getContext()) this.stop();
+				else {
+					this.changed();
+					this.nextRefresh = Date.now() + delay;
+					this.schedule();
+				}
+			}
+		}
+	}
+
+	private schedule(): void {
+		// Check ownership and age every minute even during a longer Retry-After.
+		this.timer = setTimeout(
+			() => {
+				if (!this.getContext()) {
+					this.stop();
+					return;
+				}
+				this.changed();
+				if (Date.now() >= this.nextRefresh) void this.refresh();
+				else this.schedule();
+			},
+			Math.min(INTERVAL, Math.max(0, this.nextRefresh - Date.now())),
+		);
+		this.timer.unref?.();
+	}
+}

--- a/extensions/zentui/config.ts
+++ b/extensions/zentui/config.ts
@@ -63,7 +63,7 @@ export type CompletionMenuStyle = "native" | "palette";
 export type CompactFooterMaxLines = 1 | 2 | 3 | "unlimited";
 
 export const DEFAULT_COMPACT_FOOTER_FORMAT =
-	"$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens";
+	"$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens$wrap_sep($codex_quota)";
 
 export type ContextThresholds = {
 	warning: number;
@@ -151,6 +151,7 @@ export type EditorStylesConfig = {
 };
 
 export type EditorComponentConfig = {
+	codexQuota: boolean;
 	colors?: ComponentColors<"editor">;
 	enabled: boolean;
 	style: EditorStyle;
@@ -208,6 +209,7 @@ export type StarshipFooterStyleConfig = {
 };
 
 export type FooterComponentConfig = {
+	codexQuota: boolean;
 	colors?: ComponentColors<"footer">;
 	style: FooterStyle;
 	colorSource: ColorSource;
@@ -311,7 +313,7 @@ export type ExtensionStatusesConfig = {
 
 const DEFAULT_PROJECT_REFRESH_INTERVAL_MS = 30_000;
 const MIN_PROJECT_REFRESH_INTERVAL_MS = 5_000;
-export const DEFAULT_EDITOR_METADATA_FORMAT = "$model  $provider(  $thinking)";
+export const DEFAULT_EDITOR_METADATA_FORMAT = "$model  $provider(  $thinking)(  $codex_quota)";
 
 export type ZentuiConfig = {
 	projectRefreshIntervalMs: number;
@@ -405,6 +407,7 @@ export const FOOTER_FORMAT_VARIABLES = [
 	"os",
 	"time",
 	"context",
+	"codex_quota",
 	"tokens",
 	"cache_read",
 	"cache_write",
@@ -495,6 +498,7 @@ const defaultStarshipStyle: StarshipFooterStyleConfig = {
 
 const defaultComponents: ComponentsConfig = {
 	editor: {
+		codexQuota: false,
 		enabled: true,
 		style: "opencode",
 		colorSource: "theme",
@@ -535,6 +539,7 @@ const defaultComponents: ComponentsConfig = {
 	},
 	selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 	footer: {
+		codexQuota: false,
 		style: "starship",
 		colorSource: "theme",
 		modelLabel: "id",
@@ -1246,6 +1251,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 
 	return {
 		editor: {
+			codexQuota: parseBoolean(editor.codexQuota, false),
 			...(isRecord(editor.colors)
 				? { colors: normalizeComponentColors("editor", editor.colors) }
 				: {}),
@@ -1403,6 +1409,7 @@ function resolveComponents(config: ConfigRecord): ComponentsConfig {
 			),
 		},
 		footer: {
+			codexQuota: parseBoolean(footer.codexQuota, false),
 			...(isRecord(footer.colors)
 				? { colors: normalizeComponentColors("footer", footer.colors) }
 				: {}),
@@ -1696,10 +1703,17 @@ function applyEditorComponentPatch(
 	patch: Partial<
 		Pick<
 			EditorComponentConfig,
-			"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+			| "enabled"
+			| "style"
+			| "colorSource"
+			| "borderColorMode"
+			| "modelLabel"
+			| "viewportIndicators"
+			| "codexQuota"
 		>
 	>,
 ): void {
+	if (patch.codexQuota !== undefined) component.codexQuota = patch.codexQuota;
 	if (patch.enabled !== undefined) component.enabled = patch.enabled;
 	if (patch.style !== undefined) component.style = patch.style;
 	if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
@@ -1714,7 +1728,13 @@ export function saveEditorComponentPatch(
 	patch: Partial<
 		Pick<
 			EditorComponentConfig,
-			"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+			| "enabled"
+			| "style"
+			| "colorSource"
+			| "borderColorMode"
+			| "modelLabel"
+			| "viewportIndicators"
+			| "codexQuota"
 		>
 	>,
 	path = configPath,
@@ -1892,13 +1912,16 @@ export function saveSelectorBordersComponentPatch(
 }
 
 export function saveFooterComponentPatch(
-	patch: Partial<Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel">>,
+	patch: Partial<
+		Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel" | "codexQuota">
+	>,
 	path = configPath,
 ): PolishedTuiConfig {
 	return saveComponentsMutation(
 		["footer"],
 		(components) => {
 			const component = components.footer;
+			if (patch.codexQuota !== undefined) component.codexQuota = patch.codexQuota;
 			if (patch.style !== undefined) component.style = patch.style;
 			if (patch.colorSource !== undefined) component.colorSource = patch.colorSource;
 			if (patch.modelLabel !== undefined) component.modelLabel = patch.modelLabel;

--- a/extensions/zentui/editor-metadata-format.ts
+++ b/extensions/zentui/editor-metadata-format.ts
@@ -1,4 +1,6 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
+import type { CodexQuota } from "./codex-quota";
+import { codexQuotaText, renderCodexQuota } from "./codex-quota-display";
 import { componentColor } from "./component-colors";
 import type { ZentuiConfig } from "./config";
 import { type FormatToken, parseFooterFormat } from "./footer-format";
@@ -6,6 +8,7 @@ import { buildSessionTokenLabel, formatCacheHitRate, formatContextPercentLabel }
 import { EDITOR_ACCENT_FALLBACK, renderStyleForSourceOrFallback, safeThemeFg } from "./style";
 
 export type EditorMetadataValues = {
+	codexQuota?: CodexQuota;
 	model: string;
 	modelId: string;
 	modelName: string;
@@ -177,6 +180,10 @@ function renderVariable(
 	uiTheme: Theme,
 	config: ZentuiConfig,
 ): { plain: string; styled: string } {
+	if (name === "codex_quota") {
+		const styled = renderCodexQuota(values.codexQuota, uiTheme, config, "editor");
+		return { plain: styled ? codexQuotaText(values.codexQuota) : "", styled };
+	}
 	const colorSource = config.components.editor.colorSource;
 	const thinking = values.thinking.toLowerCase() === "off" ? "" : values.thinking;
 	const raw =

--- a/extensions/zentui/footer.ts
+++ b/extensions/zentui/footer.ts
@@ -1,5 +1,8 @@
+import { stripVTControlCharacters } from "node:util";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { visibleWidth } from "@earendil-works/pi-tui";
+import type { CodexQuota } from "./codex-quota";
+import { codexQuotaText, renderCodexQuota } from "./codex-quota-display";
 import { componentColor } from "./component-colors";
 import type { SeparatorStyle, ZentuiConfig } from "./config";
 import { FOOTER_FORMAT_ALIASES } from "./config";
@@ -190,6 +193,7 @@ export function installFooter(
 		scheduleProjectRefresh: (ctx: ExtensionContext) => void;
 		setExtensionStatusesGetter?: (fn: (() => ReadonlyMap<string, string>) | undefined) => void;
 		getLiveContext?: () => LiveContextOverride | undefined;
+		getCodexQuota?: () => CodexQuota | undefined;
 		getRepositoryRoot?: (cwd: string) => string | undefined;
 		onDispose?: () => void;
 	},
@@ -210,10 +214,13 @@ export function installFooter(
 				hooks.onDispose?.();
 			},
 			invalidate() {},
-			render(width: number): string[] {
+			render: function renderFooter(width: number, showQuota = true): string[] {
 				if (width <= 0) return [""];
 				const config = getConfig();
 				const footer = config.components.footer;
+				const quota =
+					showQuota && ctx.model?.provider === "openai-codex" ? hooks.getCodexQuota?.() : undefined;
+				const quotaLabel = renderCodexQuota(quota, theme, config, "footer");
 				const footerModelLabel = modelLabelFor(state, footer.modelLabel);
 				const wideFormatTokens = config.components.footer.styles.starship.format
 					? parseFooterFormat(config.components.footer.styles.starship.format)
@@ -450,6 +457,8 @@ export function installFooter(
 								componentColor(config, "footer", "time"),
 								formatTimeLabel(config.icons.time),
 							);
+						case "codex_quota":
+							return quotaLabel;
 						case "context":
 							return renderStyleForSource(theme, colorSource, contextColor, contextLabel);
 						case "tokens":
@@ -725,6 +734,7 @@ export function installFooter(
 					.join(" ");
 				const right = [
 					modelInfoSegment,
+					quotaLabel,
 					config.components.footer.styles.starship.segments.context ? builtInContextLabel : "",
 					config.components.footer.styles.starship.segments.tokens ? builtInTokenLabel : "",
 					config.components.footer.styles.starship.segments.cost ? builtInCostLabel : "",
@@ -776,11 +786,23 @@ export function installFooter(
 						separator,
 						innerWidth,
 					);
-				const frameRows = (rows: string[]) =>
-					rows.map((row) => {
+				const frameRows = (rows: string[], source = [contentLeft, contentMiddle, contentRight]) => {
+					const framedRows = rows.map((row) => {
 						const framed = width > 2 ? ` ${truncateFooterText(row, width - 2, "")} ` : row;
 						return truncateFooterText(framed, width, "");
 					});
+					if (quotaLabel) {
+						const text = codexQuotaText(quota);
+						const count = (lines: string[]) =>
+							lines.reduce(
+								(sum, line) => sum + stripVTControlCharacters(line).split(text).length - 1,
+								0,
+							);
+						// Recompose without quota if any occurrence was clipped, split, or omitted.
+						if (count(source) !== count(framedRows)) return renderFooter(width, false);
+					}
+					return framedRows;
+				};
 
 				if (!config.components.footer.styles.starship.responsive)
 					return frameRows([renderLegacyContent()]);
@@ -861,7 +883,10 @@ export function installFooter(
 						renderFormatTokens(chunk.tokens, renderCompactVariable),
 					);
 					const references = collectFooterFormatReferences(chunk.tokens, FOOTER_FORMAT_ALIASES);
-					if (["cwd", "session_name", "git_branch"].some((name) => references.has(name))) {
+					if (
+						(!quotaLabel || !references.has("codex_quota")) &&
+						["cwd", "session_name", "git_branch"].some((name) => references.has(name))
+					) {
 						rendered = truncateFooterText(rendered, chunkBudget, "…");
 					}
 					if (rendered) compactChunks.push({ text: rendered, boundary: chunk.boundary });
@@ -873,6 +898,7 @@ export function installFooter(
 						config.components.footer.styles.starship.compactMaxLines,
 						renderVariable("sep"),
 					),
+					compactChunks.map((chunk) => chunk.text),
 				);
 			},
 		};

--- a/extensions/zentui/index.ts
+++ b/extensions/zentui/index.ts
@@ -11,6 +11,7 @@ import {
 	markAccentRailLayoutEditor,
 	retainAccentRailLayoutPatchInstallation,
 } from "./accent-rail-layout-patch";
+import { CodexQuotaCollector, editorWantsCodexQuota } from "./codex-quota";
 import { componentColor } from "./component-colors";
 import {
 	type AccentRailEditorStyleConfig,
@@ -157,6 +158,7 @@ export function activeFooterReferences(config: ZentuiConfig): Set<string> {
 	const references = starship.format
 		? collectFooterFormatReferences(parseFooterFormat(starship.format), FOOTER_FORMAT_ALIASES)
 		: new Set<string>([
+				...(config.components.footer.codexQuota ? ["codex_quota"] : []),
 				...(starship.segments.sessionName ? ["session_name"] : []),
 				...(starship.segments.runtime ? ["runtime"] : []),
 				...(starship.segments.gitCommit ? ["git_commit"] : []),
@@ -285,6 +287,7 @@ export default function (pi: ExtensionAPI) {
 
 	const refresh = () => {
 		if (!sessionLifecycle.isCurrent()) return;
+		codexQuota.reconcile();
 		requestFooterRender?.();
 		requestEditorRender?.();
 	};
@@ -338,6 +341,7 @@ export default function (pi: ExtensionAPI) {
 	const getEditorMeta = (ctx: ExtensionContext) => {
 		const context = getContextSnapshot(ctx);
 		return {
+			codexQuota: getEditorQuota(),
 			modelLabel: modelLabelFor(state, currentConfig.components.editor.modelLabel),
 			modelId: state.modelId,
 			modelName: state.modelName,
@@ -365,6 +369,38 @@ export default function (pi: ExtensionAPI) {
 		installedFooterKind === "starship" && ownsInstalledFooter()
 			? activeFooterReferences(currentConfig)
 			: new Set<string>();
+
+	const codexQuota = new CodexQuotaCollector(
+		() => {
+			const ctx = activeTuiContext;
+			if (
+				!ctx ||
+				!sessionLifecycle.isCurrent() ||
+				!isTuiContext(ctx) ||
+				ctx.model?.provider !== "openai-codex"
+			)
+				return undefined;
+			const editorDemand =
+				effectiveEditorEnabled() &&
+				ownsInstalledEditorFactory() &&
+				editorWantsCodexQuota(currentConfig);
+			const footerDemand =
+				effectiveFooterStyle() === "starship" &&
+				currentConfig.components.footer.codexQuota &&
+				installedFooterReferences().has("codex_quota");
+			return editorDemand || footerDemand ? ctx : undefined;
+		},
+		() => {
+			if (!sessionLifecycle.isCurrent()) return;
+			requestFooterRender?.();
+			requestEditorRender?.();
+		},
+	);
+	const getEditorQuota = () =>
+		currentConfig.components.editor.codexQuota &&
+		activeTuiContext?.model?.provider === "openai-codex"
+			? codexQuota.get()
+			: undefined;
 
 	type ProjectRefreshTarget = {
 		repository: RepositoryRootRequest;
@@ -605,6 +641,7 @@ export default function (pi: ExtensionAPI) {
 		const nextConfig = save();
 		const after = activeFooterReferences(nextConfig);
 		currentConfig = nextConfig;
+		codexQuota.reconcile();
 		if (sameReferences(before, after)) return;
 		reconcileSessionTimer();
 		reconcileProjectRefresh(ctx, true);
@@ -687,6 +724,7 @@ export default function (pi: ExtensionAPI) {
 		installedEditorFactory = undefined;
 		editorInstallMode = "none";
 		editorInstalled = false;
+		codexQuota.reconcile();
 	};
 
 	const trackZentuiEditorFactory = (factory: EditorFactory): boolean => {
@@ -746,6 +784,7 @@ export default function (pi: ExtensionAPI) {
 					() => getEditorMeta(ctx),
 					getThinkingLevel,
 					() => ({
+						codexQuota: getEditorQuota(),
 						cwd: ctx.cwd,
 						projectRoot: minimalistProjectRoot,
 						branch: state.branch,
@@ -785,6 +824,7 @@ export default function (pi: ExtensionAPI) {
 					() => getEditorMeta(ctx),
 					getThinkingLevel,
 					() => ({
+						codexQuota: getEditorQuota(),
 						cwd: ctx.cwd,
 						projectRoot: minimalistProjectRoot,
 						branch: state.branch,
@@ -898,6 +938,7 @@ export default function (pi: ExtensionAPI) {
 		requestFooterRender = undefined;
 		getActiveExtensionStatuses = () => new Map();
 		stopSessionTimer();
+		codexQuota.reconcile();
 		if (sessionLifecycle.isCurrent()) reconcileProjectRefresh(ctx, true);
 	};
 
@@ -951,6 +992,7 @@ export default function (pi: ExtensionAPI) {
 					getActiveExtensionStatuses = fn ?? (() => new Map());
 				},
 				getLiveContext: () => liveContext.get(),
+				getCodexQuota: () => codexQuota.get(),
 				getRepositoryRoot: (cwd) => repositoryRoots.rootForCwd(cwd),
 				onDispose: () => clearFooterOwnership(ctx, token),
 			});
@@ -1126,6 +1168,7 @@ export default function (pi: ExtensionAPI) {
 	const cleanupUi = (ctx?: ExtensionContext) => {
 		if (!ctx || !sessionLifecycle.isCurrent()) return;
 		sessionLifecycle.shutdown();
+		codexQuota.stop();
 		stopSessionTimer();
 		resetAgentTimer();
 		stopProjectRefresh();
@@ -1179,6 +1222,7 @@ export default function (pi: ExtensionAPI) {
 	};
 
 	pi.on("session_start", async (_event, ctx) => {
+		codexQuota.stop();
 		const lifecycleGeneration = sessionLifecycle.start();
 		// A new generation must not expose or route extension segments through the previous
 		// session while asynchronous TUI startup is still pending.

--- a/extensions/zentui/minimalist-editor.ts
+++ b/extensions/zentui/minimalist-editor.ts
@@ -1,6 +1,8 @@
 import { basename, isAbsolute, relative, sep } from "node:path";
 import type { Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { CodexQuota } from "./codex-quota";
+import { renderCodexQuota } from "./codex-quota-display";
 import { componentColor } from "./component-colors";
 import type { ZentuiConfig } from "./config";
 import { sanitizeEditorMetadataText } from "./editor-metadata-format";
@@ -38,6 +40,7 @@ const MINIMALIST_ADAPTIVE_TERMINAL_THINKING_FALLBACKS: Record<string, string> = 
 const MINIMALIST_BRANCH_FALLBACK = { theme: "bold syntaxKeyword", terminal: "bold blue" };
 
 export type MinimalistEditorMetadata = {
+	codexQuota?: CodexQuota;
 	cwd: string;
 	projectRoot?: string;
 	branch?: string;
@@ -274,6 +277,8 @@ function renderTopRight(
 		}
 		parts.push(context);
 	}
+	const quota = renderCodexQuota(metadata.codexQuota, uiTheme, config, "editor");
+	if (quota && visibleWidth(joinParts([...parts, quota])) <= availableWidth) parts.push(quota);
 	const joined = joinParts(parts);
 	return fit ? truncateToWidth(joined, availableWidth, "…") : joined;
 }

--- a/extensions/zentui/settings-command.ts
+++ b/extensions/zentui/settings-command.ts
@@ -189,13 +189,21 @@ type FooterSegmentSettingId = keyof FooterSegmentsConfig;
 type EditorPatch = Partial<
 	Pick<
 		EditorComponentConfig,
-		"enabled" | "style" | "colorSource" | "borderColorMode" | "modelLabel" | "viewportIndicators"
+		| "enabled"
+		| "style"
+		| "colorSource"
+		| "borderColorMode"
+		| "modelLabel"
+		| "viewportIndicators"
+		| "codexQuota"
 	>
 >;
 type UserMessagesPatch = Partial<
 	Pick<UserMessagesComponentConfig, "enabled" | "style" | "colorSource">
 >;
-type FooterPatch = Partial<Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel">>;
+type FooterPatch = Partial<
+	Pick<FooterComponentConfig, "style" | "colorSource" | "modelLabel" | "codexQuota">
+>;
 type ApplyResult = { applied: boolean; reason?: string };
 type SettingsOutcome =
 	| "close"
@@ -569,6 +577,9 @@ function buildAppearanceItems(config: PolishedTuiConfig): SettingItem[] {
 	];
 }
 
+const codexQuotaDescription =
+	"Remaining ChatGPT account quota for active openai-codex. Authenticated background refresh roughly every minute while active. Custom templates require $codex_quota; the toggle always gates access.";
+
 function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 	const editor = config.components.editor;
 	return [
@@ -593,6 +604,13 @@ function buildEditorItems(config: PolishedTuiConfig): SettingItem[] {
 			description: "Use Pi theme colors or terminal palette styles.",
 			currentValue: editor.colorSource,
 			values: colorSourceValues,
+		},
+		{
+			id: "editorCodexQuota",
+			label: "Codex quota",
+			description: codexQuotaDescription,
+			currentValue: featureValue(editor.codexQuota),
+			values: featureStateValues,
 		},
 		{
 			id: "editorModelLabel",
@@ -890,6 +908,13 @@ function buildFooterItems(config: PolishedTuiConfig): SettingItem[] {
 				description: "Use Pi theme colors or terminal palette styles.",
 				currentValue: footer.colorSource,
 				values: colorSourceValues,
+			},
+			{
+				id: "footerCodexQuota",
+				label: "Codex quota",
+				description: codexQuotaDescription,
+				currentValue: featureValue(footer.codexQuota),
+				values: featureStateValues,
 			},
 			{
 				id: "footerModelLabel",
@@ -1577,6 +1602,16 @@ export function registerZentuiSettingsCommand(pi: ExtensionAPI, deps: SettingsCo
 											return;
 										}
 										const enabled = isFeatureState(newValue) ? newValue === "enabled" : undefined;
+										if (
+											(id === "editorCodexQuota" || id === "footerCodexQuota") &&
+											enabled !== undefined
+										) {
+											if (id === "editorCodexQuota") setEditor({ codexQuota: enabled }, ctx);
+											else setFooter({ codexQuota: enabled }, ctx);
+											settingsList.updateValue(id, newValue);
+											notifyChange("Codex quota", newValue);
+											return;
+										}
 										if (id === "editorEnabled" && enabled !== undefined) {
 											if (pendingPresetEditor) {
 												const result = deps.setEditorComponent({ enabled }, ctx, {

--- a/extensions/zentui/settings-previews.ts
+++ b/extensions/zentui/settings-previews.ts
@@ -93,7 +93,12 @@ export function renderEditorSettingsPreview(
 	const safeConfig = previewConfig(config);
 	const editor = safeConfig.components.editor;
 	const borderColor = adaptiveBorder(theme);
-	const modelLabel = editor.modelLabel === "name" ? "Sonnet 4" : "sonnet-4";
+	const modelLabel = editor.codexQuota
+		? "gpt-5.4"
+		: editor.modelLabel === "name"
+			? "Sonnet 4"
+			: "sonnet-4";
+	const codexQuota = editor.codexQuota ? { fiveHour: 80, week: 60 } : undefined;
 	const editorLines = [EDITOR_PREVIEW_INPUT];
 	const autocompleteLines = [
 		safeThemeFg(theme, "accent", "→ settings     Open settings"),
@@ -104,6 +109,7 @@ export function renderEditorSettingsPreview(
 	let frame: string[];
 	if (editor.style === "accent-rail") {
 		frame = renderAccentRailEditorFrame({
+			codexQuota,
 			width: previewWidth,
 			editorLines,
 			autocompleteLines,
@@ -118,6 +124,7 @@ export function renderEditorSettingsPreview(
 			viewport,
 			inputText: EDITOR_PREVIEW_INPUT,
 			metadata: {
+				codexQuota,
 				cwd: "/workspace/zentui/src",
 				projectRoot: "/workspace/zentui",
 				branch: "feat/settings-previews",
@@ -146,10 +153,11 @@ export function renderEditorSettingsPreview(
 			uiTheme: theme,
 			config: safeConfig,
 			modelMeta: {
+				codexQuota,
 				modelLabel,
-				modelId: "sonnet-4",
-				modelName: "Sonnet 4",
-				providerLabel: "Anthropic",
+				modelId: editor.codexQuota ? "gpt-5.4" : "sonnet-4",
+				modelName: editor.codexQuota ? "GPT-5.4" : "Sonnet 4",
+				providerLabel: editor.codexQuota ? "OpenAI Codex" : "Anthropic",
 				sessionName: "Preview",
 			},
 			thinkingLevel: "high",

--- a/extensions/zentui/ui.ts
+++ b/extensions/zentui/ui.ts
@@ -9,6 +9,8 @@ import {
 	visibleWidth,
 } from "@earendil-works/pi-tui";
 import { ACCENT_RAIL_CHROME_WIDTH, renderAccentRailEditorFrame } from "./accent-rail-editor";
+import type { CodexQuota } from "./codex-quota";
+import { renderCodexQuota } from "./codex-quota-display";
 import { omitTrailingNativeCompletionCountRow, renderCompletionPalette } from "./completion-menu";
 import { componentColor } from "./component-colors";
 import type { EditorStyle, ZentuiConfig } from "./config";
@@ -89,6 +91,7 @@ type WrappedEditor = EditorComponent &
 	};
 
 export type EditorMeta = {
+	codexQuota?: CodexQuota;
 	modelLabel: string;
 	modelId?: string;
 	modelName?: string;
@@ -135,6 +138,7 @@ type PolishedFrameResult = {
 };
 
 type AccentRailFrameAdapterOptions = {
+	codexQuota?: CodexQuota;
 	width: number;
 	baseRendered: string[];
 	autocompleteSource: AutocompleteEditorInternals;
@@ -567,6 +571,7 @@ function readVimStatus(editor: WrappedEditor, uiTheme: Theme): string | undefine
 }
 
 function renderAccentRailFrameFromBase({
+	codexQuota,
 	width,
 	baseRendered,
 	autocompleteSource,
@@ -610,7 +615,10 @@ function renderAccentRailFrameFromBase({
 		above: parsedTop?.count,
 		below: parsedBottom?.count,
 	};
+	const quotaRow = renderCodexQuota(codexQuota, uiTheme, config, "editor");
+	const quotaVisible = quotaRow && visibleWidth(quotaRow) <= width - ACCENT_RAIL_CHROME_WIDTH;
 	const renderedLines = renderAccentRailEditorFrame({
+		codexQuota,
 		width,
 		editorLines,
 		autocompleteLines,
@@ -629,6 +637,7 @@ function renderAccentRailFrameFromBase({
 			0,
 			bodyStart +
 				editorLines.length +
+				(quotaVisible ? 1 : 0) +
 				(config.components.editor.viewportIndicators && viewport.below ? 1 : 0),
 		),
 	});
@@ -807,25 +816,38 @@ export function renderPolishedEditorFrame({
 	const { prompt, promptWidth, rail, railWidth } = getEditorChromeWidths(config, uiTheme, reset);
 	const innerWidth = Math.max(0, width - railWidth);
 	const lowRailContinuation = " ".repeat(promptWidth);
-	const metadataZones = renderEditorMetadataFormatSplit(
-		selectedPolishedConfig(config)?.metadataFormat ??
-			config.components.editor.styles.opencode.metadataFormat,
-		{
-			model: modelMeta.modelLabel,
-			modelId: modelMeta.modelId ?? "",
-			modelName: modelMeta.modelName ?? "",
-			provider: modelMeta.providerLabel,
-			thinking: thinkingLevel ?? "",
-			sessionName: modelMeta.sessionName ?? "",
-			contextPercent: modelMeta.contextPercent,
-			contextWindow: modelMeta.contextWindow,
-			inputTokens: modelMeta.inputTokens,
-			outputTokens: modelMeta.outputTokens,
-			cacheHitRate: modelMeta.cacheHitRate,
-		},
-		uiTheme,
-		config,
-	);
+	const renderMetadata = (codexQuota?: CodexQuota) =>
+		renderEditorMetadataFormatSplit(
+			selectedPolishedConfig(config)?.metadataFormat ??
+				config.components.editor.styles.opencode.metadataFormat,
+			{
+				codexQuota,
+				model: modelMeta.modelLabel,
+				modelId: modelMeta.modelId ?? "",
+				modelName: modelMeta.modelName ?? "",
+				provider: modelMeta.providerLabel,
+				thinking: thinkingLevel ?? "",
+				sessionName: modelMeta.sessionName ?? "",
+				contextPercent: modelMeta.contextPercent,
+				contextWindow: modelMeta.contextWindow,
+				inputTokens: modelMeta.inputTokens,
+				outputTokens: modelMeta.outputTokens,
+				cacheHitRate: modelMeta.cacheHitRate,
+			},
+			uiTheme,
+			config,
+		);
+	let metadataZones = renderMetadata(modelMeta.codexQuota);
+	// Quota is atomic: never clip away its labels or trailing stale warning.
+	const metadataBudget = isLowRailPolishedStyle(config.components.editor.style)
+		? width - 1
+		: innerWidth;
+	const naturalWidth =
+		Object.values(metadataZones).reduce((sum, zone) => sum + visibleWidth(zone), 0) +
+		Object.values(metadataZones).filter(Boolean).length -
+		1 +
+		(rightStatus ? visibleWidth(rightStatus) + 1 : 0);
+	if (modelMeta.codexQuota && naturalWidth > metadataBudget) metadataZones = renderMetadata();
 	const lowRailMeta = composeEditorMetadataLine(metadataZones, rightStatus, Math.max(0, width - 1));
 	const railedMeta = composeEditorMetadataLine(metadataZones, rightStatus, innerWidth);
 
@@ -975,6 +997,7 @@ export class PolishedEditor extends CustomEditor {
 			}
 			try {
 				const result = renderAccentRailFrameFromBase({
+					codexQuota: this.getModelMeta().codexQuota,
 					width,
 					baseRendered: captured.value,
 					autocompleteSource: this as unknown as AutocompleteEditorInternals,
@@ -1219,6 +1242,7 @@ export class WrappedPolishedEditor implements EditorComponent {
 				);
 				if (provenance.safe) {
 					const result = renderAccentRailFrameFromBase({
+						codexQuota: this.getModelMeta().codexQuota,
 						width,
 						baseRendered: captured.value,
 						autocompleteSource: this.base,

--- a/test/accent-rail-layout-patch.test.ts
+++ b/test/accent-rail-layout-patch.test.ts
@@ -10,6 +10,7 @@ import {
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import type { Theme } from "@earendil-works/pi-coding-agent";
 import { Container, VStack } from "@earendil-works/pi-tui";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -21,7 +22,9 @@ import {
 	retainAccentRailLayoutPatchInstallation,
 	ZENTUI_ACCENT_RAIL_LAYOUT_EDITOR,
 } from "../extensions/zentui/accent-rail-layout-patch";
+import { mergeConfig } from "../extensions/zentui/config";
 import { SessionLifecycle } from "../extensions/zentui/session-lifecycle";
+import { WrappedPolishedEditor } from "../extensions/zentui/ui";
 
 const LAYOUT_NODE = Symbol.for("@earendil-works/pi-tui/layout-node");
 const localPiTuiEntry = createRequire(import.meta.url).resolve("@earendil-works/pi-tui");
@@ -91,6 +94,87 @@ function installFake(version = "0.84.0", method = LAYOUT_NODE) {
 }
 
 describe("Accent Rail fullscreen layout patch", () => {
+	it.skipIf(!localSupportsAccentRailPatch)(
+		"preserves quota-enabled editor geometry through the host fullscreen dock adapter",
+		() => {
+			const config = mergeConfig({
+				components: { editor: { style: "accent-rail", codexQuota: true } },
+			});
+			const theme = {
+				fg: (_color: string, text: string) => text,
+				bg: (_color: string, text: string) => text,
+			} as Theme;
+			let completing = false;
+			const base = {
+				autocompleteList: { render: () => ["  completion"] },
+				isShowingAutocomplete: () => completing,
+				render(width: number) {
+					return [
+						"─".repeat(width),
+						"draft",
+						"─".repeat(width),
+						...(completing ? this.autocompleteList.render() : []),
+					];
+				},
+				getText: () => "draft",
+				setText() {},
+				handleInput() {},
+				invalidate() {},
+			};
+			const editor = new WrappedPolishedEditor(
+				base,
+				theme,
+				() => config,
+				() => ({
+					modelLabel: "model",
+					providerLabel: "OpenAI Codex",
+					codexQuota: { fiveHour: 80, week: 60, stale: true },
+				}),
+				() => "off",
+			);
+			const owner = Symbol("quota-dock");
+			markAccentRailLayoutEditor(editor, owner, () => true);
+			const container = new Container();
+			container.addChild(editor);
+			const footer = { render: () => ["independent footer"], invalidate() {} };
+			const stack = new VStack([
+				{ component: container, shrink: 1, minSize: 3 },
+				{ component: footer, minSize: 1 },
+			]);
+			const installation = installAccentRailLayoutPatchOnTarget(
+				{ prototype: VStack.prototype, version: localPiTuiVersion },
+				owner,
+			);
+			try {
+				expect(installation.diagnostic).toBe("installed");
+				const node = (stack as unknown as Record<symbol, () => { entries: Entry[] }>)[
+					LAYOUT_NODE
+				]();
+				expect(node.entries[0]?.minSize).toBe(3);
+				expect(node.entries[1]?.component).toBe(footer);
+				const dockEditor = node.entries[0]?.component as { render(width: number): string[] };
+				for (const width of [80, 20, 80]) {
+					const rows = dockEditor.render(width);
+					expect(rows).toEqual(editor.render(width));
+					if (width === 80) {
+						expect(rows).toHaveLength(2);
+						expect(rows[0]).toContain("draft");
+						expect(rows[1]).toContain("5h 80% | week 60% stale");
+					} else expect(rows.join("\n")).not.toContain("5h");
+				}
+				completing = true;
+				const completed = dockEditor.render(80);
+				expect(completed).toHaveLength(3);
+				expect(completed[1]).toContain("5h");
+				expect(completed[2]).toContain("completion");
+				config.components.editor.codexQuota = false;
+				expect(dockEditor.render(80)).toHaveLength(2);
+				expect(editor.getText()).toBe("draft");
+			} finally {
+				installation.cleanup();
+			}
+		},
+	);
 	it("clones one owned active entry with a stable forwarding component", () => {
 		const owner = Symbol("owner");
 		const { container, invalidate } = markedContainer(owner);

--- a/test/behavior-compatibility.mjs
+++ b/test/behavior-compatibility.mjs
@@ -11,6 +11,11 @@ if (!npmCli) throw new Error("Run through npm run test:behavior-compatibility");
 const versions = process.env.ZENTUI_PI_VERSIONS?.split(",") ?? ["0.80.5", "0.84.0", "0.85.1"];
 const packages = ["pi-ai", "pi-coding-agent", "pi-tui"];
 const tests = [
+	"codex-quota.test.ts",
+	"codex-quota-rendering.test.ts",
+	"codex-quota-lifecycle.test.ts",
+	"accent-rail-editor.test.ts",
+	"accent-rail-layout-patch.test.ts",
 	"editor-mouse.test.ts",
 	"user-message-native.test.ts",
 	"user-message-native-reduced-capabilities.test.ts",

--- a/test/codex-quota-lifecycle.test.ts
+++ b/test/codex-quota-lifecycle.test.ts
@@ -1,0 +1,257 @@
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mergeConfig, type PolishedTuiConfig } from "../extensions/zentui/config";
+
+const settings = vi.hoisted(() => ({ config: undefined as PolishedTuiConfig | undefined }));
+vi.mock("../extensions/zentui/config", async (original) => ({
+	...(await original<typeof import("../extensions/zentui/config")>()),
+	loadConfig: () => settings.config,
+	ensureConfigExists() {},
+}));
+vi.mock("../extensions/zentui/telemetry", () => ({ resolveFooterTelemetry: () => ({}) }));
+vi.mock("../extensions/zentui/git", async (original) => {
+	const actual = await original<typeof import("../extensions/zentui/git")>();
+	return {
+		...actual,
+		readGitStatus: async () => ({ kind: "ok", status: actual.emptyGitStatus() }),
+	};
+});
+vi.mock("../extensions/zentui/runtime", () => ({ readRuntimeInfo: async () => ({ kind: "ok" }) }));
+vi.mock("../extensions/zentui/accent-rail-layout-patch", async (original) => ({
+	...(await original<typeof import("../extensions/zentui/accent-rail-layout-patch")>()),
+	retainAccentRailLayoutPatchInstallation: async () => "retained",
+}));
+
+import zentui from "../extensions/zentui/index";
+
+type Handler = (event: unknown, ctx: ExtensionContext) => unknown;
+let handlers: Map<string, Handler[]>;
+let ctx: ExtensionContext;
+let http: ReturnType<typeof vi.fn>;
+let auth: ReturnType<typeof vi.fn>;
+let editorFactory: Parameters<ExtensionContext["ui"]["setEditorComponent"]>[0];
+let footer: { render(width: number): string[]; dispose?(): void } | undefined;
+const emit = async (name: string) => {
+	for (const handler of handlers.get(name) ?? []) await handler({}, ctx);
+};
+const flush = () => vi.advanceTimersByTimeAsync(0);
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	settings.config = mergeConfig({
+		projectRefreshIntervalMs: 0,
+		components: {
+			editor: { enabled: false, style: "minimalist" },
+			footer: { style: "native" },
+			userMessages: { enabled: false },
+			selectorBorders: { enabled: false },
+		},
+	});
+	http = vi.fn(async () =>
+		Response.json({
+			rate_limit: {
+				primary_window: { used_percent: 20, limit_window_seconds: 18_000 },
+				secondary_window: { used_percent: 40, limit_window_seconds: 604_800 },
+			},
+		}),
+	);
+	vi.stubGlobal("fetch", http);
+	auth = vi.fn(async () => ({ auth: { apiKey: "synthetic-token" } }));
+	editorFactory = undefined;
+	footer = undefined;
+	const theme = { fg: (_color: string, text: string) => text } as Theme;
+	ctx = {
+		hasUI: true,
+		mode: "tui",
+		cwd: "/tmp",
+		model: { id: "gpt-codex", provider: "openai-codex", contextWindow: 200000 },
+		modelRegistry: { getProviderAuth: auth },
+		getContextUsage: () => undefined,
+		sessionManager: { getBranch: () => [], getSessionName: () => undefined },
+		ui: {
+			theme,
+			getEditorText: () => "prompt",
+			setEditorText() {},
+			getEditorComponent: () => editorFactory,
+			setEditorComponent(value: typeof editorFactory) {
+				editorFactory = value;
+			},
+			setFooter(factory: Parameters<ExtensionContext["ui"]["setFooter"]>[0]) {
+				footer?.dispose?.();
+				footer = factory?.({ requestRender() {} } as never, theme, {
+					onBranchChange: () => () => {},
+					getExtensionStatuses: () => new Map(),
+				} as never);
+			},
+		},
+	} as unknown as ExtensionContext;
+	handlers = new Map();
+	zentui({
+		on(name: string, handler: Handler) {
+			handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+		},
+		registerCommand() {},
+		getThinkingLevel: () => "off",
+	} as never);
+});
+afterEach(async () => {
+	await emit("session_shutdown");
+	expect(vi.getTimerCount()).toBe(0);
+	vi.unstubAllGlobals();
+	vi.useRealTimers();
+});
+
+it.each(["editor", "footer", "both"])(
+	"shares collection for %s without requiring another surface",
+	async (consumer) => {
+		const config = settings.config as PolishedTuiConfig;
+		if (consumer !== "footer")
+			Object.assign(config.components.editor, { enabled: true, codexQuota: true });
+		if (consumer !== "editor")
+			Object.assign(config.components.footer, { style: "starship", codexQuota: true });
+		else config.components.footer.style = "hidden";
+		await emit("session_start");
+		await flush();
+		expect(http).toHaveBeenCalledOnce();
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(http).toHaveBeenCalledTimes(2);
+		if (consumer === "editor") expect(footer?.render(120)).toEqual([]);
+		else expect(footer?.render(160).join("\n")).toContain("5h 80% | week 60%");
+		if (consumer === "footer") expect(editorFactory).toBeUndefined();
+		config.components.editor.codexQuota = false;
+		await emit("model_select");
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(http).toHaveBeenCalledTimes(consumer === "editor" ? 2 : 3);
+		config.components.footer.codexQuota = false;
+		await emit("model_select");
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(http).toHaveBeenCalledTimes(consumer === "editor" ? 2 : 3);
+	},
+);
+
+it.each(["print", "json", "rpc"])("does not collect in %s mode", async (mode) => {
+	Object.assign((settings.config as PolishedTuiConfig).components.editor, {
+		enabled: true,
+		codexQuota: true,
+	});
+	Object.assign(ctx, { mode, hasUI: mode === "rpc" });
+	await emit("session_start");
+	await flush();
+	expect(auth).not.toHaveBeenCalled();
+	expect(http).not.toHaveBeenCalled();
+});
+
+it("does not collect with defaults or custom templates lacking the exact token", async () => {
+	await emit("session_start");
+	await flush();
+	expect(auth).not.toHaveBeenCalled();
+	await emit("session_shutdown");
+	const config = settings.config as PolishedTuiConfig;
+	Object.assign(config.components.editor, { enabled: true, codexQuota: true, style: "opencode" });
+	config.components.editor.styles.opencode.metadataFormat = "$model $codex_quota_other";
+	Object.assign(config.components.footer, { style: "starship", codexQuota: true });
+	config.components.footer.styles.starship.format = "$cwd";
+	config.components.footer.styles.starship.compactFormat = "$tokens";
+	await emit("session_start");
+	await flush();
+	expect(auth).not.toHaveBeenCalled();
+	config.components.footer.styles.starship.compactFormat = `\${codex_quota}`;
+	await emit("model_select");
+	await flush();
+	expect(http).toHaveBeenCalledOnce();
+});
+
+it("does not collect with a missing model and clears quota when the model disappears", async () => {
+	Object.assign((settings.config as PolishedTuiConfig).components.footer, {
+		style: "starship",
+		codexQuota: true,
+	});
+	const model = ctx.model;
+	Object.assign(ctx, { model: undefined });
+	await emit("session_start");
+	await flush();
+	expect(auth).not.toHaveBeenCalled();
+	expect(footer?.render(160).join("\n")).not.toContain("5h");
+	Object.assign(ctx, { model });
+	await emit("model_select");
+	await flush();
+	expect(http).toHaveBeenCalledOnce();
+	Object.assign(ctx, { model: undefined });
+	await emit("model_select");
+	await vi.advanceTimersByTimeAsync(120_000);
+	expect(http).toHaveBeenCalledOnce();
+	expect(footer?.render(160).join("\n")).not.toContain("5h");
+});
+
+it("reconciles quota demand across live editor styles with Native Footer", async () => {
+	const editor = (settings.config as PolishedTuiConfig).components.editor;
+	Object.assign(editor, { enabled: true, codexQuota: true });
+	editor.styles.opencode.metadataFormat = "$model";
+	await emit("session_start");
+	await flush();
+	const ownedFactory = editorFactory;
+	expect(ownedFactory).toBeDefined();
+	expect(footer).toBeUndefined();
+	expect(http).toHaveBeenCalledOnce();
+	editor.style = "opencode";
+	await emit("model_select");
+	await vi.advanceTimersByTimeAsync(120_000);
+	expect(http).toHaveBeenCalledOnce();
+	for (const style of ["opencode-copy-friendly", "accent-rail", "minimalist"] as const) {
+		editor.style = style;
+		await emit("model_select");
+		await flush();
+		expect(editorFactory).toBe(ownedFactory);
+		expect(http).toHaveBeenCalledTimes(2);
+	}
+	await vi.advanceTimersByTimeAsync(60_000);
+	expect(http).toHaveBeenCalledTimes(3);
+	editor.style = "opencode-copy-friendly";
+	editor.styles[editor.style].metadataFormat = "$model";
+	await emit("model_select");
+	await vi.advanceTimersByTimeAsync(120_000);
+	expect(http).toHaveBeenCalledTimes(3);
+});
+
+it("stops for other providers, clears cache, and starts fresh on return/new session", async () => {
+	Object.assign((settings.config as PolishedTuiConfig).components.footer, {
+		style: "starship",
+		codexQuota: true,
+	});
+	Object.assign(ctx.model as object, { provider: "openai" });
+	await emit("session_start");
+	await flush();
+	expect(auth).not.toHaveBeenCalled();
+	Object.assign(ctx.model as object, { provider: "openai-codex" });
+	await emit("model_select");
+	await flush();
+	expect(http).toHaveBeenCalledOnce();
+	Object.assign(ctx.model as object, { provider: "custom-codex-proxy" });
+	await emit("model_select");
+	expect(footer?.render(160).join("\n")).not.toContain("5h");
+	await vi.advanceTimersByTimeAsync(120_000);
+	expect(http).toHaveBeenCalledOnce();
+	Object.assign(ctx.model as object, { provider: "openai-codex" });
+	http.mockRejectedValueOnce(new Error("offline"));
+	await emit("model_select");
+	await flush();
+	expect(footer?.render(160).join("\n")).toContain("5h -- | week --");
+	await emit("session_shutdown");
+	await emit("session_start");
+	await flush();
+	expect(http).toHaveBeenCalledTimes(3);
+});
+
+it.each(["editor", "footer"])("releases collection on loss of %s ownership", async (consumer) => {
+	const config = settings.config as PolishedTuiConfig;
+	if (consumer === "editor")
+		Object.assign(config.components.editor, { enabled: true, codexQuota: true });
+	else Object.assign(config.components.footer, { style: "starship", codexQuota: true });
+	await emit("session_start");
+	await flush();
+	expect(http).toHaveBeenCalledOnce();
+	if (consumer === "editor") editorFactory = undefined;
+	else footer?.dispose?.();
+	await vi.advanceTimersByTimeAsync(120_000);
+	expect(http).toHaveBeenCalledOnce();
+});

--- a/test/codex-quota-rendering.test.ts
+++ b/test/codex-quota-rendering.test.ts
@@ -1,0 +1,257 @@
+import { stripVTControlCharacters as plain } from "node:util";
+import type { ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { describe, expect, it } from "vitest";
+import { renderAccentRailEditorFrame } from "../extensions/zentui/accent-rail-editor";
+import type { CodexQuota } from "../extensions/zentui/codex-quota";
+import { codexQuotaText } from "../extensions/zentui/codex-quota-display";
+import { mergeConfig } from "../extensions/zentui/config";
+import { renderEditorMetadataFormat } from "../extensions/zentui/editor-metadata-format";
+import { installFooter } from "../extensions/zentui/footer";
+import { emptyGitStatus } from "../extensions/zentui/git";
+import { renderMinimalistFrame } from "../extensions/zentui/minimalist-editor";
+import { renderEditorSettingsPreview } from "../extensions/zentui/settings-previews";
+import { createInitialState } from "../extensions/zentui/state";
+import { renderPolishedEditorFrame } from "../extensions/zentui/ui";
+
+const theme = {
+	fg: (_color: string, text: string) => `\x1b[32m${text}\x1b[39m`,
+	bold: (text: string) => text,
+} as Theme;
+const snapshots: CodexQuota[] = [
+	{},
+	{ fiveHour: 80, week: 60 },
+	{ fiveHour: 20, week: 0 },
+	{ week: 49 },
+	{ fiveHour: 80, week: 60, stale: true },
+];
+
+function assertAtomic(rows: string[], width: number, quota: CodexQuota) {
+	for (const row of rows) {
+		expect(visibleWidth(row)).toBeLessThanOrEqual(width);
+		if (plain(row).includes("5h")) expect(plain(row)).toContain(codexQuotaText(quota));
+	}
+}
+
+describe.each(["theme", "terminal"] as const)("quota with %s colors", (colorSource) => {
+	it.each(["opencode", "opencode-copy-friendly", "minimalist", "accent-rail"] as const)(
+		"renders %s atomically at every width without editing input",
+		(style) => {
+			const config = mergeConfig({
+				components: {
+					editor: { style, colorSource, codexQuota: true },
+					footer: { style: "hidden" },
+				},
+			});
+			for (const iconMode of ["ascii", "nerd"] as const) {
+				config.icons.mode = iconMode;
+				for (const quota of snapshots) {
+					for (let width = 1; width <= 140; width++) {
+						const common = {
+							width,
+							editorLines: ["prompt"],
+							autocompleteLines: ["completion"],
+							uiTheme: theme,
+							config,
+						};
+						const rows =
+							style === "accent-rail"
+								? renderAccentRailEditorFrame({ ...common, codexQuota: quota })
+								: style === "minimalist"
+									? renderMinimalistFrame({
+											...common,
+											inputText: "prompt",
+											metadata: {
+												cwd: "/repo",
+												modelLabel: "model",
+												contextPercent: 20,
+												codexQuota: quota,
+											},
+										})
+									: renderPolishedEditorFrame({
+											...common,
+											modelMeta: {
+												modelLabel: "model",
+												providerLabel: "OpenAI Codex",
+												codexQuota: quota,
+											},
+										});
+						assertAtomic(rows, width, quota);
+						if (width === 140) {
+							expect(plain(rows.join("\n"))).toContain(codexQuotaText(quota));
+							expect(plain(rows.join("\n"))).toContain("prompt");
+							expect(plain(rows.join("\n"))).toContain("completion");
+						}
+					}
+				}
+			}
+		},
+	);
+
+	it.each(["opencode", "opencode-copy-friendly", "minimalist", "accent-rail"] as const)(
+		"keeps stale quota atomic beside long model names and viewport controls in %s",
+		(style) => {
+			const config = mergeConfig({
+				components: { editor: { style, colorSource, codexQuota: true } },
+			});
+			config.components.editor.styles.opencode.metadataFormat =
+				"$model$fill($codex_quota)$fill$context";
+			config.components.editor.styles["opencode-copy-friendly"].metadataFormat =
+				"$model$fill($codex_quota)$fill$context";
+			const modelLabel = "very-long-model-name-".repeat(6);
+			const quota = { fiveHour: 80, week: 60, stale: true };
+			for (let width = 5; width <= 240; width++) {
+				const common = {
+					width,
+					editorLines: ["draft", "continuation"],
+					autocompleteLines: ["completion"],
+					viewport: { above: "2", below: "3" },
+					uiTheme: theme,
+					config,
+				};
+				const rows =
+					style === "minimalist"
+						? renderMinimalistFrame({
+								...common,
+								inputText: "draft\ncontinuation",
+								metadata: { cwd: "/repo", modelLabel, contextPercent: 20, codexQuota: quota },
+							})
+						: style === "accent-rail"
+							? renderAccentRailEditorFrame({ ...common, codexQuota: quota })
+							: renderPolishedEditorFrame({
+									...common,
+									modelMeta: {
+										modelLabel,
+										providerLabel: "OpenAI Codex",
+										codexQuota: quota,
+										contextPercent: 20,
+										contextWindow: 1_048_576,
+									},
+									rightStatus: "INSERT",
+								});
+				assertAtomic(rows, width, quota);
+				if (width === 240) {
+					const text = plain(rows.join("\n"));
+					for (const label of [
+						codexQuotaText(quota),
+						"draft",
+						"continuation",
+						"completion",
+						"↑ 2 more",
+						"↓ 3 more",
+					])
+						expect(text).toContain(label);
+				}
+			}
+		},
+	);
+
+	it("gates footer wide/compact templates and preserves atomic quota in mixed chunks", () => {
+		const config = mergeConfig({ components: { footer: { codexQuota: true, colorSource } } });
+		const starship = config.components.footer.styles.starship;
+		let provider = "openai-codex";
+		let quota = snapshots[4];
+		let factory: Parameters<ExtensionContext["ui"]["setFooter"]>[0];
+		installFooter(
+			{
+				cwd: "/repo",
+				get model() {
+					return { provider };
+				},
+				sessionManager: { getSessionName: () => "session" },
+				getContextUsage: () => undefined,
+				ui: {
+					setFooter(value: typeof factory) {
+						factory = value;
+					},
+				},
+			} as unknown as ExtensionContext,
+			createInitialState(emptyGitStatus()),
+			() => config,
+			{ setRequestRender() {}, scheduleProjectRefresh() {}, getCodexQuota: () => quota },
+		);
+		const footer = factory?.({ requestRender() {} } as never, theme, {
+			onBranchChange: () => () => {},
+			getExtensionStatuses: () => new Map(),
+		} as never);
+		expect(footer).toBeDefined();
+		try {
+			for (const snapshot of snapshots) {
+				quota = snapshot;
+				for (const format of [
+					"",
+					"$codex_quota",
+					"$cwd($sep$codex_quota)$fill$tokens",
+					"$codex_quota $codex_quota",
+				]) {
+					for (const responsive of [true, false]) {
+						starship.format = format;
+						starship.responsive = responsive;
+						for (const compact of [
+							"$codex_quota",
+							"$cwd $codex_quota$wrap$tokens",
+							"$cwd$wrap_sep($codex_quota)$wrap$tokens",
+						]) {
+							starship.compactFormat = compact;
+							for (let width = 1; width <= 100; width++)
+								assertAtomic(footer?.render(width) ?? [], width, snapshot);
+						}
+					}
+				}
+			}
+			starship.format = "$codex_quota";
+			expect(plain(footer?.render(140).join("\n") ?? "")).toContain("5h");
+			provider = "openai";
+			expect(plain(footer?.render(140).join("\n") ?? "")).not.toContain("5h");
+			provider = "openai-codex";
+			config.components.footer.codexQuota = false;
+			expect(plain(footer?.render(140).join("\n") ?? "")).not.toContain("5h");
+			starship.format = "long-wide-template-that-forces-compact";
+			starship.responsive = true;
+			for (let width = 1; width < 36; width++) {
+				starship.compactFormat = "$cwd$wrap$tokens";
+				const withoutToken = footer?.render(width);
+				starship.compactFormat = "$cwd( $codex_quota)$wrap$tokens";
+				expect(footer?.render(width)).toEqual(withoutToken);
+			}
+			config.components.footer.codexQuota = true;
+			starship.format = "$cwd";
+			starship.compactFormat = "$cwd";
+			expect(plain(footer?.render(140).join("\n") ?? "")).not.toContain("5h");
+		} finally {
+			footer?.dispose?.();
+		}
+	});
+});
+
+it("preserves default spacing and custom editor template authority when gated", () => {
+	const config = mergeConfig({});
+	const values = {
+		model: "model",
+		modelId: "",
+		modelName: "",
+		provider: "OpenAI Codex",
+		thinking: "high",
+		sessionName: "",
+		codexQuota: snapshots[1],
+	};
+	const render = (format: string) =>
+		plain(renderEditorMetadataFormat(format, values, theme, config));
+	expect(render(config.components.editor.styles.opencode.metadataFormat)).toBe(
+		"model  OpenAI Codex  high",
+	);
+	expect(render("$model( | $codex_quota)")).toBe("model");
+	config.components.editor.codexQuota = true;
+	expect(render("$model")).toBe("model");
+	expect(render(`$model( | \${codex_quota})`)).toBe("model | 5h 80% | week 60%");
+});
+
+it("uses synthetic preview data and adds no rail quota row when off", () => {
+	const config = mergeConfig({ components: { editor: { style: "accent-rail" } } });
+	const before = renderEditorSettingsPreview(config, theme, 72);
+	expect(plain(before.join("\n"))).not.toContain("5h");
+	config.components.editor.codexQuota = true;
+	const after = renderEditorSettingsPreview(config, theme, 72);
+	expect(plain(after.join("\n"))).toContain("5h 80% | week 60%");
+	expect(after.length).toBe(before.length + 1);
+});

--- a/test/codex-quota.test.ts
+++ b/test/codex-quota.test.ts
@@ -1,0 +1,291 @@
+import { type ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	CodexQuotaCollector,
+	editorWantsCodexQuota,
+	parseCodexQuota,
+	resolveCodexToken,
+} from "../extensions/zentui/codex-quota";
+import { codexQuotaText } from "../extensions/zentui/codex-quota-display";
+import { mergeConfig } from "../extensions/zentui/config";
+
+const window = (used_percent: unknown, limit_window_seconds: unknown = 18_000) => ({
+	used_percent,
+	limit_window_seconds,
+});
+const payload = (
+	primary_window: unknown = window(20),
+	secondary_window: unknown = window(40, 604_800),
+) => ({ rate_limit: { primary_window, secondary_window } });
+const token = (account: string, rotation = 1) =>
+	`header.${Buffer.from(JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: account }, rotation })).toString("base64url")}.signature`;
+const flush = () => vi.advanceTimersByTimeAsync(0);
+
+it("parses exact durations independently of order, percentages, and partial data", () => {
+	expect(parseCodexQuota(payload())).toEqual({ fiveHour: 80, week: 60 });
+	expect(parseCodexQuota(payload(window(100, 604_800), window(0)))).toEqual({
+		fiveHour: 100,
+		week: 0,
+	});
+	expect(parseCodexQuota(payload(window(25.6), null))).toEqual({ fiveHour: 74 });
+	for (const invalid of [null, "", "0", NaN, Infinity, -1, 101, true]) {
+		expect(parseCodexQuota(payload(window(invalid), window(50, 604_800)))).toEqual({ week: 50 });
+	}
+	for (const duration of [null, "18000", 0, -1, 18_001, 86_400, 604_799, NaN, Infinity]) {
+		expect(parseCodexQuota(payload(window(0, duration), null))).toBeUndefined();
+	}
+	for (const invalid of [
+		null,
+		[],
+		{},
+		{ rate_limit: null },
+		{ rate_limit: [] },
+		payload(null, "bad"),
+	]) {
+		expect(parseCodexQuota(invalid)).toBeUndefined();
+	}
+});
+
+it("uses parsed template references and requires independent editor consent", () => {
+	const config = mergeConfig({});
+	expect(editorWantsCodexQuota(config)).toBe(false);
+	config.components.editor.codexQuota = true;
+	for (const style of [
+		"opencode",
+		"opencode-copy-friendly",
+		"minimalist",
+		"accent-rail",
+	] as const) {
+		config.components.editor.style = style;
+		expect(editorWantsCodexQuota(config)).toBe(true);
+	}
+	config.components.editor.style = "opencode";
+	config.components.editor.styles.opencode.metadataFormat = "$codex_quota_other";
+	expect(editorWantsCodexQuota(config)).toBe(false);
+	config.components.editor.styles.opencode.metadataFormat = `(\${codex_quota})`;
+	expect(editorWantsCodexQuota(config)).toBe(true);
+	config.components.editor.enabled = false;
+	expect(editorWantsCodexQuota(config)).toBe(false);
+});
+
+it("uses the installed host's public auth capability with a synthetic runtime", async () => {
+	if (typeof ModelRegistry.prototype.getProviderAuth !== "function") {
+		expect(await resolveCodexToken(Object.create(ModelRegistry.prototype))).toBeUndefined();
+		return;
+	}
+	const getAuth = vi.fn(async () => ({ auth: { apiKey: "synthetic-host-token" } }));
+	const registry = new ModelRegistry({ getAuth } as never);
+	expect(await resolveCodexToken(registry)).toBe("synthetic-host-token");
+	expect(getAuth).toHaveBeenCalledWith("openai-codex");
+});
+
+it("fails open on older hosts without trying legacy/private auth paths", async () => {
+	const legacy = vi.fn();
+	expect(await resolveCodexToken({ getApiKeyForProvider: legacy } as never)).toBeUndefined();
+	expect(legacy).not.toHaveBeenCalled();
+});
+
+describe("session-scoped quota collection", () => {
+	let enabled: boolean;
+	let auth: ReturnType<typeof vi.fn>;
+	let http: ReturnType<typeof vi.fn<typeof fetch>>;
+	let collector: CodexQuotaCollector;
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(1_000_000);
+		enabled = false;
+		auth = vi.fn(async () => ({ auth: { apiKey: token("account-a") } }));
+		http = vi.fn<typeof fetch>().mockImplementation(async () => Response.json(payload()));
+		collector = new CodexQuotaCollector(
+			() =>
+				enabled
+					? ({ modelRegistry: { getProviderAuth: auth } } as unknown as ExtensionContext)
+					: undefined,
+			vi.fn(),
+			http,
+		);
+	});
+	afterEach(() => {
+		collector.stop();
+		expect(vi.getTimerCount()).toBe(0);
+		vi.useRealTimers();
+	});
+	const start = async () => {
+		enabled = true;
+		collector.reconcile();
+		await flush();
+	};
+
+	it("has no auth, requests or timers without demand; coalesces events and polls while idle", async () => {
+		collector.reconcile();
+		expect(collector.get()).toBeUndefined();
+		expect(vi.getTimerCount()).toBe(0);
+		expect(auth).not.toHaveBeenCalled();
+		await start();
+		for (let i = 0; i < 50; i++) collector.reconcile();
+		expect(http).toHaveBeenCalledOnce();
+		expect(auth).toHaveBeenCalledWith("openai-codex");
+		expect(http.mock.calls[0]).toEqual([
+			"https://chatgpt.com/backend-api/wham/usage",
+			{
+				headers: {
+					Authorization: `Bearer ${token("account-a")}`,
+					Accept: "application/json",
+					originator: "pi",
+					"ChatGPT-Account-Id": "account-a",
+				},
+				redirect: "error",
+				signal: expect.any(AbortSignal),
+			},
+		]);
+		expect(codexQuotaText(collector.get())).toBe("5h 80% | week 60%");
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(http).toHaveBeenCalledTimes(2);
+		enabled = false;
+		collector.reconcile();
+		expect(collector.get()).toBeUndefined();
+		await vi.advanceTimersByTimeAsync(120_000);
+		expect(http).toHaveBeenCalledTimes(2);
+	});
+
+	it.each(["network", "invalid", "server", "timeout"])(
+		"marks retained values stale on %s, replaces partial data on recovery",
+		async (failure) => {
+			await start();
+			if (failure === "network") http.mockRejectedValueOnce(new Error("offline"));
+			if (failure === "invalid") http.mockResolvedValueOnce(Response.json({}));
+			if (failure === "server") http.mockResolvedValueOnce(new Response("", { status: 500 }));
+			if (failure === "timeout") http.mockImplementationOnce(() => new Promise(() => {}));
+			await vi.advanceTimersByTimeAsync(70_000);
+			expect(codexQuotaText(collector.get())).toBe("5h 80% | week 60% stale");
+			http.mockResolvedValueOnce(Response.json(payload(null, window(100, 604_800))));
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(codexQuotaText(collector.get())).toBe("5h -- | week 0%");
+		},
+	);
+
+	it("shows initial placeholders and clears values on missing/rejected authentication", async () => {
+		http.mockRejectedValueOnce(new Error("offline"));
+		await start();
+		expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+		await vi.advanceTimersByTimeAsync(60_000);
+		for (const status of [401, 403]) {
+			http.mockResolvedValueOnce(new Response("", { status }));
+			await vi.advanceTimersByTimeAsync(60_000);
+			expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+			await vi.advanceTimersByTimeAsync(60_000);
+		}
+		auth.mockResolvedValueOnce(undefined);
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+	});
+
+	it("isolates accounts while preserving same-account token rotation", async () => {
+		await start();
+		auth.mockResolvedValueOnce({ auth: { apiKey: token("account-a", 2) } });
+		http.mockRejectedValueOnce(new Error("offline"));
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(collector.get()).toMatchObject({ fiveHour: 80, stale: true });
+		auth.mockResolvedValueOnce({ auth: { apiKey: token("account-b") } });
+		http.mockRejectedValueOnce(new Error("offline"));
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+	});
+
+	it("invalidates conservatively on opaque credential change", async () => {
+		auth.mockResolvedValue({ auth: { apiKey: "opaque-a" } });
+		await start();
+		expect(http.mock.calls[0]?.[1]?.headers).not.toHaveProperty("ChatGPT-Account-Id");
+		auth.mockResolvedValue({ auth: { apiKey: "opaque-b" } });
+		http.mockRejectedValueOnce(new Error("offline"));
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+	});
+
+	it.each(["180", new Date(1_000_000 + 240_000).toUTCString()])(
+		"honors Retry-After %s without retry storms",
+		async (retry) => {
+			await start();
+			http.mockResolvedValueOnce(
+				new Response("", { status: 429, headers: { "Retry-After": retry } }),
+			);
+			await vi.advanceTimersByTimeAsync(60_000);
+			await vi.advanceTimersByTimeAsync(179_999);
+			collector.reconcile();
+			expect(http).toHaveBeenCalledTimes(2);
+			expect(collector.get()?.stale).toBe(true);
+			await vi.advanceTimersByTimeAsync(1);
+			expect(http).toHaveBeenCalledTimes(3);
+		},
+	);
+
+	it("ages snapshots on sleep and releases lost demand on the timer", async () => {
+		await start();
+		vi.setSystemTime(Date.now() + 180_000);
+		expect(collector.get()?.stale).toBe(true);
+		enabled = false;
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(http).toHaveBeenCalledOnce();
+		expect(collector.get()).toBeUndefined();
+	});
+
+	it("retains stale quota on an auth deadline, ignores late auth, then recovers", async () => {
+		await start();
+		let resolve!: (value: unknown) => void;
+		auth.mockImplementationOnce(
+			() =>
+				new Promise((done) => {
+					resolve = done;
+				}),
+		);
+		await vi.advanceTimersByTimeAsync(70_000);
+		expect(codexQuotaText(collector.get())).toBe("5h 80% | week 60% stale");
+		expect(http).toHaveBeenCalledOnce();
+		resolve({ auth: { apiKey: token("late-account") } });
+		await flush();
+		expect(http).toHaveBeenCalledOnce();
+		expect(codexQuotaText(collector.get())).toBe("5h 80% | week 60% stale");
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(codexQuotaText(collector.get())).toBe("5h 80% | week 60%");
+		auth.mockRejectedValueOnce(new Error("invalid authentication"));
+		await vi.advanceTimersByTimeAsync(60_000);
+		expect(codexQuotaText(collector.get())).toBe("5h -- | week --");
+	});
+
+	it("bounds slow auth and ignores late auth after stop/re-enable", async () => {
+		let resolve!: (value: unknown) => void;
+		auth.mockImplementationOnce(
+			() =>
+				new Promise((done) => {
+					resolve = done;
+				}),
+		);
+		await start();
+		await vi.advanceTimersByTimeAsync(10_000);
+		expect(http).not.toHaveBeenCalled();
+		collector.stop();
+		await start();
+		resolve({ auth: { apiKey: token("old-account") } });
+		await flush();
+		expect(http).toHaveBeenCalledOnce();
+		expect(collector.get()?.fiveHour).toBe(80);
+	});
+
+	it("aborts and ignores late HTTP results from an earlier generation", async () => {
+		let resolve!: (value: Response) => void;
+		http.mockImplementationOnce(
+			() =>
+				new Promise((done) => {
+					resolve = done;
+				}),
+		);
+		await start();
+		const signal = http.mock.calls[0]?.[1]?.signal;
+		collector.stop();
+		expect(signal?.aborted).toBe(true);
+		await start();
+		resolve(Response.json(payload(window(99))));
+		await flush();
+		expect(collector.get()?.fiveHour).toBe(80);
+	});
+});

--- a/test/config-component-independence.test.ts
+++ b/test/config-component-independence.test.ts
@@ -47,6 +47,8 @@ const raw = (path: string) => JSON.parse(fs.readFileSync(path, "utf8"));
 afterEach(() => vi.clearAllMocks());
 
 const ownerSaves = [
+	["editor", (p: string) => saveEditorComponentPatch({ codexQuota: true }, p)],
+	["footer", (p: string) => saveFooterComponentPatch({ codexQuota: true }, p)],
 	["editor", (p: string) => saveEditorComponentPatch({ colorSource: "terminal" }, p)],
 	["editor", (p: string) => savePolishedEditorStylePatch({ completionMenu: "native" }, p)],
 	[
@@ -65,6 +67,35 @@ const ownerSaves = [
 ] as const;
 
 describe("owner-only component persistence", () => {
+	it("saves quota consent without enabling consumers or rewriting custom formats", () => {
+		const metadataFormat = "$model  $provider(  $thinking)";
+		const initial = {
+			components: {
+				editor: { enabled: false, styles: { opencode: { metadataFormat } } },
+				footer: {
+					style: "hidden",
+					styles: { starship: { format: "$cwd", compactFormat: "$tokens" } },
+				},
+			},
+		};
+		withFile(initial, (path) => {
+			const editor = saveEditorComponentPatch({ codexQuota: true }, path);
+			expect(editor.components.editor.enabled).toBe(false);
+			expect(editor.components.editor.styles.opencode.metadataFormat).toBe(metadataFormat);
+			expect(raw(path).components.footer).toEqual(initial.components.footer);
+			const footer = saveFooterComponentPatch({ codexQuota: true }, path);
+			expect(footer.components.footer.style).toBe("hidden");
+			expect(footer.components.footer.styles.starship).toMatchObject({
+				format: "$cwd",
+				compactFormat: "$tokens",
+			});
+			vi.mocked(fs.renameSync).mockImplementationOnce(() => {
+				throw new Error("read-only");
+			});
+			expect(() => saveEditorComponentPatch({ codexQuota: false }, path)).toThrow("read-only");
+			expect(raw(path).components.editor.codexQuota).toBe(true);
+		});
+	});
 	it.each(ownerSaves)("snapshots only %s and preserves unrelated raw JSON", (owner, save) => {
 		const initial = {
 			unknown: { keep: true },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -96,6 +96,7 @@ describe("canonical config resolution", () => {
 		const config = mergeConfig({});
 		expect(config.components).toEqual({
 			editor: {
+				codexQuota: false,
 				enabled: true,
 				style: "opencode",
 				colorSource: "theme",
@@ -152,6 +153,7 @@ describe("canonical config resolution", () => {
 			},
 			selectorBorders: { enabled: true, style: "zentui", colorSource: "theme" },
 			footer: {
+				codexQuota: false,
 				style: "starship",
 				colorSource: "theme",
 				modelLabel: "id",
@@ -1558,7 +1560,7 @@ describe("mergeConfig", () => {
 
 	it("defaults and normalizes responsive footer settings", () => {
 		expect(DEFAULT_COMPACT_FOOTER_FORMAT).toBe(
-			"$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens",
+			"$cwd$wrap(in $session_name)$wrap(on $git_branch) $git_status$wrap$context$wrap_sep$tokens$wrap_sep($codex_quota)",
 		);
 		expect(mergeConfig({})).toMatchObject({
 			responsiveFooter: true,

--- a/test/editor-mouse.test.ts
+++ b/test/editor-mouse.test.ts
@@ -88,6 +88,55 @@ const nativeMouse =
 	"function";
 
 describe("editor mouse capability and delegation", () => {
+	it("keeps quota outside the Accent Rail prompt and translates completion rows past it", () => {
+		const cfg = config("accent-rail");
+		cfg.components.editor.codexQuota = true;
+		const handleMouse = vi.fn(() => ({ handled: true }));
+		let completing = true;
+		const base = {
+			autocompleteList: { render: () => ["  completion"] },
+			isShowingAutocomplete: () => completing,
+			render(width: number) {
+				return [
+					"─".repeat(width),
+					"draft",
+					"─".repeat(width),
+					...(completing ? this.autocompleteList.render() : []),
+				];
+			},
+			getText: () => "draft",
+			setText() {},
+			handleInput() {},
+			invalidate() {},
+			handleMouse,
+		};
+		const editor = new WrappedPolishedEditor(
+			base as never,
+			uiTheme,
+			() => cfg,
+			() => ({ ...meta(), codexQuota: { fiveHour: 80, week: 60, stale: true } }),
+			() => "off",
+		);
+		const rows = editor.render(60);
+		expect(rows).toHaveLength(3);
+		const quota = cell(rows, "5h");
+		const completion = cell(rows, "completion");
+		expect(quota.y).toBe(1);
+		expect(completion.y).toBe(2);
+		mouse(editor, event(completion.x, completion.y, 60, rows.length));
+		expect(handleMouse).toHaveBeenLastCalledWith(
+			expect.objectContaining({ y: 3, width: 58, height: 4 }),
+		);
+		handleMouse.mockClear();
+		mouse(editor, event(quota.x, quota.y, 60, rows.length));
+		expect(handleMouse).not.toHaveBeenCalled();
+		expect(editor.getText()).toBe("draft");
+		completing = false;
+		// Two owned rows, not the special padded one-row rail geometry.
+		expect(editor.render(60)).toHaveLength(2);
+		cfg.components.editor.codexQuota = false;
+		expect(editor.render(60)).toHaveLength(3);
+	});
 	it("does not invent mouse support on a predecessor without it", () => {
 		const base = {
 			render: () => ["native"],

--- a/test/extension-compliance.test.ts
+++ b/test/extension-compliance.test.ts
@@ -5863,7 +5863,7 @@ describe("Pi docs compliance", () => {
 						handleInput?: (data: string) => void;
 					};
 					for (let index = 0; index < 5; index += 1) component.handleInput?.("\t");
-					for (let index = 0; index < 3; index += 1) component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 4; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
@@ -5935,7 +5935,7 @@ describe("Pi docs compliance", () => {
 						() => {},
 					) as { handleInput?: (data: string) => void };
 					for (let index = 0; index < 5; index += 1) component.handleInput?.("\t");
-					for (let index = 0; index < 6; index += 1) component.handleInput?.("\x1b[B");
+					for (let index = 0; index < 7; index += 1) component.handleInput?.("\x1b[B");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");
 					component.handleInput?.(" ");

--- a/test/responsive-dependencies.test.ts
+++ b/test/responsive-dependencies.test.ts
@@ -688,7 +688,7 @@ describe("responsive footer dependency reconciliation", () => {
 				handleInput?: (data: string) => void;
 			};
 			for (let index = 0; index < 5; index++) component.handleInput?.("\t");
-			for (let index = 0; index < 3; index++) component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();
@@ -783,7 +783,7 @@ describe("responsive footer dependency reconciliation", () => {
 				handleInput?: (data: string) => void;
 			};
 			for (let index = 0; index < 5; index++) component.handleInput?.("\t");
-			for (let index = 0; index < 4; index++) component.handleInput?.("\x1b[B");
+			for (let index = 0; index < 5; index++) component.handleInput?.("\x1b[B");
 			component.handleInput?.(" ");
 		});
 		const { handlers, command } = loadExtension();

--- a/test/settings-command.test.ts
+++ b/test/settings-command.test.ts
@@ -353,6 +353,40 @@ describe("component-oriented /zentui settings", () => {
 		expect(tokenRows).toContain("reconciles.");
 	});
 
+	it("saves quota toggles independently, including dormant editor preferences", async () => {
+		const config = cloneConfig();
+		config.components.editor.enabled = false;
+		const harness = createHarness(config);
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Codex quota");
+		component.handleInput(" ");
+		expect(harness.calls.editor).toEqual([{ codexQuota: true }]);
+		expect(config.components.editor.enabled).toBe(false);
+		expect(config.components.footer.codexQuota).toBe(false);
+		for (let index = 0; index < 4; index++) component.handleInput("\t");
+		selectLabel(component, "Codex quota");
+		component.handleInput(" ");
+		expect(harness.calls.footer).toEqual([{ codexQuota: true }]);
+		expect(config.components.editor.codexQuota).toBe(true);
+	});
+
+	it("restores quota settings after a failed save", async () => {
+		const harness = createHarness(cloneConfig(), {
+			setEditorComponent() {
+				throw new Error("read-only quota");
+			},
+		});
+		await harness.command().handler("", harness.ctx);
+		const component = harness.component();
+		goToSection(component, "Editor");
+		selectLabel(component, "Codex quota");
+		component.handleInput(" ");
+		expect(row(component, "Codex quota")).toContain("disabled");
+		expect(harness.notifications).toContain("Could not update Zentui settings: read-only quota");
+	});
+
 	it("uses exact component-owned row sets and ordering", async () => {
 		const harness = createHarness();
 		await harness.command().handler("", harness.ctx);
@@ -373,6 +407,7 @@ describe("component-oriented /zentui settings", () => {
 			"Editor",
 			"Editor style",
 			"Editor colors",
+			"Codex quota",
 			"Editor model label",
 			"Editor border color",
 			"Editor viewport indicators",
@@ -413,6 +448,7 @@ describe("component-oriented /zentui settings", () => {
 		expectFocusOrder(component, [
 			"Footer style",
 			"Footer colors",
+			"Codex quota",
 			"Footer model label",
 			"Responsive footer",
 			"Compact footer rows",
@@ -529,6 +565,7 @@ describe("component-oriented /zentui settings", () => {
 			"Editor",
 			"Editor style",
 			"Editor colors",
+			"Codex quota",
 			"Editor model label",
 			"Editor border color",
 			"Editor viewport indicators",


### PR DESCRIPTION
## Summary

Add optional remaining ChatGPT/Codex account quota to all four Editor styles and the Starship Footer, for example `5h 80% | week 60%`.

- Independent Editor and Footer **Codex quota** toggles, both off by default. Only the exact active provider `openai-codex` using native Codex API and ChatGPT-origin routing is eligible; same-ID proxy overrides are rejected.
- One shared authenticated refresh roughly every minute, including idle time, only while an owned eligible consumer needs quota. Disabling consumers, changing providers, or ending the session stops collection.
- Unknown values show `--`; transient failures retain successful values with a textual `stale` marker. Account changes or unavailable/rejected authentication clear cached values. Refreshes are bounded and canceled or ignored on teardown, and HTTP 429 honors `Retry-After`.
- `$codex_quota` supports Opencode metadata and wide/compact Footer templates without bypassing consent or rewriting saved formats. Minimalist includes quota beside context when it fits; Accent Rail adds an optional row below input, before autocomplete. Quota is omitted as a unit when space is insufficient.
- Reuse component-owned colors and existing atomic settings saves. No new dependencies, peer-minimum changes, private credential access, or changes to Working line/User messages.

### API and compatibility considerations

This is an opt-in integration with the **undocumented** `https://chatgpt.com/backend-api/wham/usage` endpoint, corroborated by OpenAI's Codex client. Authentication uses Pi's public `modelRegistry.getProviderAuth("openai-codex")` plus active-model, public-provider, and resolved-auth routing checks. Hosts without safe routing metadata do not collect or display quota; unavailable authentication shows placeholders. Credentials and quota are not persisted by Zentui, and redirects are rejected.

Only exact 18,000-second and 604,800-second windows are labeled, independently of response ordering. Other durations remain unknown. The endpoint may change or reject some account types. Maintainer review of this private-endpoint integration and the optional Accent Rail metadata row is welcome.

## Screenshots / recordings

No screenshot or recording attached yet. I installed the feature branch and tested it in a separate Pi session; it worked successfully. Synthetic rendering tests additionally cover narrow/wide widths, color sources, stale values, autocomplete, and quota-enabled fullscreen dock geometry.

## Testing

- [x] `npm run fmt`
- [x] `npm run verify`: 61 suites passed; 1,890 tests passed, 36 skipped
- [x] `npm run pack:check`: package and license assertions passed
- [x] Focused matched-package compatibility checks on Pi 0.80.5, 0.82.1, 0.83.0, 0.84.0, 0.84.4, and 0.85.1
- [x] Manual Pi test using the installed fork branch in a separate session, rather than `npm run pi:dev`
- [x] Added parser, polling/lifecycle, authentication, failure/recovery, template, rendering, settings, and ownership regression coverage

Automated quota tests use synthetic credentials/responses only. Manual success does not establish support for every ChatGPT account type. The existing informational Biome schema-version notice and existing dependency audit finding are intentionally unchanged to avoid unrelated PR churn.

## Checklist

- [x] Preserved Nerd Font/private-use icon glyphs
- [x] Updated README and configuration/template documentation
- [x] Kept changes scoped to the feature and its tests; no dependency or schema updates
- [x] Kept `index.ts` orchestration-focused
- [x] Used a conventional commit-style PR title


## Maintainer follow-up

- Guard same-ID proxy credentials before quota dispatch; preserve cache clearing and cancellation on route changes.
- Keep owned Footer quota independent of matching extension-status text and custom-template/zone-boundary collisions. Preserve the model ID/name preference in quota previews.
- Integrated current main, including #129 and #131, and added shell-color-plus-quota omission regressions.
- Verification at `5d6e032`: fmt, verify (61 suites; 1,951 passed, 36 skipped), pack:check, and matched Pi 0.80.5/0.84.0/0.85.1 behavior checks passed. Independent auth, rendering, and integration reviews passed.
- Seven fresh fullscreen Pi 0.85.1 scenarios passed with globally stubbed network and synthetic credentials: all four editor styles, Footer-only, shared Editor/Footer (one request), both off (zero requests), narrow omission, resize restoration, and preserved input. No real account credentials or live quota requests were used in maintainer verification.
